### PR TITLE
fix: Android Import/Export fixes

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/android/AndroidParsingConstants.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/android/AndroidParsingConstants.kt
@@ -10,5 +10,7 @@ object AndroidParsingConstants {
       "br", "div", "p", "a",
     )
 
-  val spaces = setOf(' ', '\n', '\t', '\u0020', '\u2008', '\u2003')
+  val spacesWithoutNewLines = setOf(' ', '\t', '\u0020', '\u2008', '\u2003')
+
+  val spaces = spacesWithoutNewLines + '\n'
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/android/out/TextToAndroidXmlConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/android/out/TextToAndroidXmlConvertor.kt
@@ -201,7 +201,7 @@ class TextToAndroidXmlConvertor(
     escapeNewLines: Boolean,
   ): String {
     return this
-      .replace(escapeCharRegexWithoutUtfEscapes, "\\\\")
+      .replace(escapeCharRegexWithoutUtfEscapes, """\\\\""")
       .replace("\"", "\\\"")
       .let {
         if (quoteMoreWhitespaces) {

--- a/backend/data/src/main/kotlin/io/tolgee/formats/android/out/TextToAndroidXmlConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/android/out/TextToAndroidXmlConvertor.kt
@@ -25,7 +25,7 @@ class TextToAndroidXmlConvertor(
 
   fun convert(): ContentToAppend {
     try {
-      if (containsXmlAndPlaceholders || value.isWrappedCdata) {
+      if (value.isWrappedCdata || containsXmlAndPlaceholders) {
         return contentWrappedInCdata
       }
 
@@ -177,12 +177,18 @@ class TextToAndroidXmlConvertor(
   companion object {
     private val documentBuilder: DocumentBuilder by lazy { DocumentBuilderFactory.newInstance().newDocumentBuilder() }
 
-    val spacesRegex = """([${AndroidParsingConstants.spaces.joinToString("")}]{2,})""".toRegex()
+    fun getSpacesRegex(spaces: Iterable<Char>) = """([${spaces.joinToString("")}]{2,})""".toRegex()
+
+    val spacesRegex = getSpacesRegex(AndroidParsingConstants.spaces)
+    val spacesRegexWithoutNewlines = getSpacesRegex(AndroidParsingConstants.spacesWithoutNewLines)
+
     private val xmlTransformer by lazy {
       val transformer: Transformer = TransformerFactory.newInstance().newTransformer()
       transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes")
       transformer
     }
+
+    private val escapeCharRegexWithoutUtfEscapes = "\\\\(?!u[0-9a-fA-F]{4})".toRegex()
   }
 
   private fun String.escape(
@@ -195,11 +201,15 @@ class TextToAndroidXmlConvertor(
     escapeNewLines: Boolean,
   ): String {
     return this
-      .replace("\\", "\\\\")
+      .replace(escapeCharRegexWithoutUtfEscapes, "\\\\")
       .replace("\"", "\\\"")
       .let {
         if (quoteMoreWhitespaces) {
-          it.replace(spacesRegex, "\"$1\"")
+          if (escapeNewLines) {
+            it.replace(spacesRegexWithoutNewlines, "\"$1\"")
+          } else {
+            it.replace(spacesRegex, "\"$1\"")
+          }
         } else {
           it
         }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
@@ -86,7 +86,7 @@ class TextToAndroidXmlConvertorTest {
   }
 
   @Test
-  fun `multiple newlines are not quoted`()  {
+  fun `multiple newlines are not quoted`() {
     "a\n\na".assertSingleTextNode("a\\n\\na")
   }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
@@ -57,7 +57,12 @@ class TextToAndroidXmlConvertorTest {
 
   @Test
   fun `all possible spaces are quoted`() {
-    "a\n\t   \u0020 \u2008 \u2003a".assertSingleTextNode("a\"\\n\t   \u0020 \u2008 \u2003\"a")
+    "a\n\t   \u0020 \u2008 \u2003a".assertSingleTextNode("a\\n\"\t   \u0020 \u2008 \u2003\"a")
+  }
+
+  @Test
+  fun `it doesn't re-escape UTF symbols`() {
+    "\\u0020\\u2008\\u2003".assertSingleTextNode("\\u0020\\u2008\\u2003")
   }
 
   @Test
@@ -72,6 +77,17 @@ class TextToAndroidXmlConvertorTest {
   fun `new lines are escaped in cdata string`() {
     val nodes = "\n\n".convertedNodes(isWrappedWithCdata = true)
     nodes.getSingleNode().assertSingleCdataNodeText().isEqualTo("\\n\\n")
+  }
+
+  @Test
+  fun `wrapping with CDATA works for invalid XML`() {
+    val nodes = "<b> a ".convertedNodes(isWrappedWithCdata = true)
+    nodes.getSingleNode().assertSingleCdataNodeText().isEqualTo("<b> a ")
+  }
+
+  @Test
+  fun `multiple newlines are not quoted`()  {
+    "a\n\na".assertSingleTextNode("a\\n\\na")
   }
 
   private fun Node.assertTextContent(text: String) {


### PR DESCRIPTION
This PR fixes 
- String not wrapped with CDATA when contains content which is not parseable with XML parser
-  Sequences  with multiple`\n` are quoted, while this is unnecessary
- UTF 8 escaped characters are not re-escaped with `\` anymore 