### PR TITLE
feat: Editor -> "Insert source" button

### DIFF
--- a/e2e/cypress/common/translations.ts
+++ b/e2e/cypress/common/translations.ts
@@ -19,6 +19,10 @@ export function getCellSaveButton() {
   return cy.gcy('translations-cell-save-button');
 }
 
+export function getCellInsertSourceButton() {
+  return cy.gcy('translations-cell-insert-source-button');
+}
+
 export const getCell = (value: string) => {
   return cy.gcy('translations-table-cell').contains(value);
 };

--- a/e2e/cypress/common/translations.ts
+++ b/e2e/cypress/common/translations.ts
@@ -19,8 +19,8 @@ export function getCellSaveButton() {
   return cy.gcy('translations-cell-save-button');
 }
 
-export function getCellInsertSourceButton() {
-  return cy.gcy('translations-cell-insert-source-button');
+export function getCellInsertBaseButton() {
+  return cy.gcy('translations-cell-insert-base-button');
 }
 
 export const getCell = (value: string) => {

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -7,7 +7,9 @@ import {
   forEachView,
   getCell,
   getCellCancelButton,
+  getCellInsertSourceButton,
   getCellSaveButton,
+  toggleLang,
   translationsBeforeEach,
   visitTranslations,
 } from '../../../common/translations';
@@ -36,6 +38,17 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool key edited').should('be.visible');
         cy.contains('Cool key 02').should('be.visible');
         cy.contains('Cool key 04').should('be.visible');
+      });
+
+      it('insert source into translation', () => {
+        toggleLang('Česky');
+        editCell('Studený přeložený text 1');
+        getCellInsertSourceButton().click();
+
+        cy.get('.CodeMirror')
+          .first()
+          .contains('Cool translated text 1')
+          .should('be.visible');
       });
 
       it('will edit translation', () => {

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -7,7 +7,7 @@ import {
   forEachView,
   getCell,
   getCellCancelButton,
-  getCellInsertSourceButton,
+  getCellInsertBaseButton,
   getCellSaveButton,
   selectLangsInLocalstorage,
   translationsBeforeEach,
@@ -40,12 +40,12 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool key 04').should('be.visible');
       });
 
-      it('insert source into translation', () => {
+      it('insert base into translation', () => {
         selectLangsInLocalstorage(project.id, ['en', 'cs']);
         visitTranslations(project.id);
 
         editCell('Studený přeložený text 1');
-        getCellInsertSourceButton().click();
+        getCellInsertBaseButton().click();
 
         cy.get('.CodeMirror')
           .first()

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -9,7 +9,7 @@ import {
   getCellCancelButton,
   getCellInsertSourceButton,
   getCellSaveButton,
-  toggleLang,
+  selectLangsInLocalstorage,
   translationsBeforeEach,
   visitTranslations,
 } from '../../../common/translations';
@@ -32,7 +32,7 @@ describe('Views with 5 Translations', () => {
   forEachView(
     () => project.id,
     () => {
-      it('will edit key', () => {
+      it.skip('will edit key', () => {
         editCell('Cool key 01', 'Cool key edited');
 
         cy.contains('Cool key edited').should('be.visible');
@@ -41,11 +41,8 @@ describe('Views with 5 Translations', () => {
       });
 
       it('insert source into translation', () => {
-        cy.gcy('translations-language-select-form-control').then(
-          (selectLanguageControl) => {
-            if (!selectLanguageControl.contains('cs')) toggleLang('Česky');
-          }
-        );
+        selectLangsInLocalstorage(project.id, ['en', 'cs']);
+        visitTranslations(project.id);
 
         editCell('Studený přeložený text 1');
         getCellInsertSourceButton().click();
@@ -56,7 +53,7 @@ describe('Views with 5 Translations', () => {
           .should('be.visible');
       });
 
-      it('will edit translation', () => {
+      it.skip('will edit translation', () => {
         editCell('Cool translated text 1', 'Super cool changed text...');
         cy.xpath(
           `${getAnyContainingText(
@@ -67,7 +64,7 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool translated text 2').should('be.visible');
       });
 
-      it('will edit key namespace', () => {
+      it.skip('will edit key namespace', () => {
         getCell('Cool key 01').click();
 
         selectNamespace('test-ns');
@@ -83,7 +80,7 @@ describe('Views with 5 Translations', () => {
           .should('be.visible');
       });
 
-      it('will cancel key edit without confirmation', () => {
+      it.skip('will cancel key edit without confirmation', () => {
         editCell('Cool key 01', 'Cool key edited', false);
         getCellCancelButton().click();
 
@@ -91,7 +88,7 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool key 01').should('be.visible');
       });
 
-      it('will ask for confirmation on changed edit', () => {
+      it.skip('will ask for confirmation on changed edit', () => {
         editCell('Cool translated text 1', 'Cool translation edited', false);
         cy.contains('Cool translated text 4').click();
         cy.contains(`Unsaved changes`).should('be.visible');

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -41,7 +41,9 @@ describe('Views with 5 Translations', () => {
       });
 
       it('insert source into translation', () => {
-        toggleLang('Česky');
+        if (!cy.gcy('translations-language-select-form-control').contains('cs'))
+          toggleLang('Česky');
+
         editCell('Studený přeložený text 1');
         getCellInsertSourceButton().click();
 

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -41,8 +41,11 @@ describe('Views with 5 Translations', () => {
       });
 
       it('insert source into translation', () => {
-        if (!cy.gcy('translations-language-select-form-control').contains('cs'))
-          toggleLang('Česky');
+        cy.gcy('translations-language-select-form-control').then(
+          (selectLanguageControl) => {
+            if (!selectLanguageControl.contains('cs')) toggleLang('Česky');
+          }
+        );
 
         editCell('Studený přeložený text 1');
         getCellInsertSourceButton().click();

--- a/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/withViews.cy.ts
@@ -32,7 +32,7 @@ describe('Views with 5 Translations', () => {
   forEachView(
     () => project.id,
     () => {
-      it.skip('will edit key', () => {
+      it('will edit key', () => {
         editCell('Cool key 01', 'Cool key edited');
 
         cy.contains('Cool key edited').should('be.visible');
@@ -53,7 +53,7 @@ describe('Views with 5 Translations', () => {
           .should('be.visible');
       });
 
-      it.skip('will edit translation', () => {
+      it('will edit translation', () => {
         editCell('Cool translated text 1', 'Super cool changed text...');
         cy.xpath(
           `${getAnyContainingText(
@@ -64,7 +64,7 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool translated text 2').should('be.visible');
       });
 
-      it.skip('will edit key namespace', () => {
+      it('will edit key namespace', () => {
         getCell('Cool key 01').click();
 
         selectNamespace('test-ns');
@@ -80,7 +80,7 @@ describe('Views with 5 Translations', () => {
           .should('be.visible');
       });
 
-      it.skip('will cancel key edit without confirmation', () => {
+      it('will cancel key edit without confirmation', () => {
         editCell('Cool key 01', 'Cool key edited', false);
         getCellCancelButton().click();
 
@@ -88,7 +88,7 @@ describe('Views with 5 Translations', () => {
         cy.contains('Cool key 01').should('be.visible');
       });
 
-      it.skip('will ask for confirmation on changed edit', () => {
+      it('will ask for confirmation on changed edit', () => {
         editCell('Cool translated text 1', 'Cool translation edited', false);
         cy.contains('Cool translated text 4').click();
         cy.contains(`Unsaved changes`).should('be.visible');

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -312,7 +312,7 @@ declare namespace DataCy {
         "translations-cell-close" |
         "translations-cell-comments-button" |
         "translations-cell-edit-button" |
-        "translations-cell-insert-source-button" |
+        "translations-cell-insert-base-button" |
         "translations-cell-save-button" |
         "translations-cell-screenshots-button" |
         "translations-cell-tab-comments" |

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -312,6 +312,7 @@ declare namespace DataCy {
         "translations-cell-close" |
         "translations-cell-comments-button" |
         "translations-cell-edit-button" |
+        "translations-cell-insert-source-button" |
         "translations-cell-save-button" |
         "translations-cell-screenshots-button" |
         "translations-cell-tab-comments" |

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useRef } from 'react';
 import { useTranslate, TFnType } from '@tolgee/react';
 import CodeMirror from 'codemirror';
-import { Controlled as CodeMirrorReact } from 'react-codemirror2-react-17';
+import {
+  Controlled as CodeMirrorReact,
+  DomEvent,
+} from 'react-codemirror2-react-17';
 import { parse } from '@formatjs/icu-messageformat-parser';
 import { GlobalStyles, styled } from '@mui/material';
 import 'codemirror/keymap/sublime';
@@ -140,6 +143,7 @@ type Props = {
   scrollMargins?: Parameters<typeof useScrollMargins>[0];
   autoScrollIntoView?: boolean;
   direction?: Direction;
+  onKeyDown?: DomEvent;
 };
 
 export const Editor: React.FC<Props> = ({
@@ -157,6 +161,7 @@ export const Editor: React.FC<Props> = ({
   scrollMargins,
   autoScrollIntoView,
   direction = 'ltr',
+  onKeyDown,
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslate();
@@ -232,6 +237,7 @@ export const Editor: React.FC<Props> = ({
           onBeforeChange={(editor, data, value) => {
             handleChange(value);
           }}
+          onKeyDown={onKeyDown}
           onBlur={() => onBlur?.()}
           onFocus={(e) => {
             onFocus?.();

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -131,7 +131,7 @@ type Props = {
   value: string;
   onChange?: (val: string) => void;
   onSave?: (val: string) => void;
-  onInsertSource?: (val?: string) => void;
+  onInsertBase?: (val?: string) => void;
   onCancel?: () => void;
   background?: string;
   plaintext?: boolean;

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -237,7 +237,7 @@ export const Editor: React.FC<Props> = ({
           onBeforeChange={(editor, data, value) => {
             handleChange(value);
           }}
-          onKeyDown={onKeyDown}
+          onKeyDown={(...params) => onKeyDown?.(...params)}
           onBlur={() => onBlur?.()}
           onFocus={(e) => {
             onFocus?.();

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -128,6 +128,7 @@ type Props = {
   value: string;
   onChange?: (val: string) => void;
   onSave?: (val: string) => void;
+  onInsertSource?: (val?: string) => void;
   onCancel?: () => void;
   background?: string;
   plaintext?: boolean;

--- a/webapp/src/component/key/KeyTemplate.tsx
+++ b/webapp/src/component/key/KeyTemplate.tsx
@@ -20,7 +20,7 @@ const StyledContainer = styled('span')`
   top: -1px;
   width: 20px;
   vertical-align: bottom;
-  font-size: ${({ theme }) => theme.typography.caption.fontSize};
+  font-size: ${({ theme }) => theme.typography.caption.fontSize}px;
 `;
 
 export const KeyTemplate: React.FC = ({ children }) => {

--- a/webapp/src/component/key/SvgKeys.tsx
+++ b/webapp/src/component/key/SvgKeys.tsx
@@ -41,6 +41,21 @@ export const KeyEnter = () => (
   </SvgTemplate>
 );
 
+export const KeyShift = () => (
+  <SvgTemplate>
+    <g
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.2"
+      transform="scale(.6)"
+    >
+      <path d="M5.0039 21 18.9961 21ZM15.9961 12 15.9961 17.0039 8.0039 17.0039 8.0039 12 3 12 12 3 21 12ZM15.9961 12"></path>
+    </g>
+  </SvgTemplate>
+);
+
 export const KeyUp = () => <ArrowUpward style={svgStyle} />;
 
 export const KeyDown = () => <ArrowDownward style={svgStyle} />;

--- a/webapp/src/fixtures/shortcuts.tsx
+++ b/webapp/src/fixtures/shortcuts.tsx
@@ -49,6 +49,8 @@ export const getKeyVisual = (key: KeyType) => {
       return <KeyRight />;
     case 'Enter':
       return <KeyEnter />;
+    case 'Insert':
+      return 'Ins';
     case 'Action':
       return IS_MAC ? '⌘' : <KeyCtrl />;
     default:

--- a/webapp/src/fixtures/shortcuts.tsx
+++ b/webapp/src/fixtures/shortcuts.tsx
@@ -7,6 +7,7 @@ import {
   KeyRight,
   KeyEnter,
   KeyCtrl,
+  KeyShift,
 } from 'tg.component/key/SvgKeys';
 import { IS_MAC } from './isMac';
 
@@ -51,6 +52,8 @@ export const getKeyVisual = (key: KeyType) => {
       return <KeyEnter />;
     case 'Insert':
       return 'Ins';
+    case 'Shift':
+      return <KeyShift />;
     case 'Action':
       return IS_MAC ? '⌘' : <KeyCtrl />;
     default:

--- a/webapp/src/fixtures/shortcuts.tsx
+++ b/webapp/src/fixtures/shortcuts.tsx
@@ -6,12 +6,10 @@ import {
   KeyLeft,
   KeyRight,
   KeyEnter,
-  KeyCtrl,
   KeyShift,
 } from 'tg.component/key/SvgKeys';
-import { IS_MAC } from './isMac';
 
-export type KeyType = 'Ctrl' | 'Alt' | 'Shift' | 'Meta' | 'Action' | string;
+export type KeyType = 'Ctrl' | 'Alt' | 'Shift' | 'Meta' | 'Cmd' | string;
 
 export type KeyMap = Record<string, ReadonlyArray<KeyType> | Array<KeyType>>;
 
@@ -28,9 +26,9 @@ const matchesKey = (e: KeyboardEvent, key: KeyType) => {
     case 'Shift':
       return e.shiftKey;
     case 'Meta':
+    case 'Cmd':
       return e.metaKey;
-    case 'Action':
-      return IS_MAC ? e.metaKey : e.ctrlKey;
+
     default:
       return key.length === 1
         ? e.key === key.toLocaleLowerCase()
@@ -54,8 +52,8 @@ export const getKeyVisual = (key: KeyType) => {
       return 'Ins';
     case 'Shift':
       return <KeyShift />;
-    case 'Action':
-      return IS_MAC ? '⌘' : <KeyCtrl />;
+    case 'Cmd':
+      return '⌘';
     default:
       return key.length === 1 ? key.toUpperCase() : key;
   }

--- a/webapp/src/views/projects/translations/TranslationOpened.tsx
+++ b/webapp/src/views/projects/translations/TranslationOpened.tsx
@@ -7,7 +7,7 @@ import { Editor } from 'tg.component/editor/Editor';
 import { components } from 'tg.service/apiSchema.generated';
 import { StateType, translationStates } from 'tg.constants/translationStates';
 import { Comments } from './comments/Comments';
-import { getMeta } from 'tg.fixtures/isMac';
+import { getMeta, IS_MAC } from 'tg.fixtures/isMac';
 import {
   useTranslationsActions,
   useTranslationsSelector,
@@ -211,7 +211,7 @@ export const TranslationOpened: React.FC<Props> = ({
               shortcuts={{
                 [`${getMeta()}-E`]: handleStateChange,
                 [`${getMeta()}-Enter`]: onCmdSave,
-                [`${getMeta()}-Insert`]: () =>
+                [IS_MAC ? `${getMeta()}-Shift-S` : `${getMeta()}-Insert`]: () =>
                   !language.base && onInsertSource(sourceText),
               }}
             />

--- a/webapp/src/views/projects/translations/TranslationOpened.tsx
+++ b/webapp/src/views/projects/translations/TranslationOpened.tsx
@@ -211,8 +211,14 @@ export const TranslationOpened: React.FC<Props> = ({
               shortcuts={{
                 [`${getMeta()}-E`]: handleStateChange,
                 [`${getMeta()}-Enter`]: onCmdSave,
-                [IS_MAC ? `${getMeta()}-Shift-S` : `${getMeta()}-Insert`]: () =>
-                  !language.base && onInsertSource(sourceText),
+                [`${getMeta()}-Insert`]: () => {
+                  !language.base && onInsertSource(sourceText);
+                },
+              }}
+              onKeyDown={(_, e) => {
+                if (IS_MAC && e.metaKey && e.shiftKey && e.key === 'S') {
+                  !language.base && onInsertSource(sourceText);
+                }
               }}
             />
           </StyledEditorContainer>

--- a/webapp/src/views/projects/translations/TranslationOpened.tsx
+++ b/webapp/src/views/projects/translations/TranslationOpened.tsx
@@ -85,7 +85,7 @@ type Props = {
   translation: TranslationViewModel | undefined;
   onChange: (val: string) => void;
   onSave: () => void;
-  onInsertSource: (val: string | undefined) => void;
+  onInsertBase: (val: string | undefined) => void;
   onCmdSave: () => void;
   onCancel: (force: boolean) => void;
   onStateChange: (state: StateType) => void;
@@ -106,7 +106,7 @@ export const TranslationOpened: React.FC<Props> = ({
   translation,
   onChange,
   onSave,
-  onInsertSource,
+  onInsertBase,
   onCmdSave,
   onCancel,
   onStateChange,
@@ -136,17 +136,16 @@ export const TranslationOpened: React.FC<Props> = ({
     }
   };
 
-  const sourceLanguage = useTranslationsSelector((v) =>
+  const baseLanguage = useTranslationsSelector((v) =>
     v.languages?.find((l) => l.base)
   )?.tag;
-  const sourceText =
-    sourceLanguage && keyData.translations[sourceLanguage]?.text;
+  const baseText = baseLanguage && keyData.translations[baseLanguage]?.text;
 
   const data = useTranslationTools({
     projectId: project.id,
     keyId: keyData.keyId,
     targetLanguageId: language.id,
-    baseText: sourceText,
+    baseText: baseText,
     enabled: !language.base,
     onValueUpdate: (value) => {
       updateEdit({
@@ -205,19 +204,19 @@ export const TranslationOpened: React.FC<Props> = ({
               onChange={onChange}
               onCancel={() => onCancel(true)}
               onSave={onSave}
-              onInsertSource={() => onInsertSource(sourceText)}
+              onInsertBase={() => onInsertBase(baseText)}
               direction={getLanguageDirection(language.tag)}
               autofocus={autofocus}
               shortcuts={{
                 [`${getMeta()}-E`]: handleStateChange,
                 [`${getMeta()}-Enter`]: onCmdSave,
                 [`${getMeta()}-Insert`]: () => {
-                  !language.base && onInsertSource(sourceText);
+                  !language.base && onInsertBase(baseText);
                 },
               }}
               onKeyDown={(_, e) => {
                 if (IS_MAC && e.metaKey && e.shiftKey && e.key === 'S') {
-                  !language.base && onInsertSource(sourceText);
+                  !language.base && onInsertBase(baseText);
                 }
               }}
             />
@@ -225,9 +224,9 @@ export const TranslationOpened: React.FC<Props> = ({
           <StyledEditorControls>
             <ControlsEditor
               state={state}
-              isSourceLanguage={language.base}
+              isBaseLanguage={language.base}
               onSave={onSave}
-              onInsertSource={() => onInsertSource(sourceText)}
+              onInsertBase={() => onInsertBase(baseText)}
               onCancel={() => onCancel(true)}
               onStateChange={onStateChange}
             />

--- a/webapp/src/views/projects/translations/TranslationOpened.tsx
+++ b/webapp/src/views/projects/translations/TranslationOpened.tsx
@@ -85,6 +85,7 @@ type Props = {
   translation: TranslationViewModel | undefined;
   onChange: (val: string) => void;
   onSave: () => void;
+  onInsertSource: (val: string | undefined) => void;
   onCmdSave: () => void;
   onCancel: (force: boolean) => void;
   onStateChange: (state: StateType) => void;
@@ -105,6 +106,7 @@ export const TranslationOpened: React.FC<Props> = ({
   translation,
   onChange,
   onSave,
+  onInsertSource,
   onCmdSave,
   onCancel,
   onStateChange,
@@ -134,17 +136,17 @@ export const TranslationOpened: React.FC<Props> = ({
     }
   };
 
-  const baseLanguage = useTranslationsSelector((v) =>
+  const sourceLanguage = useTranslationsSelector((v) =>
     v.languages?.find((l) => l.base)
   )?.tag;
-  const baseTranslation =
-    baseLanguage && keyData.translations[baseLanguage]?.text;
+  const sourceText =
+    sourceLanguage && keyData.translations[sourceLanguage]?.text;
 
   const data = useTranslationTools({
     projectId: project.id,
     keyId: keyData.keyId,
     targetLanguageId: language.id,
-    baseText: baseTranslation,
+    baseText: sourceText,
     enabled: !language.base,
     onValueUpdate: (value) => {
       updateEdit({
@@ -203,18 +205,23 @@ export const TranslationOpened: React.FC<Props> = ({
               onChange={onChange}
               onCancel={() => onCancel(true)}
               onSave={onSave}
+              onInsertSource={() => onInsertSource(sourceText)}
               direction={getLanguageDirection(language.tag)}
               autofocus={autofocus}
               shortcuts={{
                 [`${getMeta()}-E`]: handleStateChange,
                 [`${getMeta()}-Enter`]: onCmdSave,
+                [`${getMeta()}-Insert`]: () =>
+                  !language.base && onInsertSource(sourceText),
               }}
             />
           </StyledEditorContainer>
           <StyledEditorControls>
             <ControlsEditor
               state={state}
+              isSourceLanguage={language.base}
               onSave={onSave}
+              onInsertSource={() => onInsertSource(sourceText)}
               onCancel={() => onCancel(true)}
               onStateChange={onStateChange}
             />

--- a/webapp/src/views/projects/translations/TranslationsList/CellTranslation.tsx
+++ b/webapp/src/views/projects/translations/TranslationsList/CellTranslation.tsx
@@ -116,6 +116,7 @@ export const CellTranslation: React.FC<Props> = ({
     setValue,
     handleOpen,
     handleClose,
+    handleInsertSource,
     handleSave,
     handleModeChange,
     autofocus,
@@ -224,6 +225,7 @@ export const CellTranslation: React.FC<Props> = ({
           onChange={(v) => setValue(v as string)}
           onSave={() => handleSave()}
           onCmdSave={() => handleSave('EDIT_NEXT')}
+          onInsertSource={handleInsertSource}
           onCancel={handleClose}
           autofocus={autofocus}
           state={state}

--- a/webapp/src/views/projects/translations/TranslationsList/CellTranslation.tsx
+++ b/webapp/src/views/projects/translations/TranslationsList/CellTranslation.tsx
@@ -116,7 +116,7 @@ export const CellTranslation: React.FC<Props> = ({
     setValue,
     handleOpen,
     handleClose,
-    handleInsertSource,
+    handleInsertBase,
     handleSave,
     handleModeChange,
     autofocus,
@@ -225,7 +225,7 @@ export const CellTranslation: React.FC<Props> = ({
           onChange={(v) => setValue(v as string)}
           onSave={() => handleSave()}
           onCmdSave={() => handleSave('EDIT_NEXT')}
-          onInsertSource={handleInsertSource}
+          onInsertBase={handleInsertBase}
           onCancel={handleClose}
           autofocus={autofocus}
           state={state}

--- a/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
+++ b/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
@@ -165,6 +165,9 @@ export const TranslationsShortcuts = () => {
   const cursorMode = useTranslationsSelector((c) => c.cursor?.mode);
 
   const translations = useTranslationsSelector((c) => c.translations);
+  const sourceLanguage = useTranslationsSelector((c) =>
+    c.languages?.find((l) => l.base)
+  )?.tag;
 
   const elementsRef = useTranslationsSelector((c) => c.elementsRef);
 
@@ -238,6 +241,12 @@ export const TranslationsShortcuts = () => {
         <T>{translationStates[cursorKeyIdNextState].translationKey}</T>
       ),
       formula: formatShortcut(`${getMetaName()} + E`),
+    },
+    {
+      name: cursorLanguage != sourceLanguage && (
+        <T>translations_cell_insert_source</T>
+      ),
+      formula: formatShortcut(`${getMetaName()} + Insert`),
     },
   ];
 

--- a/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
+++ b/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
@@ -16,7 +16,7 @@ import {
 import clsx from 'clsx';
 
 import { useTranslationsSelector } from './context/TranslationsContext';
-import { getMetaName } from 'tg.fixtures/isMac';
+import { getMetaName, IS_MAC } from 'tg.fixtures/isMac';
 import { translationStates } from 'tg.constants/translationStates';
 import { getCurrentlyFocused } from './context/shortcuts/tools';
 
@@ -246,7 +246,9 @@ export const TranslationsShortcuts = () => {
       name: cursorLanguage != sourceLanguage && (
         <T>translations_cell_insert_source</T>
       ),
-      formula: formatShortcut(`${getMetaName()} + Insert`),
+      formula: IS_MAC
+        ? formatShortcut(`${getMetaName()} + Shift + S`)
+        : formatShortcut(`${getMetaName()} + Insert`),
     },
   ];
 

--- a/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
+++ b/webapp/src/views/projects/translations/TranslationsShortcuts.tsx
@@ -165,7 +165,7 @@ export const TranslationsShortcuts = () => {
   const cursorMode = useTranslationsSelector((c) => c.cursor?.mode);
 
   const translations = useTranslationsSelector((c) => c.translations);
-  const sourceLanguage = useTranslationsSelector((c) =>
+  const baseLanguage = useTranslationsSelector((c) =>
     c.languages?.find((l) => l.base)
   )?.tag;
 
@@ -243,8 +243,8 @@ export const TranslationsShortcuts = () => {
       formula: formatShortcut(`${getMetaName()} + E`),
     },
     {
-      name: cursorLanguage != sourceLanguage && (
-        <T>translations_cell_insert_source</T>
+      name: cursorLanguage != baseLanguage && (
+        <T>translations_cell_insert_base</T>
       ),
       formula: IS_MAC
         ? formatShortcut(`${getMetaName()} + Shift + S`)

--- a/webapp/src/views/projects/translations/TranslationsTable/CellTranslation.tsx
+++ b/webapp/src/views/projects/translations/TranslationsTable/CellTranslation.tsx
@@ -89,7 +89,7 @@ export const CellTranslation: React.FC<Props> = ({
     setValue,
     handleOpen,
     handleClose,
-    handleInsertSource,
+    handleInsertBase,
     handleSave,
     autofocus,
     handleModeChange,
@@ -144,7 +144,7 @@ export const CellTranslation: React.FC<Props> = ({
           onChange={(v) => setValue(v as string)}
           onSave={() => handleSave()}
           onCmdSave={() => handleSave('EDIT_NEXT')}
-          onInsertSource={handleInsertSource}
+          onInsertBase={handleInsertBase}
           onCancel={handleClose}
           autofocus={autofocus}
           state={state}

--- a/webapp/src/views/projects/translations/TranslationsTable/CellTranslation.tsx
+++ b/webapp/src/views/projects/translations/TranslationsTable/CellTranslation.tsx
@@ -89,6 +89,7 @@ export const CellTranslation: React.FC<Props> = ({
     setValue,
     handleOpen,
     handleClose,
+    handleInsertSource,
     handleSave,
     autofocus,
     handleModeChange,
@@ -143,6 +144,7 @@ export const CellTranslation: React.FC<Props> = ({
           onChange={(v) => setValue(v as string)}
           onSave={() => handleSave()}
           onCmdSave={() => handleSave('EDIT_NEXT')}
+          onInsertSource={handleInsertSource}
           onCancel={handleClose}
           autofocus={autofocus}
           state={state}

--- a/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
@@ -38,10 +38,10 @@ const StyledRightestPart = styled('div')`
 
 type ControlsProps = {
   state?: State;
-  isSourceLanguage?: boolean;
+  isBaseLanguage?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
-  onInsertSource?: () => void;
+  onInsertBase?: () => void;
   onScreenshots?: () => void;
   onStateChange?: (state: StateType) => void;
   screenshotRef?: React.Ref<any>;
@@ -50,10 +50,10 @@ type ControlsProps = {
 
 export const ControlsEditor: React.FC<ControlsProps> = ({
   state,
-  isSourceLanguage,
+  isBaseLanguage,
   onSave,
   onCancel,
-  onInsertSource,
+  onInsertBase,
   onScreenshots,
   onStateChange,
   screenshotRef,
@@ -63,7 +63,7 @@ export const ControlsEditor: React.FC<ControlsProps> = ({
   const displayTransitionButtons = state;
   const displayScreenshots = onScreenshots;
   const displayRightPart = displayTransitionButtons || displayScreenshots;
-  const displayInsertSource = !isSourceLanguage;
+  const displayInsertBase = !isBaseLanguage;
 
   const isEditLoading = useTranslationsSelector((c) => c.isEditLoading);
 
@@ -115,16 +115,16 @@ export const ControlsEditor: React.FC<ControlsProps> = ({
         </StyledRightPart>
       )}
 
-      {displayInsertSource && (
+      {displayInsertBase && (
         <StyledRightestPart>
           <ControlsButton
-            onClick={onInsertSource}
+            onClick={onInsertBase}
             onMouseDown={(e) => {
               e.preventDefault();
             }}
             color="default"
-            data-cy="translations-cell-insert-source-button"
-            tooltip={<T>translations_cell_insert_source</T>}
+            data-cy="translations-cell-insert-base-button"
+            tooltip={<T>translations_cell_insert_base</T>}
           >
             <ContentCopy fontSize="small" />
           </ControlsButton>

--- a/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { T } from '@tolgee/react';
 import { Button, styled } from '@mui/material';
-import { CameraAlt } from '@mui/icons-material';
+import { CameraAlt, ContentCopy } from '@mui/icons-material';
 
 import LoadingButton from 'tg.component/common/form/LoadingButton';
 import { components } from 'tg.service/apiSchema.generated';
@@ -27,10 +27,21 @@ const StyledRightPart = styled('div')`
   gap: 8px;
 `;
 
+const StyledRightestPart = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  margin-right: 5px;
+  padding: ${({ theme }) => theme.spacing(1, 1.5, 1.5, 0)};
+  gap: 8px;
+`;
+
 type ControlsProps = {
   state?: State;
+  isSourceLanguage?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
+  onInsertSource?: () => void;
   onScreenshots?: () => void;
   onStateChange?: (state: StateType) => void;
   screenshotRef?: React.Ref<any>;
@@ -39,8 +50,10 @@ type ControlsProps = {
 
 export const ControlsEditor: React.FC<ControlsProps> = ({
   state,
+  isSourceLanguage,
   onSave,
   onCancel,
+  onInsertSource,
   onScreenshots,
   onStateChange,
   screenshotRef,
@@ -50,6 +63,7 @@ export const ControlsEditor: React.FC<ControlsProps> = ({
   const displayTransitionButtons = state;
   const displayScreenshots = onScreenshots;
   const displayRightPart = displayTransitionButtons || displayScreenshots;
+  const displayInsertSource = !isSourceLanguage;
 
   const isEditLoading = useTranslationsSelector((c) => c.isEditLoading);
 
@@ -99,6 +113,19 @@ export const ControlsEditor: React.FC<ControlsProps> = ({
             </ControlsButton>
           )}
         </StyledRightPart>
+      )}
+
+      {displayInsertSource && (
+        <StyledRightestPart>
+          <ControlsButton
+            onClick={onInsertSource}
+            color="default"
+            data-cy="translations-cell-insert-source-button"
+            tooltip={<T>translations_cell_insert_source</T>}
+          >
+            <ContentCopy fontSize="small" />
+          </ControlsButton>
+        </StyledRightestPart>
       )}
     </>
   );

--- a/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsEditor.tsx
@@ -119,6 +119,9 @@ export const ControlsEditor: React.FC<ControlsProps> = ({
         <StyledRightestPart>
           <ControlsButton
             onClick={onInsertSource}
+            onMouseDown={(e) => {
+              e.preventDefault();
+            }}
             color="default"
             data-cy="translations-cell-insert-source-button"
             tooltip={<T>translations_cell_insert_source</T>}

--- a/webapp/src/views/projects/translations/context/TranslationsContext.ts
+++ b/webapp/src/views/projects/translations/context/TranslationsContext.ts
@@ -149,6 +149,9 @@ export const [
     fetchMore() {
       return translationService.fetchNextPage();
     },
+    getSourceText(keyId: number) {
+      return translationService.getSourceText(keyId);
+    },
     changeField(value: ChangeValue) {
       return editService.changeField(value);
     },

--- a/webapp/src/views/projects/translations/context/TranslationsContext.ts
+++ b/webapp/src/views/projects/translations/context/TranslationsContext.ts
@@ -149,8 +149,8 @@ export const [
     fetchMore() {
       return translationService.fetchNextPage();
     },
-    getSourceText(keyId: number) {
-      return translationService.getSourceText(keyId);
+    getBaseText(keyId: number) {
+      return translationService.getBaseText(keyId);
     },
     changeField(value: ChangeValue) {
       return editService.changeField(value);

--- a/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
@@ -247,6 +247,24 @@ export const useTranslationsService = (props: Props) => {
     });
   };
 
+  const getTranslations = useApiMutation({
+    url: '/v2/projects/{projectId}/translations',
+    method: 'get',
+  });
+
+  const getSourceText = async (keyId: number) => {
+    const sourceLanguage = props.baseLang!;
+    const sourceTextResponse = await getTranslations.mutateAsync({
+      path: { projectId: props.projectId },
+      query: { filterKeyId: [keyId], languages: [sourceLanguage] },
+    });
+
+    const sourceText =
+      sourceTextResponse._embedded?.keys![0].translations[sourceLanguage]
+        .text || '';
+    return sourceText;
+  };
+
   const setFilters = (filters: FiltersType) => {
     refetchTranslations(() => {
       _setFilters(JSON.stringify(filters));
@@ -357,6 +375,7 @@ export const useTranslationsService = (props: Props) => {
     setLanguages,
     setUrlSearch,
     setFilters,
+    getSourceText,
     updateTranslationKeys,
     updateTranslation,
     insertAsFirst,

--- a/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
@@ -252,17 +252,17 @@ export const useTranslationsService = (props: Props) => {
     method: 'get',
   });
 
-  const getSourceText = async (keyId: number) => {
-    const sourceLanguage = props.baseLang!;
-    const sourceTextResponse = await getTranslations.mutateAsync({
+  const getBaseText = async (keyId: number) => {
+    const baseLanguage = props.baseLang!;
+    const baseTextResponse = await getTranslations.mutateAsync({
       path: { projectId: props.projectId },
-      query: { filterKeyId: [keyId], languages: [sourceLanguage] },
+      query: { filterKeyId: [keyId], languages: [baseLanguage] },
     });
 
-    const sourceText =
-      sourceTextResponse._embedded?.keys![0].translations[sourceLanguage]
-        .text || '';
-    return sourceText;
+    const baseText =
+      baseTextResponse._embedded?.keys![0].translations[baseLanguage].text ||
+      '';
+    return baseText;
   };
 
   const setFilters = (filters: FiltersType) => {
@@ -375,7 +375,7 @@ export const useTranslationsService = (props: Props) => {
     setLanguages,
     setUrlSearch,
     setFilters,
-    getSourceText,
+    getBaseText,
     updateTranslationKeys,
     updateTranslation,
     insertAsFirst,

--- a/webapp/src/views/projects/translations/context/shortcuts/useTranslationsShortcuts.ts
+++ b/webapp/src/views/projects/translations/context/shortcuts/useTranslationsShortcuts.ts
@@ -15,12 +15,13 @@ import {
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
 import { ProjectPermissionType } from 'tg.service/response.types';
 import { CellPosition } from '../types';
+import { getMetaName } from 'tg.fixtures/isMac';
 
 export const KEY_MAP = {
   MOVE: ARROWS,
   EDIT: ['Enter'],
   CANCEL: ['Escape'],
-  CHANGE_STATE: ['Action+E'],
+  CHANGE_STATE: [`${getMetaName()} + E`],
 } as const;
 
 export type ShortcutsArrayType = [

--- a/webapp/src/views/projects/translations/context/shortcuts/useTranslationsShortcuts.ts
+++ b/webapp/src/views/projects/translations/context/shortcuts/useTranslationsShortcuts.ts
@@ -15,13 +15,13 @@ import {
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
 import { ProjectPermissionType } from 'tg.service/response.types';
 import { CellPosition } from '../types';
-import { getMetaName } from 'tg.fixtures/isMac';
+import { getMeta } from 'tg.fixtures/isMac';
 
 export const KEY_MAP = {
   MOVE: ARROWS,
   EDIT: ['Enter'],
   CANCEL: ['Escape'],
-  CHANGE_STATE: [`${getMetaName()} + E`],
+  CHANGE_STATE: [`${getMeta()} + E`],
 } as const;
 
 export type ShortcutsArrayType = [

--- a/webapp/src/views/projects/translations/useEditableRow.ts
+++ b/webapp/src/views/projects/translations/useEditableRow.ts
@@ -79,13 +79,6 @@ export const useEditableRow = ({
     } else {
       setValue(await getSourceText(keyId));
     }
-
-    if (cellRef.current) {
-      const editor = cellRef.current.querySelector('.CodeMirror-code') as
-        | HTMLDivElement
-        | undefined;
-      editor?.focus();
-    }
   };
 
   const handleClose = (force = false) => {

--- a/webapp/src/views/projects/translations/useEditableRow.ts
+++ b/webapp/src/views/projects/translations/useEditableRow.ts
@@ -28,6 +28,7 @@ export const useEditableRow = ({
     unregisterElement,
     setEdit,
     changeField,
+    getSourceText,
     setEditForce,
   } = useTranslationsActions();
 
@@ -72,6 +73,14 @@ export const useEditableRow = ({
     });
   };
 
+  const handleInsertSource = async (source: string | undefined) => {
+    if (source) {
+      setValue(source);
+    } else {
+      setValue(await getSourceText(keyId));
+    }
+  };
+
   const handleClose = (force = false) => {
     if (force) {
       setEditForce(undefined);
@@ -102,6 +111,7 @@ export const useEditableRow = ({
     handleOpen,
     handleClose,
     handleSave,
+    handleInsertSource,
     handleModeChange,
     value,
     setValue,

--- a/webapp/src/views/projects/translations/useEditableRow.ts
+++ b/webapp/src/views/projects/translations/useEditableRow.ts
@@ -28,7 +28,7 @@ export const useEditableRow = ({
     unregisterElement,
     setEdit,
     changeField,
-    getSourceText,
+    getBaseText,
     setEditForce,
   } = useTranslationsActions();
 
@@ -73,11 +73,11 @@ export const useEditableRow = ({
     });
   };
 
-  const handleInsertSource = async (source: string | undefined) => {
-    if (source) {
-      setValue(source);
+  const handleInsertBase = async (baseText: string | undefined) => {
+    if (baseText) {
+      setValue(baseText);
     } else {
-      setValue(await getSourceText(keyId));
+      setValue(await getBaseText(keyId));
     }
   };
 
@@ -111,7 +111,7 @@ export const useEditableRow = ({
     handleOpen,
     handleClose,
     handleSave,
-    handleInsertSource,
+    handleInsertBase,
     handleModeChange,
     value,
     setValue,

--- a/webapp/src/views/projects/translations/useEditableRow.ts
+++ b/webapp/src/views/projects/translations/useEditableRow.ts
@@ -79,6 +79,13 @@ export const useEditableRow = ({
     } else {
       setValue(await getSourceText(keyId));
     }
+
+    if (cellRef.current) {
+      const editor = cellRef.current.querySelector('.CodeMirror-code') as
+        | HTMLDivElement
+        | undefined;
+      editor?.focus();
+    }
   };
 
   const handleClose = (force = false) => {


### PR DESCRIPTION
This PR adds "Insert source" button to the editor to translation fields.
Translators can now click this button (or use the `Ctrl + Ins` keyboard shortcut) to insert the source text into the translation field. If the source language is not currently displayed, it gets the source text from API.