### PR TITLE
fix: only show api keys from non-deleted projects

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/repository/ApiKeyRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ApiKeyRepository.kt
@@ -34,6 +34,7 @@ interface ApiKeyRepository : JpaRepository<ApiKey, Long> {
     left join ak.userAccount u
     where u.id = :userAccountId 
     and (p.id = :filterProjectId or :filterProjectId is null)
+    and p.deletedAt is null
   """,
   )
   fun getAllByUserAccount(


### PR DESCRIPTION
Fixes #2571