### PR TITLE
fix: consistent sorting when sort is unspecified

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/api/v2/controllers/translation/V2TranslationsController.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/api/v2/controllers/translation/V2TranslationsController.kt
@@ -35,6 +35,7 @@ import io.tolgee.model.enums.ApiScope
 import io.tolgee.model.enums.TranslationState
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
+import io.tolgee.model.views.KeyWithTranslationsView
 import io.tolgee.security.AuthenticationFacade
 import io.tolgee.security.apiKeyAuth.AccessWithApiKey
 import io.tolgee.security.project_auth.AccessWithAnyProjectPermission
@@ -47,6 +48,7 @@ import io.tolgee.service.SecurityService
 import io.tolgee.service.TranslationService
 import io.tolgee.service.query_builders.CursorUtil
 import org.springdoc.api.annotations.ParameterObject
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PagedResourcesAssembler
@@ -175,7 +177,8 @@ class V2TranslationsController(
     val languages: Set<Language> = languageService
       .getLanguagesForTranslationsView(params.languages, projectHolder.project.id)
 
-    val data = translationService.getViewData(projectHolder.project.id, pageable, params, languages)
+    val pageableWithSort = getSafeSortPageable(pageable)
+    val data = translationService.getViewData(projectHolder.project.id, pageableWithSort, params, languages)
 
     val keysWithScreenshots = getKeysWithScreenshots(data.map { it.keyId }.toList())
 
@@ -263,6 +266,15 @@ Sorting is not supported for supported. It is automatically sorted from newest t
     if (authenticationFacade.isApiKeyAuthentication) {
       securityService.checkApiKeyScopes(setOf(ApiScope.KEYS_EDIT), authenticationFacade.apiKey)
     }
+  }
+
+  private fun getSafeSortPageable(pageable: Pageable): Pageable {
+    var sort = pageable.sort
+    if (sort.getOrderFor(KeyWithTranslationsView::keyId.name) == null) {
+      sort = sort.and(Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name))
+    }
+
+    return PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
   }
 
   private fun Translation.checkFromProject() {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/V2TranslationsControllerFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/V2TranslationsControllerFilterTest.kt
@@ -236,7 +236,7 @@ class V2TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projec
     testData.addFewKeysWithTags()
     testDataService.saveTestData(testData.root)
     userAccount = testData.user
-    performProjectAuthGet("/translations?filterTag=Cool tag&filterTag=Another cool tag")
+    performProjectAuthGet("/translations?sort=keyName&filterTag=Cool tag&filterTag=Another cool tag")
       .andPrettyPrint.andIsOk.andAssertThatJson {
         node("_embedded.keys[0].keyName").isEqualTo("A key")
         node("_embedded.keys[0].keyTags[0].name").isEqualTo("Cool tag")

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/V2TranslationsControllerViewTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/V2TranslationsControllerViewTest.kt
@@ -165,7 +165,45 @@ class V2TranslationsControllerViewTest : ProjectAuthControllerTest("/v2/projects
     val seenKeys = mutableListOf<String>()
     var cursor: String? = null
     do {
-      performProjectAuthGet(if (cursor == null) "/translations?size=2" else "/translations?size=2&cursor=$cursor")
+      var url = "/translations?size=2"
+      if (cursor != null) {
+        url += "&cursor=$cursor"
+      }
+
+      performProjectAuthGet(url)
+        .andAssertThatJson {
+          try {
+            node("nextCursor").isString.satisfies { cursor = it }
+          } catch (_: AssertionError) {
+            cursor = null
+            node("_embedded").isAbsent()
+            return@andAssertThatJson
+          }
+
+          node("_embedded.keys[0].keyName").isString.isNotIn(seenKeys).satisfies { seenKeys.add(it) }
+          node("_embedded.keys[1].keyName").isString.isNotIn(seenKeys).satisfies { seenKeys.add(it) }
+        }
+    } while (cursor != null)
+
+    assertThat(seenKeys).hasSize(8)
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `works with cursor on duplicate items sort`() {
+    testData.generateCursorWithDupeTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+
+    val seenKeys = mutableListOf<String>()
+    var cursor: String? = null
+    do {
+      var url = "/translations?sort=translations.de.text&size=2"
+      if (cursor != null) {
+        url += "&cursor=$cursor"
+      }
+
+      performProjectAuthGet(url)
         .andAssertThatJson {
           try {
             node("nextCursor").isString.satisfies { cursor = it }

--- a/backend/app/src/test/kotlin/io/tolgee/service/query_builders/CursorUtilUnitTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/query_builders/CursorUtilUnitTest.kt
@@ -51,18 +51,14 @@ class CursorUtilUnitTest {
         node("direction").isEqualTo("ASC")
         node("value").isEqualTo("Super key translated 🎌")
       }
-      node("keyId") {
-        node("direction").isEqualTo("ASC")
-        node("value").isString.isEqualTo("1")
-      }
     }
   }
 
   @Test
   fun `parses cursor`() {
     val parsed = CursorUtil.parseCursor(cursor)
-    assertThat(parsed["keyId"]?.direction).isEqualTo(Sort.Direction.ASC)
-    assertThat(parsed["keyId"]?.value).isEqualTo("1")
-    assertThat(parsed.entries).hasSize(3)
+    assertThat(parsed["keyName"]?.direction).isEqualTo(Sort.Direction.DESC)
+    assertThat(parsed["keyName"]?.value).isEqualTo("Super key")
+    assertThat(parsed.entries).hasSize(2)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
@@ -300,6 +300,25 @@ class TranslationsTestData {
     }
   }
 
+  fun generateCursorWithDupeTestData() {
+    root.data.projects[0].apply {
+      addKey { name = "a" }.build {
+        addTranslation {
+          language = germanLanguage
+          text = "a"
+        }
+      }
+      (1..5).forEach {
+        addKey { name = "key-$it" }.build {
+          addTranslation {
+            language = germanLanguage
+            text = "Key text..."
+          }
+        }
+      }
+    }
+  }
+
   fun generateCommentTestData() {
     root.data.projects[0].apply {
       addKey { name = "ee" }.build {

--- a/backend/data/src/main/kotlin/io/tolgee/service/query_builders/CursorUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/query_builders/CursorUtil.kt
@@ -18,14 +18,6 @@ class CursorUtil {
         )
       }.toMap().toMutableMap()
 
-      // add key id, to make cursor always contain unique value
-      if (cursor[KeyWithTranslationsView::keyId.name] == null) {
-        cursor[KeyWithTranslationsView::keyId.name] = CursorValue(
-          direction = Sort.Direction.ASC,
-          value = item?.keyId.toString()
-        )
-      }
-
       val json = jacksonObjectMapper().writer().writeValueAsString(cursor)
       return Base64.getEncoder().encodeToString(json.toByteArray())
     }

--- a/backend/data/src/main/kotlin/io/tolgee/service/query_builders/TranslationsViewBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/query_builders/TranslationsViewBuilder.kt
@@ -338,12 +338,10 @@ class TranslationsViewBuilder(
     ): Page<KeyWithTranslationsView> {
       val em = applicationContext.getBean(EntityManager::class.java)
       val tagService = applicationContext.getBean(TagService::class.java)
-      var sort = if (pageable.sort.isSorted)
-        pageable.sort
+      val sort = if (pageable.sort.isSorted)
+        pageable.sort.and(Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name))
       else
-        Sort.by(Sort.Order.asc(KEY_NAME_FIELD))
-
-      sort = sort.and(Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name))
+        Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name)
 
       // otherwise it takes forever for postgres to plan the execution
       em.createNativeQuery("SET join_collapse_limit TO 1").executeUpdate()

--- a/backend/data/src/main/kotlin/io/tolgee/service/query_builders/TranslationsViewBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/query_builders/TranslationsViewBuilder.kt
@@ -338,10 +338,6 @@ class TranslationsViewBuilder(
     ): Page<KeyWithTranslationsView> {
       val em = applicationContext.getBean(EntityManager::class.java)
       val tagService = applicationContext.getBean(TagService::class.java)
-      val sort = if (pageable.sort.isSorted)
-        pageable.sort.and(Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name))
-      else
-        Sort.by(Sort.Direction.ASC, KeyWithTranslationsView::keyId.name)
 
       // otherwise it takes forever for postgres to plan the execution
       em.createNativeQuery("SET join_collapse_limit TO 1").executeUpdate()
@@ -351,7 +347,7 @@ class TranslationsViewBuilder(
         projectId = projectId,
         languages = languages,
         params = params,
-        sort = sort,
+        sort = pageable.sort,
         cursor = cursor?.let { CursorUtil.parseCursor(it) }
       )
       val count = em.createQuery(translationsViewBuilder.countQuery).singleResult
@@ -361,7 +357,7 @@ class TranslationsViewBuilder(
         projectId = projectId,
         languages = languages,
         params = params,
-        sort = sort,
+        sort = pageable.sort,
         cursor = cursor?.let { CursorUtil.parseCursor(it) }
       )
       val query = em.createQuery(translationsViewBuilder.dataQuery).setMaxResults(pageable.pageSize)


### PR DESCRIPTION
When no sorting was specified, Tolgee defaulted to sorting by `keyId` and `keyName`. However, the returned cursor only specified `keyId` and this caused subsequent requests to not use the same sorting method. This patch fixes it by only using `keyId` when no sort is specified.

Regression test included.

closes #1345