### PR TITLE
chore: Reorganization of settings for correct error display

### DIFF
--- a/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
+++ b/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
@@ -110,56 +110,58 @@ export const ProjectSettingsGeneral = () => {
       <Box gridArea="avatar">
         <ProjectProfileAvatar />
       </Box>
-      <StandardForm
-        validationSchema={Validation.PROJECT_SETTINGS}
-        initialValues={initialValues}
-        onSubmit={handleEdit}
-        saveActionLoadable={updateLoadable}
-        hideCancel
-        customActions={
-          <LoadingButton
-            data-cy="project-delete-button"
-            color="secondary"
-            variant="outlined"
-            onClick={() => leave(project.name, project.id)}
-            loading={isLeaving}
-          >
-            <T keyName="project_leave_button" />
-          </LoadingButton>
-        }
-      >
-        <Box gridArea="fields" display="grid" gap={2} mb={4}>
-          <Box>
-            <FieldLabel>
-              <T keyName="project_settings_name_label" />
-            </FieldLabel>
-            <TextField
-              size="small"
-              name="name"
-              required={true}
-              data-cy="project-settings-name"
-              sx={{ mt: 0 }}
-            />
+      <Box gridArea="fields">
+        <StandardForm
+          validationSchema={Validation.PROJECT_SETTINGS}
+          initialValues={initialValues}
+          onSubmit={handleEdit}
+          saveActionLoadable={updateLoadable}
+          hideCancel
+          customActions={
+            <LoadingButton
+              data-cy="project-delete-button"
+              color="secondary"
+              variant="outlined"
+              onClick={() => leave(project.name, project.id)}
+              loading={isLeaving}
+            >
+              <T keyName="project_leave_button" />
+            </LoadingButton>
+          }
+        >
+          <Box display="grid" gap={2} mb={4}>
+            <Box>
+              <FieldLabel>
+                <T keyName="project_settings_name_label" />
+              </FieldLabel>
+              <TextField
+                size="small"
+                name="name"
+                required={true}
+                data-cy="project-settings-name"
+                sx={{ mt: 0 }}
+              />
+            </Box>
+            <Box>
+              <FieldLabel>
+                <T keyName="project_settings_description_label" />
+              </FieldLabel>
+              <TextField
+                size="small"
+                minRows={2}
+                multiline
+                name="description"
+                data-cy="project-settings-description"
+                sx={{ mt: 0 }}
+              />
+            </Box>
+            <ProjectLanguagesProvider>
+              <LanguageSelect />
+            </ProjectLanguagesProvider>
+            <NamespaceSelect />
           </Box>
-          <Box>
-            <FieldLabel>
-              <T keyName="project_settings_description_label" />
-            </FieldLabel>
-            <TextField
-              size="small"
-              minRows={2}
-              multiline
-              name="description"
-              data-cy="project-settings-description"
-              sx={{ mt: 0 }}
-            />
-          </Box>
-          <ProjectLanguagesProvider>
-            <LanguageSelect />
-          </ProjectLanguagesProvider>
-          <NamespaceSelect />
-        </Box>
-      </StandardForm>
+        </StandardForm>
+      </Box>
     </StyledContainer>
   );
 };


### PR DESCRIPTION
The current layout of settings pushes the form below the project avatar when a validation failure occurs.

![Snímek obrazovky z 2024-12-03 11-37-13](https://github.com/user-attachments/assets/04ae10a2-b9e1-4c90-8dd8-cb77517a7603)

This PR alters the layout which fixes the form position.

![Snímek obrazovky z 2024-12-03 11-34-54](https://github.com/user-attachments/assets/9fd06852-9174-426c-b751-3b82cb6f074e)
