### PR TITLE
fix: ICU plural-case handling during Machine-Translation

### DIFF
--- a/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
@@ -49,15 +49,21 @@ class MtBatchTranslatorTest {
         ),
       ).first()
 
-    translated.translatedText.assert.isEqualTo(
+    assertSameLines(
+      translated.translatedText ?: "",
       "{value, plural,\n" +
-        "one {Jeden pes}\n" +
+        "=0 {žádný pes..!}\n" +
+        "=1 {Jeden pes..!}\n" +
+        "=13 {'#' psa}\n" +
+        "zero {žádný pes..?}\n" +
+        "one {Jeden pes..?}\n" +
         "few {'#' psi}\n" +
         "many {'#' psa}\n" +
         "other {'#' psů}\n" +
         "}",
     )
-    translated.actualPrice.assert.isEqualTo(400)
+
+    translated.actualPrice.assert.isEqualTo(100)
   }
 
   @Test
@@ -80,15 +86,32 @@ class MtBatchTranslatorTest {
         ),
       ).first()
 
-    translated.translatedText.assert.isEqualTo(
+    assertSameLines(
+      translated.translatedText ?: "",
       "{value, plural,\n" +
-        "one {Jeden pes}\n" +
+        "=0 {žádný pes..!}\n" +
+        "=1 {Jeden pes..!}\n" +
+        "=13 {'#' psa}\n" +
+        "zero {žádný pes..?}\n" +
+        "one {Jeden pes..?}\n" +
         "few {'#' psi}\n" +
         "many {'#' psa}\n" +
         "other {'#' psů}\n" +
         "}",
     )
+
     translated.actualPrice.assert.isEqualTo(100)
+  }
+
+  private fun assertSameLines(
+    txt1: String,
+    txt2: String,
+  ) {
+    val out1 = txt1.split("\n")
+    val out2 = txt2.split("\n")
+
+    // we are not picky about the order
+    out1.toSortedSet().assert.isEqualTo(out2.toSortedSet())
   }
 
   private fun prepareValidKey() {
@@ -98,7 +121,7 @@ class MtBatchTranslatorTest {
         name = "key",
         namespace = "test",
         description = "test",
-        baseTranslation = "{value, plural, one {# dog} other {# dogs}}",
+        baseTranslation = "{value, plural, =0 {No dog..!} zero {No dog..?} one {# dog} other {# dogs}}",
         isPlural = true,
       )
   }
@@ -110,7 +133,11 @@ class MtBatchTranslatorTest {
           translatedText = null,
           translatedPluralForms =
             mapOf(
-              "one" to "Jeden pes",
+              "=0" to "žádný pes..!",
+              "=1" to "Jeden pes..!",
+              "=13" to "# psa",
+              "zero" to "žádný pes..?",
+              "one" to "Jeden pes..?",
               "few" to "# psi",
               "many" to "# psa",
               "other" to "# psů",
@@ -125,7 +152,27 @@ class MtBatchTranslatorTest {
     mtServiceManagerResults =
       listOf(
         TranslateResult(
-          translatedText = "Jeden pes",
+          translatedText = "žádný pes..!",
+          actualPrice = 100,
+          usedService = MtServiceType.GOOGLE,
+        ),
+        TranslateResult(
+          translatedText = "Jeden pes..!",
+          actualPrice = 100,
+          usedService = MtServiceType.GOOGLE,
+        ),
+        TranslateResult(
+          translatedText = "<x id=\"tolgee-number\">13</x> psů",
+          actualPrice = 100,
+          usedService = MtServiceType.GOOGLE,
+        ),
+        TranslateResult(
+          translatedText = "žádný pes..?",
+          actualPrice = 100,
+          usedService = MtServiceType.GOOGLE,
+        ),
+        TranslateResult(
+          translatedText = "Jeden pes..?",
           actualPrice = 100,
           usedService = MtServiceType.GOOGLE,
         ),


### PR DESCRIPTION
# ICU plural element mishandling explicit case values during translation
When submitting ICU to the machine-translation, it will correctly handle plural-cases 'one' and 'other', but not explicit value cases like '=1' and '=0'

```
Input A: {productCount,plural,one{You have one product.}other{You have # products.}}
Input B: {productCount,plural,=1{You have one product.}other{You have # products.}}

Output A: {productCount,plural,one{You have one product.}other{You have # products.}}
Output B: {productCount,plural,one{You have 1 products.}other{You have # products.}}
```

- `Output B` outputs case 'one' for input case '=1'
- `Output B` uses the value of case 'other' instead of the value of case '=1', and therefore yields **'1 products'**, which is grammatically incorrect. 


# Machine translation
As the ICU text is correctly stored in the database, and correctly shown in the web-interface, but is corrupted during the machine-translation, there must be a text-transformation just prior to making the call to the translation-provider.

During machine-translation, the following queries are sent to the provider.
```
Input A: {productCount,plural,one{You have one product.}other{You have # products.}}
  Translate case 'one':   You have one product.
  Translate case 'other': You have <x id="tolgee-number">10</x> products.

Input B: {productCount,plural,=1{You have one product.}other{You have # products.}}
  Translate case '=1':    You have <x id="tolgee-number">1</x> products.
  Translate case 'other': You have <x id="tolgee-number">10</x> products.

```

# Bug
The reason this is happening is that Tolgee rewrites plural-case '=1' to 'one' (similarly, it maps '=0' to 'zero'), and then tries to find 'one' in the original plural-element, which does not exist, as the plural-element contains the '=1' case. This causes it to fallback to the 'other' case.

# Solution
Besides looking for the 'one' case, we should also look for the '=1' plural-case when doing the lookup.