### PR TITLE
chore: Create test base project with random UUID by default

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/AuthTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/AuthTest.kt
@@ -7,7 +7,6 @@ import io.tolgee.controllers.PublicController
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsUnauthorized
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.mapResponseTo
 import io.tolgee.model.Project
 import io.tolgee.security.authentication.JwtService
@@ -55,7 +54,7 @@ class AuthTest : AbstractControllerTest() {
 
   @BeforeEach
   fun setup() {
-    project = dbPopulator.createBase(generateUniqueString()).project
+    project = dbPopulator.createBase().project
     authMvc = MockMvcBuilders.standaloneSetup(publicController).setControllerAdvice(ExceptionHandlers()).build()
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/StartupImportCommandLineRunnerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/StartupImportCommandLineRunnerTest.kt
@@ -43,7 +43,7 @@ class StartupImportCommandLineRunnerTest : AbstractSpringTest() {
           baseLanguageTag = "de"
         },
       )
-      base = dbPopulator.createBase("labaala", "admin")
+      base = dbPopulator.createBase("admin")
       startupImportCommandLineRunner.run()
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/SlugControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/SlugControllerTest.kt
@@ -34,7 +34,7 @@ class SlugControllerTest : AuthorizedControllerTest() {
       Project(
         name = "aaa",
         slug = "hello-1",
-      ).also { it.organizationOwner = dbPopulator.createBase("proj").organization },
+      ).also { it.organizationOwner = dbPopulator.createBase().organization },
     )
     performAuthGet("/v2/slug/validate-project/hello-1").andIsOk.andAssertThatJson {
       isEqualTo(false)
@@ -82,7 +82,7 @@ class SlugControllerTest : AuthorizedControllerTest() {
       Project(
         name = "aaa",
         slug = "hello-world",
-      ).also { it.organizationOwner = dbPopulator.createBase("proj").organization },
+      ).also { it.organizationOwner = dbPopulator.createBase().organization },
     )
     performAuthPost("/v2/slug/generate-project", GenerateSlugDto("Hello world"))
       .andIsOk.andAssertThatJson {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2InvitationControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2InvitationControllerTest.kt
@@ -31,7 +31,7 @@ class V2InvitationControllerTest : AuthorizedControllerTest() {
 
   @Test
   fun `does not return when has no project permission`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     userAccount = dbPopulator.createUserIfNotExists("pavol")
     performAuthGet("/v2/projects/${project.id}/invitations").andIsNotFound
@@ -39,7 +39,7 @@ class V2InvitationControllerTest : AuthorizedControllerTest() {
 
   @Test
   fun `deletes translate invitation with languages`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     tolgeeProperties.frontEndUrl = "https://dummyUrl.com"
     val invitation = createTranslateInvitation(project)
@@ -51,7 +51,7 @@ class V2InvitationControllerTest : AuthorizedControllerTest() {
 
   @Test
   fun `deletes edit invitation`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
 
     val invitation =
@@ -68,7 +68,7 @@ class V2InvitationControllerTest : AuthorizedControllerTest() {
 
   @Test
   fun `accepts invitation`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     val code =
       invitationService.create(
@@ -87,7 +87,7 @@ class V2InvitationControllerTest : AuthorizedControllerTest() {
 
   @Test
   fun `accepts translate invitation with languages`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     val code =
       invitationService.create(

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2LanguageControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2LanguageControllerTest.kt
@@ -31,7 +31,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun createLanguage() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     createLanguageTestValidation(project.id)
     createLanguageCorrectRequest(project.id)
@@ -39,7 +39,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun editLanguage() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     val en = project.findLanguageOptional("en").orElseThrow { NotFoundException() }
     val languageDTO =
@@ -75,7 +75,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun deleteLanguage() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     val deutsch = project.findLanguageOptional("de").orElseThrow { NotFoundException() }
     performDelete(project.id, deutsch.id).andExpect(MockMvcResultMatchers.status().isOk)
@@ -88,7 +88,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   @ProjectApiKeyAuthTestMethod(scopes = [Scope.LANGUAGES_EDIT])
   fun `deletes language with API key`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     this.userAccount = base.userAccount
     this.projectSupplier = { base.project }
     val deutsch = project.findLanguageOptional("de").orElseThrow { NotFoundException() }
@@ -103,7 +103,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   @ProjectApiKeyAuthTestMethod(scopes = [Scope.TRANSLATIONS_VIEW])
   fun `does not delete language with API key (permissions)`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     this.userAccount = base.userAccount
     this.projectSupplier = { base.project }
     val deutsch = project.findLanguageOptional("de").orElseThrow { NotFoundException() }
@@ -114,7 +114,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun `cannot delete base language`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     executeInNewTransaction {
       val project = projectService.get(base.project.id)
       val en = project.findLanguageOptional("en").orElseThrow { NotFoundException() }
@@ -129,7 +129,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun `automatically sets base language`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     val project =
       executeInNewTransaction {
@@ -152,7 +152,7 @@ class V2LanguageControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun createLanguageTestValidationComa() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     performCreate(
       project.id,

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerAddFilesTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerAddFilesTest.kt
@@ -6,7 +6,6 @@ import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.node
 import io.tolgee.model.Project
 import io.tolgee.model.UserAccount
@@ -74,7 +73,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
   @Test
   fun `it parses zip file stores it for debugging and saves issues`() {
     tolgeeProperties.import.storeFilesForDebugging = true
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
 
     val fileName = "zipOfUnknown.zip"
@@ -87,7 +86,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `doesn't store file for when disabled`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
 
     val fileName = "zipOfUnknown.zip"
@@ -105,7 +104,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it handles po file`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     performImport(projectId = base.project.id, listOf(Pair("example.po", poFile)))
       .andPrettyPrint.andAssertThatJson {
@@ -125,7 +124,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it handles xliff file`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     performImport(projectId = base.project.id, listOf(Pair("example.xliff", xliffFile)))
       .andPrettyPrint.andAssertThatJson {
@@ -135,7 +134,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it returns error when json could not be parsed`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     performImport(projectId = base.project.id, listOf(Pair("error.json", errorJson)))
       .andIsOk.andAssertThatJson {
@@ -147,7 +146,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it throws when more then 100 languages`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     val data = (1..101).map { "simple$it.json" to simpleJson }
 
@@ -175,7 +174,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it imports nested keys with provided delimiter`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
 
     performImport(projectId = base.project.id, listOf("nested.json" to nested), mapOf("structureDelimiter" to ";"))
       .andIsOk
@@ -189,7 +188,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it saves proper data and returns correct response`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
 
     performImport(projectId = base.project.id, listOf(Pair("zipOfJsons.zip", zipOfJsons)))
@@ -201,7 +200,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `it adds a file with long translation text and stores issues`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
     tolgeeProperties.maxTranslationTextLength = 20
 
@@ -224,7 +223,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `gracefully handles missing files part`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
 
     executeInNewTransaction {
@@ -241,7 +240,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `pre-selects namespaces and languages correctly`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
     tolgeeProperties.maxTranslationTextLength = 20
 
@@ -265,7 +264,7 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
 
   @Test
   fun `works fine with Mac generated zip`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     commitTransaction()
     tolgeeProperties.maxTranslationTextLength = 20
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
@@ -35,7 +35,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
 
   @BeforeEach
   fun setup() {
-    val base = dbPopulator.createBase("SomeProject", "user")
+    val base = dbPopulator.createBase("user")
     userAccount = base.userAccount
     createForLanguagesDto =
       CreateProjectRequest(
@@ -62,7 +62,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
 
   @Test
   fun createProject() {
-    dbPopulator.createBase("test")
+    dbPopulator.createBase()
     testCreateValidationSizeShort()
     testCreateValidationSizeLong()
     testCreateCorrectRequest()

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerEditTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerEditTest.kt
@@ -15,7 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest
 class ProjectsControllerEditTest : AuthorizedControllerTest() {
   @Test
   fun `edits project`() {
-    val base = dbPopulator.createBase("What a project")
+    val base = dbPopulator.createBase()
     val content =
       EditProjectRequest(
         name = "new name",
@@ -33,7 +33,7 @@ class ProjectsControllerEditTest : AuthorizedControllerTest() {
 
   @Test
   fun `validates project on edit`() {
-    val base = dbPopulator.createBase("What a project")
+    val base = dbPopulator.createBase()
     val content =
       EditProjectRequest(
         name = "",
@@ -46,7 +46,7 @@ class ProjectsControllerEditTest : AuthorizedControllerTest() {
 
   @Test
   fun `automatically chooses base language`() {
-    val base = dbPopulator.createBase("What a project")
+    val base = dbPopulator.createBase()
     val content =
       EditProjectRequest(
         name = "test",

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerInvitationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerInvitationTest.kt
@@ -14,7 +14,6 @@ import io.tolgee.fixtures.andGetContentAsString
 import io.tolgee.fixtures.andHasErrorMessage
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.node
 import io.tolgee.model.Invitation
 import io.tolgee.model.Permission
@@ -55,7 +54,7 @@ class ProjectsControllerInvitationTest : ProjectAuthControllerTest("/v2/projects
 
   @Test
   fun `returns project invitations`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     tolgeeProperties.frontEndUrl = "https://dummyUrl.com"
     createTranslateInvitation(project)

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
@@ -8,7 +8,6 @@ import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.isPermissionScopes
 import io.tolgee.fixtures.node
 import io.tolgee.model.Permission
@@ -26,8 +25,8 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   fun getAll() {
     executeInNewTransaction {
-      dbPopulator.createBase("one", "kim")
-      dbPopulator.createBase("two", "kim")
+      dbPopulator.createBase("kim")
+      dbPopulator.createBase("kim")
 
       loginAsUser("kim")
 
@@ -126,7 +125,7 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun `get single returns permissions`() {
-    val base = dbPopulator.createBase("one")
+    val base = dbPopulator.createBase()
     userAccount = dbPopulator.createUserIfNotExists("another-user")
     permissionService.create(
       Permission(
@@ -145,7 +144,7 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun getNotPermitted() {
-    val base = dbPopulator.createBase("one")
+    val base = dbPopulator.createBase()
 
     val account = dbPopulator.createUserIfNotExists("peter")
     loginAsUser(account.name)
@@ -248,7 +247,7 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun revokeUsersAccessOwn() {
-    val base = dbPopulator.createBase("base", "jirina")
+    val base = dbPopulator.createBase("jirina")
 
     loginAsUser("jirina")
 
@@ -271,7 +270,7 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   fun deleteProject() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     performAuthDelete("/v2/projects/${base.project.id}", null).andIsOk
     val project = projectService.find(base.project.id)
     Assertions.assertThat(project).isNull()

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ScreenshotController/SecuredKeyScreenshotControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ScreenshotController/SecuredKeyScreenshotControllerTest.kt
@@ -37,7 +37,7 @@ class SecuredKeyScreenshotControllerTest : AbstractV2ScreenshotControllerTest() 
   @Test
   fun getScreenshotFileNoTimestamp() {
     executeInNewTransaction {
-      val base = dbPopulator.createBase(generateUniqueString())
+      val base = dbPopulator.createBase()
       val project = base.project
       val key = keyService.create(project, CreateKeyDto("test"))
       val screenshot = screenshotService.store(screenshotFile, key, null)
@@ -49,7 +49,7 @@ class SecuredKeyScreenshotControllerTest : AbstractV2ScreenshotControllerTest() 
   @Test
   fun getScreenshotFileInvalidTimestamp() {
     executeInNewTransaction {
-      val base = dbPopulator.createBase(generateUniqueString())
+      val base = dbPopulator.createBase()
       val project = base.project
       val key = keyService.create(project, CreateKeyDto("test"))
       val screenshot = screenshotService.store(screenshotFile, key, null)
@@ -73,7 +73,7 @@ class SecuredKeyScreenshotControllerTest : AbstractV2ScreenshotControllerTest() 
   @Test
   fun getScreenshotFile() {
     executeInNewTransaction {
-      val base = dbPopulator.createBase(generateUniqueString())
+      val base = dbPopulator.createBase()
       val project = base.project
       val key = keyService.create(project, CreateKeyDto("test"))
       val screenshot = screenshotService.store(screenshotFile, key, null)

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/ExportControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/ExportControllerTest.kt
@@ -4,7 +4,6 @@ import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.development.testDataBuilder.data.LanguagePermissionsTestData
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.model.Language
 import io.tolgee.model.enums.Scope
 import io.tolgee.testing.annotations.ProjectApiKeyAuthTestMethod
@@ -24,7 +23,7 @@ class ExportControllerTest : ProjectAuthControllerTest() {
   @Transactional
   @ProjectJWTAuthTestMethod
   fun exportZipJson() {
-    val base = dbPopulator.populate(generateUniqueString())
+    val base = dbPopulator.populate()
     commitTransaction()
     projectSupplier = { base.project }
     userAccount = base.userAccount
@@ -45,7 +44,7 @@ class ExportControllerTest : ProjectAuthControllerTest() {
   @Transactional
   @ProjectApiKeyAuthTestMethod
   fun exportZipJsonWithApiKey() {
-    val base = dbPopulator.populate(generateUniqueString())
+    val base = dbPopulator.populate()
     commitTransaction()
     projectSupplier = { base.project }
     val mvcResult =

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/PublicControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/PublicControllerTest.kt
@@ -6,7 +6,6 @@ import io.tolgee.dtos.request.auth.SignUpDto
 import io.tolgee.fixtures.andAssertResponse
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.testing.AbstractControllerTest
@@ -99,7 +98,7 @@ class PublicControllerTest :
 
   @Test
   fun `doesn't create organization when invitation provided`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val project = base.project
     val invitation =
       invitationService.create(

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/internal/SqlControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/internal/SqlControllerTest.kt
@@ -46,7 +46,7 @@ class SqlControllerTest : AbstractControllerTest(), Logging {
   @Test
   fun getList() {
     logger.info("Internal controller enabled: ${tolgeeProperties.internal.controllerEnabled}")
-    dbPopulator.createBase("Test")
+    dbPopulator.createBase()
     val parseResponseTo: List<Any> =
       mvc.perform(
         post("/internal/sql/list")
@@ -60,7 +60,7 @@ class SqlControllerTest : AbstractControllerTest(), Logging {
   @Test
   fun delete() {
     logger.info("Internal controller enabled: ${tolgeeProperties.internal.controllerEnabled}")
-    val project = dbPopulator.createBase("Test").project
+    val project = dbPopulator.createBase().project
     mvc.perform(
       post("/internal/sql/execute")
         .content("delete from permission"),

--- a/backend/app/src/test/kotlin/io/tolgee/repository/ProjectRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/ProjectRepositoryTest.kt
@@ -25,7 +25,7 @@ class ProjectRepositoryTest {
   @Test
   fun testPermittedProjects() {
     val users = dbPopulatorReal.createUsersAndOrganizations()
-    dbPopulatorReal.createBase("No org project", users[3].username)
+    dbPopulatorReal.createBase(users[3].username)
     val result = projectRepository.findAllPermitted(users[3].id)
     assertThat(result).hasSize(10)
     assertThat(result[0][0]).isInstanceOf(Project::class.java)
@@ -36,7 +36,7 @@ class ProjectRepositoryTest {
 
   @Test
   fun testPermittedProjectsJustNoOrg() {
-    val base = dbPopulatorReal.createBase("No org project", generateUniqueString())
+    val base = dbPopulatorReal.createBase(generateUniqueString())
     val result = projectRepository.findAllPermitted(base.userAccount.id)
     assertThat(result).hasSize(1)
   }
@@ -44,7 +44,7 @@ class ProjectRepositoryTest {
   @Test
   fun testPermittedJustOrg() {
     val users = dbPopulatorReal.createUsersAndOrganizations()
-    dbPopulatorReal.createBase("No org project", users[1].username)
+    dbPopulatorReal.createBase(users[1].username)
     val result = projectRepository.findAllPermitted(users[3].id)
     assertThat(result).hasSize(9)
   }
@@ -52,7 +52,7 @@ class ProjectRepositoryTest {
   @Test
   fun findAllPermittedPaged() {
     val users = dbPopulatorReal.createUsersAndOrganizations()
-    dbPopulatorReal.createBase("No org project", users[3].username)
+    dbPopulatorReal.createBase(users[3].username)
     val result =
       projectRepository.findAllPermitted(
         users[3].id,

--- a/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportFileRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportFileRepositoryTest.kt
@@ -54,7 +54,7 @@ class ImportFileRepositoryTest : AbstractSpringTest() {
   }
 
   private fun createBaseImport(): Import {
-    val base = dbPopulator.createBase("hello", "import-user")
+    val base = dbPopulator.createBase("import-user")
     return importService.save(Import(project = base.project).also { it.author = base.userAccount })
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportRepositoryTest.kt
@@ -16,7 +16,7 @@ class ImportRepositoryTest : AbstractSpringTest() {
 
   @Test
   fun `creates, saves and gets Import entity`() {
-    val base = dbPopulator.createBase("hello", "import-user")
+    val base = dbPopulator.createBase("import-user")
     Import(project = base.project).let {
       it.author = base.userAccount
       importRepository.save(it).let {

--- a/backend/app/src/test/kotlin/io/tolgee/security/DenyInternalTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/security/DenyInternalTest.kt
@@ -12,7 +12,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 class DenyInternalTest : AbstractControllerTest() {
   @Test
   fun getListFail() {
-    dbPopulator.createBase("Test")
+    dbPopulator.createBase()
     val response =
       mvc.perform(
         MockMvcRequestBuilders.post("/internal/sql/list")
@@ -23,7 +23,7 @@ class DenyInternalTest : AbstractControllerTest() {
 
   @Test
   fun setPropertyFail() {
-    dbPopulator.createBase("Test")
+    dbPopulator.createBase()
     val response =
       mvc.perform(
         MockMvcRequestBuilders.post("/internal/properties")

--- a/backend/app/src/test/kotlin/io/tolgee/security/ProjectApiKeyAuthenticationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/security/ProjectApiKeyAuthenticationTest.kt
@@ -6,7 +6,6 @@ import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andIsUnauthorized
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.enums.Scope
 import io.tolgee.security.authentication.JwtService
@@ -36,7 +35,7 @@ class ProjectApiKeyAuthenticationTest : AbstractControllerTest() {
 
   @Test
   fun `access with legacy key works`() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val apiKey = apiKeyService.create(base.userAccount, setOf(*Scope.values()), base.project)
     mvc.perform(MockMvcRequestBuilders.get("/v2/projects/translations?ak=" + apiKey.key)).andIsOk
   }
@@ -49,7 +48,7 @@ class ProjectApiKeyAuthenticationTest : AbstractControllerTest() {
 
   @Test
   fun accessWithApiKey_failure_api_path() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     val apiKey = apiKeyService.create(base.userAccount, setOf(*Scope.entries.toTypedArray()), base.project)
     mvc.perform(MockMvcRequestBuilders.get("/v2/projects?ak=${apiKey.key}")).andIsForbidden
   }

--- a/backend/app/src/test/kotlin/io/tolgee/security/ProjectPermissionFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/security/ProjectPermissionFilterTest.kt
@@ -2,7 +2,6 @@ package io.tolgee.security
 
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.generateUniqueString
 import io.tolgee.testing.AuthorizedControllerTest
 import org.junit.jupiter.api.Test
 import org.springframework.transaction.annotation.Transactional
@@ -11,14 +10,14 @@ import org.springframework.transaction.annotation.Transactional
 class ProjectPermissionFilterTest : AuthorizedControllerTest() {
   @Test
   fun allowsAccessToPrivilegedUser() {
-    val base = dbPopulator.createBase(generateUniqueString())
+    val base = dbPopulator.createBase()
     performAuthGet("/v2/projects/${base.project.id}/translations").andIsOk
   }
 
   @Test
   fun deniesAccessToNonPrivilegedUser() {
     loginAsUserIfNotLogged()
-    val base2 = dbPopulator.createBase(generateUniqueString(), "new-user")
+    val base2 = dbPopulator.createBase("new-user")
     performAuthGet("/v2/projects/${base2.project.id}/translations").andIsNotFound
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/service/TranslationServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/TranslationServiceTest.kt
@@ -15,7 +15,7 @@ class TranslationServiceTest : AbstractSpringTest() {
   @Transactional
   @Test
   fun getTranslations() {
-    val id = dbPopulator.populate("App").project.id
+    val id = dbPopulator.populate().project.id
     val data =
       translationService.getTranslations(
         languageTags = HashSet(Arrays.asList("en", "de")),
@@ -29,7 +29,7 @@ class TranslationServiceTest : AbstractSpringTest() {
   @Transactional
   @Test
   fun `returns correct map when collision`() {
-    val project = dbPopulator.populate("App").project
+    val project = dbPopulator.populate().project
     keyService.create(project, CreateKeyDto("folder.folder", null, mapOf("en" to "Ha")))
     keyService.create(project, CreateKeyDto("folder.folder.translation", null, mapOf("en" to "Ha")))
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectServiceTest.kt
@@ -43,7 +43,7 @@ class ProjectServiceTest : AbstractSpringTest() {
   fun testFindAllPermitted() {
     executeInNewTransaction {
       val users = dbPopulator.createUsersAndOrganizations()
-      dbPopulator.createBase("Test", users[3].username)
+      dbPopulator.createBase(users[3].username)
       val projects = projectService.findAllPermitted(users[3])
       assertThat(projects).hasSize(10)
     }
@@ -63,7 +63,7 @@ class ProjectServiceTest : AbstractSpringTest() {
   fun testFindAllSingleProject() {
     executeInNewTransaction {
       dbPopulator.createUsersAndOrganizations() // create some data
-      val base = dbPopulator.createBase("Hello world", generateUniqueString())
+      val base = dbPopulator.createBase(generateUniqueString())
       val projects = projectService.findAllPermitted(base.userAccount)
       assertThat(projects).hasSize(1)
       assertThat(projects[0].scopes).containsExactlyInAnyOrder(*ProjectPermissionType.MANAGE.availableScopes)
@@ -74,7 +74,7 @@ class ProjectServiceTest : AbstractSpringTest() {
   fun testFindMultiple() {
     executeInNewTransaction {
       val usersWithOrganizations = dbPopulator.createUsersAndOrganizations("helga") // create some data
-      val base = dbPopulator.createBase("Hello world")
+      val base = dbPopulator.createBase()
       val organization = usersWithOrganizations[0].organizationRoles[0].organization
       organizationRoleService.grantRoleToUser(base.userAccount, organization!!, OrganizationRoleType.MEMBER)
 
@@ -94,7 +94,7 @@ class ProjectServiceTest : AbstractSpringTest() {
   fun testFindMultiplePermissions() {
     executeInNewTransaction(platformTransactionManager) {
       val usersWithOrganizations = dbPopulator.createUsersAndOrganizations("agnes") // create some data
-      val base = dbPopulator.createBase("Hello world")
+      val base = dbPopulator.createBase()
       val organization = usersWithOrganizations[0].organizationRoles[0].organization
       organizationRoleService.grantRoleToUser(base.userAccount, organization!!, OrganizationRoleType.MEMBER)
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
@@ -54,7 +54,7 @@ class DbPopulatorReal(
   fun autoPopulate() {
     // do not populate if db is not empty
     if (userAccountRepository.count() == 0L) {
-      this.populate("Application")
+      this.populate()
     }
   }
 
@@ -170,32 +170,26 @@ class DbPopulatorReal(
   }
 
   @Transactional
-  fun createBase(
-    projectName: String,
-    username: String,
-  ): Base {
-    return createBase(projectName, username, null)
+  fun createBase(username: String): Base {
+    return createBase(UUID.randomUUID().toString(), username, null)
   }
 
   @Transactional
-  fun createBase(projectName: String): Base {
-    return createBase(projectName, tolgeeProperties.authentication.initialUsername)
+  fun createBase(): Base {
+    return createBase(tolgeeProperties.authentication.initialUsername)
   }
 
-  fun populate(projectName: String): Base {
+  fun populate(): Base {
     return executeInNewTransaction(platformTransactionManager) {
-      populate(projectName, tolgeeProperties.authentication.initialUsername)
+      populate(userName = tolgeeProperties.authentication.initialUsername)
     }.also {
       languageStatsService.refreshLanguageStats(it.project.id)
     }
   }
 
   @Transactional
-  fun populate(
-    projectName: String,
-    userName: String,
-  ): Base {
-    val base = createBase(projectName, userName)
+  fun populate(userName: String): Base {
+    val base = createBase(userName)
     val project = projectService.get(base.project.id)
     createApiKey(project)
     createTranslation(project, "Hello world!", "Hallo Welt!", en, de)

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/ProjectAuthRequestPerformer.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/ProjectAuthRequestPerformer.kt
@@ -18,7 +18,7 @@ abstract class ProjectAuthRequestPerformer(
     get() = projectSupplier?.invoke() ?: defaultProject
 
   val defaultProject: Project by lazy {
-    dbPopulator.createBase(generateUniqueString(), username = userAccountProvider.invoke().username).project
+    dbPopulator.createBase(userAccountProvider.invoke().username).project
   }
 
   var projectSupplier: (() -> Project)? = null


### PR DESCRIPTION
The functionality of creating a base project with a particular name is not used anywhere. It can be replaced by creating a base project with UUID as a name for readability.