### PR TITLE
fix: Import ConstraintViolationException

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportTranslation.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportTranslation.kt
@@ -5,7 +5,6 @@ import io.tolgee.model.translation.Translation
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToOne
 import jakarta.validation.constraints.NotNull
 import org.apache.commons.codec.digest.MurmurHash3
 import java.nio.ByteBuffer
@@ -21,7 +20,7 @@ class ImportTranslation(
   @ManyToOne(optional = false)
   lateinit var key: ImportKey
 
-  @OneToOne
+  @ManyToOne
   var conflict: Translation? = null
 
   /**

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -3028,4 +3028,7 @@
             create unique index import_author_project_unique on import(author_id, project_id) where deleted_at is null
         </sql>
     </changeSet>
+    <changeSet author="jenik (generated)" id="1704461236234-1">
+        <dropUniqueConstraint constraintName="uc_import_translationconflict_id_col" tableName="import_translation"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
It was throwing 500 with ConstraintViolationException, because we are soft deleting the import and Liquibase update added strict unique key constraint for import translations -> translation conflict OneToOne relations. Moving to OneToMany with dropping the unique key should resolve this.