### PR TITLE
chore: Local development setup in readme's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,7 @@ contribute:
 
 ## Running and debugging the project
 
-- Everything you should know is described in
-  the [development wiki](https://github.com/tolgee/tolgee-platform/wiki/Development)
+- Everything you should know is described at the [development page](DEVELOPMENT.md)
 
 # Resources
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,97 @@
+## Install Prerequisites
+
+* [Java 21](https://openjdk.org/install)
+* [Docker](https://docs.docker.com/engine/install)
+* [Node.js 18](https://nodejs.org/en/download) (or higher)
+* [Intellij Idea](https://www.jetbrains.com/help/idea/installation-guide.html) (optional)
+
+## Clone this repo
+
+```shell
+git clone git@github.com:tolgee/tolgee-platform.git
+```
+
+## Run the stack
+
+1. Run backend
+   * With the prepared Idea run configuration `Backend localhost`
+   * With command line:
+     ```shell
+     ./gradlew server-app:bootRun --args='--spring.profiles.active=dev'
+     ```
+2. Run frontend
+   * With the prepared Idea run configuration `Frontend localhost`
+   * With command line:
+     ```shell
+     cd webapp && npm ci && npm run start
+     ```
+3. Open your browser and go to http://localhost:3000.
+
+## Testing
+
+The backend of Tolgee is tested with unit and integration tests.
+
+### Backend testing
+
+To run backend tests, you can run Gradle test task
+
+```shell
+./gradlew test
+```
+
+Or you can select any integration test the code and run it via Idea CE or Idea Ultimate.
+It should just work out of the box.
+
+### E2E testing
+
+Follow the steps in the [E2E readme](e2e/README.md).
+
+## Backend configuration
+
+To configure Tolgee, create an empty file `backend/app/src/main/resources/application-dev.yaml`.
+In this file, you can override default configuration properties.
+You can check `application-e2e.yaml` for inspiration.
+To learn more about externalized configuration in Spring boot, read [the docs](https://docs.spring.io/spring-boot/docs/2.1.8.RELEASE/reference/html/boot-features-external-config.html).
+
+Since we set the active profile to `dev`, Spring uses the `application-dev.yaml` configuration file.
+
+## Updating the database changelog
+
+Tolgee uses Liquibase to handle the database migration. The migrations are run on every app startup. To update the changelog, run:
+
+```shell
+./gradlew diffChangeLog
+```
+
+### Troubleshooting updating the changelog
+
+If you misspell the command and run diffChangelog, it will find the command, but it would fail, since liquibase changed the command name in the past.
+We have enhanced the diffChangeLog (with capital L) command, so you have to run that.
+
+Sometimes, Gradle cannot find a docker command to start the database instance to generate the changelog against.
+This happens due to some issue with setting the paths for Gradle daemon.
+Running the command without daemon fixes the issue:
+```shell
+./gradlew diffChangeLog --no-daemon
+```
+
+## Static analysis
+
+For the frontend, there are npm tasks `prettier` and `eslint`, which you should run before every commit.
+Otherwise, the "Frontend static check" workflow will fail.
+You can also use prettier plugins for VS Code, Idea, or WebStorm.
+
+To fix prettier issues and check everything is fine, run these commands:
+
+```shell
+cd webapp
+npm run prettier
+npm run tsc
+npm run eslint
+```
+
+On the backend, there is Gradle task `ktlintFormat`, which helps you to format Kotlin code.
+
+```shell
+./gradlew ktlintFormat
+```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Join Tolgee Community [Tolgee Slack Community <img src="https://img.shields.io/b
   - [More...](https://tolgee.io/integrations/all)
 - [Tolgee platform docs](https://tolgee.io/docs/platform)
   - [Self-hosting](https://tolgee.io/docs/platform/self_hosting/running_with_docker)
-- [Development notes (How to develop Tolgee locally)](https://github.com/tolgee/tolgee-platform/wiki/Development)
+- [How to develop Tolgee locally](DEVELOPMENT.md)
 
 ## Why use Tolgee?
 
@@ -145,6 +145,10 @@ For more detailed documentation about Tolgee, visit [tolgee.io](https://tolgee.i
 4. Have fun!
 
 ![Integration guides](https://user-images.githubusercontent.com/18496315/188818166-d70d4676-7bd2-4328-91eb-720add935ab6.gif)
+
+## How to contribute
+
+You wanna contribute? Great to hear that! You can start [right away](CONTRIBUTING.md)!
 
 ## Contributors
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,41 @@
+# E2E tests
+
+UI and its interaction with the backend are tested using E2E (end-to-end) cypress tests.
+
+## Running the E2E tests
+
+To just run it, you can execute the runE2e Gradle task. This command runs a complex task, which installs all dependencies and runs everything it needs.
+
+```shell
+./gradlew runE2e
+```
+
+## Step-by-step run
+
+1. Prepare the environment by the [development guide](DEVELOPMENT.md)
+2. Install dependencies
+   ```shell
+   cd e2e && npm i
+   ```
+
+3. Run the tested environment
+   ```shell
+   # Run frontend with E2E settings
+   ./gradlew runWebAppNpmStartE2eDev
+   # Run the E2E Docker services (like fake SMTP server)
+   ./gradlew runDockerE2eDev
+   # Run backend with e2e profile
+   ./gradlew server-app:bootRun --args='--spring.profiles.active=e2e'
+   # You can also do this by running the application with the E2e profile using Idea CE or Ultimate.
+   # Then you will be also able to debug the backend and hotswap classes while running the tests, which can be pretty useful.
+   ```
+
+4. Run the tests
+   ```shell
+   ./gradlew openE2eDev
+   ```
+
+5. Stop the environment when done
+   ```shell
+   ./gradlew stopDockerE2e
+   ```


### PR DESCRIPTION
Hi guys,

I was heaving a creative mind on Sunday, so I created pages for setting up the development environment right in the code, instead of wiki, to be easily editable by everyone and openable also from IDE.

It also adds the play-buttons to the scripts and run configurations in Idea to be clickable:

![image](https://github.com/user-attachments/assets/d77ca81b-6f35-4dff-a630-80ed48dee7e4)

Have a nice day!