### PR TITLE
Fix Japanese static data load

### DIFF
--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -55,6 +55,7 @@ const tolgee = Tolgee()
       de: () => import('./i18n/de.json').then((m) => m.default),
       pt: () => import('./i18n/pt.json').then((m) => m.default),
       da: () => import('./i18n/da.json').then((m) => m.default),
+      ja: () => import('./i18n/ja.json').then((m) => m.default),
     },
   });
 


### PR DESCRIPTION
## Summary
Thank you for releasing the Japanese translation.

In v3.103.0, Japanese is selectable, but it is not displayed. 
From my understanding, I think that the static data for i18n included in this pull request needs to be loaded.

ref: https://github.com/tolgee/tolgee-platform/pull/2932
## ScreenShots
### v3.103.0
![スクリーンショット 2025-02-22 135048](https://github.com/user-attachments/assets/7ac126aa-6d25-4f9f-a242-42fde081af86)
### tolgee:main
![スクリーンショット 2025-02-22 140327](https://github.com/user-attachments/assets/764d6d2e-4af8-4799-bd8c-a2afa5e83805)
### Rapilias:feature/fix-japanese-static-data-load
![スクリーンショット 2025-02-22 135759](https://github.com/user-attachments/assets/60ebc04d-3f79-4133-a5c5-07ae5af1d7c9)

## Checked
- [x] Even if I select Japanese in v3.103.0, Japanese is not displayed
- [x] If I make changes to the PR, Japanese is displayed