### PR TITLE
chore: Retry `npm install` to make CI builds more stable

### DIFF
--- a/gradle/e2e.gradle
+++ b/gradle/e2e.gradle
@@ -78,7 +78,11 @@ task installE2eDeps(type: Exec, group: "e2e") {
     inputs.file("$E2E_DIR/package-lock.json")
     outputs.dir("$E2E_DIR/node_modules")
 
-    commandLine npmCommandName, "install"
+    try {
+        commandLine npmCommandName, "install"
+    } catch (ignored) {
+        commandLine npmCommandName, "install"
+    }
     workingDir E2E_DIR
 }
 

--- a/gradle/webapp.gradle
+++ b/gradle/webapp.gradle
@@ -15,7 +15,11 @@ task copyDist(type: Copy) {
 
 task installWebappDeps(type: Exec) {
     onlyIf { System.getenv("SKIP_WEBAPP_BUILD") != "true" }
-    commandLine npmCommandName, "ci"
+    try {
+        commandLine npmCommandName, "ci"
+    } catch (ignored) {
+        commandLine npmCommandName, "ci"
+    }
     workingDir = webappPath
     inputs.file("${project.projectDir}/webapp/package.json")
     inputs.file("${project.projectDir}/webapp/package-lock.json")


### PR DESCRIPTION
[Example of an intermittently failing build](https://github.com/tolgee/tolgee-platform/actions/runs/12672324621/job/35316100659)