### PR TITLE
fix: Check for empty namespace in complex-update endpoint

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/V2KeyInNamespaceControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/V2KeyInNamespaceControllerTest.kt
@@ -2,7 +2,6 @@ package io.tolgee.api.v2.controllers.v2KeyController
 
 import io.tolgee.controllers.ProjectAuthControllerTest
 import io.tolgee.development.testDataBuilder.data.NamespacesTestData
-import io.tolgee.dtos.request.key.ComplexEditKeyDto
 import io.tolgee.dtos.request.key.CreateKeyDto
 import io.tolgee.dtos.request.key.EditKeyDto
 import io.tolgee.fixtures.andAssertError
@@ -120,17 +119,17 @@ class V2KeyInNamespaceControllerTest : ProjectAuthControllerTest("/v2/projects/"
 
     val keyId = keyService.get(project.id, keyName, namespace).id
 
-    performProjectAuthPut("keys/${keyId}/complex-update", ComplexEditKeyDto(name = keyName, namespace = ""))
+    performProjectAuthPut("keys/$keyId/complex-update", mapOf("name" to keyName, "namespace" to ""))
       .andIsBadRequest
       .andAssertError
       .isCustomValidation.hasMessage("key_exists")
 
-    performProjectAuthPut("keys/${keyId}/complex-update", ComplexEditKeyDto(name = keyName, namespace = null))
+    performProjectAuthPut("keys/$keyId/complex-update", mapOf("name" to keyName, "namespace" to null))
       .andIsBadRequest
       .andAssertError
       .isCustomValidation.hasMessage("key_exists")
 
-    performProjectAuthPut("keys/${keyId}/complex-update", ComplexEditKeyDto(name = keyName))
+    performProjectAuthPut("keys/$keyId/complex-update", mapOf("name" to keyName))
       .andIsBadRequest
       .andAssertError
       .isCustomValidation.hasMessage("key_exists")

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/key/ComplexEditKeyDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/key/ComplexEditKeyDto.kt
@@ -38,4 +38,3 @@ data class ComplexEditKeyDto(
     this.namespace = namespace
   }
 }
-

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/key/ComplexEditKeyDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/key/ComplexEditKeyDto.kt
@@ -1,5 +1,6 @@
 package io.tolgee.dtos.request.key
 
+import com.fasterxml.jackson.annotation.JsonSetter
 import io.swagger.v3.oas.annotations.media.Schema
 import org.hibernate.validator.constraints.Length
 import org.springframework.validation.annotation.Validated
@@ -14,7 +15,7 @@ data class ComplexEditKeyDto(
 
   @field:Length(max = 100)
   @Schema(description = "The namespace of the key. (When empty or null default namespace will be used)")
-  val namespace: String? = null,
+  var namespace: String? = null,
 
   @Schema(description = "Translations to update")
   val translations: Map<String, String?>? = null,
@@ -27,4 +28,14 @@ data class ComplexEditKeyDto(
 
   @Schema(description = "Ids of screenshots uploaded with /v2/image-upload endpoint")
   val screenshotUploadedImageIds: List<Long>? = null
-)
+) {
+  @JsonSetter("namespace")
+  fun setJsonNamespace(namespace: String?) {
+    if (namespace == "") {
+      this.namespace = null
+      return
+    }
+    this.namespace = namespace
+  }
+}
+


### PR DESCRIPTION
This PR fixes #1520 by implementing `setJsonNamespace` function on the `ComplexEditKeyDto` (the same as in `EditKeyDto` and `CreateKeyDto`).