### PR TITLE
fix: Set outdated flag in resolvable import

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -4,7 +4,6 @@ import io.tolgee.development.testDataBuilder.data.ResolvableImportTestData
 import io.tolgee.fixtures.MachineTranslationTest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
-import io.tolgee.model.enums.TranslationState
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -45,8 +44,6 @@ class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
       keyService.get(testData.projectBuilder.self.id, keyName, null)
         .getLangTranslation(testData.secondLanguage)
     Assertions.assertThat(translation.outdated).isTrue
-
-    Assertions.assertThat(translation.state).isEqualTo(TranslationState.TRANSLATED)
   }
 
   private fun assertThatKeyAutoTranslated(keyName: String) {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -5,15 +5,19 @@ import io.tolgee.fixtures.MachineTranslationTest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.enums.TranslationState
+import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.test.annotation.DirtiesContext
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@ContextRecreatingTest
 class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
   companion object {
     private const val INITIAL_BUCKET_CREDITS = 150000L
-    private const val TRANSLATED_WITH_GOOGLE_RESPONSE = "Translated with Google"
+    private const val TRANSLATED_WITH_GOOGLE_RESPONSE = "changed translated with GOOGLE from en to de"
   }
 
   lateinit var testData: ResolvableImportTestData
@@ -21,7 +25,7 @@ class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
   @BeforeEach
   fun setup() {
     testData = ResolvableImportTestData()
-    initMachineTranslationMocks(1_000)
+    initMachineTranslationMocks()
     initMachineTranslationProperties(INITIAL_BUCKET_CREDITS)
     this.projectSupplier = { testData.projectBuilder.self }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -5,15 +5,11 @@ import io.tolgee.fixtures.MachineTranslationTest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.enums.TranslationState
-import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.test.annotation.DirtiesContext
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@ContextRecreatingTest
 class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
   companion object {
     private const val INITIAL_BUCKET_CREDITS = 150000L

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -5,19 +5,11 @@ import io.tolgee.fixtures.MachineTranslationTest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.enums.TranslationState
-import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@ContextRecreatingTest
 class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
   companion object {
     private const val INITIAL_BUCKET_CREDITS = 150000L

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -1,0 +1,97 @@
+package io.tolgee.api.v2.controllers.v2KeyController
+
+import io.tolgee.development.testDataBuilder.data.ResolvableImportTestData
+import io.tolgee.fixtures.MachineTranslationTest
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@ContextRecreatingTest
+class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
+  companion object {
+    private const val INITIAL_BUCKET_CREDITS = 150000L
+    private const val TRANSLATED_WITH_GOOGLE_RESPONSE = "Translated with Google"
+  }
+
+  lateinit var testData: ResolvableImportTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = ResolvableImportTestData()
+    initMachineTranslationMocks(1_000)
+    initMachineTranslationProperties(INITIAL_BUCKET_CREDITS)
+    this.projectSupplier = { testData.projectBuilder.self }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `auto translates on import`() {
+    val keyName = "test"
+    saveTestData()
+    doImport(keyName)
+    assertThatKeyAutoTranslated(keyName)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `sets outdated flag on base changed`() {
+    val keyName = "keyWith2Translations"
+    saveTestData()
+    doImport(keyName)
+    val flag =
+      keyService.get(testData.projectBuilder.self.id, keyName, null)
+        .getLangTranslation(testData.secondLanguage).outdated
+    Assertions.assertThat(flag).isTrue
+  }
+
+  private fun assertThatKeyAutoTranslated(keyName: String) {
+    waitForNotThrowing(timeout = 3_000) {
+      transactionTemplate.execute {
+        val translatedText =
+          keyService.get(testData.projectBuilder.self.id, keyName, null)
+            .getLangTranslation(testData.secondLanguage).text
+
+        Assertions.assertThat(
+          translatedText,
+        ).isEqualTo(TRANSLATED_WITH_GOOGLE_RESPONSE)
+      }
+    }
+  }
+
+  fun saveTestData() {
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+  }
+
+  fun doImport(keyName: String) {
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to keyName,
+              "translations" to
+                mapOf(
+                  "en" to
+                    mapOf(
+                      "text" to "changed",
+                      "resolution" to "OVERRIDE",
+                    ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportAutomationsTest.kt
@@ -4,6 +4,7 @@ import io.tolgee.development.testDataBuilder.data.ResolvableImportTestData
 import io.tolgee.fixtures.MachineTranslationTest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.model.enums.TranslationState
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.assertj.core.api.Assertions
@@ -48,10 +49,12 @@ class KeyControllerResolvableImportAutomationsTest : MachineTranslationTest() {
     val keyName = "keyWith2Translations"
     saveTestData()
     doImport(keyName)
-    val flag =
+    val translation =
       keyService.get(testData.projectBuilder.self.id, keyName, null)
-        .getLangTranslation(testData.secondLanguage).outdated
-    Assertions.assertThat(flag).isTrue
+        .getLangTranslation(testData.secondLanguage)
+    Assertions.assertThat(translation.outdated).isTrue
+
+    Assertions.assertThat(translation.state).isEqualTo(TranslationState.TRANSLATED)
   }
 
   private fun assertThatKeyAutoTranslated(keyName: String) {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
@@ -1,5 +1,6 @@
 package io.tolgee.development.testDataBuilder.data
 
+import io.tolgee.model.Language
 import io.tolgee.model.Screenshot
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.Scope
@@ -11,10 +12,11 @@ class ResolvableImportTestData : BaseTestData() {
   lateinit var viewOnlyUser: UserAccount
   lateinit var keyCreateOnlyUser: UserAccount
   lateinit var translateOnlyUser: UserAccount
+  lateinit var secondLanguage: Language
 
   init {
     projectBuilder.apply {
-      addGerman()
+      secondLanguage = addGerman().self
 
       addKey("namespace-1", "key-1") {
         addTranslation("de", "existing translation")
@@ -34,6 +36,22 @@ class ResolvableImportTestData : BaseTestData() {
       }
       addKey("test") {
         addTranslation("en", "existing translation")
+      }
+
+      addKey("keyWith2Translations") {
+        addTranslation("en", "existing translation")
+        addTranslation {
+          this.language = secondLanguage
+          this.text = "existing translation"
+          this.outdated = false
+        }
+      }
+
+      addAutoTranslationConfig {
+        usingTm = true
+        usingPrimaryMtService = true
+        enableForImport = true
+        targetLanguage = secondLanguage
       }
     }
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
@@ -4,6 +4,7 @@ import io.tolgee.model.Language
 import io.tolgee.model.Screenshot
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.Scope
+import io.tolgee.model.enums.TranslationState
 
 class ResolvableImportTestData : BaseTestData() {
   lateinit var key1and2Screenshot: Screenshot
@@ -44,6 +45,7 @@ class ResolvableImportTestData : BaseTestData() {
           this.language = secondLanguage
           this.text = "existing translation"
           this.outdated = false
+          this.state = TranslationState.REVIEWED
         }
       }
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -153,22 +153,6 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
 
   @Query(
     """
-    update Translation t
-    set t.state = TranslationState.TRANSLATED
-    where t.id in (
-      select t.id
-      from Translation t
-      join t.key k on k.id in :keyIds
-      join k.project p
-      where t.language.id <> p.baseLanguage.id and t.state = TranslationState.REVIEWED
-    )
-  """,
-  )
-  @Modifying
-  fun setUnreviewState(keyIds: List<Long>)
-
-  @Query(
-    """
     from Translation t
     join t.language l on l.tag in :languageTags
     where t.key.id in :keys

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -153,6 +153,22 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
 
   @Query(
     """
+    update Translation t
+    set t.state = TranslationState.TRANSLATED
+    where t.id in (
+      select t.id
+      from Translation t
+      join t.key k on k.id in :keyIds
+      join k.project p
+      where t.language.id <> p.baseLanguage.id and t.state = TranslationState.REVIEWED
+    )
+  """,
+  )
+  @Modifying
+  fun setUnreviewState(keyIds: List<Long>)
+
+  @Query(
+    """
     from Translation t
     join t.language l on l.tag in :languageTags
     where t.key.id in :keys

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -49,7 +49,7 @@ class ResolvingKeyImporter(
   private var importedKeys: List<Key> = emptyList()
   private val updatedTranslationIds = mutableListOf<Long>()
   private val isPluralChangedForKeys = mutableMapOf<Long, String>()
-  private val outdatedFlagKeys: MutableList<Long> = mutableListOf()
+  private val outdatedKeys: MutableList<Long> = mutableListOf()
 
   operator fun invoke(): KeyImportResolvableResult {
     importedKeys = tryImport()
@@ -83,7 +83,7 @@ class ResolvingKeyImporter(
 
           if (language.base) {
             if (isNew || existingTranslation?.text != resolvable.text) {
-              outdatedFlagKeys.add(key.id)
+              outdatedKeys.add(key.id)
             }
           }
 
@@ -146,7 +146,8 @@ class ResolvingKeyImporter(
   }
 
   private fun List<TranslationToModify>.save() {
-    translationService.setOutdatedBatch(outdatedFlagKeys)
+    translationService.setOutdatedBatch(outdatedKeys)
+    translationService.setUnreviewedStateBatch(outdatedKeys)
 
     this.forEach {
       translationService.setTranslation(it.translation, it.text)

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -147,7 +147,6 @@ class ResolvingKeyImporter(
 
   private fun List<TranslationToModify>.save() {
     translationService.setOutdatedBatch(outdatedKeys)
-    translationService.setUnreviewedStateBatch(outdatedKeys)
 
     this.forEach {
       translationService.setTranslation(it.translation, it.text)

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -8,12 +8,7 @@ import io.tolgee.dtos.request.translation.TranslationFilters
 import io.tolgee.events.OnTranslationsSet
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
-import io.tolgee.formats.PluralForms
-import io.tolgee.formats.StringIsNotPluralException
-import io.tolgee.formats.convertToIcuPlural
-import io.tolgee.formats.getPluralForms
-import io.tolgee.formats.normalizePlurals
-import io.tolgee.formats.optimizePluralForms
+import io.tolgee.formats.*
 import io.tolgee.helpers.TextHelper
 import io.tolgee.model.ILanguage
 import io.tolgee.model.Language
@@ -396,6 +391,10 @@ class TranslationService(
 
   fun setOutdatedBatch(keyIds: List<Long>) {
     translationRepository.setOutdated(keyIds)
+  }
+
+  fun setUnreviewedStateBatch(keyIds: List<Long>) {
+    translationRepository.setUnreviewState(keyIds)
   }
 
   fun get(keyLanguagesMap: Map<Key, List<LanguageDto>>): List<Translation> {

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -393,10 +393,6 @@ class TranslationService(
     translationRepository.setOutdated(keyIds)
   }
 
-  fun setUnreviewedStateBatch(keyIds: List<Long>) {
-    translationRepository.setUnreviewState(keyIds)
-  }
-
   fun get(keyLanguagesMap: Map<Key, List<LanguageDto>>): List<Translation> {
     val cb = entityManager.criteriaBuilder
     val query = cb.createQuery(Translation::class.java)


### PR DESCRIPTION
- Update the translation state when the base is changed upon import from Figma.
- Test the new behavior.
Also, I discovered that there is no problem with autotranslation of keys upon Figma imports.