### PR TITLE
fix: Self-hosted free plan MT credit issue > user's being logged out

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/uasge/current/CurrentUsageModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/uasge/current/CurrentUsageModel.kt
@@ -16,4 +16,5 @@ open class CurrentUsageModel(
   @Schema(description = "For MT credits, the values are in full credits. Not Cents.")
   val credits: CurrentUsageItemModel,
   val keys: CurrentUsageItemModel,
+  val isPayAsYouGo: Boolean,
 ) : RepresentationModel<CurrentUsageModel>(), Serializable

--- a/e2e/cypress/e2e/selfHostedLimits.cy.ts
+++ b/e2e/cypress/e2e/selfHostedLimits.cy.ts
@@ -1,12 +1,12 @@
 import 'cypress-file-upload';
-import {fillAndSubmitSignUpForm, visitSignUp} from '../common/login';
-import {waitForGlobalLoading} from '../common/loading';
-import {E2TranslationsView} from '../compounds/E2TranslationsView';
-import {gcy} from '../common/shared';
-import {selfHostedLimitsTestData} from '../common/apiCalls/testData/testData';
-import {TestDataStandardResponse} from '../common/apiCalls/testData/generator';
-import {login} from '../common/apiCalls/common';
-import {visitTranslations} from '../common/translations';
+import { fillAndSubmitSignUpForm, visitSignUp } from '../common/login';
+import { waitForGlobalLoading } from '../common/loading';
+import { E2TranslationsView } from '../compounds/E2TranslationsView';
+import { gcy } from '../common/shared';
+import { selfHostedLimitsTestData } from '../common/apiCalls/testData/testData';
+import { TestDataStandardResponse } from '../common/apiCalls/testData/generator';
+import { login } from '../common/apiCalls/common';
+import { visitTranslations } from '../common/translations';
 
 /**
  * This is not a traditional test. We mock the results of the API calls,
@@ -178,6 +178,7 @@ function mockSubscriptionUsage() {
   cy.intercept('GET', '/v2/ee-current-subscription-usage', {
     statusCode: 200,
     body: {
+      isPayAsYouGo: false,
       seats: { current: 5, included: 10, limit: 10 },
       keys: { current: 900, included: 1000, limit: 1000 },
       strings: { current: 0, included: -1, limit: -1 },

--- a/e2e/cypress/e2e/selfHostedLimits.cy.ts
+++ b/e2e/cypress/e2e/selfHostedLimits.cy.ts
@@ -1,12 +1,12 @@
 import 'cypress-file-upload';
-import { fillAndSubmitSignUpForm, visitSignUp } from '../common/login';
-import { waitForGlobalLoading } from '../common/loading';
-import { E2TranslationsView } from '../compounds/E2TranslationsView';
-import { gcy } from '../common/shared';
-import { selfHostedLimitsTestData } from '../common/apiCalls/testData/testData';
-import { TestDataStandardResponse } from '../common/apiCalls/testData/generator';
-import { login } from '../common/apiCalls/common';
-import { visitTranslations } from '../common/translations';
+import {fillAndSubmitSignUpForm, visitSignUp} from '../common/login';
+import {waitForGlobalLoading} from '../common/loading';
+import {E2TranslationsView} from '../compounds/E2TranslationsView';
+import {gcy} from '../common/shared';
+import {selfHostedLimitsTestData} from '../common/apiCalls/testData/testData';
+import {TestDataStandardResponse} from '../common/apiCalls/testData/generator';
+import {login} from '../common/apiCalls/common';
+import {visitTranslations} from '../common/translations';
 
 /**
  * This is not a traditional test. We mock the results of the API calls,
@@ -28,7 +28,6 @@ describe('Self-hosted Limits', () => {
 
     // Mock the subscription usage and license info endpoints
     mockSubscriptionUsage();
-    mockLicenseInfo();
   });
 
   afterEach(() => {
@@ -76,7 +75,6 @@ describe('Self-hosted Limits', () => {
       loginAndVisitTranslations(testData);
       mockKeyCreation('plan_key_limit_exceeded');
       mockSubscriptionUsage();
-      mockLicenseInfo();
       tryCreateKey();
       cy.wait('@createKey');
       assertPlanLimitPopoverWithUsageVisible();
@@ -186,18 +184,6 @@ function mockSubscriptionUsage() {
       credits: { current: 5000, included: 10000, limit: 10000 },
     },
   }).as('subscriptionUsage');
-}
-
-/**
- * Mocks the license info endpoint
- */
-function mockLicenseInfo() {
-  cy.intercept('GET', '/v2/ee-license/info', {
-    statusCode: 200,
-    body: {
-      isPayAsYouGo: false,
-    },
-  }).as('licenseInfo');
 }
 
 /**

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/EeSubscriptionUsageControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/EeSubscriptionUsageControllerTest.kt
@@ -66,6 +66,7 @@ class EeSubscriptionUsageControllerTest : AuthorizedControllerTest() {
           keys = CurrentUsageItemModel(current = 0, included = 5000, limit = 5000),
           strings = CurrentUsageItemModel(current = 0, included = -1, limit = -1),
           credits = CurrentUsageItemModel(current = 10000, included = 10000, limit = 10000),
+          isPayAsYouGo = true,
         )
       }
 
@@ -92,6 +93,7 @@ class EeSubscriptionUsageControllerTest : AuthorizedControllerTest() {
               node("included").isEqualTo(5000)
               node("limit").isEqualTo(5000)
             }
+            node("isPayAsYouGo").isEqualTo(true)
           }
 
         val body = this.captor.allValues.single().body

--- a/webapp/src/ee/billing/limitPopover/PlanLimitPopoverSelfHosted.tsx
+++ b/webapp/src/ee/billing/limitPopover/PlanLimitPopoverSelfHosted.tsx
@@ -1,8 +1,8 @@
-import React, { FC } from 'react';
-import { PlanLimitPopoverWrapperProps } from './generic/PlanLimitPopoverWrapper';
-import { GenericPlanLimitPopover } from './generic/GenericPlanLimitPopover';
-import { useApiQuery } from 'tg.service/http/useQueryApi';
-import { getSelfHostedProgressData } from '../getSelfHostedProgressData';
+import React, {FC} from 'react';
+import {PlanLimitPopoverWrapperProps} from './generic/PlanLimitPopoverWrapper';
+import {GenericPlanLimitPopover} from './generic/GenericPlanLimitPopover';
+import {useApiQuery} from 'tg.service/http/useQueryApi';
+import {getSelfHostedProgressData} from '../getSelfHostedProgressData';
 
 type SelfHostedPlanLimitPopoverProps = PlanLimitPopoverWrapperProps;
 
@@ -21,14 +21,6 @@ export const PlanLimitPopoverSelfHosted: FC<
     },
   });
 
-  const infoLoadable = useApiQuery({
-    url: '/v2/ee-license/info',
-    method: 'get',
-    options: {
-      enabled: open,
-    },
-  });
-
   const progressData =
     usageLoadable.data &&
     getSelfHostedProgressData({ usage: usageLoadable.data });
@@ -37,9 +29,9 @@ export const PlanLimitPopoverSelfHosted: FC<
     <GenericPlanLimitPopover
       onClose={onClose}
       open={open}
-      isPayAsYouGo={infoLoadable.data?.isPayAsYouGo}
+      isPayAsYouGo={usageLoadable.data?.isPayAsYouGo}
       progressData={progressData}
-      loading={usageLoadable.isLoading || infoLoadable.isLoading}
+      loading={usageLoadable.isLoading}
     />
   );
 };

--- a/webapp/src/ee/billing/limitPopover/PlanLimitPopoverSelfHosted.tsx
+++ b/webapp/src/ee/billing/limitPopover/PlanLimitPopoverSelfHosted.tsx
@@ -1,8 +1,8 @@
-import React, {FC} from 'react';
-import {PlanLimitPopoverWrapperProps} from './generic/PlanLimitPopoverWrapper';
-import {GenericPlanLimitPopover} from './generic/GenericPlanLimitPopover';
-import {useApiQuery} from 'tg.service/http/useQueryApi';
-import {getSelfHostedProgressData} from '../getSelfHostedProgressData';
+import React, { FC } from 'react';
+import { PlanLimitPopoverWrapperProps } from './generic/PlanLimitPopoverWrapper';
+import { GenericPlanLimitPopover } from './generic/GenericPlanLimitPopover';
+import { useApiQuery } from 'tg.service/http/useQueryApi';
+import { getSelfHostedProgressData } from '../getSelfHostedProgressData';
 
 type SelfHostedPlanLimitPopoverProps = PlanLimitPopoverWrapperProps;
 

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -1709,6 +1709,7 @@ export interface components {
     };
     CurrentUsageModel: {
       credits: components["schemas"]["CurrentUsageItemModel"];
+      isPayAsYouGo: boolean;
       keys: components["schemas"]["CurrentUsageItemModel"];
       seats: components["schemas"]["CurrentUsageItemModel"];
       strings: components["schemas"]["CurrentUsageItemModel"];

--- a/webapp/src/service/billingApiSchema.generated.ts
+++ b/webapp/src/service/billingApiSchema.generated.ts
@@ -502,6 +502,7 @@ export interface components {
     };
     CurrentUsageModel: {
       credits: components["schemas"]["CurrentUsageItemModel"];
+      isPayAsYouGo: boolean;
       keys: components["schemas"]["CurrentUsageItemModel"];
       seats: components["schemas"]["CurrentUsageItemModel"];
       strings: components["schemas"]["CurrentUsageItemModel"];
@@ -718,6 +719,7 @@ export interface components {
         | "current_user_does_not_own_image"
         | "user_cannot_view_this_organization"
         | "user_is_not_owner_of_organization"
+        | "user_is_not_owner_or_maintainer_of_organization"
         | "pak_created_for_different_project"
         | "custom_slug_is_only_applicable_for_custom_storage"
         | "invalid_slug_format"
@@ -1226,8 +1228,11 @@ export interface components {
     };
     SetLicenseKeyLicensingDto: {
       instanceId: string;
-      /** Format: int64 */
-      keys: number;
+      /**
+       * Format: int64
+       * @description Number of keys in the project. If not provided, the number of keys will not be updated.
+       */
+      keys?: number;
       licenseKey: string;
       /** Format: int64 */
       seats: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new indicator to display whether the current subscription is "Pay As You Go".
- **Refactor**
  - Streamlined data fetching in the plan limit popover by consolidating API calls for subscription usage and removing redundant license info queries.
- **Tests**
  - Updated tests to verify the presence and correctness of the new "Pay As You Go" indicator in subscription usage responses.
- **Bug Fixes**
  - Removed obsolete license info mocks from end-to-end tests to align with updated data fetching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->