### PR TITLE
feat: slack integration improvements

### DIFF
--- a/backend/data/src/main/resources/I18n_en.properties
+++ b/backend/data/src/main/resources/I18n_en.properties
@@ -24,6 +24,7 @@ slack.common.message.unsubscribed-successfully = Unsubscribed.
 slack.common.text.button.tolgee_redirect=Open in Tolgee
 slack.common.message.success_login = Success! :tada: The operation was completed successfully.
 slack.common.context.success_login = Now you can use other commands.
+slack.common.message.unsubscribe_bad-request = It seems like you haven't subscribed to that language yet or you misspelled the language tag. Please check the language tag and try again.
 
 # Strings for help command
 slack.help.message.intro=Hi there :wave: here are some tips for you:

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/slack/SlackSlashCommandController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/slack/SlackSlashCommandController.kt
@@ -80,7 +80,12 @@ class SlackSlashCommandController(
             optionsMap,
           ).asSlackResponseString
 
-        "unsubscribe" -> unsubscribe(payload, projectId.toLongOrThrowInvalidCommand()).asSlackResponseString
+        "unsubscribe" ->
+          unsubscribe(
+            payload,
+            projectId.toLongOrThrowInvalidCommand(),
+            languageTag,
+          ).asSlackResponseString
 
         "subscriptions" -> listOfSubscriptions(payload).asSlackResponseString
 
@@ -210,13 +215,12 @@ class SlackSlashCommandController(
   private fun unsubscribe(
     payload: SlackCommandDto,
     projectId: Long,
+    languageTag: String,
   ): SlackMessageDto {
     val user = getUserAccount(payload)
     checkPermissions(projectId, user.id)
 
-    if (!slackConfigService.delete(projectId, payload.channel_id)) {
-      throw SlackErrorException(slackErrorProvider.getNotSubscribedYetError())
-    }
+    slackConfigService.delete(projectId, payload.channel_id, languageTag)
 
     return SlackMessageDto(
       text = i18n.translate("slack.common.message.unsubscribed-successfully"),

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackErrorProvider.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackErrorProvider.kt
@@ -91,6 +91,19 @@ class SlackErrorProvider(
     }
   }
 
+  fun getNotSubscribedToLanguageOrBadLanguageTagError(): List<LayoutBlock> {
+    return withBlocks {
+      section {
+        markdownText(
+          i18n.translate("slack.common.message.unsubscribe_bad-request"),
+        )
+      }
+      actions {
+        helpButton()
+      }
+    }
+  }
+
   fun getNoPermissionError(): List<LayoutBlock> {
     return withBlocks {
       section {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutor.kt
@@ -72,17 +72,7 @@ class SlackExecutor(
 
   fun getSlackNickName(authorId: Long): String? {
     val slackId = slackUserConnectionService.findByUserAccountId(authorId)?.slackUserId ?: return null
-    val response =
-      slackClient.methods(tolgeeProperties.slack.token).usersInfo {
-        it.user(slackId)
-      }
-
-    return if (response.isOk) {
-      response.user?.name
-    } else {
-      logger.info(response.error)
-      null
-    }
+    return "<@$slackId>"
   }
 
   private fun processSavedMessage(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutorHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutorHelper.kt
@@ -308,7 +308,7 @@ class SlackExecutorHelper(
     val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
     val formattedTime = formatter.format(date)
 
-    val authorMention = author?.let { "@$it" } ?: data.activityData?.author?.name
+    val authorMention = author ?: data.activityData?.author?.name
     return i18n.translate("slack.common.message.modification-info").format(authorMention, event, formattedTime)
   }
 
@@ -378,7 +378,7 @@ class SlackExecutorHelper(
   }
 
   private fun SectionBlockBuilder.authorHeadSection(head: String) {
-    val authorMention = author?.let { "@$it" } ?: data.activityData?.author?.name
+    val authorMention = author ?: data.activityData?.author?.name
     markdownText(" *$authorMention* $head")
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutorHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackExecutorHelper.kt
@@ -156,6 +156,9 @@ class SlackExecutorHelper(
       markdownText(currentTranslate)
     }
     val contextText = author ?: return@withBlocks
+    if (contextText.isEmpty()) {
+      return@withBlocks
+    }
     context {
       markdownText(contextText)
     }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/slackIntegration/SlackConfigPreferenceService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/slackIntegration/SlackConfigPreferenceService.kt
@@ -26,10 +26,7 @@ class SlackConfigPreferenceService(
     return slackConfigPreferenceRepository.save(slackConfigPreference)
   }
 
-  fun get(id: Long) {
-  }
-
   fun delete(slackConfigPreference: SlackConfigPreference) {
-    delete(slackConfigPreference)
+    slackConfigPreferenceRepository.delete(slackConfigPreference)
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/slack/SlackConfigServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/slack/SlackConfigServiceTest.kt
@@ -17,7 +17,7 @@ class SlackConfigServiceTest : AbstractSpringTest() {
   fun `deletes configs`() {
     val testData = SlackTestData()
     testDataService.saveTestData(testData.root)
-    slackConfigService.delete(testData.projectBuilder.self.id, testData.slackConfig.channelId)
+    slackConfigService.delete(testData.projectBuilder.self.id, testData.slackConfig.channelId, "")
     Assertions.assertThat(slackConfigService.findAll()).isEmpty()
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/slack/SlackIntegrationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/slack/SlackIntegrationTest.kt
@@ -86,7 +86,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
         onEvent = EventName.ALL,
         slackTeamId = "",
       )
-    slackConfigService.delete(testData.slackConfig.project.id, "testChannel")
+    slackConfigService.delete(testData.slackConfig.project.id, "testChannel", "")
     val config = slackConfigService.createOrUpdate(updatedConfig)
 
     loginAsUser(testData.user.username)
@@ -114,7 +114,7 @@ class SlackIntegrationTest : ProjectAuthControllerTest(), Logging {
         onEvent = EventName.TRANSLATION_CHANGED,
         slackTeamId = "",
       )
-    slackConfigService.delete(testData.slackConfig.project.id, "testChannel")
+    slackConfigService.delete(testData.slackConfig.project.id, "testChannel", "")
     val config = slackConfigService.createOrUpdate(updatedConfig)
 
     loginAsUser(testData.user.username)


### PR DESCRIPTION
- changing the method of obtaining the alias of an authorized Slack user
- The user can now unsubscribe from the specified language (/tolgee unsubscribe 1 cs)
- add new scopes to request
- fixed a bug where changes were not updated if the base language was changed first.