### PR TITLE
feat: update postgres to 18 Debian-based and release `*-pg18` Docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,10 @@ jobs:
         if: ${{ steps.version.outputs.VERSION != '' }}
         run: |
           docker buildx create --use
-          docker buildx build . -t tolgee/tolgee:${{ steps.version.outputs.VERSION }} --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
-          docker buildx build . -t tolgee/tolgee:latest --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
+          docker buildx build . -f legacy.Dockerfile -t tolgee/tolgee:${{ steps.version.outputs.VERSION }} --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
+          docker buildx build . -f legacy.Dockerfile -t tolgee/tolgee:latest --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
+          docker buildx build . -t tolgee/tolgee:${{ steps.version.outputs.VERSION }}-pg18 --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
+          docker buildx build . -t tolgee/tolgee:latest-pg18 --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
         working-directory: build/docker
 
       - name: Pack with webapp

--- a/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
@@ -14,7 +14,7 @@ class PostgresDockerRunner(
   override fun run() {
     instance =
       DockerContainerRunner(
-        image = "postgres:16.3",
+        image = "postgres:16.8-alpine3.21",
         expose = mapOf(postgresAutostartProperties.port to "5432"),
         waitForLog = "database system is ready to accept connections",
         waitForLogTimesForNewContainer = 2,

--- a/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
@@ -14,7 +14,7 @@ class PostgresDockerRunner(
   override fun run() {
     instance =
       DockerContainerRunner(
-        image = "postgres:16.8-alpine3.21",
+        image = "postgres:16.8",
         expose = mapOf(postgresAutostartProperties.port to "5432"),
         waitForLog = "database system is ready to accept connections",
         waitForLogTimesForNewContainer = 2,

--- a/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/postgresRunners/PostgresDockerRunner.kt
@@ -14,7 +14,7 @@ class PostgresDockerRunner(
   override fun run() {
     instance =
       DockerContainerRunner(
-        image = "postgres:16.8",
+        image = "postgres:18.0",
         expose = mapOf(postgresAutostartProperties.port to "5432"),
         waitForLog = "database system is ready to accept connections",
         waitForLogTimesForNewContainer = 2,

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ project(':server-app').afterEvaluate {
                         "-d",
                         "-p55538:5432",
                         "--name", dbSchemaContainerName,
-                        "postgres:16.8"
+                        "postgres:18.0"
             }
             Thread.sleep(5000)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ project(':server-app').afterEvaluate {
                 commandLine "docker", "rm", "--force", "--volumes", dbSchemaContainerName
             }
             exec {
-                commandLine "docker", "run", "-e", "POSTGRES_PASSWORD=postgres", "-d", "-p55538:5432", "--name", dbSchemaContainerName, "postgres:13"
+                commandLine "docker", "run", "-e", "POSTGRES_PASSWORD=postgres", "-d", "-p55538:5432", "--name", dbSchemaContainerName, "postgres:16.8-alpine3.21"
             }
             Thread.sleep(5000)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,12 @@ project(':server-app').afterEvaluate {
                 commandLine "docker", "rm", "--force", "--volumes", dbSchemaContainerName
             }
             exec {
-                commandLine "docker", "run", "-e", "POSTGRES_PASSWORD=postgres", "-d", "-p55538:5432", "--name", dbSchemaContainerName, "postgres:16.8-alpine3.21"
+                commandLine "docker", "run",
+                        "-e", "POSTGRES_PASSWORD=postgres",
+                        "-d",
+                        "-p55538:5432",
+                        "--name", dbSchemaContainerName,
+                        "postgres:16.8"
             }
             Thread.sleep(5000)
         }

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.8-alpine3.21
+FROM postgres:16.8
 
 ENTRYPOINT []
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,8 +2,17 @@ FROM postgres:16.8
 
 ENTRYPOINT []
 
-RUN apk --no-cache add openjdk21
-RUN apk --no-cache add libxml2
+RUN <<EOF
+  set -eux
+  apt -qq update
+  apt -qq -y install wget
+  wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
+  echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
+  apt -qq update
+  apt -qq -y install temurin-21-jdk libxml2
+  apt -qq -y remove wget --purge --auto-remove
+  rm -rf /var/lib/apt/lists/*
+EOF
 
 #############
 ### Tolgee  #

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.8
+FROM postgres:18.0
 
 ENTRYPOINT []
 

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.21-alpine3.22
+FROM postgres:16.8-alpine3.21
 
 ENTRYPOINT []
 

--- a/docker/app/legacy.Dockerfile
+++ b/docker/app/legacy.Dockerfile
@@ -1,0 +1,39 @@
+# TODO: remove for Tolgee 4 release
+FROM postgres:13.21-alpine3.22
+
+ENTRYPOINT []
+
+RUN apk --no-cache add openjdk21
+RUN apk --no-cache add libxml2
+
+#############
+### Tolgee  #
+#############
+
+# Expose application port
+EXPOSE 8080
+
+# Define persistent volume for data storage
+VOLUME /data
+
+# Environment variables for configuration
+ENV HEALTHCHECK_PORT=8080 \
+    spring_profiles_active=docker
+
+# Copy necessary application files
+COPY BOOT-INF/lib /app/lib
+COPY META-INF /app/META-INF
+COPY BOOT-INF/classes /app
+COPY --chmod=755 cmd.sh /app
+
+#################
+### Let's go   ##
+#################
+
+# Define the startup command
+ENTRYPOINT ["/app/cmd.sh"]
+
+
+# Health check to ensure the app is up and running
+HEALTHCHECK --interval=10s --timeout=3s --retries=20 \
+    CMD wget --spider -q "http://127.0.0.1:$HEALTHCHECK_PORT/actuator/health" || exit 1

--- a/docker/docker-compose.template.yml
+++ b/docker/docker-compose.template.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:11
+    image: postgres:16.8-alpine3.21
     environment:
       - POSTGRES_PASSWORD=postgres
   app:

--- a/docker/docker-compose.template.yml
+++ b/docker/docker-compose.template.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16.8
+    image: postgres:18.0
     environment:
       - POSTGRES_PASSWORD=postgres
   app:

--- a/docker/docker-compose.template.yml
+++ b/docker/docker-compose.template.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16.8-alpine3.21
+    image: postgres:16.8
     environment:
       - POSTGRES_PASSWORD=postgres
   app:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16.8-alpine3.21
+    image: postgres:16.8
     volumes:
       - ../build/db-data:/var/lib/postgresql/data/
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:11
+    image: postgres:16.8-alpine3.21
     volumes:
       - ../build/db-data:/var/lib/postgresql/data/
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16.8
+    image: postgres:18.0
     volumes:
       - ../build/db-data:/var/lib/postgresql/data/
     environment:

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -21,8 +21,12 @@ task docker {
     doLast {
         exec {
             workingDir dockerPath
-            commandLine "docker", "build", ".", "-t", "tolgee/tolgee", "--cache-from", "type=registry,ref=tolgee/tolgee:latest"
+            commandLine "docker", "build", ".", "-t", "tolgee/tolgee", "--cache-from", "type=registry,ref=tolgee/tolgee:latest-pg18"
         }
+		exec {
+			workingDir dockerPath
+			commandLine "docker", "build", ".", "-f", "legacy.Dockerfile", "-t", "tolgee/tolgee", "--cache-from", "type=registry,ref=tolgee/tolgee:latest"
+		}
     }
     dependsOn("dockerPrepare")
 }
@@ -32,13 +36,19 @@ void createDockerBuildxTask(String taskName, boolean isPush) {
         doLast {
             if (project.hasProperty('dockerImageTag')) {
                 def commandParams = ["docker", "buildx", "build", ".", "-t", project.property('dockerImageTag'), "--platform", "linux/arm64,linux/amd64"]
-                if (isPush) {
+				def commandParamsLegacy = ["docker", "buildx", "build", ".", "-f", "legacy.Dockerfile", "-t", project.property('dockerImageTag') + "-pg18", "--platform", "linux/arm64,linux/amd64"]
+				if (isPush) {
                     commandParams += ["--push"]
+					commandParamsLegacy += ["--push"]
                 }
-                exec {
-                    workingDir dockerPath
-                    commandLine commandParams
-                }
+				exec {
+					workingDir dockerPath
+					commandLine commandParams
+				}
+				exec {
+					workingDir dockerPath
+					commandLine commandParamsLegacy
+				}
             } else {
                 throw new GradleException('A "dockerImageTag" project property must be defined! e.g. ./gradlew dockerBuildx -PdockerImageTag=myImageTag');
             }


### PR DESCRIPTION
See #3033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded PostgreSQL used across deployment and local Docker images to 16.8 for consistent runtime.
  - Updated the dev/test container runner to use a newer PostgreSQL image variant (PG18) for compatibility testing.
  - Release pipeline now builds additional Docker image tags (including -pg18 variants) to publish artifacts for both standard and PG18 builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->