### PR TITLE
fix: Normalize content root prefix in AWS CloudFront cache purging

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/cachePurging/awsCloudFront/AWSContentDeliveryCachePurging.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/cachePurging/awsCloudFront/AWSContentDeliveryCachePurging.kt
@@ -1,6 +1,7 @@
 package io.tolgee.component.contentDelivery.cachePurging.awsCloudFront
 
 import io.tolgee.component.contentDelivery.cachePurging.ContentDeliveryCachePurging
+import io.tolgee.fixtures.removeSlashSuffix
 import io.tolgee.model.contentDelivery.AWSCloudFrontConfig
 import io.tolgee.model.contentDelivery.ContentDeliveryConfig
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
@@ -18,13 +19,17 @@ class AWSCloudFrontContentDeliveryCachePurging(
     contentDeliveryConfig: ContentDeliveryConfig,
     paths: Set<String>,
   ) {
+    val contentPaths = paths.map { "$prefix/${contentDeliveryConfig.slug}/$it" }.toSet()
+    val credentialProvider = AWSCredentialProvider.get(config)
+    invalidateCloudFrontCache(credentialProvider, config.distributionId, contentPaths)
+  }
+
+  private val prefix by lazy {
     var contentRoot = config.contentRoot?.removeSuffix("/") ?: ""
     if (!contentRoot.startsWith("/")) {
       contentRoot = "/$contentRoot"
     }
-    val contentPaths = paths.map { "$contentRoot/${contentDeliveryConfig.slug}/$it" }.toSet()
-    val credentialProvider = AWSCredentialProvider.get(config)
-    invalidateCloudFrontCache(credentialProvider, config.distributionId, contentPaths)
+    contentRoot.removeSlashSuffix()
   }
 
   private fun createClient(credentialsProvider: StaticCredentialsProvider): CloudFrontClient {


### PR DESCRIPTION
**Summary:**
This PR addresses an issue where AWS CloudFront cache invalidation fails due to improperly constructed paths containing double slashes (e.g., `//f1a7d82c4b3597e1d94c2efb3896a3d5/common/en.json`).

**Fix:**

- Normalizes the content root prefix used in CloudFront path generation to prevent double slashes.
- Ensures compatibility whether the content root is set to `<empty string>`, `/`, or another value.

**Problem:**
When the CloudFront configuration uses a default content root of `<empty string>` or `/`, the resulting paths may include unintended double slashes. CloudFront treats these as invalid paths and does not invalidate the corresponding cached files, leading to stale content being served.

**Impact:**
This fix ensures that all invalidation paths are correctly formatted and respected by CloudFront, preventing cache issues and ensuring that updated files are served as expected.

**Related PR:**

- #2988


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache purging to ensure paths are consistently formatted and prefixed, resulting in more reliable cache invalidation for content delivery.

- **Tests**
  - Added comprehensive tests to verify that cache purging correctly handles various path formats and prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->