### PR TITLE
fix: Add healthcheck to dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -18,3 +18,5 @@ COPY BOOT-INF/classes /app
 
 ENV spring_profiles_active docker
 CMD ["ash", "-c", "java -cp app:app/lib/* io.tolgee.Application"]
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=2 CMD wget -q -O -  http://127.0.0.1:8080/actuator/health | sed -n "/UPa/p;q1" || exit 1

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -19,4 +19,5 @@ COPY BOOT-INF/classes /app
 ENV spring_profiles_active docker
 CMD ["ash", "-c", "java -cp app:app/lib/* io.tolgee.Application"]
 
-HEALTHCHECK --interval=10s --timeout=3s --retries=2 CMD wget -q -O -  http://127.0.0.1:8080/actuator/health | sed -n "/UPa/p;q1" || exit 1
+HEALTHCHECK --interval=10s --timeout=3s --retries=20 \
+    CMD [[ "$(wget -q -O -  http://127.0.0.1:8080/actuator/health)" == *"UP"* ]] || exit 1

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -19,5 +19,7 @@ COPY BOOT-INF/classes /app
 ENV spring_profiles_active docker
 CMD ["ash", "-c", "java -cp app:app/lib/* io.tolgee.Application"]
 
+ENV HEALTHCHECK_PORT=8080
+
 HEALTHCHECK --interval=10s --timeout=3s --retries=20 \
-    CMD [[ "$(wget -q -O -  http://127.0.0.1:8080/actuator/health)" == *"UP"* ]] || exit 1
+    CMD [[ "$(wget -q -O -  http://127.0.0.1:$HEALTHCHECK_PORT/actuator/health)" == *"UP"* ]] || exit 1


### PR DESCRIPTION
It would be nice if the docker container get a healthcheck.

Currently it is hard set to Port 8080. The Problem is that it can change through env and config, but I don't know how to get the port from the config file without installing something like [yq](https://github.com/mikefarah/yq).