### PR TITLE
Add Intellij run configurations for localhost development

### DIFF
--- a/.run/Backend localhost.run.xml
+++ b/.run/Backend localhost.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Backend localhost" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+    <option name="ACTIVE_PROFILES" value="dev" />
+    <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources" />
+    <module name="tolgee-platform.server-app.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.tolgee.Application" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Frontend localhost.run.xml
+++ b/.run/Frontend localhost.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Frontend localhost" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/webapp/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
Having the Intellij run configurations for local development ready to use would be easier than following a step-by-step manual.