### PR TITLE
fix: Content delivery configured check & docs

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ConfigurationController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ConfigurationController.kt
@@ -26,7 +26,7 @@ class ConfigurationController
     private val applicationContext: ApplicationContext,
     private val publicBillingConfProvider: PublicBillingConfProvider,
     private val versionProvider: VersionProvider,
-    private val CDFileStorageProvider: ContentDeliveryFileStorageProvider,
+    private val cdFileStorageProvider: ContentDeliveryFileStorageProvider,
   ) : IController {
     @GetMapping(value = ["configuration"])
     @Operation(summary = "Get server configuration")
@@ -41,7 +41,7 @@ class ConfigurationController
         machineTranslationServices = machineTranslationServices,
         billing = publicBillingConfProvider(),
         versionProvider.version,
-        contentDeliveryEnabled = CDFileStorageProvider.isServerContentDeliveryConfigured(),
+        contentDeliveryEnabled = cdFileStorageProvider.isServerContentDeliveryConfigured(),
       )
     }
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ConfigurationController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ConfigurationController.kt
@@ -2,6 +2,7 @@ package io.tolgee.api.v2.controllers
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.component.contentDelivery.ContentDeliveryFileStorageProvider
 import io.tolgee.component.publicBillingConfProvider.PublicBillingConfProvider
 import io.tolgee.configuration.PublicConfigurationDTO
 import io.tolgee.configuration.tolgee.TolgeeProperties
@@ -25,6 +26,7 @@ class ConfigurationController
     private val applicationContext: ApplicationContext,
     private val publicBillingConfProvider: PublicBillingConfProvider,
     private val versionProvider: VersionProvider,
+    private val CDFileStorageProvider: ContentDeliveryFileStorageProvider,
   ) : IController {
     @GetMapping(value = ["configuration"])
     @Operation(summary = "Get server configuration")
@@ -39,6 +41,7 @@ class ConfigurationController
         machineTranslationServices = machineTranslationServices,
         billing = publicBillingConfProvider(),
         versionProvider.version,
+        contentDeliveryEnabled = CDFileStorageProvider.isServerContentDeliveryConfigured(),
       )
     }
 

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/PublicConfigurationDTO.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/PublicConfigurationDTO.kt
@@ -8,10 +8,12 @@ import io.tolgee.dtos.response.PublicBillingConfigurationDTO
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 class PublicConfigurationDTO(
-  @Schema(hidden = true) properties: TolgeeProperties,
+  @Schema(hidden = true)
+  val properties: TolgeeProperties,
   val machineTranslationServices: MtServicesDTO,
   val billing: PublicBillingConfigurationDTO,
   val version: String,
+  contentDeliveryEnabled: Boolean,
 ) {
   val authentication: Boolean = properties.authentication.enabled
   var authMethods: AuthMethodsDTO? = null
@@ -32,7 +34,8 @@ class PublicConfigurationDTO(
   val ga4Tag = properties.ga4Tag
   val postHogApiKey: String? = properties.postHog.apiKey
   val postHogHost: String? = properties.postHog.host
-  val contentDeliveryConfigured: Boolean = properties.contentDelivery.publicUrlPrefix != null
+  val contentDeliveryConfigured: Boolean = contentDeliveryEnabled
+
   val userSourceField: Boolean = properties.userSourceField
   val slack: SlackDTO =
     SlackDTO(
@@ -93,5 +96,10 @@ class PublicConfigurationDTO(
     }
     passwordResettable = properties.authentication.nativeEnabled
     allowRegistrations = properties.authentication.registrationsAllowed
+  }
+
+  private fun isContentDeliveryEnabled(): Boolean {
+    return properties.contentDelivery.publicUrlPrefix != null &&
+      properties.contentDelivery.storage.s3.enabled
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryFileStorageProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryFileStorageProvider.kt
@@ -46,7 +46,7 @@ class ContentDeliveryFileStorageProvider(
       (tolgeeProperties.contentDelivery.storage.s3.enabled) xor (tolgeeProperties.contentDelivery.storage.azure.enabled)
 
     if (!isSingleSet) {
-      throw RuntimeException("Exactly one content storage must be set")
+      throw RuntimeException("You have to configure exactly one content storage via configuration properties")
     }
 
     if (tolgeeProperties.contentDelivery.storage.s3.enabled) {
@@ -58,6 +58,19 @@ class ContentDeliveryFileStorageProvider(
     }
 
     throw RuntimeException("No Content Storage is set")
+  }
+
+  fun isServerContentDeliveryConfigured(): Boolean {
+    if (tolgeeProperties.contentDelivery.publicUrlPrefix.isNullOrEmpty()) {
+      return false
+    }
+
+    return try {
+      getDefaultStorageProperties()
+      true
+    } catch (e: Throwable) {
+      false
+    }
   }
 
   private fun bypassForTesting(): FileStorage? {

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/ContentDeliveryProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/ContentDeliveryProperties.kt
@@ -8,7 +8,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties
   displayName = "Content Delivery",
   description =
     "These properties are used to configure " +
-      "default server content delivery storage.",
+      "default server content delivery storage." +
+      "\n \n" +
+      "To get content delivery working, " +
+      "you have to configure the Storage (e.g. S3 or Blob).",
 )
 class ContentDeliveryProperties {
   @DocProperty(
@@ -22,6 +25,7 @@ class ContentDeliveryProperties {
   var storage: ContentStorageProperties = ContentStorageProperties()
 
   @DocProperty(
+    displayName = "Cache purging",
     description =
       "Several services can be used as cache. Tolgee is able to purge the cache when " +
         "new files are published when this configuration is set.",


### PR DESCRIPTION
- Checks storage is configured to show CD options in the UI
- Noted that CD storage needs to be configured in the docs