### PR TITLE
Add STS dependency so that web identity token authentication works

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     implementation libs.sentry
     implementation libs.commonsCodec
     implementation libs.amazonS3
+    implementation libs.amazonSTS
     implementation libs.icu4j
     implementation("org.redisson:redisson-spring-boot-starter:3.21.0")
     implementation 'org.redisson:redisson-spring-data-27:3.21.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,7 @@ dependencyResolutionManagement {
             library('icu4j', 'com.ibm.icu:icu4j:69.1')
             library('jsonUnitAssert', 'net.javacrumbs.json-unit:json-unit-assertj:2.28.0')
             library('amazonS3', "software.amazon.awssdk:s3:$amazonAwsSdkVersion")
+            library('amazonSTS', "software.amazon.awssdk:sts:$amazonAwsSdkVersion")
             library('amazonTranslate', "software.amazon.awssdk:translate:$amazonAwsSdkVersion")
             library('googleCloud', "com.google.cloud:libraries-bom:24.0.0")
             library('sentry', "io.sentry:sentry-spring-boot-starter:5.7.3")


### PR DESCRIPTION
This is a follow on to PR #1614 and issue #1271 

One of the primary motivations for moving to AWS SDK v2 was to gain flexible and secure ways of authenticating, including STS Web Tokens. However, this method is not tried if the STS dependency is not on the app classpath. This PR adds the dependency to the build.

FYI @kenske