### PR TITLE
fix: OTP name contains double ending brackets

### DIFF
--- a/webapp/src/views/userSettings/accountSecurity/EnableMfaDialog.tsx
+++ b/webapp/src/views/userSettings/accountSecurity/EnableMfaDialog.tsx
@@ -97,7 +97,7 @@ export const EnableMfaDialog: FunctionComponent = () => {
   }
 
   const encodedOtpName = encodeURIComponent(`Tolgee (${user.username})`);
-  const otpUri = `otpauth://totp/${encodedOtpName})?secret=${secret}`;
+  const otpUri = `otpauth://totp/${encodedOtpName}?secret=${secret}`;
 
   return (
     <Dialog


### PR DESCRIPTION
This PR fixes double ending brackets in the generated OTP. This change is only visual and only changes how the account is displayed in the authenticator app for newly generated OTPs.

### Explanation
When user has email address `example@domain.com`, the generated OTP name will become `Tolgee (example@domain.com)`.
After that, the OTP name is URI-encoded, but then another ending bracket is added, so the full OTP name is `Tolgee (example@domain.com))`.