### PR TITLE
chore: Add everything passed action for easier auto-merge conditions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -454,3 +454,18 @@ jobs:
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck
+
+  everything-passed:
+    name: Everything passed 🎉
+    needs:
+      - backend-build
+      - backend-test
+      - backend-code-checks
+      - frontend-build
+      - frontend-code-check
+      - e2e
+      - e2e-code-checks
+      - e2e-install-deps
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Everything passed 🎉"


### PR DESCRIPTION
Nowadays, all the actions need to be defined in GitHub UI to enable auto-merge.

This change adds an arbitrary `Everything passed` action dependent on all other, therefore it is the only one which needs to be defined to pass.