### PR TITLE
fix: import - create new keys - use cached existing keys

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/CoreImportFilesProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/CoreImportFilesProcessor.kt
@@ -274,8 +274,7 @@ class CoreImportFilesProcessor(
     if (importSettings.createNewKeys) {
       return true
     }
-    val n = this.getNamespaceToPreselect()
-    return keyService.find(import.project.id, keyName, this.getNamespaceToPreselect()) != null
+    return importDataManager.existingKeys[this.getNamespaceToPreselect() to keyName] != null
   }
 
   private fun FileProcessorContext.processTranslation(

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportDataManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportDataManager.kt
@@ -382,15 +382,11 @@ class ImportDataManager(
       if (createNewKeys) {
         key.shouldBeImported = true
       } else {
-        key.shouldBeImported = keyService.find(
-          import.project.id,
-          key.name,
-          getSafeNamespace(key.file.namespace),
-        ) != null
+        key.shouldBeImported = existingKeys[getSafeNamespace(key.file.namespace) to key.name] != null
       }
-      if (saveData) {
-        importService.saveKey(key)
-      }
+    }
+    if (saveData) {
+      saveAllStoredKeys()
     }
   }
 


### PR DESCRIPTION
This fixes poor performance when the "Create new keys" option is disabled, and many keys are to be imported.