### PR TITLE
feat: Allow multiple Google Workspace domains for user authentication

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/security/thirdParty/GoogleOAuthDelegate.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/security/thirdParty/GoogleOAuthDelegate.kt
@@ -65,13 +65,13 @@ class GoogleOAuthDelegate(
         }
 
         // Split the comma-separated list of domains into a List
-        val allowedDomains = googleConfigurationProperties.workspaceDomain.split(",").map { it.trim() }
+        val allowedDomains = googleConfigurationProperties.workspaceDomain?.split(",")?.map { it.trim() } ?: listOf()
 
         // ensure that only Google Workspace users from allowed domains can log in
         if (allowedDomains.isNotEmpty()) {
-            if (!allowedDomains.contains(userResponse.hd)) {
-                throw AuthenticationException(Message.THIRD_PARTY_GOOGLE_WORKSPACE_MISMATCH)
-            }
+          if (!allowedDomains.contains(userResponse.hd)) {
+            throw AuthenticationException(Message.THIRD_PARTY_GOOGLE_WORKSPACE_MISMATCH)
+          }
         }
 
         val googleEmail = userResponse.email ?: throw AuthenticationException(Message.THIRD_PARTY_AUTH_NO_EMAIL)

--- a/backend/api/src/main/kotlin/io/tolgee/security/thirdParty/GoogleOAuthDelegate.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/security/thirdParty/GoogleOAuthDelegate.kt
@@ -64,11 +64,14 @@ class GoogleOAuthDelegate(
           throw AuthenticationException(Message.THIRD_PARTY_AUTH_NO_EMAIL)
         }
 
-        // ensure that only Google Workspace users can log in
-        if (!googleConfigurationProperties.workspaceDomain.isNullOrEmpty()) {
-          if (userResponse.hd != googleConfigurationProperties.workspaceDomain) {
-            throw AuthenticationException(Message.THIRD_PARTY_GOOGLE_WORKSPACE_MISMATCH)
-          }
+        // Split the comma-separated list of domains into a List
+        val allowedDomains = googleConfigurationProperties.workspaceDomain.split(",").map { it.trim() }
+
+        // ensure that only Google Workspace users from allowed domains can log in
+        if (allowedDomains.isNotEmpty()) {
+            if (!allowedDomains.contains(userResponse.hd)) {
+                throw AuthenticationException(Message.THIRD_PARTY_GOOGLE_WORKSPACE_MISMATCH)
+            }
         }
 
         val googleEmail = userResponse.email ?: throw AuthenticationException(Message.THIRD_PARTY_AUTH_NO_EMAIL)

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/GoogleAuthenticationProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/GoogleAuthenticationProperties.kt
@@ -20,6 +20,7 @@ class GoogleAuthenticationProperties {
   @DocProperty(
     description =
       "The registration can be limited to users of a Google Workspace domain. " +
+        "Multiple Google Workspace domains can be separated by a comma `,`. " +
         "If nothing is set, anyone can log in with their Google account.",
   )
   var workspaceDomain: String? = null


### PR DESCRIPTION
Enhanced the authentication logic to support a comma-separated list of Google Workspace domains in `googleConfigurationProperties.workspaceDomain`.

This feature would be useful in my case. I have opened a PR and if you think that this benefits the project, you are welcome to merge it.

Disclaimers:
- I have never used Kotlin
- I don't know if this even builds

If you require any improvements or changes to keep up with the project's standards don't hesitate to let me know but my experience in this stack is very limited