### PR TITLE
fix: OpenApi docs for exporting endpoints

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/ExportApiResponse.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/ExportApiResponse.kt
@@ -1,0 +1,14 @@
+package io.tolgee.api.v2.controllers.batch
+
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+
+@ApiResponse(
+  responseCode = "200",
+  description =
+    "When multiple files are exported, they are zipped and returned as a single zip file." +
+      "\n" +
+      "When a single file is exported, it is returned directly.",
+  content = [Content(mediaType = "application/*")],
+)
+annotation class ExportApiResponse()

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
@@ -50,6 +50,7 @@ class V2ExportController(
   @Operation(summary = "Export data")
   @RequiresProjectPermissions([Scope.TRANSLATIONS_VIEW])
   @AllowApiAccess
+  @ExportApiResponse
   fun exportData(
     @ParameterObject params: ExportParams,
   ): ResponseEntity<StreamingResponseBody> {
@@ -71,6 +72,7 @@ class V2ExportController(
   )
   @RequiresProjectPermissions([Scope.TRANSLATIONS_VIEW])
   @AllowApiAccess
+  @ExportApiResponse
   fun exportPost(
     @RequestBody params: ExportParams,
   ): ResponseEntity<StreamingResponseBody> {


### PR DESCRIPTION
Closes #2871 