### PR TITLE
chore: Websockets auth for `users` instead of `user`

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/websocket/WebSocketConfig.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/websocket/WebSocketConfig.kt
@@ -90,7 +90,7 @@ class WebSocketConfig(
   ) {
     val userId =
       destination?.let {
-        "/user/([0-9]+)".toRegex().find(it)?.groupValues
+        "/users/([0-9]+)".toRegex().find(it)?.groupValues
           ?.getOrNull(1)?.toLong()
       } ?: return
 


### PR DESCRIPTION
To make it consistent with the other auth for `projects`.