### PR TITLE
fix: Activity relation storing

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/activity/EntityDescriptionProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/EntityDescriptionProvider.kt
@@ -6,9 +6,11 @@ import io.tolgee.activity.data.EntityDescription
 import io.tolgee.activity.data.EntityDescriptionWithRelations
 import io.tolgee.model.EntityWithId
 import io.tolgee.util.EntityUtil
+import org.hibernate.proxy.HibernateProxy
 import org.springframework.stereotype.Component
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.superclasses
 
 @Component
 class EntityDescriptionProvider(
@@ -19,7 +21,7 @@ class EntityDescriptionProvider(
 
     val relations = mutableMapOf<String, EntityDescriptionWithRelations>()
 
-    entity::class.findAnnotation<ActivityEntityDescribingPaths>()?.paths?.forEach pathsForEach@{ path ->
+    getAnnotation(entity)?.paths?.forEach pathsForEach@{ path ->
       var realDescribingEntity: Any = entity
       path.split(".").forEach { pathItem ->
         val member = realDescribingEntity::class.members.find { it.name == pathItem }
@@ -37,6 +39,13 @@ class EntityDescriptionProvider(
       description.data,
       relations,
     )
+  }
+
+  private fun getAnnotation(entity: EntityWithId): ActivityEntityDescribingPaths? {
+    if (entity is HibernateProxy) {
+      return entity::class.superclasses.firstNotNullOf { it.findAnnotation<ActivityEntityDescribingPaths>() }
+    }
+    return entity::class.findAnnotation<ActivityEntityDescribingPaths>()
   }
 
   fun getDescription(entity: EntityWithId): EntityDescription? {

--- a/backend/data/src/main/kotlin/io/tolgee/activity/EntityDescriptionProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/EntityDescriptionProvider.kt
@@ -43,7 +43,7 @@ class EntityDescriptionProvider(
 
   private fun getAnnotation(entity: EntityWithId): ActivityEntityDescribingPaths? {
     if (entity is HibernateProxy) {
-      return entity::class.superclasses.firstNotNullOf { it.findAnnotation<ActivityEntityDescribingPaths>() }
+      return entity::class.superclasses.firstNotNullOfOrNull { it.findAnnotation<ActivityEntityDescribingPaths>() }
     }
     return entity::class.findAnnotation<ActivityEntityDescribingPaths>()
   }

--- a/backend/data/src/main/kotlin/io/tolgee/activity/projectActivityView/ActivityViewByRevisionsProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/projectActivityView/ActivityViewByRevisionsProvider.kt
@@ -71,7 +71,7 @@ class ActivityViewByRevisionsProvider(
   private fun prepareData() {
     revisionIds = revisions.map { it.id }.toMutableList()
 
-    allDataReturningEventTypes = ActivityType.values().filter { !it.onlyCountsInList }
+    allDataReturningEventTypes = ActivityType.entries.filter { !it.onlyCountsInList }
 
     allRelationData = getAllowedRevisionRelations(revisionIds, allDataReturningEventTypes)
 
@@ -105,7 +105,7 @@ class ActivityViewByRevisionsProvider(
   }
 
   private fun getCounts(): MutableMap<Long, MutableMap<String, Long>> {
-    val allowedTypes = ActivityType.values().filter { it.onlyCountsInList }
+    val allowedTypes = ActivityType.entries.filter { it.onlyCountsInList }
     val counts: MutableMap<Long, MutableMap<String, Long>> = mutableMapOf()
     activityRevisionRepository.getModifiedEntityTypeCounts(
       revisionIds = revisionIds,
@@ -194,7 +194,7 @@ class ActivityViewByRevisionsProvider(
     val whereConditions = mutableListOf<Predicate>()
     whereConditions.add(revision.get(ActivityRevision_.type).`in`(allDataReturningEventTypes))
     whereConditions.add(revision.get(ActivityRevision_.id).`in`(revisionIds))
-    ActivityType.values().forEach {
+    ActivityType.entries.forEach {
       it.restrictEntitiesInList?.let { restrictEntitiesInList ->
         val restrictedEntityNames = restrictEntitiesInList.map { it.simpleName }
         whereConditions.add(


### PR DESCRIPTION
When the entity was hibernate proxy, the `EntityDescriptionProvider` wasn't able to get `ActivityEntityDescribingPaths` annotation and so it didn't store all activity relations. This PR fixes it.