### PR TITLE
chore: Do not depend on Spring test library as implementation in backend

### DIFF
--- a/backend/data/build.gradle
+++ b/backend/data/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation("org.springframework.data:spring-data-envers")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation 'org.springframework.boot:spring-boot-starter-mail'
-    implementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
     kapt "org.springframework.boot:spring-boot-configuration-processor"
     implementation "org.springframework.boot:spring-boot-configuration-processor"
     implementation "org.springframework.boot:spring-boot-starter-batch"
@@ -159,9 +159,7 @@ dependencies {
     implementation 'net.datafaker:datafaker:1.5.0'
     implementation 'jaxen:jaxen:1.2.0'
     implementation libs.sendInBlue
-    implementation(libs.mailjet) {
-        exclude group: 'org.json', module: 'json'
-    }
+    implementation(libs.mailjet)
     implementation libs.hibernateTypes
     liquibaseRuntime libs.hibernateTypes
     implementation 'com.eatthepath:java-otp:0.4.0'


### PR DESCRIPTION
## Issue

* We are now depending on `spring-boot-starter-test` and its transitive dependency on `org.json` which is from some strange "Android Vaadin" lib.

## Proposed solution

* Depend on the test lib only in tests.
* Use the `org.json` package from Mailjet which uses it as an interface.