### PR TITLE
chore: Distinct names for E2E artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,7 +255,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: e2e
+          name: e2e_${{ matrix.job_index }}
           path: |
             ./e2e/cypress/videos/**/*
             ./e2e/cypress/screenshots/**/*


### PR DESCRIPTION
`actions/upload-artifact@v4` does not allow multiple artifacts with the same name which causes upload failures in case of multiple E2E suites failing