### PR TITLE
fix: Absolute address for pricing link

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/MachineTranslationProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/MachineTranslationProperties.kt
@@ -18,7 +18,7 @@ open class MachineTranslationProperties(
   @DocProperty(
     description =
       "Amount of machine translations users of the Free tier can request per month. " +
-        "Used by Tolgee Cloud, see [pricing](/pricing). Set to `-1` to disable credit-based limitation.",
+        "Used by Tolgee Cloud, see [pricing](https://tolgee.io/pricing). Set to `-1` to disable credit-based limitation.",
   )
   var freeCreditsAmount: Long = -1,
 )


### PR DESCRIPTION
It was breaking the builds of tolgee/documentation repo:

https://github.com/tolgee/documentation/actions/runs/11912164153/job/33197197488