### PR TITLE
chore: Define limit of wildcard imports in the editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*.{kt, kts}]
 ktlint_standard_no-wildcard-imports = disabled
 ktlint_standard_filename = disabled
+ij_kotlin_name_count_to_use_star_import = 5
 indent_size = 2
 insert_final_newline = true
 # possible values: number (e.g. 120) (package name, imports & comments are ignored), "off"


### PR DESCRIPTION
Nowadays, our IDEAs may not be consistent and may cause conflicts in imports.

This PR sets the limit to a fixed number to be followed across IDEs.