### PR TITLE
fix: add stricter pattern for projectId urls and handle NumberFormatException if organizationId or projectId contain non-numeric values

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/AllKeysController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/AllKeysController.kt
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}",
+    "/v2/projects/{projectId:[0-9]+}",
   ],
 )
 @Tag(name = "All localization keys", description = "All localization keys in the project")

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/NamespaceController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/NamespaceController.kt
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.*
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/",
+    "/v2/projects/{projectId:[0-9]+}/",
     "/v2/projects/",
   ],
 )

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectActivityController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectActivityController.kt
@@ -24,17 +24,12 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection")
 @RestController
 @CrossOrigin(origins = ["*"])
-@RequestMapping(value = ["/v2/projects/{projectId}/activity", "/v2/projects/activity"])
+@RequestMapping(value = ["/v2/projects/{projectId:[0-9]+}/activity", "/v2/projects/activity"])
 @Tag(name = "Projects")
 class ProjectActivityController(
   private val activityService: ActivityService,

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2InvitationController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2InvitationController.kt
@@ -31,13 +31,7 @@ import jakarta.validation.Valid
 import org.springframework.hateoas.CollectionModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("")
@@ -104,7 +98,7 @@ class V2InvitationController(
     return projectInvitationModelAssembler.toCollectionModel(invitations)
   }
 
-  @PutMapping("/v2/projects/{projectId}/invite")
+  @PutMapping("/v2/projects/{projectId:[0-9]+}/invite")
   @Operation(summary = "Generate user invitation link for project")
   @RequiresProjectPermissions([Scope.MEMBERS_EDIT])
   @RequiresSuperAuthentication

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryConfigController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryConfigController.kt
@@ -20,22 +20,14 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection")
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/content-delivery-configs",
+    "/v2/projects/{projectId:[0-9]+}/content-delivery-configs",
   ],
 )
 @Tag(name = "Content Delivery", description = "Endpoints for Content Delivery management")

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/KeyController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/KeyController.kt
@@ -19,14 +19,7 @@ import io.tolgee.dtos.request.translation.ImportKeysDto
 import io.tolgee.dtos.request.translation.importKeysResolvable.ImportKeysResolvableDto
 import io.tolgee.dtos.request.validators.exceptions.ValidationException
 import io.tolgee.exceptions.NotFoundException
-import io.tolgee.hateoas.key.KeyImportResolvableResultModel
-import io.tolgee.hateoas.key.KeyModel
-import io.tolgee.hateoas.key.KeyModelAssembler
-import io.tolgee.hateoas.key.KeySearchResultModelAssembler
-import io.tolgee.hateoas.key.KeySearchSearchResultModel
-import io.tolgee.hateoas.key.KeyWithDataModel
-import io.tolgee.hateoas.key.KeyWithDataModelAssembler
-import io.tolgee.hateoas.key.KeyWithScreenshotsModelAssembler
+import io.tolgee.hateoas.key.*
 import io.tolgee.hateoas.language.LanguageModel
 import io.tolgee.hateoas.language.LanguageModelAssembler
 import io.tolgee.hateoas.screenshot.ScreenshotModelAssembler
@@ -56,24 +49,14 @@ import org.springframework.hateoas.PagedModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection")
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/keys",
+    "/v2/projects/{projectId:[0-9]+}/keys",
     "/v2/projects/keys",
   ],
 )
@@ -105,7 +88,7 @@ class KeyController(
   @OpenApiHideFromPublicDocs(
     paths = [
       // inconsistent REST path
-      "/v2/projects/{projectId}/keys/create",
+      "/v2/projects/{projectId:[0-9]+}/keys/create",
     ],
   )
   fun create(

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/SelectAllController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/keys/SelectAllController.kt
@@ -17,11 +17,7 @@ import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.TranslationService
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.ModelAttribute
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection")
 @RestController
@@ -55,7 +51,7 @@ class SelectAllController(
     paths = [
       // should be included in keys, not in translations
       "/v2/projects/translations/select-all",
-      "/v2/projects/{projectId}/translations/select-all",
+      "/v2/projects/{projectId:[0-9]+}/translations/select-all",
     ],
   )
   fun selectKeys(

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/machineTranslation/MachineTranslationSettingsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/machineTranslation/MachineTranslationSettingsController.kt
@@ -17,12 +17,7 @@ import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
 import io.tolgee.service.machineTranslation.MtServiceConfigService
 import org.springframework.hateoas.CollectionModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress(names = ["MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection"])
 @RestController
@@ -34,7 +29,7 @@ class MachineTranslationSettingsController(
   private val languageConfigItemModelAssembler: LanguageConfigItemModelAssembler,
   private val mtServiceConfigService: MtServiceConfigService,
 ) {
-  @GetMapping("/{projectId}/machine-translation-service-settings")
+  @GetMapping("/{projectId:[0-9]+}/machine-translation-service-settings")
   @Operation(summary = "Get machine translation settings")
   @UseDefaultPermissions
   @AllowApiAccess
@@ -43,7 +38,7 @@ class MachineTranslationSettingsController(
     return languageConfigItemModelAssembler.toCollectionModel(data)
   }
 
-  @PutMapping("/{projectId}/machine-translation-service-settings")
+  @PutMapping("/{projectId:[0-9]+}/machine-translation-service-settings")
   @Operation(summary = "Sets machine translation settings")
   @RequiresProjectPermissions([ Scope.LANGUAGES_EDIT ])
   @AllowApiAccess
@@ -54,7 +49,7 @@ class MachineTranslationSettingsController(
     return getMachineTranslationSettings()
   }
 
-  @GetMapping("/{projectId}/machine-translation-language-info")
+  @GetMapping("/{projectId:[0-9]+}/machine-translation-language-info")
   @Operation(
     summary = "Machine translation info",
     description =

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsAutoTranslationSettingsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsAutoTranslationSettingsController.kt
@@ -17,12 +17,7 @@ import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
 import io.tolgee.service.translation.AutoTranslationService
 import org.springframework.hateoas.CollectionModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress(names = ["MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection"])
 @RestController
@@ -34,7 +29,7 @@ class ProjectsAutoTranslationSettingsController(
   private val autoTranslateService: AutoTranslationService,
   private val autoTranslationSettingsModelAssembler: AutoTranslationSettingsModelAssembler,
 ) {
-  @PutMapping("/{projectId}/per-language-auto-translation-settings")
+  @PutMapping("/{projectId:[0-9]+}/per-language-auto-translation-settings")
   @Operation(
     summary = "Set per-language auto-translation settings",
   )
@@ -47,7 +42,7 @@ class ProjectsAutoTranslationSettingsController(
     return autoTranslationSettingsModelAssembler.toCollectionModel(config)
   }
 
-  @GetMapping("/{projectId}/per-language-auto-translation-settings")
+  @GetMapping("/{projectId:[0-9]+}/per-language-auto-translation-settings")
   @Operation(summary = "Get per-language auto-translation settings")
   @UseDefaultPermissions
   @AllowApiAccess
@@ -56,7 +51,7 @@ class ProjectsAutoTranslationSettingsController(
     return autoTranslationSettingsModelAssembler.toCollectionModel(configs)
   }
 
-  @PutMapping("/{projectId}/auto-translation-settings")
+  @PutMapping("/{projectId:[0-9]+}/auto-translation-settings")
   @Operation(
     summary = "Set default auto translation settings for project",
     description =
@@ -74,7 +69,7 @@ class ProjectsAutoTranslationSettingsController(
     return autoTranslationSettingsModelAssembler.toModel(config)
   }
 
-  @GetMapping("/{projectId}/auto-translation-settings")
+  @GetMapping("/{projectId:[0-9]+}/auto-translation-settings")
   @Operation(
     summary = "Get default auto-translation settings for project",
     description =

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
@@ -50,17 +50,7 @@ import org.springframework.data.web.SortDefault
 import org.springframework.hateoas.PagedModel
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
 @Suppress(names = ["MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection"])
@@ -104,15 +94,14 @@ class ProjectsController(
     return projectModelAssembler.toModel(projectService.getView(project.id))
   }
 
-  @GetMapping("/{projectId}")
+  @GetMapping("/{projectId:[0-9]+}")
   @Operation(summary = "Get one project")
   @UseDefaultPermissions
   @AllowApiAccess
   @OpenApiOrderExtension(2)
   fun get(
-    @PathVariable("projectId") projectId: Long,
   ): ProjectModel {
-    return projectService.getView(projectId).let {
+    return projectService.getView(projectHolder.project.id).let {
       projectModelAssembler.toModel(it)
     }
   }
@@ -135,7 +124,7 @@ class ProjectsController(
   }
 
   @Operation(summary = "Update project settings")
-  @PutMapping(value = ["/{projectId}"])
+  @PutMapping(value = ["/{projectId:[0-9]+}"])
   @RequestActivity(ActivityType.EDIT_PROJECT)
   @RequiresProjectPermissions([Scope.PROJECT_EDIT])
   @RequiresSuperAuthentication
@@ -149,7 +138,7 @@ class ProjectsController(
     return projectModelAssembler.toModel(projectService.getView(project.id))
   }
 
-  @DeleteMapping(value = ["/{projectId}"])
+  @DeleteMapping(value = ["/{projectId:[0-9]+}"])
   @Operation(summary = "Delete project")
   @RequiresProjectPermissions([Scope.PROJECT_EDIT])
   @RequiresSuperAuthentication
@@ -175,7 +164,7 @@ class ProjectsController(
     return projectWithStatsFacade.getPagedModelWithStats(projects)
   }
 
-  @GetMapping("/{projectId}/users")
+  @GetMapping("/{projectId:[0-9]+}/users")
   @Operation(
     summary = "Get users with project access",
     description = "Returns all project users, who have permission to access project",
@@ -226,7 +215,7 @@ class ProjectsController(
     return projectModelAssembler.toModel(projectService.getView(projectId))
   }
 
-  @PutMapping("/{projectId}/users/{userId}/set-permissions/{permissionType}")
+  @PutMapping("/{projectId:[0-9]+}/users/{userId}/set-permissions/{permissionType}")
   @Operation(summary = "Set direct permission to user")
   @RequiresProjectPermissions([ Scope.MEMBERS_EDIT ])
   @RequiresSuperAuthentication
@@ -244,7 +233,7 @@ class ProjectsController(
     )
   }
 
-  @PutMapping("/{projectId}/users/{userId}/set-by-organization")
+  @PutMapping("/{projectId:[0-9]+}/users/{userId}/set-by-organization")
   @Operation(
     summary = "Remove direct project permission",
     description =
@@ -263,7 +252,7 @@ class ProjectsController(
     )
   }
 
-  @PutMapping("/{projectId}/users/{userId}/revoke-access")
+  @PutMapping("/{projectId:[0-9]+}/users/{userId}/revoke-access")
   @Operation(summary = "Revoke project access")
   @RequiresProjectPermissions([ Scope.MEMBERS_EDIT ])
   @RequiresSuperAuthentication

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
@@ -99,8 +99,7 @@ class ProjectsController(
   @UseDefaultPermissions
   @AllowApiAccess
   @OpenApiOrderExtension(2)
-  fun get(
-  ): ProjectModel {
+  fun get(): ProjectModel {
     return projectService.getView(projectHolder.project.id).let {
       projectModelAssembler.toModel(it)
     }

--- a/backend/api/src/main/kotlin/io/tolgee/controllers/ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/controllers/ExportController.kt
@@ -14,11 +14,7 @@ import io.tolgee.service.translation.TranslationService
 import io.tolgee.util.StreamingResponseBodyProvider
 import org.apache.tomcat.util.http.fileupload.IOUtils
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
 import java.io.ByteArrayInputStream
 import java.io.OutputStream
@@ -28,9 +24,9 @@ import java.util.zip.ZipOutputStream
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
-  "/api/project/{projectId}/export",
+  "/api/project/{projectId:[0-9]+}/export",
   "/api/project/export",
-  "/api/repository/{projectId}/export",
+  "/api/repository/{projectId:[0-9]+}/export",
   "/api/repository/export",
 )
 @Tag(name = "Export")

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
@@ -1,6 +1,5 @@
 package io.tolgee.hateoas.project
 
-import io.tolgee.api.v2.controllers.organization.OrganizationController
 import io.tolgee.api.v2.controllers.project.ProjectsController
 import io.tolgee.dtos.ComputedPermissionDto
 import io.tolgee.dtos.cacheable.LanguageDto
@@ -17,7 +16,6 @@ import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.PermissionService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
-import org.springframework.hateoas.server.mvc.linkTo
 import org.springframework.stereotype.Component
 
 @Component
@@ -37,7 +35,6 @@ class ProjectModelAssembler(
     ProjectModel::class.java,
   ) {
   override fun toModel(view: ProjectWithLanguagesView): ProjectModel {
-    val link = linkTo<ProjectsController> { get(view.id) }.withSelfRel()
     val baseLanguage =
       languageService.getProjectLanguages(view.id).find { it.base } ?: let {
         projectService.getOrAssignBaseLanguage(view.id)
@@ -63,9 +60,7 @@ class ProjectModelAssembler(
       directPermission = view.directPermission?.let { permissionModelAssembler.toModel(it) },
       computedPermission = computedPermissionModelAssembler.toModel(computedPermissions),
       icuPlaceholders = view.icuPlaceholders,
-    ).add(link).also { model ->
-      model.add(linkTo<OrganizationController> { get(view.organizationOwner.slug) }.withRel("organizationOwner"))
-    }
+    )
   }
 
   private fun getComputedPermissions(view: ProjectWithLanguagesView): ComputedPermissionDto {

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
@@ -1,6 +1,5 @@
 package io.tolgee.hateoas.project
 
-import io.tolgee.api.v2.controllers.organization.OrganizationController
 import io.tolgee.api.v2.controllers.project.ProjectsController
 import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.hateoas.language.LanguageModelAssembler
@@ -15,7 +14,6 @@ import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.PermissionService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
-import org.springframework.hateoas.server.mvc.linkTo
 import org.springframework.stereotype.Component
 
 @Component
@@ -34,7 +32,6 @@ class ProjectWithStatsModelAssembler(
     ProjectWithStatsModel::class.java,
   ) {
   override fun toModel(view: ProjectWithStatsView): ProjectWithStatsModel {
-    val link = linkTo<ProjectsController> { get(view.id) }.withSelfRel()
     val baseLanguage =
       languageService.getProjectLanguages(view.id).find { it.base } ?: let {
         projectService.getOrAssignBaseLanguage(view.id)
@@ -61,10 +58,6 @@ class ProjectWithStatsModelAssembler(
       stats = view.stats,
       languages = view.languages.map { languageModelAssembler.toModel(it) },
       icuPlaceholders = view.icuPlaceholders,
-    ).add(link).also { model ->
-      view.organizationOwner.slug.let {
-        model.add(linkTo<OrganizationController> { get(it) }.withRel("organizationOwner"))
-      }
-    }
+    )
   }
 }

--- a/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
@@ -36,7 +36,8 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.multipart.support.MissingServletRequestPartException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import java.io.Serializable
-import java.util.*
+import java.util.Arrays
+import java.util.Collections
 import java.util.function.Consumer
 
 @RestControllerAdvice
@@ -284,4 +285,15 @@ class ExceptionHandlers : Logging {
     val headerXFF = request.getHeader("X-FORWARDED-FOR")
     logger.warn(message, request.method, request.requestURL, request.remoteAddr, headerXFF)
   }
+
+	@ExceptionHandler(InvalidPathException::class)
+	fun handleInvalidPathException(
+		exception: InvalidPathException
+	): ResponseEntity<ErrorResponseBody> {
+		val params = exception.message?.let { listOf(it) }
+		return ResponseEntity(
+			ErrorResponseBody(Message.INVALID_PATH.code, params),
+			HttpStatus.BAD_REQUEST,
+		)
+	}
 }

--- a/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
@@ -285,15 +285,4 @@ class ExceptionHandlers : Logging {
     val headerXFF = request.getHeader("X-FORWARDED-FOR")
     logger.warn(message, request.method, request.requestURL, request.remoteAddr, headerXFF)
   }
-
-	@ExceptionHandler(InvalidPathException::class)
-	fun handleInvalidPathException(
-		exception: InvalidPathException
-	): ResponseEntity<ErrorResponseBody> {
-		val params = exception.message?.let { listOf(it) }
-		return ResponseEntity(
-			ErrorResponseBody(Message.INVALID_PATH.code, params),
-			HttpStatus.BAD_REQUEST,
-		)
-	}
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
@@ -1,15 +1,10 @@
 package io.tolgee.api.v2.controllers.v2ProjectsController
 
 import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.development.testDataBuilder.data.ProjectsTestData
-import io.tolgee.fixtures.andAssertThatJson
-import io.tolgee.fixtures.andIsBadRequest
-import io.tolgee.fixtures.andIsNotFound
-import io.tolgee.fixtures.andIsOk
-import io.tolgee.fixtures.andPrettyPrint
-import io.tolgee.fixtures.isPermissionScopes
-import io.tolgee.fixtures.node
+import io.tolgee.fixtures.*
 import io.tolgee.model.Permission
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.ProjectPermissionType
@@ -277,4 +272,15 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     val project = projectService.find(base.project.id)
     Assertions.assertThat(project).isNull()
   }
+
+	@Test
+	fun `test bad request error is returned when requested url with wrong pattern`() {
+		performAuthGet("/v2/projects/export&format=JSON")
+			.andIsNotFound
+			.andPrettyPrint
+			.andAssertThatJson.let {
+				it.node("code").isEqualTo(Message.RESOURCE_NOT_FOUND.code)
+				it.node("params[0]").isEqualTo("v2/projects/export&format=JSON")
+			}
+	}
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
@@ -273,14 +273,14 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     Assertions.assertThat(project).isNull()
   }
 
-	@Test
-	fun `test bad request error is returned when requested url with wrong pattern`() {
-		performAuthGet("/v2/projects/export&format=JSON")
-			.andIsNotFound
-			.andPrettyPrint
-			.andAssertThatJson.let {
-				it.node("code").isEqualTo(Message.RESOURCE_NOT_FOUND.code)
-				it.node("params[0]").isEqualTo("v2/projects/export&format=JSON")
-			}
-	}
+  @Test
+  fun `test bad request error is returned when requested url with wrong pattern`() {
+    performAuthGet("/v2/projects/export&format=JSON")
+      .andIsNotFound
+      .andPrettyPrint
+      .andAssertThatJson.let {
+        it.node("code").isEqualTo(Message.RESOURCE_NOT_FOUND.code)
+        it.node("params[0]").isEqualTo("v2/projects/export&format=JSON")
+      }
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/constants/Message.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/Message.kt
@@ -4,7 +4,7 @@
 package io.tolgee.constants
 
 import com.fasterxml.jackson.annotation.JsonValue
-import java.util.*
+import java.util.Locale
 
 enum class Message {
   UNAUTHENTICATED,
@@ -280,6 +280,7 @@ enum class Message {
   KEYS_SPENDING_LIMIT_EXCEEDED,
   PLAN_SEAT_LIMIT_EXCEEDED,
   INSTANCE_NOT_USING_LICENSE_KEY,
+	INVALID_PATH,
   ;
 
   val code: String

--- a/backend/data/src/main/kotlin/io/tolgee/constants/Message.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/Message.kt
@@ -4,7 +4,7 @@
 package io.tolgee.constants
 
 import com.fasterxml.jackson.annotation.JsonValue
-import java.util.Locale
+import java.util.*
 
 enum class Message {
   UNAUTHENTICATED,
@@ -280,7 +280,7 @@ enum class Message {
   KEYS_SPENDING_LIMIT_EXCEEDED,
   PLAN_SEAT_LIMIT_EXCEEDED,
   INSTANCE_NOT_USING_LICENSE_KEY,
-	INVALID_PATH,
+  INVALID_PATH,
   ;
 
   val code: String

--- a/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidPathException.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidPathException.kt
@@ -4,4 +4,4 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
 @ResponseStatus(value = HttpStatus.BAD_REQUEST)
-class InvalidPathException : RuntimeException()
+class InvalidPathException(message: String) : RuntimeException(message)

--- a/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidPathException.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidPathException.kt
@@ -1,7 +1,3 @@
 package io.tolgee.exceptions
 
-import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.ResponseStatus
-
-@ResponseStatus(value = HttpStatus.BAD_REQUEST)
-class InvalidPathException(message: String) : RuntimeException(message)
+class InvalidPathException(message: String) : BadRequestException(message)

--- a/backend/data/src/main/kotlin/io/tolgee/security/RequestContextService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/security/RequestContextService.kt
@@ -18,6 +18,7 @@ package io.tolgee.security
 
 import io.tolgee.dtos.cacheable.OrganizationDto
 import io.tolgee.dtos.cacheable.ProjectDto
+import io.tolgee.exceptions.InvalidPathException
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService
@@ -58,10 +59,11 @@ class RequestContextService(
       // No permission check needs to occur here.
       return null
     }
-
-    val id = (pathVariablesMap.values.first() as String).toLong()
-    return projectService.findDto(id)
-  }
+		val idAsString = pathVariablesMap.values.first() as String
+		return runCatching { projectService.findDto(idAsString.toLong())}
+			.onFailure { throw InvalidPathException("Invalid format of project id: $idAsString") }
+			.getOrNull()
+	}
 
   private fun getTargetProjectImplicit(): ProjectDto? {
     // This method is the source of complexity for the global handling, but is itself quite simple. Oh, the irony!
@@ -90,8 +92,9 @@ class RequestContextService(
     if (idOrSlug.contains(IS_SLUG_RE)) {
       return organizationService.findDto(idOrSlug)
     }
-
-    return organizationService.findDto(idOrSlug.toLong())
+		return runCatching { organizationService.findDto(idOrSlug.toLong())}
+			.onFailure { throw InvalidPathException("Invalid format of organization id: $idOrSlug") }
+			.getOrNull()
   }
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/security/RequestContextService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/security/RequestContextService.kt
@@ -59,11 +59,11 @@ class RequestContextService(
       // No permission check needs to occur here.
       return null
     }
-		val idAsString = pathVariablesMap.values.first() as String
-		return runCatching { projectService.findDto(idAsString.toLong())}
-			.onFailure { throw InvalidPathException("Invalid format of project id: $idAsString") }
-			.getOrNull()
-	}
+    val idAsString = pathVariablesMap.values.first() as String
+    return runCatching { projectService.findDto(idAsString.toLong()) }
+      .onFailure { throw InvalidPathException("Invalid format of project id: $idAsString") }
+      .getOrNull()
+  }
 
   private fun getTargetProjectImplicit(): ProjectDto? {
     // This method is the source of complexity for the global handling, but is itself quite simple. Oh, the irony!
@@ -92,9 +92,9 @@ class RequestContextService(
     if (idOrSlug.contains(IS_SLUG_RE)) {
       return organizationService.findDto(idOrSlug)
     }
-		return runCatching { organizationService.findDto(idOrSlug.toLong())}
-			.onFailure { throw InvalidPathException("Invalid format of organization id: $idOrSlug") }
-			.getOrNull()
+    return runCatching { organizationService.findDto(idOrSlug.toLong()) }
+      .onFailure { throw InvalidPathException("Invalid format of organization id: $idOrSlug") }
+      .getOrNull()
   }
 
   companion object {

--- a/backend/data/src/test/kotlin/io/tolgee/security/RequestContextServiceTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/security/RequestContextServiceTest.kt
@@ -19,6 +19,7 @@ package io.tolgee.security
 import io.tolgee.dtos.cacheable.ApiKeyDto
 import io.tolgee.dtos.cacheable.OrganizationDto
 import io.tolgee.dtos.cacheable.ProjectDto
+import io.tolgee.exceptions.InvalidPathException
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService
@@ -156,5 +157,17 @@ class RequestContextServiceTest {
 
     assertThat(org?.id).isEqualTo(TEST_ORGANIZATION_ID)
     assertThat(org?.slug).isEqualTo(TEST_ORGANIZATION_SLUG)
+  }
+
+  @Test
+  fun `it throws invalid path when the path variable of project is not in proper format`() {
+    val req = makeRequest("/v2/projects/{projectId}")
+		assertThrows<InvalidPathException> { requestContextService.getTargetProject(req) }
+  }
+
+	@Test
+  fun `it throws invalid path when the path variable of organization is not in proper format`() {
+    val req = makeRequest("/v2/organizations/{organizationId}")
+		assertThrows<InvalidPathException> { requestContextService.getTargetOrganization(req) }
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/security/RequestContextServiceTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/security/RequestContextServiceTest.kt
@@ -162,12 +162,12 @@ class RequestContextServiceTest {
   @Test
   fun `it throws invalid path when the path variable of project is not in proper format`() {
     val req = makeRequest("/v2/projects/{projectId}")
-		assertThrows<InvalidPathException> { requestContextService.getTargetProject(req) }
+    assertThrows<InvalidPathException> { requestContextService.getTargetProject(req) }
   }
 
-	@Test
+  @Test
   fun `it throws invalid path when the path variable of organization is not in proper format`() {
     val req = makeRequest("/v2/organizations/{organizationId}")
-		assertThrows<InvalidPathException> { requestContextService.getTargetOrganization(req) }
+    assertThrows<InvalidPathException> { requestContextService.getTargetOrganization(req) }
   }
 }

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/TranslationsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/TranslationsE2eDataController.kt
@@ -8,11 +8,7 @@ import io.tolgee.service.key.KeyService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.UserAccountService
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @CrossOrigin(origins = ["*"])
@@ -25,7 +21,7 @@ class TranslationsE2eDataController(
   private val testDataService: TestDataService,
   private val userAccountService: UserAccountService,
 ) {
-  @GetMapping(value = ["/generate/{projectId}/{number}"])
+  @GetMapping(value = ["/generate/{projectId:[0-9]+}/{number}"])
   @Transactional
   fun generateKeys(
     @PathVariable projectId: Long,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AdvancedPermissionController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AdvancedPermissionController.kt
@@ -17,11 +17,7 @@ import io.tolgee.security.authorization.RequiresOrganizationRole
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.service.organization.OrganizationRoleService
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/v2/")
@@ -35,7 +31,7 @@ class AdvancedPermissionController(
   private val organizationRoleService: OrganizationRoleService,
 ) {
   @Suppress("MVCPathVariableInspection")
-  @PutMapping("projects/{projectId}/users/{userId}/set-permissions")
+  @PutMapping("projects/{projectId:[0-9]+}/users/{userId}/set-permissions")
   @Operation(
     summary = "Set user's project permission",
     description = "Set user's granular (scope-based) direct project permission",

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/ContentStorageController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/ContentStorageController.kt
@@ -22,22 +22,14 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection", "SpringJavaInjectionPointsAutowiringInspection")
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/content-storages",
+    "/v2/projects/{projectId:[0-9]+}/content-storages",
   ],
 )
 @Tag(name = "Content Storages")

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/TaskController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/TaskController.kt
@@ -37,22 +37,14 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @Suppress("MVCPathVariableInspection")
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/tasks",
+    "/v2/projects/{projectId:[0-9]+}/tasks",
     "/v2/projects/tasks",
   ],
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/WebhookConfigController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/WebhookConfigController.kt
@@ -21,22 +21,14 @@ import org.springdoc.core.annotations.ParameterObject
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
-import org.springframework.web.bind.annotation.CrossOrigin
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @Suppress("MVCPathVariableInspection")
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(
   value = [
-    "/v2/projects/{projectId}/webhook-configs",
+    "/v2/projects/{projectId:[0-9]+}/webhook-configs",
   ],
 )
 @Tag(name = "Webhooks configuration")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced numeric-only project and organization ID formats in API endpoint URLs to prevent invalid requests.
  - Improved error handling and responses for invalid URL patterns, providing clearer feedback.

- **Tests**
  - Added tests to verify error handling for invalid project and organization ID formats in API requests.

- **Documentation**
  - Introduced a new error code for invalid path errors.

- **Refactor**
  - Consolidated import statements across controllers for cleaner code.
  - Removed HATEOAS links from project-related API responses to simplify returned models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->