### PR TITLE
Upgrade libxml2 to >=2.14.2 in Dockerfile to Fix CVE-2025-32415 and CVE-2025-32414

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:13.20-alpine3.21
 ENTRYPOINT []
 
 RUN apk --no-cache add openjdk21
-RUN apk --no-cache add "libxml2>=2.13.4-r5"
+RUN apk --no-cache add "libxml2>=2.14.2"
 
 #############
 ### Tolgee  #


### PR DESCRIPTION
The update to libxml2>=2.14.2 is necessary to mitigate the following vulnerabilities:

CVE-2025-32415: Heap buffer overflow in xmlSchemaIDCFillNodeTables, which could lead to crashes or arbitrary code execution.
CVE-2025-32414: Buffer overflow in Python API due to reading excessive characters (patch by Maks Verver). These fixes ensure the security and stability of our application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a system package used in the application container to improve compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->