### PR TITLE
chore: Keep running fakesmtp even after system restart

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - tolgee.frontend-url=http://localhost:8201
   fakesmtp:
     image: reachfive/fake-smtp-server:0.8.1
+    restart: unless-stopped
     ports:
       - "21025:1025"
       - "21080:1080"


### PR DESCRIPTION
For easier local development - the only needed step is to run the cypress window. It doesn't eat significant amount of resources anyway.