### PR TITLE
feat: import resolvable force override

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportTest.kt
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.development.testDataBuilder.data.ResolvableImportTestData
 import io.tolgee.dtos.request.ImageUploadInfoDto
-import io.tolgee.fixtures.andAssertThatJson
-import io.tolgee.fixtures.andIsBadRequest
-import io.tolgee.fixtures.andIsForbidden
-import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.node
+import io.tolgee.fixtures.*
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
 import io.tolgee.util.generateImage
@@ -38,17 +34,19 @@ class KeyControllerResolvableImportTest : ProjectAuthControllerTest("/v2/project
     projectSupplier = { testData.projectBuilder.self }
     userAccount = testData.user
     uploadedImageId =
-      imageUploadService.store(
-        generateImage(),
-        userAccount!!,
-        ImageUploadInfoDto(location = "My cool frame"),
-      ).id
+      imageUploadService
+        .store(
+          generateImage(),
+          userAccount!!,
+          ImageUploadInfoDto(location = "My cool frame"),
+        ).id
     uploadedImageId2 =
-      imageUploadService.store(
-        generateImage(),
-        testData.viewOnlyUser,
-        ImageUploadInfoDto(location = "My cool frame"),
-      ).id
+      imageUploadService
+        .store(
+          generateImage(),
+          testData.viewOnlyUser,
+          ImageUploadInfoDto(location = "My cool frame"),
+        ).id
   }
 
   @Test
@@ -364,19 +362,69 @@ class KeyControllerResolvableImportTest : ProjectAuthControllerTest("/v2/project
     ).andIsOk
   }
 
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `option force-override works`() {
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "key-1",
+              "namespace" to "namespace-1",
+              "translations" to
+                mapOf(
+                  "de" to
+                    mapOf(
+                      "text" to "new",
+                      "resolution" to "FORCE_OVERRIDE",
+                    ),
+                  "en" to
+                    mapOf(
+                      "text" to "new",
+                      "resolution" to "FORCE_OVERRIDE",
+                    ),
+                ),
+            ),
+            mapOf(
+              "name" to "key-2",
+              "namespace" to "namespace-1",
+              "translations" to
+                mapOf(
+                  "en" to
+                    mapOf(
+                      "text" to "existing translation",
+                      "resolution" to "FORCE_OVERRIDE",
+                    ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      assertTranslationText("namespace-1", "key-1", "de", "new")
+      assertTranslationText("namespace-1", "key-1", "en", "new")
+      assertTranslationText("namespace-1", "key-2", "en", "existing translation")
+    }
+  }
+
   fun assertTranslationText(
     namespace: String?,
     keyName: String,
     languageTag: String,
     expectedText: String,
   ) {
-    projectService.get(testData.projectBuilder.self.id)
+    projectService
+      .get(testData.projectBuilder.self.id)
       .keys
       .find { it.name == keyName && it.namespace?.name == namespace }!!
       .translations
       .find { it.language.tag == languageTag }!!
       .text
-      .assert.isEqualTo(
+      .assert
+      .isEqualTo(
         expectedText,
       )
   }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/importKeysResolvable/ImportTranslationResolution.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/importKeysResolvable/ImportTranslationResolution.kt
@@ -4,4 +4,5 @@ enum class ImportTranslationResolution {
   KEEP,
   OVERRIDE,
   NEW,
+  FORCE_OVERRIDE,
 }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/importKeysResolvable/ImportTranslationResolvableDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/importKeysResolvable/ImportTranslationResolvableDto.kt
@@ -13,7 +13,8 @@ class ImportTranslationResolvableDto(
 
 - KEEP: Translation is not changed
 - OVERRIDE: Translation is overridden
-- NEW: New translation is created)
+- NEW: New translation is created
+- FORCE_OVERRIDE: Translation is updated, created or kept.
 """,
     example = "OVERRIDE",
   )


### PR DESCRIPTION
I added new option `force-override` to import resolvable endpoint. It should forcefully update/create/keeps the translation to the new value. Also I wrote unit test. 