### PR TITLE
fix(oauth2): generate valid auth url when auth url already contains query params

### DIFF
--- a/webapp/src/component/security/OAuthService.tsx
+++ b/webapp/src/component/security/OAuthService.tsx
@@ -58,13 +58,15 @@ export const oauth2Service = (
   const redirectUri = LINKS.OAUTH_RESPONSE.buildWithOrigin({
     [PARAMS.SERVICE_TYPE]: 'oauth2',
   });
+  const authUrl = new URL(authorizationUrl);
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('scope', scopes.join(' '));
+  authUrl.searchParams.set('state', state);
   return {
     id: 'oauth2',
-    authenticationUrl: encodeURI(
-      `${authorizationUrl}?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=${scopes
-        .map((scope) => `${scope}`)
-        .join('+')}&state=${state}`
-    ),
+    authenticationUrl: authUrl.toString(),
     buttonIcon: <LoginIcon />,
     loginButtonTitle: <T keyName="login_oauth2_login_button" />,
     signUpButtonTitle: <T keyName="login_oauth2_signup_button" />,


### PR DESCRIPTION
Currently, if you use an authorization url such as `https://auth.example.com/oauth2/auth?foo=bar`, then the generated url when authenticating becomes `https://auth.example.com/oauth2/auth?foo=bar?client_id=...` instead of `https://auth.example.com/oauth2/auth?foo=bar&client_id=...`. By using the browsers URL api, we can let it figure that out and we can set the parameters on top of it. In addition, the `toString()` call on `URL` will also ensure the url is encoded, so the `encodeURI` method call is no longer necessary.

Some things to note as a result of this change:
* The spaces `scope` parameter will now be encoded as `%20` rather than a `+`. But in general, the `%20` is the safer option and is covered by the RFC spec.
* Each of the query params will now be properly url encoded, so if somebody did hack around this issue previously by injecting parameters through something like the scope, or client id, etc (say perhaps by something like `tolgee.authentication.oauth2.scopes=openid email profile&foo=bar` or `tolgee.authentication.oauth2.client-id=my-client-id&foo=bar` producing something akin to `https://example.com?scope=openid+email+profile&foo=bar`) will no longer work (they will now produce something akin to `https://example.com?scope=openid%20email%20profile%26foo%3Dbar`.