### PR TITLE
chore: Fix clicking on `Project API keys`

### DIFF
--- a/e2e/cypress/e2e/userSettings/userSettings.cy.ts
+++ b/e2e/cypress/e2e/userSettings/userSettings.cy.ts
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-import { getAnyContainingText } from '../../common/xPath';
 import { HOST } from '../../common/constants';
 import { createTestProject, login } from '../../common/apiCalls/common';
 import { gcy, getPopover } from '../../common/shared';
@@ -13,7 +12,7 @@ describe('User settings', () => {
 
   it('Accesses api keys', () => {
     cy.xpath("//*[@aria-controls='user-menu']").click();
-    cy.xpath(getAnyContainingText('Api keys')).should('be.visible').click();
+    cy.get('#user-menu').contains('Project API keys').click();
   });
 
   it('Opens user menu from projects', () => {

--- a/e2e/cypress/e2e/userSettings/userSettings.cy.ts
+++ b/e2e/cypress/e2e/userSettings/userSettings.cy.ts
@@ -11,8 +11,7 @@ describe('User settings', () => {
   });
 
   it('Accesses api keys', () => {
-    cy.xpath("//*[@aria-controls='user-menu']").click();
-    cy.get('#user-menu').contains('Project API keys').click();
+    clickOnMenuItem('Project API keys');
   });
 
   it('Opens user menu from projects', () => {
@@ -26,14 +25,17 @@ describe('User settings', () => {
   });
 
   it('Accesses user settings', () => {
-    cy.xpath("//*[@aria-controls='user-menu']").click();
-    cy.get('#user-menu').contains('Account settings').click();
+    clickOnMenuItem('Account settings');
   });
 
   it('Accesses personal access tokens', () => {
-    cy.xpath("//*[@aria-controls='user-menu']").click();
-    cy.get('#user-menu').contains('Personal Access Tokens').click();
+    clickOnMenuItem('Personal Access Tokens');
     cy.get('h6').contains('Personal Access Tokens').should('be.visible');
     gcy('global-empty-list').should('be.visible');
   });
+
+  function clickOnMenuItem(itemLabel: string) {
+    cy.xpath("//*[@aria-controls='user-menu']").click();
+    cy.get('#user-menu').contains(itemLabel).click();
+  }
 });


### PR DESCRIPTION
`getAnyContainingText` probably sometimes selects a different element in the page.

This PR unifies it with the other tests in the suite which passes on localhost consistently.