### PR TITLE
fix: Healthcheck of docker image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -28,4 +28,4 @@ CMD ["java", "-cp", "app:app/lib/*", "io.tolgee.Application"]
 
 # Health check to ensure the app is up and running
 HEALTHCHECK --interval=10s --timeout=3s --retries=20 \
-    CMD curl -f http://127.0.0.1:$HEALTHCHECK_PORT/actuator/health || exit 1
+    CMD wget --spider -q "http://127.0.0.1:$HEALTHCHECK_PORT/actuator/health" || exit 1


### PR DESCRIPTION
We use `wget` because `curl` is not installed on the image.

Originally developed by @vexdev in #2676, thank you for that!

Closes #2675.

![image](https://github.com/user-attachments/assets/bdd7c689-1747-48fa-a59f-104a3851e97e)