### PR TITLE
chore: Add run configurations for E2E tests

### DIFF
--- a/.run/E2E tests.run.xml
+++ b/.run/E2E tests.run.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="E2E tests" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/e2e/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="cy:open" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs>
+      <env name="CYPRESS_HOST" value="http://localhost:8081" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Frontend for E2E tests.run.xml
+++ b/.run/Frontend for E2E tests.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Frontend for E2E tests" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/webapp/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <arguments value="-- --port 8081 --host" />
+    <node-interpreter value="project" />
+    <envs>
+      <env name="VITE_APP_API_URL" value="http://localhost:8201" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
To make it possible to run also FE for E2E tests and open the Cypress window, directly from IDEA.