### PR TITLE
fix: use file name instead of whole path for language guess

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/ImportFileProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/ImportFileProcessor.kt
@@ -8,7 +8,9 @@ abstract class ImportFileProcessor {
   abstract fun process()
 
   val languageNameGuesses: List<String> by lazy {
-    val fileName = context.file.name
+    val filePath = context.file.name
+
+    val fileName = filePath.substringAfterLast("/")
 
     val result =
       arrayOf(


### PR DESCRIPTION
Namespaces are allowed to contain dots (`.`). Exporting projects with such namespaces will result in directories for namespaces containing dots. The current implementation assumes the first dot-separated section to be language and guesses the language incorrectly.