### PR TITLE
chore: Making intermittent test stable

### DIFF
--- a/e2e/cypress/e2e/userSettings/userSettings.cy.ts
+++ b/e2e/cypress/e2e/userSettings/userSettings.cy.ts
@@ -13,8 +13,7 @@ describe('User settings', () => {
 
   it('Accesses api keys', () => {
     cy.xpath("//*[@aria-controls='user-menu']").click();
-    cy.wait(50);
-    cy.xpath(getAnyContainingText('Api keys')).click();
+    cy.xpath(getAnyContainingText('Api keys')).should('be.visible').click();
   });
 
   it('Opens user menu from projects', () => {


### PR DESCRIPTION
It was failing in the builds a lot when the loading took more than the static 50 ms. This change waits for the element to be visible therefore making it more stable.