### PR TITLE
fix: Soft delete language, machine translation, translation memory UI enhancements

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
@@ -48,7 +48,7 @@ class ProjectStatsController(
     val languageStats =
       languageStatsService.getLanguageStats(projectHolder.project.id)
         .sortedBy { languages[it.languageId]?.name }
-        .sortedBy { languages[it.languageId]?.base }
+        .sortedBy { languages[it.languageId]?.base == false }
 
     val totals = projectStatsService.computeProjectTotals(baseLanguage, languageStats)
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
@@ -13,6 +13,7 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.LanguageStatsService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.project.ProjectStatsService
@@ -34,6 +35,7 @@ class ProjectStatsController(
   private val projectService: ProjectService,
   private val languageStatsService: LanguageStatsService,
   private val languageStatsModelAssembler: LanguageStatsModelAssembler,
+  private val languageService: LanguageService,
 ) {
   @Operation(summary = "Get project stats")
   @GetMapping("", produces = [MediaTypes.HAL_JSON_VALUE])
@@ -42,12 +44,15 @@ class ProjectStatsController(
   fun getProjectStats(): ProjectStatsModel {
     val projectStats = projectStatsService.getProjectStats(projectHolder.project.id)
     val baseLanguage = projectService.getOrAssignBaseLanguage(projectHolder.project.id)
+    val languages = languageService.getProjectLanguages(projectHolder.project.id).associateBy { it.id }
     val languageStats =
       languageStatsService.getLanguageStats(projectHolder.project.id)
-        .sortedBy { it.language.name }
-        .sortedBy { it.language.id != baseLanguage.id }
+        .sortedBy { languages[it.languageId]?.name }
+        .sortedBy { languages[it.languageId]?.base }
 
     val totals = projectStatsService.computeProjectTotals(baseLanguage, languageStats)
+
+    val statsLanguagePairs = languageStats.map { it to languages[it.languageId]!! }
 
     return ProjectStatsModel(
       projectId = projectStats.id,
@@ -58,7 +63,7 @@ class ProjectStatsController(
       reviewedPercentage = totals.reviewedPercent,
       membersCount = projectStats.memberCount,
       tagCount = projectStats.tagCount,
-      languageStats = languageStats.map { languageStatsModelAssembler.toModel(it) },
+      languageStats = statsLanguagePairs.map { languageStatsModelAssembler.toModel(it) },
     )
   }
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2LanguagesController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2LanguagesController.kt
@@ -21,7 +21,7 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
@@ -11,8 +11,8 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authorization.RequiresProjectPermissions
-import io.tolgee.service.LanguageService
 import io.tolgee.service.export.ExportService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.util.StreamingResponseBodyProvider
 import io.tolgee.util.nullIfEmpty
 import org.apache.tomcat.util.http.fileupload.IOUtils

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/dataImport/V2ImportLanguagesController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/dataImport/V2ImportLanguagesController.kt
@@ -20,8 +20,8 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authorization.RequiresProjectPermissions
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.ImportService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.util.Logging
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/SelectAllController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/SelectAllController.kt
@@ -14,7 +14,7 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authorization.RequiresProjectPermissions
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.TranslationService
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.web.bind.annotation.CrossOrigin

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationProjectController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationProjectController.kt
@@ -107,7 +107,7 @@ class OrganizationProjectController(
     @RequestParam("search") search: String?,
     @PathVariable("slug") organizationSlug: String,
   ): PagedModel<ProjectWithStatsModel> {
-    return organizationService.find(organizationSlug)?.let { organization ->
+    return organizationService.findDto(organizationSlug)?.let { organization ->
       return getAllWithStatistics(pageable, search, organization.id)
     } ?: throw NotFoundException()
   }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/MachineTranslationSuggestionFacade.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/MachineTranslationSuggestionFacade.kt
@@ -9,7 +9,7 @@ import io.tolgee.exceptions.OutOfCreditsException
 import io.tolgee.hateoas.machineTranslation.SuggestResultModel
 import io.tolgee.hateoas.machineTranslation.TranslationItemModel
 import io.tolgee.security.ProjectHolder
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.MtCreditBucketService
 import io.tolgee.service.machineTranslation.MtService
 import io.tolgee.service.security.SecurityService

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
@@ -15,8 +15,8 @@ import io.tolgee.model.views.TranslationMemoryItemView
 import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authorization.RequiresProjectPermissions
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationMemoryService
 import io.tolgee.util.disableAccelBuffering

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/translation/TranslationsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/translation/TranslationsController.kt
@@ -38,8 +38,8 @@ import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.ScreenshotService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.queryBuilders.CursorUtil
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationService

--- a/backend/api/src/main/kotlin/io/tolgee/component/KeyComplexEditHelper.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/component/KeyComplexEditHelper.kt
@@ -15,12 +15,12 @@ import io.tolgee.model.enums.TranslationState
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.security.ProjectHolder
-import io.tolgee.service.LanguageService
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.ScreenshotService
 import io.tolgee.service.key.TagService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationService
 import io.tolgee.util.executeInNewRepeatableTransaction

--- a/backend/api/src/main/kotlin/io/tolgee/component/LanguageValidator.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/component/LanguageValidator.kt
@@ -6,7 +6,7 @@ import io.tolgee.dtos.request.validators.ValidationError
 import io.tolgee.dtos.request.validators.ValidationErrorType
 import io.tolgee.dtos.request.validators.exceptions.ValidationException
 import io.tolgee.model.Project
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import org.springframework.stereotype.Component
 import java.util.*
 

--- a/backend/api/src/main/kotlin/io/tolgee/facade/ProjectWithStatsFacade.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/facade/ProjectWithStatsFacade.kt
@@ -31,12 +31,12 @@ class ProjectWithStatsFacade(
     val projectIds = projects.content.map { it.id }
     val totals = projectStatsService.getProjectsTotals(projectIds)
     val languages = languageService.getDtosOfProjects(projectIds)
-    val languageStats = languageStatsService.getLanguageStats(projectIds)
+    val languageStats = languageStatsService.getLanguageStatsDtos(projectIds)
 
     val projectsWithStatsContent =
       projects.content.map { projectWithLanguagesView ->
         val projectTotals = totals[projectWithLanguagesView.id]
-        val baseLanguage = projectWithLanguagesView.baseLanguage
+        val baseLanguage = languages[projectWithLanguagesView.id]?.find { it.base }
         val projectLanguageStats =
           languageStats[projectWithLanguagesView.id]
 

--- a/backend/api/src/main/kotlin/io/tolgee/facade/ProjectWithStatsFacade.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/facade/ProjectWithStatsFacade.kt
@@ -7,7 +7,7 @@ import io.tolgee.hateoas.project.ProjectWithStatsModelAssembler
 import io.tolgee.model.enums.TranslationState
 import io.tolgee.model.views.ProjectWithLanguagesView
 import io.tolgee.model.views.ProjectWithStatsView
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.LanguageStatsService
 import io.tolgee.service.project.ProjectStatsService
 import org.springframework.data.domain.Page

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
@@ -13,6 +13,7 @@ import io.tolgee.model.UserAccount
 import io.tolgee.model.views.ProjectWithLanguagesView
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.AvatarService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.PermissionService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
@@ -30,6 +31,7 @@ class ProjectModelAssembler(
   private val permissionModelAssembler: PermissionModelAssembler,
   private val computedPermissionModelAssembler: ComputedPermissionModelAssembler,
   private val authenticationFacade: AuthenticationFacade,
+  private val languageService: LanguageService,
 ) : RepresentationModelAssemblerSupport<ProjectWithLanguagesView, ProjectModel>(
     ProjectsController::class.java,
     ProjectModel::class.java,
@@ -37,7 +39,7 @@ class ProjectModelAssembler(
   override fun toModel(view: ProjectWithLanguagesView): ProjectModel {
     val link = linkTo<ProjectsController> { get(view.id) }.withSelfRel()
     val baseLanguage =
-      view.baseLanguage ?: let {
+      languageService.getProjectLanguages(view.id).find { it.base } ?: let {
         projectService.getOrAssignBaseLanguage(view.id)
       }
     val defaultNamespace =

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
@@ -11,6 +11,7 @@ import io.tolgee.model.UserAccount
 import io.tolgee.model.views.ProjectWithStatsView
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.AvatarService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.PermissionService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
@@ -27,6 +28,7 @@ class ProjectWithStatsModelAssembler(
   private val permissionModelAssembler: PermissionModelAssembler,
   private val computedPermissionModelAssembler: ComputedPermissionModelAssembler,
   private val authenticationFacade: AuthenticationFacade,
+  private val languageService: LanguageService,
 ) : RepresentationModelAssemblerSupport<ProjectWithStatsView, ProjectWithStatsModel>(
     ProjectsController::class.java,
     ProjectWithStatsModel::class.java,
@@ -34,7 +36,7 @@ class ProjectWithStatsModelAssembler(
   override fun toModel(view: ProjectWithStatsView): ProjectWithStatsModel {
     val link = linkTo<ProjectsController> { get(view.id) }.withSelfRel()
     val baseLanguage =
-      view.baseLanguage ?: let {
+      languageService.getProjectLanguages(view.id).find { it.base } ?: let {
         projectService.getOrAssignBaseLanguage(view.id)
       }
     val computedPermissions =

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/SimpleProjectModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/SimpleProjectModelAssembler.kt
@@ -5,7 +5,7 @@ import io.tolgee.api.v2.controllers.project.ProjectsController
 import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.hateoas.language.LanguageModelAssembler
 import io.tolgee.service.AvatarService
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
@@ -1,31 +1,35 @@
 package io.tolgee.hateoas.project.stats
 
+import io.tolgee.api.ILanguageStats
 import io.tolgee.api.v2.controllers.project.ProjectsController
-import io.tolgee.model.LanguageStats
+import io.tolgee.dtos.cacheable.LanguageDto
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 
 @Component
-class LanguageStatsModelAssembler : RepresentationModelAssemblerSupport<LanguageStats, LanguageStatsModel>(
-  ProjectsController::class.java,
-  LanguageStatsModel::class.java,
-) {
-  override fun toModel(it: LanguageStats): LanguageStatsModel {
+class LanguageStatsModelAssembler :
+  RepresentationModelAssemblerSupport<Pair<ILanguageStats, LanguageDto>, LanguageStatsModel>(
+    ProjectsController::class.java,
+    LanguageStatsModel::class.java,
+  ) {
+  override fun toModel(it: Pair<ILanguageStats, LanguageDto>): LanguageStatsModel {
+    val language = it.second
+    val stats = it.first
     return LanguageStatsModel(
-      languageId = it.language.id,
-      languageTag = it.language.tag,
-      languageName = it.language.name,
-      languageOriginalName = it.language.originalName,
-      languageFlagEmoji = it.language.flagEmoji,
-      translatedKeyCount = it.translatedKeys,
-      translatedWordCount = it.translatedWords,
-      translatedPercentage = it.translatedPercentage,
-      reviewedKeyCount = it.reviewedKeys,
-      reviewedWordCount = it.reviewedWords,
-      reviewedPercentage = it.reviewedPercentage,
-      untranslatedKeyCount = it.untranslatedKeys,
-      untranslatedWordCount = it.untranslatedWords,
-      untranslatedPercentage = it.untranslatedPercentage,
+      languageId = language.id,
+      languageTag = language.tag,
+      languageName = language.name,
+      languageOriginalName = language.originalName,
+      languageFlagEmoji = language.flagEmoji,
+      translatedKeyCount = stats.translatedKeys,
+      translatedWordCount = stats.translatedWords,
+      translatedPercentage = stats.translatedPercentage,
+      reviewedKeyCount = stats.reviewedKeys,
+      reviewedWordCount = stats.reviewedWords,
+      reviewedPercentage = stats.reviewedPercentage,
+      untranslatedKeyCount = stats.untranslatedKeys,
+      untranslatedWordCount = stats.untranslatedWords,
+      untranslatedPercentage = stats.untranslatedPercentage,
     )
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/component/LanguageStatsListenerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/LanguageStatsListenerTest.kt
@@ -21,10 +21,12 @@ class LanguageStatsListenerTest : AbstractControllerTest() {
     val testData = TranslationsTestData()
     testDataService.saveTestData(testData.root)
 
+    val projectLanguages = languageService.getProjectLanguages(testData.project.id).associateBy { it.id }
+
     val deutschStats =
       executeInNewTransaction(platformTransactionManager) {
         languageStatsService.getLanguageStats(projectId = testData.project.id)
-          .find { it.language.tag == "de" }
+          .find { projectLanguages[it.languageId]!!.tag == "de" }
       }
 
     executeInNewTransaction(platformTransactionManager) {
@@ -45,7 +47,7 @@ class LanguageStatsListenerTest : AbstractControllerTest() {
       executeInNewTransaction(platformTransactionManager) {
         val newDeutschStats =
           languageStatsService.getLanguageStats(projectId = testData.project.id)
-            .find { it.language.tag == "de" }
+            .find { projectLanguages[it.languageId]!!.tag == "de" }
         assertThat(newDeutschStats!!.untranslatedWords - 1).isEqualTo(deutschStats?.untranslatedWords)
       }
     }

--- a/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
@@ -24,7 +24,7 @@ class LanguageServiceTest : AbstractSpringTest() {
 
     var foundImportLanguage = importService.findLanguages(testData.import).first()
     assertThat(foundImportLanguage.existingLanguage!!.id).isEqualTo(testData.english.id)
-    languageService.deleteLanguage(testData.german.id)
+    languageService.hardDeleteLanguage(testData.german.id)
     entityManager.flush()
     entityManager.clear()
     foundImportLanguage = importService.findLanguages(testData.import).find { it.name == "de" }!!
@@ -37,7 +37,7 @@ class LanguageServiceTest : AbstractSpringTest() {
     val testData = MtSettingsTestData()
     testDataService.saveTestData(testData.root)
     entityManager.flush()
-    languageService.deleteLanguage(testData.germanLanguage.id)
+    languageService.hardDeleteLanguage(testData.germanLanguage.id)
     languageService.findEntity(testData.germanLanguage.id).assert.isNull()
   }
 
@@ -47,7 +47,7 @@ class LanguageServiceTest : AbstractSpringTest() {
     val testData = TranslationCommentsTestData()
     testDataService.saveTestData(testData.root)
     entityManager.flush()
-    languageService.deleteLanguage(testData.englishLanguage.id)
+    languageService.hardDeleteLanguage(testData.englishLanguage.id)
     languageService.findEntity(testData.englishLanguage.id).assert.isNull()
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/activity/data/ActivityType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/data/ActivityType.kt
@@ -37,6 +37,11 @@ enum class ActivityType(
   CREATE_LANGUAGE,
   EDIT_LANGUAGE,
   DELETE_LANGUAGE(restrictEntitiesInList = arrayOf(Language::class)),
+
+  /**
+   * When language is deleted permanently, this happens asynchronously after language is deleted
+   */
+  HARD_DELETE_LANGUAGE(hideInList = true),
   CREATE_PROJECT,
   EDIT_PROJECT,
   NAMESPACE_EDIT,

--- a/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
@@ -1,0 +1,14 @@
+package io.tolgee.api
+
+interface ILanguageStats {
+  val languageId: Long
+  val untranslatedWords: Long
+  val translatedWords: Long
+  val reviewedWords: Long
+  val untranslatedKeys: Long
+  val translatedKeys: Long
+  val reviewedKeys: Long
+  val untranslatedPercentage: Double
+  val translatedPercentage: Double
+  val reviewedPercentage: Double
+}

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/GenericAutoTranslationChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/GenericAutoTranslationChunkProcessor.kt
@@ -12,8 +12,8 @@ import io.tolgee.exceptions.LanguageNotSupportedException
 import io.tolgee.exceptions.OutOfCreditsException
 import io.tolgee.exceptions.PlanTranslationLimitExceeded
 import io.tolgee.exceptions.TranslationSpendingLimitExceeded
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.AutoTranslationService
 import kotlinx.coroutines.ensureActive
 import org.springframework.stereotype.Component

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
@@ -5,7 +5,7 @@ import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.PreTranslationByTmRequest
 import io.tolgee.model.batch.params.PreTranslationByTmJobParams
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import org.springframework.stereotype.Component
 import kotlin.coroutines.CoroutineContext
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/demoProject/DemoProjectCreator.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/demoProject/DemoProjectCreator.kt
@@ -15,12 +15,12 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.key.KeyMeta
 import io.tolgee.model.translation.Translation
 import io.tolgee.model.translation.TranslationComment
-import io.tolgee.service.LanguageService
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.ScreenshotService
 import io.tolgee.service.key.TagService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.UserAccountService
 import io.tolgee.service.translation.TranslationCommentService

--- a/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
@@ -14,7 +14,7 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.repository.UserAccountRepository
 import io.tolgee.security.InitialPasswordManager
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.LanguageStatsService

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
@@ -10,7 +10,6 @@ import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
 import io.tolgee.development.testDataBuilder.builders.TranslationBuilder
 import io.tolgee.development.testDataBuilder.builders.UserAccountBuilder
 import io.tolgee.development.testDataBuilder.builders.UserPreferencesBuilder
-import io.tolgee.service.LanguageService
 import io.tolgee.service.automations.AutomationService
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.contentDelivery.ContentDeliveryConfigService
@@ -20,6 +19,7 @@ import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.NamespaceService
 import io.tolgee.service.key.ScreenshotService
 import io.tolgee.service.key.TagService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.MtCreditBucketService
 import io.tolgee.service.machineTranslation.MtServiceConfigService
 import io.tolgee.service.organization.OrganizationRoleService

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
@@ -1,0 +1,17 @@
+package io.tolgee.dtos.queryResults
+
+import io.tolgee.api.ILanguageStats
+
+data class LanguageStatsDto(
+  override val languageId: Long,
+  val projectId: Long,
+  override val untranslatedWords: Long,
+  override val translatedWords: Long,
+  override val reviewedWords: Long,
+  override val untranslatedKeys: Long,
+  override val translatedKeys: Long,
+  override val reviewedKeys: Long,
+  override val untranslatedPercentage: Double,
+  override val translatedPercentage: Double,
+  override val reviewedPercentage: Double,
+) : ILanguageStats

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnLanguagePreRemove.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnLanguagePreRemove.kt
@@ -1,9 +1,0 @@
-package io.tolgee.events
-
-import io.tolgee.model.Language
-import org.springframework.context.ApplicationEvent
-
-class OnLanguagePreRemove(
-  source: Any,
-  val language: Language,
-) : ApplicationEvent(source)

--- a/backend/data/src/main/kotlin/io/tolgee/facade/ProjectPermissionFacade.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/facade/ProjectPermissionFacade.kt
@@ -6,7 +6,7 @@ import io.tolgee.dtos.request.project.RequestWithLanguagePermissions
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.model.Language
 import io.tolgee.security.authentication.AuthenticationFacade
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import org.springframework.stereotype.Component
 
 @Component

--- a/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
@@ -56,7 +56,7 @@ import java.util.*
 @ActivityReturnsExistence
 class Language : StandardAuditModel(), ILanguage, SoftDeletable {
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "language", orphanRemoval = true)
-  var translations: MutableSet<Translation>? = null
+  var translations: MutableList<Translation> = mutableListOf()
 
   @ManyToOne(fetch = FetchType.LAZY)
   lateinit var project: Project

--- a/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
@@ -95,6 +95,7 @@ class Language : StandardAuditModel(), ILanguage, SoftDeletable {
   @Column(columnDefinition = "text")
   override var aiTranslatorPromptDescription: String? = null
 
+  @ActivityLoggedProp
   override var deletedAt: Date? = null
 
   fun updateByDTO(dto: LanguageRequest) {

--- a/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Language.kt
@@ -8,7 +8,6 @@ import io.tolgee.dtos.request.LanguageRequest
 import io.tolgee.events.OnLanguagePrePersist
 import io.tolgee.model.mtServiceConfig.MtServiceConfig
 import io.tolgee.model.translation.Translation
-import io.tolgee.service.dataImport.ImportService
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
@@ -19,7 +18,6 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.PrePersist
 import jakarta.persistence.Table
-import jakarta.persistence.Transient
 import jakarta.persistence.UniqueConstraint
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
@@ -106,13 +104,6 @@ class Language : StandardAuditModel(), ILanguage, SoftDeletable {
     flagEmoji = dto.flagEmoji
   }
 
-  /**
-   * Executing ot the #ImportService.onExistingLanguageRemoved(Language) method leads to stack overflow
-   * so we need to prevent it from being executed multiple times
-   */
-  @Transient
-  private var _removedHookExecuted = false
-
   override fun toString(): String {
     return "Language(tag=$tag, name=$name, originalName=$originalName)"
   }
@@ -130,9 +121,6 @@ class Language : StandardAuditModel(), ILanguage, SoftDeletable {
 
     @Configurable
     class LanguageListeners {
-      @Autowired
-      lateinit var importServiceProvider: ObjectFactory<ImportService>
-
       @Autowired
       lateinit var eventPublisherProvider: ObjectFactory<ApplicationEventPublisher>
 

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -4,7 +4,10 @@
 
 package io.tolgee.model
 
+import io.tolgee.api.ILanguageStats
+import io.tolgee.dtos.queryResults.LanguageStatsDto
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -12,24 +15,41 @@ import jakarta.persistence.UniqueConstraint
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["language_id"], name = "language_stats_language_id_key")])
 class LanguageStats(
-  @OneToOne
+  @OneToOne(fetch = FetchType.LAZY)
   val language: Language,
-) : StandardAuditModel() {
-  var untranslatedWords: Long = 0
+) : StandardAuditModel(), ILanguageStats {
+  override var untranslatedWords: Long = 0
 
-  var translatedWords: Long = 0
+  override var translatedWords: Long = 0
 
-  var reviewedWords: Long = 0
+  override var reviewedWords: Long = 0
 
-  var untranslatedKeys: Long = 0
+  override var untranslatedKeys: Long = 0
 
-  var translatedKeys: Long = 0
+  override var translatedKeys: Long = 0
 
-  var reviewedKeys: Long = 0
+  override var reviewedKeys: Long = 0
 
-  var untranslatedPercentage: Double = 0.0
+  override var untranslatedPercentage: Double = 0.0
 
-  var translatedPercentage: Double = 0.0
+  override var translatedPercentage: Double = 0.0
 
-  var reviewedPercentage: Double = 0.0
+  override var reviewedPercentage: Double = 0.0
+  override val languageId: Long
+    get() = language.id
+
+  fun toDto() =
+    LanguageStatsDto(
+      languageId = language.id,
+      projectId = language.project.id,
+      untranslatedWords = untranslatedWords,
+      translatedWords = translatedWords,
+      reviewedWords = reviewedWords,
+      untranslatedKeys = untranslatedKeys,
+      translatedKeys = translatedKeys,
+      reviewedKeys = reviewedKeys,
+      untranslatedPercentage = untranslatedPercentage,
+      translatedPercentage = translatedPercentage,
+      reviewedPercentage = reviewedPercentage,
+    )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/Project.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Project.kt
@@ -11,7 +11,7 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.key.Namespace
 import io.tolgee.model.mtServiceConfig.MtServiceConfig
 import io.tolgee.model.webhook.WebhookConfig
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column

--- a/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectView.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectView.kt
@@ -1,6 +1,5 @@
 package io.tolgee.model.views
 
-import io.tolgee.model.Language
 import io.tolgee.model.Organization
 import io.tolgee.model.Permission
 import io.tolgee.model.enums.OrganizationRoleType
@@ -12,7 +11,6 @@ interface ProjectView {
   val description: String?
   val slug: String?
   val avatarHash: String?
-  val baseLanguage: Language?
   val defaultNamespace: Namespace?
   val organizationOwner: Organization
   val organizationRole: OrganizationRoleType?

--- a/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectWithLanguagesView.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectWithLanguagesView.kt
@@ -1,6 +1,5 @@
 package io.tolgee.model.views
 
-import io.tolgee.model.Language
 import io.tolgee.model.Organization
 import io.tolgee.model.Permission
 import io.tolgee.model.enums.OrganizationRoleType
@@ -12,7 +11,6 @@ open class ProjectWithLanguagesView(
   override val description: String?,
   override val slug: String?,
   override val avatarHash: String?,
-  override val baseLanguage: Language?,
   override val defaultNamespace: Namespace?,
   override val organizationOwner: Organization,
   override val organizationRole: OrganizationRoleType?,
@@ -31,7 +29,6 @@ open class ProjectWithLanguagesView(
         description = view.description,
         slug = view.slug,
         avatarHash = view.avatarHash,
-        baseLanguage = view.baseLanguage,
         defaultNamespace = view.defaultNamespace,
         organizationOwner = view.organizationOwner,
         organizationRole = view.organizationRole,

--- a/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectWithStatsView.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/views/ProjectWithStatsView.kt
@@ -13,7 +13,6 @@ class ProjectWithStatsView(
     view.description,
     view.slug,
     view.avatarHash,
-    view.baseLanguage,
     view.defaultNamespace,
     view.organizationOwner,
     view.organizationRole,

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageRepository.kt
@@ -11,11 +11,25 @@ import java.util.*
 
 @Repository
 interface LanguageRepository : JpaRepository<Language, Long> {
+  @Query(
+    """
+    select l
+    from Language l
+    where l.name = :name and l.project = :project and l.deletedAt is null
+  """,
+  )
   fun findByNameAndProject(
     name: String?,
     project: io.tolgee.model.Project,
   ): Optional<Language>
 
+  @Query(
+    """
+    select l
+    from Language l
+    where l.project.id = :projectId and l.deletedAt is null
+  """,
+  )
   fun findAllByProjectId(projectId: Long?): Set<Language>
 
   @Query(
@@ -30,7 +44,7 @@ interface LanguageRepository : JpaRepository<Language, Long> {
       coalesce((l.id = l.project.baseLanguage.id), false)
     )
     from Language l
-    where l.project.id = :projectId
+    where l.project.id = :projectId and l.deletedAt is null
   """,
   )
   fun findAllByProjectId(
@@ -45,6 +59,13 @@ interface LanguageRepository : JpaRepository<Language, Long> {
 
   fun deleteAllByProjectId(projectId: Long?)
 
+  @Query(
+    """
+    select l
+    from Language l
+    where l.project.id = :projectId and l.id in :languageIds and l.deletedAt is null
+  """,
+  )
   fun findAllByProjectIdAndIdInOrderById(
     projectId: Long,
     languageIds: List<Long>,
@@ -54,7 +75,7 @@ interface LanguageRepository : JpaRepository<Language, Long> {
     """
     select l
     from Language l
-    where l.project.id = :projectId and l.id in :languageId
+    where l.project.id = :projectId and l.id in :languageId and l.deletedAt is null
   """,
   )
   fun find(
@@ -73,7 +94,7 @@ interface LanguageRepository : JpaRepository<Language, Long> {
       l.aiTranslatorPromptDescription,
       coalesce((l.id = l.project.baseLanguage.id), false)
     )
-    from Language l where l.project.id = :projectId
+    from Language l where l.project.id = :projectId and l.deletedAt is null
   """,
   )
   fun findAllDtosByProjectId(projectId: Long): List<LanguageDto>

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageRepository.kt
@@ -85,6 +85,15 @@ interface LanguageRepository : JpaRepository<Language, Long> {
 
   @Query(
     """
+    select l
+    from Language l
+    where l.id = :languageId and l.deletedAt is null
+  """,
+  )
+  fun find(languageId: Long): Language?
+
+  @Query(
+    """
     select new io.tolgee.dtos.cacheable.LanguageDto(
       l.id,
       l.name,

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
@@ -1,5 +1,6 @@
 package io.tolgee.repository
 
+import io.tolgee.dtos.queryResults.LanguageStatsDto
 import io.tolgee.model.LanguageStats
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
@@ -9,15 +10,6 @@ import org.springframework.transaction.annotation.Transactional
 
 @Repository
 interface LanguageStatsRepository : JpaRepository<LanguageStats, Long> {
-  @Query(
-    """
-    from LanguageStats ls
-    join ls.language l
-    where l.project.id = :projectId
-  """,
-  )
-  fun getAllByProjectId(projectId: Long): List<LanguageStats>
-
   @Modifying
   @Transactional
   @Query(
@@ -26,6 +18,27 @@ interface LanguageStatsRepository : JpaRepository<LanguageStats, Long> {
   """,
   )
   fun deleteAllByLanguage(languageId: Long)
+
+  @Query(
+    """
+    select new io.tolgee.dtos.queryResults.LanguageStatsDto(
+      ls.language.id,
+      ls.language.project.id,
+      ls.untranslatedWords,
+      ls.translatedWords,
+      ls.reviewedWords,
+      ls.untranslatedKeys,
+      ls.translatedKeys,
+      ls.reviewedKeys,
+      ls.untranslatedPercentage,
+      ls.translatedPercentage,
+      ls.reviewedPercentage
+    )
+    from LanguageStats ls
+    where ls.language.project.id in :projectIds
+  """,
+  )
+  fun getDtosByProjectIds(projectIds: List<Long>): List<LanguageStatsDto>
 
   @Query(
     """

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -15,7 +15,7 @@ interface ProjectRepository : JpaRepository<Project, Long> {
   companion object {
     const val BASE_VIEW_QUERY = """select r.id as id, r.name as name, r.description as description,
         r.slug as slug, r.avatarHash as avatarHash,
-        bl as baseLanguage, dn as defaultNamespace, o as organizationOwner,
+        dn as defaultNamespace, o as organizationOwner,
         role.type as organizationRole, p as directPermission, r.icuPlaceholders as icuPlaceholders
         from Project r
         left join r.baseLanguage bl

--- a/backend/data/src/main/kotlin/io/tolgee/service/LanguageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/LanguageService.kt
@@ -73,16 +73,17 @@ class LanguageService(
   }
 
   @Transactional
-  fun deleteLanguage(language: Language) {
-    language.deletedAt = currentDateProvider.date
-    importService.onExistingLanguageRemoved(language)
-    save(language)
-    self.hardDeleteLanguageAsync(language)
+  fun deleteLanguage(id: Long) {
+    deleteLanguage(getEntity(id))
   }
 
   @Transactional
-  fun deleteLanguage(id: Long) {
-    hardDeleteLanguage(getEntity(id))
+  fun deleteLanguage(language: Language) {
+    language.deletedAt = currentDateProvider.date
+    importService.onExistingLanguageRemoved(language)
+    permissionService.removeLanguageFromPermissions(language)
+    save(language)
+    self.hardDeleteLanguageAsync(language)
   }
 
   @Async
@@ -93,7 +94,6 @@ class LanguageService(
 
   @Transactional
   fun hardDeleteLanguage(language: Language) {
-    permissionService.removeLanguageFromPermissions(language)
     languageRepository.delete(language)
     entityManager.flush()
     evictCache(language)
@@ -162,7 +162,7 @@ class LanguageService(
   }
 
   fun findEntity(id: Long): Language? {
-    return languageRepository.findById(id).orElse(null)
+    return languageRepository.find(id)
   }
 
   fun getEntity(id: Long): Language {

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/CoreImportFilesProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/CoreImportFilesProcessor.kt
@@ -19,8 +19,8 @@ import io.tolgee.model.dataImport.ImportLanguage
 import io.tolgee.model.dataImport.ImportTranslation
 import io.tolgee.model.dataImport.issues.issueTypes.FileIssueType
 import io.tolgee.model.dataImport.issues.paramTypes.FileIssueParamType
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.processors.FileProcessorContext
+import io.tolgee.service.language.LanguageService
 import io.tolgee.util.Logging
 import io.tolgee.util.filterFiles
 import io.tolgee.util.getOrThrowIfMoreThanOne

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportDataManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportDataManager.kt
@@ -15,10 +15,10 @@ import io.tolgee.model.dataImport.issues.paramTypes.FileIssueParamType
 import io.tolgee.model.key.Key
 import io.tolgee.model.key.KeyMeta
 import io.tolgee.model.translation.Translation
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.NamespaceService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.TranslationService
 import io.tolgee.util.Logging
 import io.tolgee.util.getSafeNamespace

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -454,7 +454,7 @@ class KeyService(
       translation.state = TranslationState.DISABLED
       translationService.save(translation)
     }
-    return languages
+    return languages.sortedBy { languageIds.indexOf(it.id) }
   }
 
   fun getViewsByKeyIds(ids: List<Long>): List<KeyView> {

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -25,7 +25,7 @@ import io.tolgee.model.key.screenshotReference.KeyScreenshotReference
 import io.tolgee.model.translation.Translation
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.ImageUploadService
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationService
 import io.tolgee.util.equalNullable

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeysImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeysImporter.kt
@@ -6,11 +6,11 @@ import io.tolgee.model.Project
 import io.tolgee.model.key.Key
 import io.tolgee.model.key.KeyMeta
 import io.tolgee.model.key.Namespace
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.NamespaceService
 import io.tolgee.service.key.TagService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationService
 import io.tolgee.util.getSafeNamespace

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageHardDeleter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageHardDeleter.kt
@@ -1,0 +1,63 @@
+package io.tolgee.service.language
+
+import io.tolgee.model.Language
+import io.tolgee.model.translation.Translation
+import io.tolgee.repository.LanguageRepository
+import jakarta.persistence.EntityManager
+import org.springframework.context.ApplicationContext
+
+/**
+ * This class helps to delete language without n+1 problems.
+ *
+ * It fetches all the relations first, so they're not fetched later when
+ * required for orphan removal or activity storing.
+ *
+ * It's tested by `io.tolgee.service.LanguageServiceTest.hard deletes language without n+1s`
+ */
+class LanguageHardDeleter(
+  private val language: Language,
+  private val applicationContext: ApplicationContext,
+) {
+  fun delete() {
+    val languageWithData = getWithFetchedTranslations(language)
+    val allTranslations = getAllTranslations(languageWithData)
+    languageWithData.translations = allTranslations
+    languageRepository.delete(language)
+    entityManager.flush()
+  }
+
+  private fun getAllTranslations(languageWithData: Language) =
+    languageWithData.translations.chunked(30000).flatMap {
+      entityManager.createQuery(
+        """from Translation t
+            join fetch t.key k
+            left join fetch k.keyMeta km
+            left join fetch k.namespace
+            left join fetch t.comments
+            where t.id in :ids""",
+        Translation::class.java,
+      )
+        .setParameter("ids", it.map { it.id })
+        .resultList
+    }.toMutableList()
+
+  private fun getWithFetchedTranslations(language: Language): Language {
+    return entityManager.createQuery(
+      """
+          from Language l
+          left join fetch l.translations t
+          where l = :language""",
+      Language::class.java,
+    )
+      .setParameter("language", language)
+      .singleResult
+  }
+
+  private val entityManager by lazy {
+    applicationContext.getBean(EntityManager::class.java)
+  }
+
+  private val languageRepository by lazy {
+    applicationContext.getBean(LanguageRepository::class.java)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
@@ -1,4 +1,4 @@
-package io.tolgee.service
+package io.tolgee.service.language
 
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.activity.data.ActivityType
@@ -24,6 +24,7 @@ import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -49,6 +50,7 @@ class LanguageService(
   private val importService: ImportService,
   private val activityHolder: ActivityHolder,
   private val authenticationFacade: AuthenticationFacade,
+  private val applicationContext: ApplicationContext,
 ) {
   @set:Autowired
   @set:Lazy
@@ -105,8 +107,7 @@ class LanguageService(
 
   @Transactional
   fun hardDeleteLanguage(language: Language) {
-    languageRepository.delete(language)
-    entityManager.flush()
+    LanguageHardDeleter(language, applicationContext).delete()
     evictCache(language)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtServiceConfigService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtServiceConfigService.kt
@@ -13,7 +13,7 @@ import io.tolgee.model.Project
 import io.tolgee.model.mtServiceConfig.Formality
 import io.tolgee.model.mtServiceConfig.MtServiceConfig
 import io.tolgee.repository.machineTranslation.MtServiceConfigRepository
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationContext

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtTranslatorContext.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtTranslatorContext.kt
@@ -7,7 +7,7 @@ import io.tolgee.constants.MtServiceType
 import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.formats.PluralForms
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.PluralTranslationUtil.Companion.REPLACE_NUMBER_PLACEHOLDER
 import io.tolgee.service.project.ProjectService
 import jakarta.persistence.EntityManager

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationStatsService.kt
@@ -57,6 +57,7 @@ class OrganizationStatsService(
     return entityManager.createQuery(
       """
       select count(t) from Translation t where 
+        t.language.deletedAt is null and
         t.key.project.organizationOwner.id = :organizationId and 
         t.state <> io.tolgee.model.enums.TranslationState.UNTRANSLATED and t.key.project.deletedAt is null
       """.trimIndent(),

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
@@ -6,7 +6,7 @@ import io.tolgee.model.Language
 import io.tolgee.model.LanguageStats
 import io.tolgee.model.views.projectStats.ProjectLanguageStatsResultView
 import io.tolgee.repository.LanguageStatsRepository
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.queryBuilders.LanguageStatsProvider
 import io.tolgee.util.Logging
 import io.tolgee.util.debug

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
@@ -36,7 +36,7 @@ class LanguageStatsService(
         try {
           val baseLanguage = projectService.getOrAssignBaseLanguage(projectId)
           val rawBaseLanguageStats =
-            allRawLanguageStats.find { it.languageId == baseLanguage?.id }
+            allRawLanguageStats.find { it.languageId == baseLanguage.id }
               ?: return@tx
           val projectStats = projectStatsService.getProjectStats(projectId)
           val languageStats =

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -26,12 +26,12 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.ProjectNotSelectedException
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.AvatarService
-import io.tolgee.service.LanguageService
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.dataImport.ImportService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.NamespaceService
 import io.tolgee.service.key.ScreenshotService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.MtServiceConfigService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.security.ApiKeyService

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
@@ -1,7 +1,7 @@
 package io.tolgee.service.project
 
+import io.tolgee.dtos.queryResults.LanguageStatsDto
 import io.tolgee.model.ILanguage
-import io.tolgee.model.LanguageStats
 import io.tolgee.model.Project
 import io.tolgee.model.Project_
 import io.tolgee.model.views.projectStats.ProjectStatsView
@@ -52,14 +52,14 @@ class ProjectStatsService(
 
   fun computeProjectTotals(
     baseLanguage: ILanguage,
-    languageStats: List<LanguageStats>,
+    languageStats: List<LanguageStatsDto>,
   ): ProjectStateTotals {
     val baseStats =
-      languageStats.find { it.language.id == baseLanguage.id }
+      languageStats.find { it.languageId == baseLanguage.id }
         ?: return ProjectStateTotals(0, 0.0, 0.0)
 
     val baseWordsCount = baseStats.translatedWords + baseStats.reviewedWords
-    val nonBaseLanguages = languageStats.filterNot { it.language.id == baseLanguage.id }
+    val nonBaseLanguages = languageStats.filterNot { it.languageId == baseLanguage.id }
 
     val allNonBaseTotalBaseWords = baseWordsCount * nonBaseLanguages.size
     val allNonBaseTotalTranslatedWords = nonBaseLanguages.sumOf { it.translatedWords }

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
@@ -24,7 +24,7 @@ import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.repository.PermissionRepository
 import io.tolgee.service.CachedPermissionService
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
@@ -14,7 +14,7 @@ import io.tolgee.model.translation.Translation
 import io.tolgee.repository.KeyRepository
 import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AuthenticationFacade
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
@@ -15,7 +15,7 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.repository.AutoTranslationConfigRepository
 import io.tolgee.security.authentication.AuthenticationFacade
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.MtService
 import io.tolgee.util.executeInNewTransaction
 import io.tolgee.util.tryUntilItDoesntBreakConstraint

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -27,9 +27,9 @@ import io.tolgee.model.views.KeyWithTranslationsView
 import io.tolgee.model.views.SimpleTranslationView
 import io.tolgee.model.views.TranslationMemoryItemView
 import io.tolgee.repository.TranslationRepository
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.ImportService
 import io.tolgee.service.key.KeyService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.queryBuilders.translationViewBuilder.TranslationViewDataProvider
 import io.tolgee.util.nullIfEmpty

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -3251,4 +3251,9 @@
             create index translation_comment_translation_id_state on translation_comment(translation_id, state);
         </sql>
     </changeSet>
+    <changeSet author="jenik (generated)" id="1717855133193-1">
+        <addColumn tableName="language">
+            <column name="deleted_at" type="timestamp(6)"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
@@ -8,8 +8,8 @@ import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.dtos.cacheable.ProjectDto
 import io.tolgee.model.mtServiceConfig.Formality
 import io.tolgee.model.views.TranslationMemoryItemView
-import io.tolgee.service.LanguageService
 import io.tolgee.service.bigMeta.BigMetaService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.TranslationMemoryService
 import io.tolgee.testing.assert
 import jakarta.persistence.EntityManager

--- a/backend/data/src/test/kotlin/io/tolgee/unit/CoreImportFileProcessorUnitTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/CoreImportFileProcessorUnitTest.kt
@@ -17,11 +17,11 @@ import io.tolgee.model.dataImport.ImportLanguage
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.security.authentication.AuthenticationFacade
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.CoreImportFilesProcessor
 import io.tolgee.service.dataImport.ImportService
 import io.tolgee.service.dataImport.processors.FileProcessorContext
 import io.tolgee.service.key.KeyMetaService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.TranslationService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/backend/data/src/test/kotlin/io/tolgee/util/FileProcessorContextMockUtil.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/util/FileProcessorContextMockUtil.kt
@@ -13,11 +13,11 @@ import io.tolgee.model.Project
 import io.tolgee.model.dataImport.Import
 import io.tolgee.model.dataImport.ImportFile
 import io.tolgee.model.dataImport.ImportTranslation
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.CoreImportFilesProcessor
 import io.tolgee.service.dataImport.ImportService
 import io.tolgee.service.dataImport.processors.FileProcessorContext
 import io.tolgee.service.key.KeyMetaService
+import io.tolgee.service.language.LanguageService
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/ProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/ProjectsE2eDataController.kt
@@ -13,8 +13,8 @@ import io.tolgee.repository.OrganizationRepository
 import io.tolgee.repository.PermissionRepository
 import io.tolgee.repository.ProjectRepository
 import io.tolgee.repository.UserAccountRepository
-import io.tolgee.service.LanguageService
 import io.tolgee.service.key.KeyService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService

--- a/backend/testing/src/main/kotlin/io/tolgee/AbstractSpringTest.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/AbstractSpringTest.kt
@@ -1,7 +1,6 @@
 package io.tolgee
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.clear
 import io.tolgee.activity.ActivityService
 import io.tolgee.component.AllCachesProvider
 import io.tolgee.component.CurrentDateProvider
@@ -29,12 +28,12 @@ import io.tolgee.security.InitialPasswordManager
 import io.tolgee.service.EmailVerificationService
 import io.tolgee.service.ImageUploadService
 import io.tolgee.service.InvitationService
-import io.tolgee.service.LanguageService
 import io.tolgee.service.dataImport.ImportService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.NamespaceService
 import io.tolgee.service.key.ScreenshotService
 import io.tolgee.service.key.TagService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.machineTranslation.MtCreditBucketService
 import io.tolgee.service.machineTranslation.MtService
 import io.tolgee.service.machineTranslation.MtServiceConfigService

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationController.kt
@@ -17,7 +17,7 @@ import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authorization.RequiresOrganizationRole
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import jakarta.validation.Valid
 import org.springframework.hateoas.CollectionModel
 import org.springframework.web.bind.annotation.GetMapping

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/AiPromptCustomizationService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/AiPromptCustomizationService.kt
@@ -3,7 +3,7 @@ package io.tolgee.ee.service
 import io.tolgee.ee.data.SetLanguagePromptCustomizationRequest
 import io.tolgee.ee.data.SetProjectPromptCustomizationRequest
 import io.tolgee.model.Project
-import io.tolgee.service.LanguageService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional

--- a/webapp/src/views/projects/languages/LanguageEdit/LanguageEditDialog.tsx
+++ b/webapp/src/views/projects/languages/LanguageEdit/LanguageEditDialog.tsx
@@ -13,6 +13,7 @@ import { StandardForm } from 'tg.component/common/form/StandardForm';
 import { useGlobalActions } from 'tg.globalContext/GlobalContext';
 import { messageService } from 'tg.service/MessageService';
 import { BoxLoading } from 'tg.component/common/BoxLoading';
+import LoadingButton from 'tg.component/common/form/LoadingButton';
 
 type LanguageModel = components['schemas']['LanguageModel'];
 
@@ -124,7 +125,8 @@ export const LanguageEditDialog = () => {
             saveActionLoadable={editLoadable}
             validationSchema={Validation.LANGUAGE(t)}
             customActions={
-              <Button
+              <LoadingButton
+                loading={deleteLoadable.isLoading}
                 variant="outlined"
                 color="secondary"
                 data-cy="language-delete-button"
@@ -149,7 +151,7 @@ export const LanguageEditDialog = () => {
                 }}
               >
                 <T keyName="delete_language_button" />
-              </Button>
+              </LoadingButton>
             }
           >
             <Box data-cy="language-modify-form">

--- a/webapp/src/views/projects/languages/LanguageEdit/LanguageEditDialog.tsx
+++ b/webapp/src/views/projects/languages/LanguageEdit/LanguageEditDialog.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Dialog, DialogContent, DialogTitle } from '@mui/material';
+import { Box, Dialog, DialogContent, DialogTitle } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 import { useHistory, useRouteMatch } from 'react-router-dom';
 

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/MachineTranslation/MachineTranslation.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/MachineTranslation/MachineTranslation.tsx
@@ -8,6 +8,7 @@ import { TabMessage } from '../../common/TabMessage';
 import { PanelContentProps } from '../../common/types';
 import { useEffect } from 'react';
 import { MachineTranslationItem } from './MachineTranslationItem';
+import { useLoadingRegister } from 'tg.component/GlobalLoading';
 
 const StyledContainer = styled('div')`
   display: flex;
@@ -66,6 +67,8 @@ export const MachineTranslation: React.FC<PanelContentProps> = ({
       keepPreviousData: true,
     },
   });
+
+  useLoadingRegister(machineLoadable.isFetching);
 
   const data = machineLoadable.data;
 

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from '@tolgee/react';
-import { Skeleton, styled } from '@mui/material';
+import { styled } from '@mui/material';
 
 import { TabMessage } from '../../common/TabMessage';
 import { PanelContentProps } from '../../common/types';

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
@@ -1,15 +1,12 @@
 import { useTranslate } from '@tolgee/react';
-import { styled } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 
 import { TabMessage } from '../../common/TabMessage';
 import { PanelContentProps } from '../../common/types';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { stringHash } from 'tg.fixtures/stringHash';
 import { useEffect } from 'react';
-import {
-  SkeletonTranslationMemoryItem,
-  TranslationMemoryItem,
-} from './TranslationMemoryItem';
+import { TranslationMemoryItem } from './TranslationMemoryItem';
 
 const StyledContainer = styled('div')`
   display: flex;
@@ -56,7 +53,9 @@ export const TranslationMemory: React.FC<PanelContentProps> = ({
   if (!data) {
     return (
       <StyledContainer>
-        <SkeletonTranslationMemoryItem />
+        <TabMessage>
+          <Skeleton variant="text" />
+        </TabMessage>
       </StyledContainer>
     );
   }

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemory.tsx
@@ -1,12 +1,15 @@
 import { useTranslate } from '@tolgee/react';
-import { styled } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 
 import { TabMessage } from '../../common/TabMessage';
 import { PanelContentProps } from '../../common/types';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { stringHash } from 'tg.fixtures/stringHash';
 import { useEffect } from 'react';
-import { TranslationMemoryItem } from './TranslationMemoryItem';
+import {
+  SkeletonTranslationMemoryItem,
+  TranslationMemoryItem,
+} from './TranslationMemoryItem';
 
 const StyledContainer = styled('div')`
   display: flex;
@@ -51,7 +54,11 @@ export const TranslationMemory: React.FC<PanelContentProps> = ({
   }, [items?.length]);
 
   if (!data) {
-    return null;
+    return (
+      <StyledContainer>
+        <SkeletonTranslationMemoryItem />
+      </StyledContainer>
+    );
   }
 
   return (

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -1,4 +1,4 @@
-import { Skeleton, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { green, grey, orange } from '@mui/material/colors';
 import { components } from 'tg.service/apiSchema.generated';
 import { TranslationWithPlaceholders } from 'tg.views/projects/translations/translationVisual/TranslationWithPlaceholders';

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -183,20 +183,3 @@ export const TranslationMemoryItem = ({
     </StyledItem>
   );
 };
-
-export const SkeletonTranslationMemoryItem = () => {
-  return (
-    <StyledItem>
-      <StyledTarget>
-        <Skeleton variant="text" />
-      </StyledTarget>
-      <StyledBase>
-        <Skeleton variant="text" />
-      </StyledBase>
-      <StyledSkeletonSimilarity />
-      <StyledSource>
-        <Skeleton variant="text" />
-      </StyledSource>
-    </StyledItem>
-  );
-};

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -1,4 +1,4 @@
-import { styled } from '@mui/material';
+import { Skeleton, styled } from '@mui/material';
 import { green, grey, orange } from '@mui/material/colors';
 import { components } from 'tg.service/apiSchema.generated';
 import { TranslationWithPlaceholders } from 'tg.views/projects/translations/translationVisual/TranslationWithPlaceholders';
@@ -65,6 +65,13 @@ const StyledSimilarity = styled('div')`
   grid-area: similarity;
   font-size: 13px;
   color: white;
+  padding: 1px 9px;
+  border-radius: 10px;
+`;
+
+const StyledSkeletonSimilarity = styled(Skeleton)`
+  grid-area: similarity;
+  font-size: 13px;
   padding: 1px 9px;
   border-radius: 10px;
 `;
@@ -173,6 +180,23 @@ export const TranslationMemoryItem = ({
         {Math.round(100 * item.similarity)}%
       </StyledSimilarity>
       <StyledSource>{item.keyName}</StyledSource>
+    </StyledItem>
+  );
+};
+
+export const SkeletonTranslationMemoryItem = () => {
+  return (
+    <StyledItem>
+      <StyledTarget>
+        <Skeleton variant="text" />
+      </StyledTarget>
+      <StyledBase>
+        <Skeleton variant="text" />
+      </StyledBase>
+      <StyledSkeletonSimilarity />
+      <StyledSource>
+        <Skeleton variant="text" />
+      </StyledSource>
     </StyledItem>
   );
 };

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -69,13 +69,6 @@ const StyledSimilarity = styled('div')`
   border-radius: 10px;
 `;
 
-const StyledSkeletonSimilarity = styled(Skeleton)`
-  grid-area: similarity;
-  font-size: 13px;
-  padding: 1px 9px;
-  border-radius: 10px;
-`;
-
 const StyledSource = styled('div')`
   grid-area: source;
   font-size: 13px;


### PR DESCRIPTION
In this PR i have
 - Added soft delete for language for better performance. Lot of entities are being deleted and this takes time, so it happens asynchronously now, wile the language is soft deleted immediately
 - Made language delete button loading button
 - Removed top loading when machine translation suggestions are loaded and skeleton is displayed
 - Added skeleton for translation memory suggestion