### PR TITLE
fix: Remove sentry enabled from properties TG-365

### DIFF
--- a/src/main/kotlin/io/tolgee/configuration/tolgee/SentryProperties.kt
+++ b/src/main/kotlin/io/tolgee/configuration/tolgee/SentryProperties.kt
@@ -4,7 +4,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "tolgee.sentry")
 class SentryProperties {
-  var enabled = false
   var serverDsn: String? = null
   var clientDsn: String? = null
 }

--- a/src/main/kotlin/io/tolgee/dtos/response/PublicConfigurationDTO.kt
+++ b/src/main/kotlin/io/tolgee/dtos/response/PublicConfigurationDTO.kt
@@ -16,7 +16,7 @@ class PublicConfigurationDTO(
   val allowRegistrations: Boolean
   val screenshotsUrl = properties.screenshotsUrl
   val maxUploadFileSize = properties.maxUploadFileSize
-  val clientSentryDsn = if (properties.sentry.enabled) properties.sentry.clientDsn else null
+  val clientSentryDsn = properties.sentry.clientDsn
   val needsEmailVerification = properties.authentication.needsEmailVerification
   val userCanCreateProjects = properties.authentication.userCanCreateProjects
   val userCanCreateOrganizations = properties.authentication.userCanCreateOrganizations


### PR DESCRIPTION
Sentry.enabled is not needed since disabling of sentry may be achieved by omitting dsn in configuration