### PR TITLE
feat: Add translation update time to the stats endpoint

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
@@ -1,6 +1,7 @@
 package io.tolgee.hateoas.project.stats
 
 import org.springframework.hateoas.RepresentationModel
+import java.util.*
 
 open class LanguageStatsModel(
   val languageId: Long?,
@@ -17,4 +18,5 @@ open class LanguageStatsModel(
   val untranslatedKeyCount: Long,
   val untranslatedWordCount: Long,
   val untranslatedPercentage: Double,
+  val translationsUpdatedAt: Date?,
 ) : RepresentationModel<LanguageStatsModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
@@ -18,5 +18,5 @@ open class LanguageStatsModel(
   val untranslatedKeyCount: Long,
   val untranslatedWordCount: Long,
   val untranslatedPercentage: Double,
-  val lastModified: Date?,
+  val translationsUpdatedAt: Date?,
 ) : RepresentationModel<LanguageStatsModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModel.kt
@@ -18,5 +18,5 @@ open class LanguageStatsModel(
   val untranslatedKeyCount: Long,
   val untranslatedWordCount: Long,
   val untranslatedPercentage: Double,
-  val translationsUpdatedAt: Date?,
+  val lastModified: Date?,
 ) : RepresentationModel<LanguageStatsModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
@@ -30,7 +30,7 @@ class LanguageStatsModelAssembler :
       untranslatedKeyCount = stats.untranslatedKeys,
       untranslatedWordCount = stats.untranslatedWords,
       untranslatedPercentage = stats.untranslatedPercentage,
-      translationsUpdatedAt = stats.translationsUpdatedAt,
+      lastModified = stats.lastModified,
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
@@ -30,6 +30,7 @@ class LanguageStatsModelAssembler :
       untranslatedKeyCount = stats.untranslatedKeys,
       untranslatedWordCount = stats.untranslatedWords,
       untranslatedPercentage = stats.untranslatedPercentage,
+      translationsUpdatedAt = stats.translationsUpdatedAt,
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/stats/LanguageStatsModelAssembler.kt
@@ -30,7 +30,7 @@ class LanguageStatsModelAssembler :
       untranslatedKeyCount = stats.untranslatedKeys,
       untranslatedWordCount = stats.untranslatedWords,
       untranslatedPercentage = stats.untranslatedPercentage,
-      lastModified = stats.lastModified,
+      translationsUpdatedAt = stats.translationsUpdatedAt,
     )
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
@@ -63,6 +63,7 @@ class ProjectStatsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
           node("reviewedKeyCount").isEqualTo(3)
           node("reviewedWordCount").isEqualTo(3)
           node("reviewedPercentage").isEqualTo(42.857142857142854)
+          node("translationsUpdatedAt").isNotNull
         }
         node("[1]") {
           node("languageId").isValidId
@@ -79,6 +80,7 @@ class ProjectStatsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
           node("untranslatedKeyCount").isEqualTo(5)
           node("untranslatedWordCount").isEqualTo(5)
           node("untranslatedPercentage").isEqualTo(71.42857142857143)
+          node("translationsUpdatedAt").isNotNull
         }
       }
     }

--- a/backend/app/src/test/kotlin/io/tolgee/component/LanguageStatsListenerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/LanguageStatsListenerTest.kt
@@ -49,6 +49,7 @@ class LanguageStatsListenerTest : AbstractControllerTest() {
           languageStatsService.getLanguageStats(projectId = testData.project.id)
             .find { projectLanguages[it.languageId]!!.tag == "de" }
         assertThat(newDeutschStats!!.untranslatedWords - 1).isEqualTo(deutschStats?.untranslatedWords)
+        assertThat(newDeutschStats.translationsUpdatedAt!!.after(deutschStats!!.translationsUpdatedAt))
       }
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
@@ -1,5 +1,7 @@
 package io.tolgee.api
 
+import java.util.*
+
 interface ILanguageStats {
   val languageId: Long
   val untranslatedWords: Long
@@ -11,4 +13,5 @@ interface ILanguageStats {
   val untranslatedPercentage: Double
   val translatedPercentage: Double
   val reviewedPercentage: Double
+  val translationsUpdatedAt: Date?
 }

--- a/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
@@ -13,5 +13,5 @@ interface ILanguageStats {
   val untranslatedPercentage: Double
   val translatedPercentage: Double
   val reviewedPercentage: Double
-  val lastModified: Date
+  val translationsUpdatedAt: Date?
 }

--- a/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/api/ILanguageStats.kt
@@ -13,5 +13,5 @@ interface ILanguageStats {
   val untranslatedPercentage: Double
   val translatedPercentage: Double
   val reviewedPercentage: Double
-  val translationsUpdatedAt: Date?
+  val lastModified: Date
 }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
@@ -15,5 +15,5 @@ data class LanguageStatsDto(
   override val untranslatedPercentage: Double,
   override val translatedPercentage: Double,
   override val reviewedPercentage: Double,
-  override val lastModified: Date,
+  override val translationsUpdatedAt: Date?
 ) : ILanguageStats

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
@@ -1,6 +1,7 @@
 package io.tolgee.dtos.queryResults
 
 import io.tolgee.api.ILanguageStats
+import java.util.*
 
 data class LanguageStatsDto(
   override val languageId: Long,
@@ -14,4 +15,5 @@ data class LanguageStatsDto(
   override val untranslatedPercentage: Double,
   override val translatedPercentage: Double,
   override val reviewedPercentage: Double,
+  override val translationsUpdatedAt: Date?,
 ) : ILanguageStats

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
@@ -15,5 +15,5 @@ data class LanguageStatsDto(
   override val untranslatedPercentage: Double,
   override val translatedPercentage: Double,
   override val reviewedPercentage: Double,
-  override val translationsUpdatedAt: Date?
+  override val translationsUpdatedAt: Date?,
 ) : ILanguageStats

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/LanguageStatsDto.kt
@@ -15,5 +15,5 @@ data class LanguageStatsDto(
   override val untranslatedPercentage: Double,
   override val translatedPercentage: Double,
   override val reviewedPercentage: Double,
-  override val translationsUpdatedAt: Date?,
+  override val lastModified: Date,
 ) : ILanguageStats

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -37,10 +37,7 @@ class LanguageStats(
 
   override var reviewedPercentage: Double = 0.0
 
-  override val translationsUpdatedAt: Date?
-    get() = language.translations
-      .mapNotNull { it.updatedAt ?: it.createdAt }
-      .maxByOrNull { it }
+  override var translationsUpdatedAt: Date? = null
 
   override val languageId: Long
     get() = language.id

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -37,8 +37,10 @@ class LanguageStats(
 
   override var reviewedPercentage: Double = 0.0
 
-  override val lastModified: Date
-    get() = updatedAt ?: Date()
+  override val translationsUpdatedAt: Date?
+    get() = language.translations
+      .mapNotNull { it.updatedAt ?: it.createdAt }
+      .maxByOrNull { it }
 
   override val languageId: Long
     get() = language.id
@@ -56,6 +58,6 @@ class LanguageStats(
       untranslatedPercentage = untranslatedPercentage,
       translatedPercentage = translatedPercentage,
       reviewedPercentage = reviewedPercentage,
-      lastModified = lastModified
+      translationsUpdatedAt = translationsUpdatedAt
     )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -37,8 +37,8 @@ class LanguageStats(
 
   override var reviewedPercentage: Double = 0.0
 
-  override val translationsUpdatedAt: Date?
-    get() = updatedAt
+  override val lastModified: Date
+    get() = updatedAt ?: Date()
 
   override val languageId: Long
     get() = language.id
@@ -56,6 +56,6 @@ class LanguageStats(
       untranslatedPercentage = untranslatedPercentage,
       translatedPercentage = translatedPercentage,
       reviewedPercentage = reviewedPercentage,
-      translationsUpdatedAt = translationsUpdatedAt
+      lastModified = lastModified
     )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
+import java.util.*
 
 @Entity
 @Table(uniqueConstraints = [UniqueConstraint(columnNames = ["language_id"], name = "language_stats_language_id_key")])
@@ -35,6 +36,10 @@ class LanguageStats(
   override var translatedPercentage: Double = 0.0
 
   override var reviewedPercentage: Double = 0.0
+
+  override val translationsUpdatedAt: Date?
+    get() = updatedAt
+
   override val languageId: Long
     get() = language.id
 
@@ -51,5 +56,6 @@ class LanguageStats(
       untranslatedPercentage = untranslatedPercentage,
       translatedPercentage = translatedPercentage,
       reviewedPercentage = reviewedPercentage,
+      translationsUpdatedAt = translationsUpdatedAt
     )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -58,6 +58,6 @@ class LanguageStats(
       untranslatedPercentage = untranslatedPercentage,
       translatedPercentage = translatedPercentage,
       reviewedPercentage = reviewedPercentage,
-      translationsUpdatedAt = translationsUpdatedAt
+      translationsUpdatedAt = translationsUpdatedAt,
     )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -10,6 +10,8 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.Temporal
+import jakarta.persistence.TemporalType
 import jakarta.persistence.UniqueConstraint
 import java.util.*
 
@@ -37,6 +39,7 @@ class LanguageStats(
 
   override var reviewedPercentage: Double = 0.0
 
+  @Temporal(TemporalType.TIMESTAMP)
   override var translationsUpdatedAt: Date? = null
 
   override val languageId: Long

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
@@ -34,8 +34,7 @@ interface LanguageStatsRepository : JpaRepository<LanguageStats, Long> {
       ls.reviewedKeys,
       ls.untranslatedPercentage,
       ls.translatedPercentage,
-      ls.reviewedPercentage,
-      ls.updatedAt
+      ls.reviewedPercentage
     )
     from LanguageStats ls
     where ls.language.project.id in :projectIds and ls.language.deletedAt is null

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
@@ -34,7 +34,8 @@ interface LanguageStatsRepository : JpaRepository<LanguageStats, Long> {
       ls.reviewedKeys,
       ls.untranslatedPercentage,
       ls.translatedPercentage,
-      ls.reviewedPercentage
+      ls.reviewedPercentage,
+      ls.translationsUpdatedAt
     )
     from LanguageStats ls
     where ls.language.project.id in :projectIds and ls.language.deletedAt is null

--- a/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/LanguageStatsRepository.kt
@@ -34,7 +34,8 @@ interface LanguageStatsRepository : JpaRepository<LanguageStats, Long> {
       ls.reviewedKeys,
       ls.untranslatedPercentage,
       ls.translatedPercentage,
-      ls.reviewedPercentage
+      ls.reviewedPercentage,
+      ls.updatedAt
     )
     from LanguageStats ls
     where ls.language.project.id in :projectIds and ls.language.deletedAt is null

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -221,4 +221,7 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     projectId: Long,
     translationId: Long,
   ): Translation?
+
+  @Query("select max(coalesce(t.updatedAt, t.createdAt)) from Translation t where t.language.id = :languageId")
+  fun getLastModifiedDate(languageId: Long): Date?
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
@@ -7,6 +7,7 @@ import io.tolgee.model.Language
 import io.tolgee.model.LanguageStats
 import io.tolgee.model.views.projectStats.ProjectLanguageStatsResultView
 import io.tolgee.repository.LanguageStatsRepository
+import io.tolgee.repository.TranslationRepository
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.queryBuilders.LanguageStatsProvider
 import io.tolgee.util.Logging
@@ -24,6 +25,7 @@ class LanguageStatsService(
   private val languageService: LanguageService,
   private val projectStatsService: ProjectStatsService,
   private val languageStatsRepository: LanguageStatsRepository,
+  private val translationRepository: TranslationRepository,
   private val entityManager: EntityManager,
   private val projectService: ProjectService,
   private val lockingProvider: LockingProvider,
@@ -58,6 +60,9 @@ class LanguageStatsService(
                 languageStats.computeIfAbsent(language.id) {
                   LanguageStats(entityManager.getReference(Language::class.java, language.id))
                 }
+
+              val lastUpdatedAt = translationRepository.getLastModifiedDate(language.id)
+
               stats.apply {
                 translatedKeys = rawLanguageStats.translatedKeys
                 translatedWords = rawLanguageStats.translatedWords
@@ -68,6 +73,7 @@ class LanguageStatsService(
                 untranslatedKeys = projectStats.keyCount - translatedOrReviewedKeys
                 this.untranslatedWords = baseWords - translatedOrReviewedWords
                 untranslatedPercentage = untranslatedWords.toDouble() / baseWords * 100
+                translationsUpdatedAt = lastUpdatedAt
               }
             }
 

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4192,4 +4192,9 @@
     <changeSet author="anty (generated)" id="1741689879651-1">
         <dropColumn columnName="account_type" tableName="auth_provider_change_request"/>
     </changeSet>
+    <changeSet id="1743416359510-1" author="icodetea">
+        <addColumn tableName="language_stats">
+            <column name="translations_updated_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
We now expose a timestamp of the last modification as explain in #3008 
I planned to write tests, however I wasn't sure where and what kind of tests you prefer. I would like to have some guidance, and then I can add tests as well.

I tested this manually by updating translations for a language, and then I expected the timestamp to change.
In the video, you can see that I was checking the network tab in the devtools which also query the stats endpoint.

The interesting part is the new timestmap which changes from 
`1743062340802` which is `Thu Mar 27 2025 07:59:00.802` to
`1743063177609`  which is `Thu Mar 27 2025 08:12:57.609`

https://github.com/user-attachments/assets/40cf8990-c8da-4751-a79e-f526b5e3e54c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Language statistics now include a “Last Translation Update” timestamp, giving you clear insight into when translations were last refreshed.
  
- **Bug Fixes**
	- Improved data retrieval for language statistics to accurately reflect the last modified date of translations.

- **Tests**
	- Enhanced test coverage confirms the new timestamp is correctly reflected in language statistics responses.
	- Additional validation ensures updates to language statistics reflect the most recent translation update time.
	- New assertions added to verify the presence of the last translation update timestamp in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->