### PR TITLE
Word count performance improvements

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/util/WordCounter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/WordCounter.kt
@@ -4,23 +4,26 @@ import com.ibm.icu.text.BreakIterator
 import com.ibm.icu.util.ULocale
 
 object WordCounter {
+  private val NON_WORD = """[\p{P} \t\n\r~!@#$%^&*()_+{}\[\]:;,.<>/?-]""".toRegex()
+  private val LANGUAGE_PART = "^([A-Za-z]+).*".toRegex()
+
   fun countWords(text: String, languageTag: String): Int {
     val uLocale = getLocaleFromTag(languageTag)
     val iterator: BreakIterator = BreakIterator.getWordInstance(uLocale)
     iterator.setText(text)
 
-    val words: MutableList<String> = ArrayList()
+    var words = 0
     var start: Int = iterator.first()
     var end: Int = iterator.next()
     while (end != BreakIterator.DONE) {
       val word = text.substring(start, end)
-      if (!word.matches("""[\p{P} \t\n\r~!@#$%^&*()_+{}\[\]:;,.<>/?-]""".toRegex())) {
-        words.add(word)
+      if (!NON_WORD.matches(word)) {
+        words = words.inc()
       }
       start = end
       end = iterator.next()
     }
-    return words.size
+    return words
   }
 
   fun getLocaleFromTag(tag: String): ULocale {
@@ -29,7 +32,7 @@ object WordCounter {
       return result
     }
 
-    val languagePart = tag.replace("^([A-Za-z]+).*".toRegex(), "$1")
+    val languagePart = tag.replace(LANGUAGE_PART, "$1")
     result = ULocale.forLanguageTag(languagePart)
     if (result.language.isNotBlank()) {
       return result

--- a/backend/data/src/test/kotlin/io/tolgee/util/WordCounterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/util/WordCounterTest.kt
@@ -20,5 +20,6 @@ internal class WordCounterTest {
     assertThat(WordCounter.countWords("你好，这是一个简体中文文本。", "zh-Hans")).isEqualTo(7)
     assertThat(WordCounter.countWords("Hello, I am fred. (Super friend!)", "en-US")).isEqualTo(6)
     assertThat(WordCounter.countWords("Hello, I am fred. <html>yep!</html>", "en-US")).isEqualTo(7)
+    assertThat(WordCounter.countWords("What about {var_ids-var-ids}", "en-US")).isEqualTo(5) // 3 or 2?
   }
 }


### PR DESCRIPTION
I was thrilled to see the usage of BreakIterator and the word counting was more robust than I realized! However, these changes should greatly improve the performance (if it's slow) by pre-compiling the regexes and not having allocate memory for lists of words that aren't actually used. 

I added one test case- my question is if we should really count ICU variables and HTML tags. I think ideally, when you're paying a translator, they "preserve" these tags and don't "translate" them. But I guess that's subjective and the current implementation is more conservative (since it represents work done to preserve those variables and tags in the new translation).