### PR TITLE
chore: Make the default `gradle test` passing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,14 @@ project(':server-app').afterEvaluate {
     }
 }
 
+// Tests of `ee-test` collide with tests of `server-app`, therefore we run them sequentially.
+// It would be great to make the tests not collide and therefore this block of code can be deleted.
+gradle.projectsEvaluated {
+    project(':server-app').tasks.withType(Test) {
+        dependsOn project(':ee-test').tasks.withType(Test)
+    }
+}
+
 ktlint {
     debug = true
     verbose = true


### PR DESCRIPTION
Instead of running multiple gradle jobs sequentially