### PR TITLE
fix: Git line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf


### PR DESCRIPTION
Force LF on text files for windows with autocrlf=true. This avoids having issues with lint requiring LF endings.

Note that for the change to take place people on windows will need to save their changes and rebuild the repository:

**Running commands below remove all local changes**:
```bash
> git rm --cached -r . 
> git reset --hard
```