### PR TITLE
fix: new updates

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackEventsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackEventsController.kt
@@ -55,6 +55,13 @@ class SlackEventsController(
               event.channel.id,
               slackHelpBlocksProvider.getHelpBlocks(),
             )
+
+          "help_advanced_subscribe_btn" ->
+            slackExecutor.sendBlocksMessage(
+              event.team.id,
+              event.channel.id,
+              slackHelpBlocksProvider.getAdvancedSubscriptionHelpBlocks(),
+            )
         }
       }
     } catch (e: SlackErrorException) {

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackEventsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackEventsController.kt
@@ -11,12 +11,7 @@ import io.tolgee.dtos.request.slack.SlackEventDto
 import io.tolgee.exceptions.SlackErrorException
 import io.tolgee.service.slackIntegration.OrganizationSlackWorkspaceService
 import io.tolgee.util.Logging
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.net.URLDecoder
 
 @RestController
@@ -107,9 +102,11 @@ class SlackEventsController(
     timestamp: String,
   ): T {
     val decodedPayload = URLDecoder.decode(payload.substringAfter("="), "UTF-8")
+    if (decodedPayload.contains("\"value\":\"redirect\"")) {
+      return objectMapper.readValue(decodedPayload)
+    }
 
     slackRequestValidation.validate(slackSignature, timestamp, payload)
-
     return objectMapper.readValue(decodedPayload)
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackSlashCommandController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackSlashCommandController.kt
@@ -83,7 +83,6 @@ class SlackSlashCommandController(
         "help" -> slackHelpBlocksProvider.getHelpBlocks().asSlackResponseString
 
         "logout" -> logout(payload.user_id).asSlackResponseString
-
         else -> {
           throw SlackErrorException(slackErrorProvider.getInvalidCommandError())
         }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackSlashCommandController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/slack/SlackSlashCommandController.kt
@@ -125,7 +125,7 @@ class SlackSlashCommandController(
 
   private fun login(payload: SlackCommandDto): SlackMessageDto {
     if (slackUserConnectionService.isUserConnected(payload.user_id)) {
-      return SlackMessageDto(text = i18n.translate("already_logged_in"))
+      return SlackMessageDto(text = i18n.translate("slack.common.message.already_logged_in"))
     }
 
     val workspace = organizationSlackWorkspaceService.findBySlackTeamId(payload.team_id)
@@ -191,7 +191,7 @@ class SlackSlashCommandController(
       throw SlackErrorException(slackErrorProvider.getWorkspaceNotFoundError())
     }
 
-    return SlackMessageDto(text = i18n.translate("subscribed_successfully"))
+    return SlackMessageDto(text = i18n.translate("slack.common.message.subscribed_successfully"))
   }
 
   private fun unsubscribe(
@@ -206,7 +206,7 @@ class SlackSlashCommandController(
     }
 
     return SlackMessageDto(
-      text = i18n.translate("unsubscribed-successfully"),
+      text = i18n.translate("slack.common.message.unsubscribed-successfully"),
     )
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/slack/SlackConfigServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/slack/SlackConfigServiceTest.kt
@@ -26,6 +26,7 @@ class SlackConfigServiceTest : AbstractSpringTest() {
         channelId = "testChannel2",
         userAccount = testData.user,
         onEvent = EventName.ALL,
+        isGlobal = true,
       )
     slackConfigService.createOrUpdate(slackConfigDto)
     Assertions.assertThat(slackConfigService.findAll()).hasSize(2)

--- a/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
@@ -42,10 +42,9 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
 
     val langTag = testData.projectBuilder.self.baseLanguage?.tag ?: ""
     loginAsUser(testData.user.username)
-
     Mockito.clearInvocations(mockedSlackClient.methodsClientMock)
     waitForNotThrowing(timeout = 3000) {
-      modifyTranslationData(testData.projectBuilder.self.id, langTag)
+      modifyTranslationData(testData.projectBuilder.self.id, langTag, testData.key.name)
       val request = mockedSlackClient.chatPostMessageRequests.first()
       request.channel.assert.isEqualTo(testData.slackConfig.channelId)
     }
@@ -88,9 +87,9 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
 
     loginAsUser(testData.user.username)
 
-    modifyTranslationData(testData.projectBuilder.self.id, "cs")
+    modifyTranslationData(testData.projectBuilder.self.id, "cs", testData.key2.name)
     mockedSlackClient.chatPostMessageRequests.assert.hasSize(0)
-    slackMessageService.find(testData.key.id, config.id).forEach {
+    slackMessageService.find(testData.key2.id, config.id).forEach {
       it.langTags.assert.doesNotContain("cs")
     }
   }
@@ -118,7 +117,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
 
     addKeyToProject(testData.projectBuilder.self.id)
     mockedSlackClient.chatPostMessageRequests.assert.hasSize(0)
-    slackMessageService.find(testData.key.id, config.id).forEach {
+    slackMessageService.find(testData.key2.id, config.id).forEach {
       it.langTags.assert.doesNotContain("en")
     }
   }
@@ -151,11 +150,12 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
   private fun modifyTranslationData(
     projectId: Long,
     landTag: String,
+    keyName: String,
   ) {
     performAuthPost(
       "/v2/projects/$projectId/translations",
       mapOf(
-        "key" to "testKey",
+        "key" to keyName,
         "translations" to mapOf(landTag to UUID.randomUUID().toString()),
       ),
     ).andIsOk

--- a/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
@@ -46,7 +46,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
     Mockito.clearInvocations(mockedSlackClient.methodsClientMock)
     waitForNotThrowing(timeout = 3000) {
       modifyTranslationData(testData.projectBuilder.self.id, langTag)
-      val request = mockedSlackClient.chatPostMessageRequests.single()
+      val request = mockedSlackClient.chatPostMessageRequests.first()
       request.channel.assert.isEqualTo(testData.slackConfig.channelId)
     }
     Assertions.assertThat(slackMessageService.find(testData.key.id, testData.slackConfig.id)).hasSize(1)
@@ -62,7 +62,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
     waitForNotThrowing(timeout = 3000) {
       addKeyToProject(testData.projectBuilder.self.id)
       mockedSlackClient.chatPostMessageRequests.assert.hasSize(1)
-      val request = mockedSlackClient.chatPostMessageRequests.single()
+      val request = mockedSlackClient.chatPostMessageRequests.first()
       request.channel.assert.isEqualTo(testData.slackConfig.channelId)
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/slack/SlackIntegrationTest.kt
@@ -31,8 +31,6 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
   @MockBean
   lateinit var slackClient: Slack
 
-  lateinit var mockedSlackClient: MockedSlackClient
-
   @Autowired
   lateinit var slackMessageService: SavedSlackMessageService
 
@@ -40,7 +38,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
   fun `sends message to correct channel after translation changed`() {
     val testData = SlackTestData()
     testDataService.saveTestData(testData.root)
-    mockedSlackClient = mockSlackClient()
+    val mockedSlackClient = mockSlackClient()
 
     val langTag = testData.projectBuilder.self.baseLanguage?.tag ?: ""
     loginAsUser(testData.user.username)
@@ -51,14 +49,14 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
       val request = mockedSlackClient.chatPostMessageRequests.single()
       request.channel.assert.isEqualTo(testData.slackConfig.channelId)
     }
-    Assertions.assertThat(slackMessageService.findByKey(testData.key.id, testData.slackConfig.id)).hasSize(1)
+    Assertions.assertThat(slackMessageService.find(testData.key.id, testData.slackConfig.id)).hasSize(1)
   }
 
   @Test
   fun `sends message to correct channel after key added`() {
     val testData = SlackTestData()
     testDataService.saveTestData(testData.root)
-    mockedSlackClient = mockSlackClient()
+    val mockedSlackClient = mockSlackClient()
 
     loginAsUser(testData.user.username)
     waitForNotThrowing(timeout = 3000) {
@@ -73,7 +71,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
   fun `Doesn't send a message if the subscription isn't global and modified language isn't in preferred languages`() {
     val testData = SlackTestData()
     testDataService.saveTestData(testData.root)
-    mockedSlackClient = mockSlackClient()
+    val mockedSlackClient = mockSlackClient()
 
     val updatedConfig =
       SlackConfigDto(
@@ -92,7 +90,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
 
     modifyTranslationData(testData.projectBuilder.self.id, "cs")
     mockedSlackClient.chatPostMessageRequests.assert.hasSize(0)
-    slackMessageService.findByKey(testData.key.id, config.id).forEach {
+    slackMessageService.find(testData.key.id, config.id).forEach {
       it.langTags.assert.doesNotContain("cs")
     }
   }
@@ -101,7 +99,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
   fun `Doesn't send a message if the event isn't in subscribed by user`() {
     val testData = SlackTestData()
     testDataService.saveTestData(testData.root)
-    mockedSlackClient = mockSlackClient()
+    val mockedSlackClient = mockSlackClient()
 
     val updatedConfig =
       SlackConfigDto(
@@ -120,7 +118,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
 
     addKeyToProject(testData.projectBuilder.self.id)
     mockedSlackClient.chatPostMessageRequests.assert.hasSize(0)
-    slackMessageService.findByKey(testData.key.id, config.id).forEach {
+    slackMessageService.find(testData.key.id, config.id).forEach {
       it.langTags.assert.doesNotContain("en")
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackErrorProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackErrorProvider.kt
@@ -29,15 +29,15 @@ class SlackErrorProvider(
     return withBlocks {
       section {
         markdownText(
-          i18n.translate("slack-not-connected-message"),
+          i18n.translate("slack.common.message.not-connected"),
         )
       }
       section {
-        markdownText(i18n.translate("connect-account-instruction"))
+        markdownText(i18n.translate("slack.common.message.connect-account-instruction"))
       }
       actions {
         button {
-          text(i18n.translate("connect-button-text"), emoji = true)
+          text(i18n.translate("slack.common.text.button.connect"), emoji = true)
           url(url)
           style("primary")
         }
@@ -48,10 +48,10 @@ class SlackErrorProvider(
   fun getInvalidCommandError(): List<LayoutBlock> {
     return withBlocks {
       section {
-        markdownText(i18n.translate("command-not-recognized"))
+        markdownText(i18n.translate("slack.common.message.command-not-recognized"))
       }
       section {
-        markdownText(i18n.translate("check-command-solutions"))
+        markdownText(i18n.translate("slack.common.message.check-command-solutions"))
       }
       actions {
         helpButton()
@@ -63,11 +63,11 @@ class SlackErrorProvider(
     return withBlocks {
       section {
         markdownText(
-          i18n.translate("not-subscribed-yet-message"),
+          i18n.translate("slack.common.message.not-subscribed-yet"),
         )
       }
       section {
-        markdownText(i18n.translate("not-subscribed-solution"))
+        markdownText(i18n.translate("slack.common.message.not-subscribed-solution"))
       }
       actions {
         helpButton()
@@ -98,12 +98,12 @@ class SlackErrorProvider(
   fun getWorkspaceNotFoundError(): List<LayoutBlock> {
     return withBlocks {
       section {
-        markdownText(i18n.translate("slack-workspace-not-connected-to-any-organization"))
+        markdownText(i18n.translate("slack.common.message.slack-workspace-not-connected-to-any-organization"))
       }
 
       actions {
         button {
-          text(i18n.translate("connect-workspace-button-text"), emoji = true)
+          text(i18n.translate("slack.common.text.button.connect-workspace"), emoji = true)
           url(tolgeeProperties.frontEndUrl + "/preferred-organization?path=apps")
           style("primary")
         }
@@ -122,7 +122,7 @@ class SlackErrorProvider(
   private fun ActionsBlockBuilder.helpButton() {
     button {
       value("help_btn")
-      text(i18n.translate("view-help-button-text"), emoji = true)
+      text(i18n.translate("slack.common.text.button.view-help"), emoji = true)
     }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackErrorProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackErrorProvider.kt
@@ -59,6 +59,22 @@ class SlackErrorProvider(
     }
   }
 
+  fun getInvalidLangTagError(): List<LayoutBlock> {
+    return withBlocks {
+      section {
+        markdownText(i18n.translate("slack.common.message.invalid-lang-tag"))
+      }
+    }
+  }
+
+  fun getInvalidGlobalSubscriptionError(): List<LayoutBlock> {
+    return withBlocks {
+      section {
+        markdownText(i18n.translate("slack.common.message.global-subscription-error"))
+      }
+    }
+  }
+
   fun getNotSubscribedYetError(): List<LayoutBlock> {
     return withBlocks {
       section {

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
@@ -10,6 +10,7 @@ import io.tolgee.dtos.request.slack.SlackUserLoginDto
 import io.tolgee.model.slackIntegration.OrganizationSlackWorkspace
 import io.tolgee.model.slackIntegration.SavedSlackMessage
 import io.tolgee.model.slackIntegration.SlackConfig
+import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.security.PermissionService
 import io.tolgee.service.slackIntegration.OrganizationSlackWorkspaceService
@@ -35,6 +36,7 @@ class SlackExecutor(
   private val organizationSlackWorkspaceService: OrganizationSlackWorkspaceService,
   private val slackUserLoginUrlProvider: SlackUserLoginUrlProvider,
   private val slackClient: Slack,
+  private val languageService: LanguageService,
 ) : Logging {
   fun sendMessageOnTranslationSet(
     slackConfig: SlackConfig,
@@ -303,7 +305,16 @@ class SlackExecutor(
           }
           config.preferences.forEach {
             section {
-              markdownText("*Subscribed Languages:*\n- ${it.languageTag} :${it.languageTag}: on ${it.onEvent.name}")
+              if (it.languageTag == null) {
+                return@section
+              }
+              val language = languageService.getByTag(it.languageTag!!, config.project)
+              val flagEmoji = language.flagEmoji
+
+              val fullName = language.name
+              markdownText(
+                "*Subscribed Languages:*\n- $fullName $flagEmoji : on ${it.onEvent.name}",
+              )
             }
           }
           divider()

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
@@ -143,16 +143,16 @@ class SlackExecutor(
   ): List<LayoutBlock> {
     return withBlocks {
       section {
-        markdownText(i18n.translate("slack-not-connected-message"))
+        markdownText(i18n.translate("slack.common.message.not-connected"))
       }
 
       section {
-        markdownText(i18n.translate("connect-account-instruction"))
+        markdownText(i18n.translate("slack.common.message.connect-account-instruction"))
       }
 
       actions {
         button {
-          text(i18n.translate("connect-button-text"), emoji = true)
+          text(i18n.translate("slack.common.text.button.connect"), emoji = true)
           value("connect_slack")
           url(slackUserLoginUrlProvider.getUrl(slackChannelId, slackId, workspace?.id))
           actionId("button_connect_slack")
@@ -170,10 +170,10 @@ class SlackExecutor(
       it.channel(dto.slackChannelId)
         .blocks {
           section {
-            markdownText(i18n.translate("success_login_message"))
+            markdownText(i18n.translate("slack.common.message.success_login"))
           }
           context {
-            plainText(i18n.translate("success_login_context"))
+            plainText(i18n.translate("slack.common.context.success_login"))
           }
         }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutor.kt
@@ -54,7 +54,7 @@ class SlackExecutor(
     val messagesDto = slackExecutorHelper.createTranslationChangeMessage()
 
     messagesDto.forEach { message ->
-      val savedMessage = findSavedMessageOrNull(message.keyId, config.id)
+      val savedMessage = savedSlackMessageService.find(message.keyId, config.id)
 
       if (savedMessage.isEmpty()) {
         sendRegularMessageWithSaving(message, config)
@@ -247,11 +247,6 @@ class SlackExecutor(
       getSlackNickName(data.activityData?.author?.name ?: ""),
     )
   }
-
-  private fun findSavedMessageOrNull(
-    keyId: Long,
-    configId: Long,
-  ) = savedSlackMessageService.find(keyId, configId)
 
   private fun saveMessage(
     messageDto: SavedMessageDto,

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
@@ -482,7 +482,7 @@ class SlackExecutorHelper(
       .build()
 
   private fun ActionsBlockBuilder.redirectOnPlatformButton() {
-    val tolgeeUrl = "${tolgeeProperties.frontEndUrl}/projects/${slackConfig.project.id}/translations"
+    val tolgeeUrl = "${tolgeeProperties.frontEndUrl}/projects/${slackConfig.project.id}/activity-detail?activity=${data.activityData?.revisionId}"
 
     button {
       text(i18n.translate("tolgee_redirect_button_text"), emoji = true)

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
@@ -64,7 +64,7 @@ class SlackExecutorHelper(
 
     val keyId = modifiedEntity.entityId
     val key = keyService.get(keyId)
-    blocksHeader = buildKeyInfoBlock(key, i18n.translate("new-key-text"))
+    blocksHeader = buildKeyInfoBlock(key, i18n.translate("slack.common.message.new-key"))
     key.translations.forEach translations@{ translation ->
       if (!shouldProcessEventNewKeyAdded(translation.language.tag, baseLanguage.tag)) {
         return@translations
@@ -204,14 +204,14 @@ class SlackExecutorHelper(
   private fun buildImportBlocks(count: Long) =
     withBlocks {
       section {
-        authorHeadSection(i18n.translate("imported-text") + " $count keys")
+        authorHeadSection(i18n.translate("slack.common.message.imported") + " $count keys")
       }
     }
 
   private fun buildBlocksTooManyTranslations(count: Long) =
     withBlocks {
       section {
-        authorHeadSection(i18n.translate("too-many-translations-text") + " $count translations")
+        authorHeadSection(i18n.translate("slack.common.message.too-many-translations").format(count))
       }
     }
 
@@ -249,7 +249,7 @@ class SlackExecutorHelper(
         translation.language.name
       }
 
-    val headerBlock = buildKeyInfoBlock(key, i18n.translate("new-translation-text").format(langName))
+    val headerBlock = buildKeyInfoBlock(key, i18n.translate("slack.common.message.new-translation").format(langName))
     val attachments = mutableListOf(createAttachmentForLanguage(translation) ?: return null)
     val langTags = mutableSetOf(modifiedLangTag)
 
@@ -485,7 +485,7 @@ class SlackExecutorHelper(
     val tolgeeUrl = "${tolgeeProperties.frontEndUrl}/projects/${slackConfig.project.id}/activity-detail?activity=${data.activityData?.revisionId}"
 
     button {
-      text(i18n.translate("tolgee_redirect_button_text"), emoji = true)
+      text(i18n.translate("slack.common.text.button.tolgee_redirect"), emoji = true)
       value("redirect")
       url(tolgeeUrl)
       actionId("button_redirect_to_tolgee")

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackExecutorHelper.kt
@@ -482,7 +482,9 @@ class SlackExecutorHelper(
       .build()
 
   private fun ActionsBlockBuilder.redirectOnPlatformButton() {
-    val tolgeeUrl = "${tolgeeProperties.frontEndUrl}/projects/${slackConfig.project.id}/activity-detail?activity=${data.activityData?.revisionId}"
+    val tolgeeUrl =
+      "${tolgeeProperties.frontEndUrl}/projects/${slackConfig.project.id}/" +
+        "activity-detail?activity=${data.activityData?.revisionId}"
 
     button {
       text(i18n.translate("slack.common.text.button.tolgee_redirect"), emoji = true)

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackHelpBlocksProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackHelpBlocksProvider.kt
@@ -12,39 +12,39 @@ class SlackHelpBlocksProvider(
   fun getHelpBlocks() =
     withBlocks {
       section {
-        markdownText(i18n.translate("help-intro"))
+        markdownText(i18n.translate("slack.help.message.intro"))
       }
       divider()
 
       section {
-        markdownText(i18n.translate("help-subscribe-to-project"))
+        markdownText(i18n.translate("slack.help.message.subscribe-to-project"))
       }
 
       section {
         fields {
-          markdownText(i18n.translate("help-subscribe"))
+          markdownText(i18n.translate("slack.help.message.subscribe"))
 
-          markdownText(i18n.translate("help-subscribe-command"))
+          markdownText(i18n.translate("slack.help.message.subscribe-command"))
         }
       }
 
       section {
         fields {
-          markdownText(i18n.translate("help-unsubscribe"))
+          markdownText(i18n.translate("slack.help.message.unsubscribe"))
 
-          markdownText(i18n.translate("help-unsubscribe-command"))
+          markdownText(i18n.translate("slack.help.message.unsubscribe-command"))
         }
       }
 
       section {
         fields {
-          markdownText(i18n.translate("help-show-subscriptions"))
-          markdownText(i18n.translate("help-show-subscriptions-command"))
+          markdownText(i18n.translate("slack.help.message.show-subscriptions"))
+          markdownText(i18n.translate("slack.help.message.show-subscriptions-command"))
         }
       }
 
       section {
-        markdownText(i18n.translate("help-subscribe-default-subscription"))
+        markdownText(i18n.translate("slack.help.message.default-subscription"))
       }
 
       actions {
@@ -54,27 +54,27 @@ class SlackHelpBlocksProvider(
       divider()
 
       section {
-        markdownText(i18n.translate("help-account"))
+        markdownText(i18n.translate("slack.help.message.account"))
       }
 
       section {
         fields {
-          markdownText(i18n.translate("help-connect-tolgee"))
-          markdownText(i18n.translate("help-connect-tolgee-command"))
+          markdownText(i18n.translate("slack.help.message.connect-tolgee"))
+          markdownText(i18n.translate("slack.help.message.connect-tolgee-command"))
         }
       }
 
       section {
         fields {
-          markdownText(i18n.translate("help-disconnect-tolgee"))
-          markdownText(i18n.translate("help-disconnect-tolgee-command"))
+          markdownText(i18n.translate("slack.help.message.disconnect-tolgee"))
+          markdownText(i18n.translate("slack.help.message.disconnect-tolgee-command"))
         }
       }
 
       divider()
 
       section {
-        markdownText(i18n.translate("help-more"))
+        markdownText(i18n.translate("slack.help.message.more"))
       }
 
       actions {
@@ -87,59 +87,59 @@ class SlackHelpBlocksProvider(
   fun getAdvancedSubscriptionHelpBlocks() =
     withBlocks {
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-intro"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-intro"))
       }
 
       divider()
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-language"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-language"))
       }
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-language-info"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-language-info"))
       }
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-language-example"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-language-example"))
       }
 
       divider()
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-events"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-events"))
       }
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-events-info"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-events-info"))
       }
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-events-usage"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-events-usage"))
       }
 
       section {
-        markdownText(i18n.translate("help-advanced-subscribe-events-example"))
+        markdownText(i18n.translate("slack.help.message.advanced-subscribe-events-example"))
       }
     }
 
   private fun ActionsBlockBuilder.advancedCommandsButton() {
     button {
-      text(i18n.translate("help-button-advanced-subscribe"), emoji = true)
+      text(i18n.translate("slack.help.text.button.advanced-subscribe"), emoji = true)
       value("help_advanced_subscribe_btn")
     }
   }
 
   private fun ActionsBlockBuilder.contactSupportButton() {
     button {
-      text(i18n.translate("help-button-contact-support"), emoji = true)
+      text(i18n.translate("slack.help.text.button.contact-support"), emoji = true)
       actionId("contact_support_btn")
     }
   }
 
   private fun ActionsBlockBuilder.docsButton() {
     button {
-      text(i18n.translate("help-button-docs"), emoji = true)
+      text(i18n.translate("slack.help.text.button.docs"), emoji = true)
       actionId("docs_btn")
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackHelpBlocksProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/slackIntegration/SlackHelpBlocksProvider.kt
@@ -1,5 +1,6 @@
 package io.tolgee.component.automations.processors.slackIntegration
 
+import com.slack.api.model.kotlin_extension.block.ActionsBlockBuilder
 import com.slack.api.model.kotlin_extension.block.withBlocks
 import io.tolgee.util.I18n
 import org.springframework.stereotype.Component
@@ -14,65 +15,132 @@ class SlackHelpBlocksProvider(
         markdownText(i18n.translate("help-intro"))
       }
       divider()
+
       section {
-        markdownText(i18n.translate("help-subscribe"))
+        markdownText(i18n.translate("help-subscribe-to-project"))
       }
 
       section {
-        markdownText(i18n.translate("help-subscribe-command"))
+        fields {
+          markdownText(i18n.translate("help-subscribe"))
+
+          markdownText(i18n.translate("help-subscribe-command"))
+        }
       }
 
       section {
-        markdownText(i18n.translate("help-subscribe-events"))
+        fields {
+          markdownText(i18n.translate("help-unsubscribe"))
+
+          markdownText(i18n.translate("help-unsubscribe-command"))
+        }
       }
 
       section {
-        markdownText(i18n.translate("help-subscribe-all-event"))
+        fields {
+          markdownText(i18n.translate("help-show-subscriptions"))
+          markdownText(i18n.translate("help-show-subscriptions-command"))
+        }
       }
 
       section {
-        markdownText(i18n.translate("help-subscribe-new-key-event"))
+        markdownText(i18n.translate("help-subscribe-default-subscription"))
       }
 
-      section {
-        markdownText(i18n.translate("help-subscribe-base-changed-event"))
-      }
-
-      section {
-        markdownText(i18n.translate("help-subscribe-translation-change-event"))
-      }
-
-      divider()
-      section {
-        markdownText(i18n.translate("help-unsubscribe"))
-      }
-
-      section {
-        markdownText(i18n.translate("help-unsubscribe-command"))
-      }
-
-      divider()
-      section {
-        markdownText(i18n.translate("help-show-subscriptions"))
-      }
-      section {
-        markdownText(i18n.translate("help-show-subscriptions-command"))
+      actions {
+        advancedCommandsButton()
       }
 
       divider()
+
       section {
-        markdownText(i18n.translate("help-connect-tolgee"))
+        markdownText(i18n.translate("help-account"))
       }
+
       section {
-        markdownText(i18n.translate("help-connect-tolgee-command"))
+        fields {
+          markdownText(i18n.translate("help-connect-tolgee"))
+          markdownText(i18n.translate("help-connect-tolgee-command"))
+        }
+      }
+
+      section {
+        fields {
+          markdownText(i18n.translate("help-disconnect-tolgee"))
+          markdownText(i18n.translate("help-disconnect-tolgee-command"))
+        }
       }
 
       divider()
+
       section {
-        markdownText(i18n.translate("help-disconnect-tolgee"))
+        markdownText(i18n.translate("help-more"))
       }
-      section {
-        markdownText(i18n.translate("help-disconnect-tolgee-command"))
+
+      actions {
+        contactSupportButton()
+
+        docsButton()
       }
     }
+
+  fun getAdvancedSubscriptionHelpBlocks() =
+    withBlocks {
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-intro"))
+      }
+
+      divider()
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-language"))
+      }
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-language-info"))
+      }
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-language-example"))
+      }
+
+      divider()
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-events"))
+      }
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-events-info"))
+      }
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-events-usage"))
+      }
+
+      section {
+        markdownText(i18n.translate("help-advanced-subscribe-events-example"))
+      }
+    }
+
+  private fun ActionsBlockBuilder.advancedCommandsButton() {
+    button {
+      text(i18n.translate("help-button-advanced-subscribe"), emoji = true)
+      value("help_advanced_subscribe_btn")
+    }
+  }
+
+  private fun ActionsBlockBuilder.contactSupportButton() {
+    button {
+      text(i18n.translate("help-button-contact-support"), emoji = true)
+      actionId("contact_support_btn")
+    }
+  }
+
+  private fun ActionsBlockBuilder.docsButton() {
+    button {
+      text(i18n.translate("help-button-docs"), emoji = true)
+      actionId("docs_btn")
+    }
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SlackTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SlackTestData.kt
@@ -21,7 +21,7 @@ class SlackTestData() {
   var organization: Organization
   var automation: Automation
   var key: Key
-
+  var key2: Key
   lateinit var slackWorkspace: OrganizationSlackWorkspace
   lateinit var slackUserConnection: SlackUserConnection
 
@@ -46,6 +46,9 @@ class SlackTestData() {
           this@buildProject.self.baseLanguage = this@buildProject.addEnglish().self
         }
       projectBuilder.addKey("testKey").also { key = it.self }
+        .addTranslation("en", "Hello")
+
+      projectBuilder.addKey("testKey2").also { key2 = it.self }
         .addTranslation("en", "Hello")
 
       userAccountBuilder.defaultOrganizationBuilder.addSlackWorkspace {

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/slackintegration/SlackConfigDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/slackintegration/SlackConfigDto.kt
@@ -12,4 +12,5 @@ data class SlackConfigDto(
   val languageTag: String? = "",
   val onEvent: EventName?,
   val slackTeamId: String = "",
+  val isGlobal: Boolean? = false,
 )

--- a/backend/data/src/main/kotlin/io/tolgee/service/slackIntegration/SavedSlackMessageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/slackIntegration/SavedSlackMessageService.kt
@@ -57,13 +57,6 @@ class SavedSlackMessageService(
     )
   }
 
-  fun findByKey(
-    keyId: Long,
-    configId: Long,
-  ): List<SavedSlackMessage> {
-    return savedSlackMessageRepository.findByKeyIdAndSlackConfigId(keyId, configId)
-  }
-
   fun findAll(): List<SavedSlackMessage> {
     return savedSlackMessageRepository.findAll()
   }

--- a/backend/data/src/main/resources/I18n_en.properties
+++ b/backend/data/src/main/resources/I18n_en.properties
@@ -1,78 +1,72 @@
 # Message displayed when the user tries to use a command that requires a connected Slack account
-connect-button-text = Connect Tolgee account
-connect-workspace-button-text = Connect Slack workspace account
-slack-not-connected-message = :wave: Hello! It seems your Slack account isn't connected to our service yet. For full access to features, please connect :rocket:
-connect-account-instruction = *Connect account*: Click the button below to get started.
+slack.common.text.button.connect = Connect Tolgee account
+slack.common.text.button.connect-workspace = Connect Slack workspace account
+slack.common.message.not-connected = :wave: Hello! It seems your Slack account isn't connected to our service yet. For full access to features, please connect :rocket:
+slack.common.message.connect-account-instruction = *Connect account*: Click the button below to get started.
 
-command-not-recognized = :thinking_face: It looks like we couldn't recognize that command.
-check-command-solutions = *Possible solutions*: Check the command for accuracy or use our help guide: Type `/tolgee help` or click the button bellow.
-unknown-error-occurred = :grey_question: Oops, we've encountered an unknown error. But don't worry, we're already working on fixing it!
-view-help-button-text = View Help
-need-help = Need help? Type `/tolgee help
-new-key-text = has created a new key
-new-translation-text = has changed a %s translation
-imported-text = has imported
-too-many-translations-text = has updated
-already_logged_in = You are already logged in.
+slack.common.message.command-not-recognized = :thinking_face: It looks like we couldn't recognize that command.
+slack.common.message.check-command-solutions = *Possible solutions*: Check the command for accuracy or use our help guide: Type `/tolgee help` or click the button bellow.
+slack.common.message.unknown-error-occurred = :grey_question: Oops, we've encountered an unknown error. But don't worry, we're already working on fixing it!
+slack.common.text.button.view-help = View Help
+slack.common.message.new-key = has created a new key
+slack.common.message.new-translation = has changed a %s translation
+slack.common.message.imported = has imported
+slack.common.message.too-many-translations = has updated %d translations
+slack.common.message.already_logged_in = You are already logged in.
 
-not-subscribed-yet-message = It seems like you haven't subscribed yet, but we're here to help!
-not-subscribed-solution = To start receiving notifications, simply type `/tolgee subscribe $projectId`. If you want to see more information about commands, type `/tolgee help` or click the button below.
-subscribed_successfully = Subscribed.
-unsubscribed-successfully = Unsubscribed.
-tolgee_redirect_button_text=Open in Tolgee
-success_login_message = Success! :tada: The operation was completed successfully.
-success_login_context = Now you can use other commands.
+slack.common.message.not-subscribed-yet = It seems like you haven't subscribed yet, but we're here to `help`!
+slack.common.message.not-subscribed-solution = To start receiving notifications, simply type `/tolgee subscribe $projectId`. If you want to see more information about commands, type `/tolgee help` or click the button below.
+slack.common.message.subscribed_successfully = Subscribed.
+slack.common.message.unsubscribed-successfully = Unsubscribed.
+slack.common.text.button.tolgee_redirect=Open in Tolgee
+slack.common.message.success_login = Success! :tada: The operation was completed successfully.
+slack.common.context.success_login = Now you can use other commands.
 
 # Strings for help command
-help-intro=Hi there :wave: here are some tips for you:
-help-subscribe-to-project=*Subscribe to project*
-help-subscribe= Subscribe
-help-subscribe-command=`/tolgee subscribe $project_id`
-help-button-advanced-subscribe=:rocket:Advanced subscriptions
-help-subscribe-events=Where [EVENT] can be one of the following:
-help-subscribe-all-event=ALL - receive notifications for all events,
-help-subscribe-new-key-event=NEW_KEY - receive notifications only when a new key is created,
-help-subscribe-base-changed-event=BASE_CHANGED - receive notifications when the base text is changed,
-help-subscribe-translation-change-event=TRANSLATION_CHANGE - receive notifications when a translation is changed.
-help-subscribe-default-subscription=By default, you will receive notifications for all events and languages.
-help-button-contact-support=:speech_balloon: Contact Support
+slack.help.message.intro=Hi there :wave: here are some tips for you:
+slack.help.message.subscribe-to-project=*Subscribe to project*
+slack.help.message.subscribe= Subscribe
+slack.help.message.subscribe-command=`/tolgee subscribe $project_id`
+slack.help.text.button.advanced-subscribe=:rocket:Advanced subscriptions
+slack.help.message.default-subscription=By default, you will receive notifications for all events and languages.
+slack.help.text.button.contact-support=:speech_balloon: Contact Support
 
-help-unsubscribe=Unsubscribe
-help-unsubscribe-command=`/tolgee unsubscribe $project_id $language_tag(optional)`
+slack.help.message.unsubscribe=Unsubscribe
+slack.help.message.unsubscribe-command=`/tolgee unsubscribe $project_id $language_tag(optional)`
 
-help-show-subscriptions=Show subscriptions
-help-show-subscriptions-command=`/tolgee subscriptions`
+slack.help.message.show-subscriptions=Show subscriptions
+slack.help.message.show-subscriptions-command=`/tolgee subscriptions`
 
+slack.help.message.account=*Account*
 
-help-account=*Account*
+slack.help.message.connect-tolgee=Connect Tolgee to Slack
+slack.help.message.connect-tolgee-command=`/tolgee login`
 
-help-connect-tolgee=Connect Tolgee to Slack
-help-connect-tolgee-command=`/tolgee login`
+slack.help.message.disconnect-tolgee=Logout
+slack.help.message.disconnect-tolgee-command=`/tolgee logout`
 
-help-disconnect-tolgee=Logout
-help-disconnect-tolgee-command=`/tolgee logout`
+slack.help.message.more=*More*
 
-help-more=*More*
+slack.help.text.button.docs=:page_facing_up: Documentation
 
-help-button-docs=:page_facing_up: Documentation
-slack-workspace-not-connected-to-any-organization=Your Slack workspace is not connected to any organization. Please connect slack in Tolgee Platform.
+slack.common.message.slack-workspace-not-connected-to-any-organization=Your Slack workspace is not connected to any organization. Please connect slack in Tolgee Platform.
 
-help-advanced-subscribe-intro=Here are some advanced subscription options
+slack.help.message.advanced-subscribe-intro=Here are some advanced subscription options
 
-help-advanced-subscribe-language=*Language subscription*
+slack.help.message.advanced-subscribe-language=*Language subscription*
 
-help-advanced-subscribe-language-info=Subscribe to a specific language in a project. Note that if you are already \
+slack.help.message.advanced-subscribe-language-info=Subscribe to a specific language in a project. Note that if you are already \
   subscribed globally (to all languages), the notifications will be merged, so you will not receive the same\
   \ notifications. If you want to receive notifications only for a specific language, you need to unsubscribe from the global subscription.
-help-advanced-subscribe-language-example=`/tolgee subscribe 1 fr` - subscribe to French translations in project 1
+slack.help.message.advanced-subscribe-language-example=`/tolgee subscribe 1 fr` - subscribe to French translations in project 1
 
-help-advanced-subscribe-events=*Event subscription*
+slack.help.message.advanced-subscribe-events=*Event subscription*
 
-help-advanced-subscribe-events-info=Subscribe to specific events in a project.
-help-advanced-subscribe-events-usage=`/tolgee subscribe $project_id --on [event]` \n event can be one of the following: \
+slack.help.message.advanced-subscribe-events-info=Subscribe to specific events in a project.
+slack.help.message.advanced-subscribe-events-usage=`/tolgee subscribe $project_id --on [event]` \n event can be one of the following: \
   \n `new_key` - receive notifications only when a new key is created, \
   \n `base_changed` - receive notifications when the base text is changed, \
   \n `translation_changed` - receive notifications when a translation is changed. \
   \n `all` - receive notifications for all events.
 
-help-advanced-subscribe-events-example=`/tolgee subscribe 1 fr --on new_key` - subscribe to new key events in project 1 for French translations
+slack.help.message.advanced-subscribe-events-example=`/tolgee subscribe 1 fr --on new_key` - subscribe to new key events in project 1 for French translations

--- a/backend/data/src/main/resources/I18n_en.properties
+++ b/backend/data/src/main/resources/I18n_en.properties
@@ -69,4 +69,8 @@ slack.help.message.advanced-subscribe-events-usage=`/tolgee subscribe $project_i
   \n `translation_changed` - receive notifications when a translation is changed. \
   \n `all` - receive notifications for all events.
 
+slack.common.message.invalid-lang-tag=Invalid language tag. Please check the language tag and try again.
+
+slack.common.message.global-subscription-error=You can't set global subscription on false while you aren't subscribed to any language. Please subscribe to a language or set global subscription to true.
+
 slack.help.message.advanced-subscribe-events-example=`/tolgee subscribe 1 fr --on new_key` - subscribe to new key events in project 1 for French translations

--- a/backend/data/src/main/resources/I18n_en.properties
+++ b/backend/data/src/main/resources/I18n_en.properties
@@ -4,7 +4,7 @@ connect-workspace-button-text = Connect Slack workspace account
 slack-not-connected-message = :wave: Hello! It seems your Slack account isn't connected to our service yet. For full access to features, please connect :rocket:
 connect-account-instruction = *Connect account*: Click the button below to get started.
 
-command-not-recognized = :thinking_face: It looks like we couldn't recognize that command. Don't worry, here are some tips that might help.
+command-not-recognized = :thinking_face: It looks like we couldn't recognize that command.
 check-command-solutions = *Possible solutions*: Check the command for accuracy or use our help guide: Type `/tolgee help` or click the button bellow.
 unknown-error-occurred = :grey_question: Oops, we've encountered an unknown error. But don't worry, we're already working on fixing it!
 view-help-button-text = View Help
@@ -25,25 +25,54 @@ success_login_context = Now you can use other commands.
 
 # Strings for help command
 help-intro=Hi there :wave: here are some tips for you:
-help-subscribe=*Subscribe to project*
-help-subscribe-command=`/tolgee subscribe $project_id $language_tag(optional) --on [EVENT](optional)`
-
+help-subscribe-to-project=*Subscribe to project*
+help-subscribe= Subscribe
+help-subscribe-command=`/tolgee subscribe $project_id`
+help-button-advanced-subscribe=:rocket:Advanced subscriptions
 help-subscribe-events=Where [EVENT] can be one of the following:
 help-subscribe-all-event=ALL - receive notifications for all events,
 help-subscribe-new-key-event=NEW_KEY - receive notifications only when a new key is created,
 help-subscribe-base-changed-event=BASE_CHANGED - receive notifications when the base text is changed,
 help-subscribe-translation-change-event=TRANSLATION_CHANGE - receive notifications when a translation is changed.
+help-subscribe-default-subscription=By default, you will receive notifications for all events and languages.
+help-button-contact-support=:speech_balloon: Contact Support
 
-help-unsubscribe=*Unsubscribe*
+help-unsubscribe=Unsubscribe
 help-unsubscribe-command=`/tolgee unsubscribe $project_id $language_tag(optional)`
 
-help-show-subscriptions=*Show subscriptions*
+help-show-subscriptions=Show subscriptions
 help-show-subscriptions-command=`/tolgee subscriptions`
 
-help-connect-tolgee=*Connect Tolgee to Slack*
+
+help-account=*Account*
+
+help-connect-tolgee=Connect Tolgee to Slack
 help-connect-tolgee-command=`/tolgee login`
 
-
-help-disconnect-tolgee=*Logout*
+help-disconnect-tolgee=Logout
 help-disconnect-tolgee-command=`/tolgee logout`
+
+help-more=*More*
+
+help-button-docs=:page_facing_up: Documentation
 slack-workspace-not-connected-to-any-organization=Your Slack workspace is not connected to any organization. Please connect slack in Tolgee Platform.
+
+help-advanced-subscribe-intro=Here are some advanced subscription options
+
+help-advanced-subscribe-language=*Language subscription*
+
+help-advanced-subscribe-language-info=Subscribe to a specific language in a project. Note that if you are already \
+  subscribed globally (to all languages), the notifications will be merged, so you will not receive the same\
+  \ notifications. If you want to receive notifications only for a specific language, you need to unsubscribe from the global subscription.
+help-advanced-subscribe-language-example=`/tolgee subscribe 1 fr` - subscribe to French translations in project 1
+
+help-advanced-subscribe-events=*Event subscription*
+
+help-advanced-subscribe-events-info=Subscribe to specific events in a project.
+help-advanced-subscribe-events-usage=`/tolgee subscribe $project_id --on [event]` \n event can be one of the following: \
+  \n `new_key` - receive notifications only when a new key is created, \
+  \n `base_changed` - receive notifications when the base text is changed, \
+  \n `translation_changed` - receive notifications when a translation is changed. \
+  \n `all` - receive notifications for all events.
+
+help-advanced-subscribe-events-example=`/tolgee subscribe 1 fr --on new_key` - subscribe to new key events in project 1 for French translations


### PR DESCRIPTION
What I have done:

- Rename all translation keys (i18n) according to the Tolgee guide.
- Refresh message design.
- Redesign the /help message.
- Now, users can set whether the subscription is global or not.