### PR TITLE
fix: redirect to /login on failed Google OAuth login

### DIFF
--- a/webapp/src/component/security/Login/OAuthRedirectionHandler.tsx
+++ b/webapp/src/component/security/Login/OAuthRedirectionHandler.tsx
@@ -25,6 +25,12 @@ export const OAuthRedirectionHandler: FunctionComponent<
   useEffect(() => {
     const url = new URLSearchParams(window.location.search);
     const code = url.get('code');
+    const error = url.get('error');
+
+    if (error === 'access_denied') {
+      history.replace(LINKS.LOGIN.build());
+      return;
+    }
 
     if (match.params[PARAMS.SERVICE_TYPE] == 'oauth2') {
       const state = url.get('state');


### PR DESCRIPTION
Closes #2585 

Resolves issue where denied Google OAuth redirects incorrectly; now forwards users to /login page.