### PR TITLE
chore: integration tests performance fixes

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -80,6 +80,8 @@ sourceSets {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -271,3 +271,9 @@ jar {
 bootJar {
     duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 }
+
+normalization {
+    runtimeClasspath {
+        ignore '**/build-info.properties'
+    }
+}

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -48,6 +48,9 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    applyMavenExclusions = false
+}
 
 allOpen {
     annotation("jakarta.persistence.Entity")

--- a/backend/data/build.gradle
+++ b/backend/data/build.gradle
@@ -218,6 +218,8 @@ sourceSets {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/backend/development/build.gradle
+++ b/backend/development/build.gradle
@@ -80,6 +80,8 @@ sourceSets {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/backend/security/build.gradle
+++ b/backend/security/build.gradle
@@ -84,6 +84,7 @@ sourceSets {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/backend/testing/build.gradle
+++ b/backend/testing/build.gradle
@@ -142,6 +142,8 @@ sourceSets {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/ee/backend/app/build.gradle
+++ b/ee/backend/app/build.gradle
@@ -96,6 +96,8 @@ kotlin {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/ee/backend/tests/build.gradle
+++ b/ee/backend/tests/build.gradle
@@ -61,6 +61,8 @@ kotlin {
 }
 
 dependencyManagement {
+    applyMavenExclusions = false
+
     imports {
         mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ org.gradle.parallel=true
 jacksonVersion=2.13.5
 slackSdkVersion=1.37.0
 commonsLang3Version=3.14.0
+org.gradle.caching=true


### PR DESCRIPTION
I've investigated tests performance with AuthTest as the test subject.

* Spring context starts in under 3 seconds on my machine (Mac 3 Pro), which is alright.

* Gradle build takes about 15 seconds each time. I would expect less then 3 seconds on subsequent runs.
* Gradle configuration phase takes around 3 sec, from which 90% takes Sentry.
* `dependencyResolution` phase took 4-7 seconds. I've fixed it around 1 sec with https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/222#issuecomment-411005109

* Task `kaptTestKotlin` takes at least 1.5 seconds and misses cache every time. Consider upgrade to KSP and to Kotlin 2.0. I excluded `build-info.properties` that causes cache miss through Gradle Cache normalization, but exclusion doesn't seem to work consistently. Is `Spring.buildInfo()` call important in this project or is just a leftover?
* `backend/data/build/resources/main/sentry-debug-meta.properties` causes cache miss every time as well, adding 0.5 sec. I couldn’t exclude this file from Gradle Cache hit computation using the same normalisation config.

* Sometimes build (without clean) takes 1min. Not sure if this issue happens during normal development as well, but I reckon it does, making negative impact on developers experience.

* The log output is heavily polluted (e.g. by Hibernate queries dump). It affects execution performance, though currently the impact shouldn't be very high.

For further performance boost consider dropping Sentry altogether :) I didn't find simple solution of how to speed up its build, and the tool itself seems to be build-heavy. Never have used it, though, maybe it it vital.