### PR TITLE
chore: Fix slug conflict in docs

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
@@ -50,7 +50,7 @@ class V2ExportController(
   @Operation(summary = "Export data")
   @RequiresProjectPermissions([Scope.TRANSLATIONS_VIEW])
   @AllowApiAccess
-  fun export(
+  fun exportData(
     @ParameterObject params: ExportParams,
   ): ResponseEntity<StreamingResponseBody> {
     params.languages =
@@ -74,7 +74,7 @@ class V2ExportController(
   fun exportPost(
     @RequestBody params: ExportParams,
   ): ResponseEntity<StreamingResponseBody> {
-    return export(params)
+    return exportData(params)
   }
 
   private fun getZipHeaders(projectName: String): HttpHeaders {


### PR DESCRIPTION
`/export` is now used for both, operation and tag.

Proper fix for tolgee/documentation#756.