### PR TITLE
chore: Add retry logic to custom commands

### DIFF
--- a/e2e/cypress/support/registerCommands.ts
+++ b/e2e/cypress/support/registerCommands.ts
@@ -4,9 +4,9 @@ import { addCustomCommand } from 'cy-verify-downloads';
 export const register = () => {
   Cypress.Commands.add(
     'closestDcy',
-    { prevSubject: true },
+    { prevSubject: 'element' },
     (subject, dataCy) => {
-      return subject.closest('[data-cy="' + dataCy + '"]');
+      return cy.wrap(subject).closest(`[data-cy="${dataCy}"]`);
     }
   );
 
@@ -14,23 +14,27 @@ export const register = () => {
     return cy.get('[data-cy="' + dataCy + '"]', options);
   });
 
-  Cypress.Commands.add('findDcy', { prevSubject: true }, (subject, dataCy) => {
-    return subject.find('[data-cy="' + dataCy + '"]');
-  });
+  Cypress.Commands.add(
+    'findDcy',
+    { prevSubject: 'element' },
+    (subject, dataCy) => {
+      return cy.wrap(subject).find(`[data-cy="${dataCy}"]`);
+    }
+  );
 
   Cypress.Commands.add(
     'nextUntilDcy',
-    { prevSubject: true },
+    { prevSubject: 'element' },
     (subject, dataCy) => {
-      return subject.nextUntil('[data-cy="' + dataCy + '"]');
+      return cy.wrap(subject).nextUntil(`[data-cy="${dataCy}"]`);
     }
   );
 
   Cypress.Commands.add(
     'findInputByName',
-    { prevSubject: true },
+    { prevSubject: 'element' },
     (subject, name) => {
-      return subject.find('input[name="' + name + '"]');
+      return cy.wrap(subject).find(`input[name="${name}"]`);
     }
   );
 


### PR DESCRIPTION
Calling `findDcy`, `nextUntilDcy` and `findInputByName` was calling the `.find('[data-cy="${dataCy}"]')` function on a jQuery object, therefore disabling the Cypress native retry functionality.

This change wraps the jQuery object into a Cypress object which enables the retry-timeout functionality waiting for the state to be correct.