### PR TITLE
fix: single-step-import lack of auto-translation

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/StoredDataImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/StoredDataImporter.kt
@@ -100,7 +100,7 @@ class StoredDataImporter(
     result
   }
 
-  fun doImport() {
+  fun doImport() : Collection<Key> {
     reportStatus(ImportApplicationStatus.PREPARING_AND_VALIDATING)
     importDataManager.storedLanguages.forEach {
       it.prepareImport()
@@ -136,6 +136,8 @@ class StoredDataImporter(
     deleteOtherKeys()
 
     entityManager.flushAndClear()
+
+    return keyEntitiesToSave
   }
 
   private fun tagNewKeys() {


### PR DESCRIPTION
# Issue
The auto-translation step is not executed after single-step-import, when the project is configured to have auto-translation executed on import.

# Solution
The PR is functional, but may not be in line with the event triggering/handling of Tolgee.
It may be possible that this PR can be boiled down to 1 line: firing the correct Event.