### PR TITLE
fix: add XML parsing error fallback

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -44,7 +44,7 @@ class TextToXmlResourcesConvertor(
         children = parsed.childNodes.item(0).childNodes.asSequence().toList(),
       )
     } catch (ex: Exception) {
-      logger.debug("Cannot value '$string'", ex)
+      logger.debug("Cannot process value '$string'", ex)
       return ContentToAppend(text = string)
     }
   }
@@ -99,8 +99,20 @@ class TextToXmlResourcesConvertor(
     }
   }
 
-  private fun parseString(contentNotNull: String): Document =
-    documentBuilder.parse(InputSource(StringReader("<root>$contentNotNull</root>")))
+  private fun parseString(contentNotNull: String): Document {
+    try {
+      return documentBuilder.parse(InputSource(StringReader("<root>$contentNotNull</root>")))
+    } catch (e: Exception) {
+      logger.debug("Cannot process XML value '$string'", e)
+
+      // Fallback - all the text as a single text node
+      val doc = documentBuilder.newDocument()
+      val rootElement = doc.createElement("root")
+      doc.appendChild(rootElement)
+      rootElement.appendChild(doc.createTextNode(contentNotNull))
+      return doc
+    }
+  }
 
   private fun Node.writeToString(): String {
     val source = DOMSource(this)

--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -32,21 +32,16 @@ class TextToXmlResourcesConvertor(
   val string = value.string
 
   fun convert(): ContentToAppend {
-    try {
-      if (value.isWrappedCdata || containsXmlAndPlaceholders) {
-        return contentWrappedInCdata
-      }
-
-      wrapUnsupportedTagsWithCdata(analysisResult, parsed)
-      escapeTextNodes()
-
-      return ContentToAppend(
-        children = parsed.childNodes.item(0).childNodes.asSequence().toList(),
-      )
-    } catch (ex: Exception) {
-      logger.debug("Cannot process value '$string'", ex)
-      return ContentToAppend(text = string)
+    if (value.isWrappedCdata || containsXmlAndPlaceholders) {
+      return contentWrappedInCdata
     }
+
+    wrapUnsupportedTagsWithCdata(analysisResult, parsed)
+    escapeTextNodes()
+
+    return ContentToAppend(
+      children = parsed.childNodes.item(0).childNodes.asSequence().toList(),
+    )
   }
 
   private val parsed by lazy {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
@@ -121,6 +121,27 @@ class TextToAndroidXmlConvertorTest {
     "a\n\na".assertSingleTextNode("a\\n\\na")
   }
 
+  @Test
+  fun `handles malformed XML with fallback`() {
+    "<unclosed>tag & special chars".assertSingleTextNode().isEqualTo("<unclosed>tag & special chars")
+  }
+
+  @Test
+  fun `recovers from invalid XML and creates text node`() {
+    "<tag>with & unescaped ampersand</tag>".assertSingleTextNode().isEqualTo("<tag>with & unescaped ampersand</tag>")
+  }
+
+  @Test
+  fun `escapes apostrophes and quotes in malformed XML for Android`() {
+    "<tag attr='value\">text with ' and \" characters</tag".assertSingleTextNode()
+      .isEqualTo("<tag attr=\\'value\\\">text with \\' and \\\" characters</tag")
+  }
+
+  @Test
+  fun `escapes percent signs in malformed XML`() {
+    "<unclosed>text with % and %% signs".assertSingleTextNode().isEqualTo("<unclosed>text with % and %% signs")
+  }
+
   private fun Node.assertTextContent(text: String) {
     this.nodeType.assert.isEqualTo(Node.TEXT_NODE)
     this.textContent.assert.isEqualTo(text)

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/TextToAndroidXmlConvertorTest.kt
@@ -122,24 +122,20 @@ class TextToAndroidXmlConvertorTest {
   }
 
   @Test
-  fun `handles malformed XML with fallback`() {
-    "<unclosed>tag & special chars".assertSingleTextNode().isEqualTo("<unclosed>tag & special chars")
+  fun `doesnt fail with malformed XML`() {
+    "<unclosed>tag".assertSingleTextNode().isEqualTo("<unclosed>tag")
   }
 
   @Test
-  fun `recovers from invalid XML and creates text node`() {
-    "<tag>with & unescaped ampersand</tag>".assertSingleTextNode().isEqualTo("<tag>with & unescaped ampersand</tag>")
-  }
-
-  @Test
-  fun `escapes apostrophes and quotes in malformed XML for Android`() {
+  fun `escapes special characters in malformed XML`() {
     "<tag attr='value\">text with ' and \" characters</tag".assertSingleTextNode()
       .isEqualTo("<tag attr=\\'value\\\">text with \\' and \\\" characters</tag")
   }
 
   @Test
-  fun `escapes percent signs in malformed XML`() {
-    "<unclosed>text with % and %% signs".assertSingleTextNode().isEqualTo("<unclosed>text with % and %% signs")
+  fun `escapes special characters in malformed XML #2`() {
+    "text ' text <>".assertSingleTextNode()
+      .isEqualTo("text \\' text <>")
   }
 
   private fun Node.assertTextContent(text: String) {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
@@ -99,6 +99,39 @@ class TextToComposeXmlConvertorTest {
     "a\n\na".assertSingleTextNode("a\n\na")
   }
 
+  @Test
+  fun `handles malformed XML with fallback`() {
+    "<unclosed>tag & special chars".assertSingleTextNode().isEqualTo("<unclosed>tag & special chars")
+  }
+
+  @Test
+  fun `recovers from invalid XML and creates text node`() {
+    "<tag>with & unescaped ampersand</tag>".assertSingleTextNode().isEqualTo("<tag>with & unescaped ampersand</tag>")
+  }
+
+  @Test
+  fun `nested invalid XML elements use fallback mechanism`() {
+    "<outer><inner>content with < unescaped</inner></outer>".assertSingleTextNode()
+      .isEqualTo("<outer><inner>content with < unescaped</inner></outer>")
+  }
+
+  @Test
+  fun `preserves apostrophes and quotes in malformed XML`() {
+    "<tag attr='value\">text with ' and \" characters</tag".assertSingleTextNode()
+      .isEqualTo("<tag attr='value\">text with ' and \" characters</tag")
+  }
+
+  @Test
+  fun `preserves percent signs in malformed XML`() {
+    "<unclosed>text with % and %% signs".assertSingleTextNode().isEqualTo("<unclosed>text with % and %% signs")
+  }
+
+  @Test
+  fun `preserves whitespace in malformed XML`() {
+    "<tag>   text with \n newlines and \t tabs   </tag".assertSingleTextNode()
+      .isEqualTo("<tag>   text with \n newlines and \t tabs   </tag")
+  }
+
   private fun Node.assertTextContent(text: String) {
     this.nodeType.assert.isEqualTo(Node.TEXT_NODE)
     this.textContent.assert.isEqualTo(text)

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
@@ -100,30 +100,30 @@ class TextToComposeXmlConvertorTest {
   }
 
   @Test
-  fun `handles malformed XML with fallback`() {
-    "<unclosed>tag & special chars".assertSingleTextNode().isEqualTo("<unclosed>tag & special chars")
+  fun `doesnt fail with malformed XML`() {
+    "<unclosed>tag".assertSingleTextNode().isEqualTo("<unclosed>tag")
   }
 
   @Test
-  fun `recovers from invalid XML and creates text node`() {
-    "<tag>with & unescaped ampersand</tag>".assertSingleTextNode().isEqualTo("<tag>with & unescaped ampersand</tag>")
+  fun `doesnt fail with malformed XML #2`() {
+    "tag <>".assertSingleTextNode().isEqualTo("tag <>")
   }
 
   @Test
-  fun `nested invalid XML elements use fallback mechanism`() {
+  fun `doesnt fail with malformed XML #3`() {
+    "tag <".assertSingleTextNode().isEqualTo("tag <")
+  }
+
+  @Test
+  fun `doesnt fail with malformed XML #4`() {
     "<outer><inner>content with < unescaped</inner></outer>".assertSingleTextNode()
       .isEqualTo("<outer><inner>content with < unescaped</inner></outer>")
   }
 
   @Test
-  fun `preserves apostrophes and quotes in malformed XML`() {
+  fun `preserves special characters in malformed XML`() {
     "<tag attr='value\">text with ' and \" characters</tag".assertSingleTextNode()
       .isEqualTo("<tag attr='value\">text with ' and \" characters</tag")
-  }
-
-  @Test
-  fun `preserves percent signs in malformed XML`() {
-    "<unclosed>text with % and %% signs".assertSingleTextNode().isEqualTo("<unclosed>text with % and %% signs")
   }
 
   @Test


### PR DESCRIPTION
- Add fallback when XML parsing fails, assume the text is single XML text node
- Add tests for handling malformed XML in Android and Compose converters

Fixes #2967