### PR TITLE
chore: Flaky cypress test - assert equality of text for easier debugging

### DIFF
--- a/e2e/cypress/common/tasks.ts
+++ b/e2e/cypress/common/tasks.ts
@@ -30,13 +30,13 @@ export function checkTaskPreview({
 }) {
   getTaskPreview(language)
     .findDcy('task-preview-keys')
-    .should('contain', keys)
+    .should('have.text', keys)
     .findDcy('task-preview-alert')
     .should(alert ? 'exist' : 'not.exist');
   getTaskPreview(language)
     .findDcy('task-preview-words')
-    .should('contain', words);
+    .should('have.text', words);
   getTaskPreview(language)
     .findDcy('task-preview-characters')
-    .should('contain', characters);
+    .should('have.text', characters);
 }


### PR DESCRIPTION
It was giving not very useful error message:

```
AssertionError: expected '<div.css-196vxgn>' to contain 4
```

https://github.com/tolgee/tolgee-platform/actions/runs/12932526767/job/36069312993#step:14:2558