### PR TITLE
chore: Endpoints outside public should be authenticated by default

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
@@ -78,7 +78,7 @@ class WebSecurityConfig(
         )
         it.requestMatchers("/api/public/**", "/v2/public/**").permitAll()
         it.requestMatchers("/v2/administration/**", "/v2/ee-license/**").hasRole("ADMIN")
-        it.requestMatchers("/api/**", "/v2/**")
+        it.requestMatchers("/api/**", "/v2/**").authenticated()
         it.anyRequest().permitAll()
       }.headers { headers ->
         headers.xssProtection(Customizer.withDefaults())


### PR DESCRIPTION
While upgrading to Spring 3, I converted 
```
.mvcMatchers("/api/**", "/v2/**").authenticated()
```
to 

```
it.requestMatchers("/api/**", "/v2/**")
```
Forgetting to add the `authenticated` modifier. 

However, there is no endpoint outside `/v2/public` or `/api/public`, so this is causes no vulnerability. However, I am adding it back to force keeping all the public endpoints under `/v2|api/public` 