### PR TITLE
Use an unlikely-to-be-used port when updating changelog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,10 @@ project(':server-app').afterEvaluate {
 
 
         doFirst {
-            project(':server-app').bootRun.systemProperty('spring.profiles.active', 'dbschema')
+            project(':server-app').bootRun
+                    .systemProperty('spring.profiles.active', 'dbschema')
+                    // Use an unlikely-to-be-used port
+                    .systemProperty('server.port', '61987')
         }
     }
 }


### PR DESCRIPTION
When a developer has a running stack on their machine on the standard port 8080, running the `diffChangeLog` task fails because of a port conflict.

This change uses another port which should be free on most machines in most cases.