### PR TITLE
feat: Add markdown to key descriptions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,7 +21,7 @@ To just run it, you can execute the runE2e Gradle task. This command runs a comp
 3. Run the tested environment
    ```shell
    # Run frontend with E2E settings
-   ./gradlew runWebAppNpmStartE2eDev
+   cd webapp && VITE_APP_API_URL=http://localhost:8201 npm run start -- --port 8081 --host --no-open
    # Run the E2E Docker services (like fake SMTP server)
    ./gradlew runDockerE2eDev
    # Run backend with e2e profile

--- a/e2e/cypress/e2e/translations/keyDescription.cy.ts
+++ b/e2e/cypress/e2e/translations/keyDescription.cy.ts
@@ -25,4 +25,18 @@ describe('Key description', () => {
       .contains(description)
       .should('be.visible');
   });
+
+  it('renders markdown in key description correctly', () => {
+    const markdownDescription = '**Bold text** and [link](https://tolgee.io) and *italic text*';
+    cy.gcy('translations-table-cell').contains('Cool key 01').click();
+    cy.gcy('translations-key-edit-description-field').clear().type(markdownDescription);
+    cy.gcy('translations-cell-save-button').click();
+    waitForGlobalLoading();
+
+    cy.gcy('translations-key-cell-description').within(() => {
+      cy.get('strong').contains('Bold text').should('be.visible');
+      cy.get('a').should('have.attr', 'href', 'https://tolgee.io').contains('link');
+      cy.get('em').contains('italic text').should('be.visible');
+    });
+  });
 });

--- a/e2e/cypress/e2e/translations/keyDescription.cy.ts
+++ b/e2e/cypress/e2e/translations/keyDescription.cy.ts
@@ -27,15 +27,20 @@ describe('Key description', () => {
   });
 
   it('renders markdown in key description correctly', () => {
-    const markdownDescription = '**Bold text** and [link](https://tolgee.io) and *italic text*';
+    const markdownDescription =
+      '**Bold text** and [link](https://tolgee.io) and *italic text*';
     cy.gcy('translations-table-cell').contains('Cool key 01').click();
-    cy.gcy('translations-key-edit-description-field').clear().type(markdownDescription);
+    cy.gcy('translations-key-edit-description-field')
+      .clear()
+      .type(markdownDescription);
     cy.gcy('translations-cell-save-button').click();
     waitForGlobalLoading();
 
     cy.gcy('translations-key-cell-description').within(() => {
       cy.get('strong').contains('Bold text').should('be.visible');
-      cy.get('a').should('have.attr', 'href', 'https://tolgee.io').contains('link');
+      cy.get('a')
+        .should('have.attr', 'href', 'https://tolgee.io')
+        .contains('link');
       cy.get('em').contains('italic text').should('be.visible');
     });
   });

--- a/gradle/e2e.gradle
+++ b/gradle/e2e.gradle
@@ -121,7 +121,7 @@ task openE2e(type: Exec, group: "e2e") {
 task openE2eDev(type: Exec, group: "e2e") {
     commandLine npmCommandName, "run", "cy:open"
 
-    environment "CYPRESS_HOST", "http://localhost:8082"
+    environment "CYPRESS_HOST", "http://localhost:8081"
 
     workingDir E2E_DIR
 }

--- a/gradle/e2e.gradle
+++ b/gradle/e2e.gradle
@@ -121,7 +121,7 @@ task openE2e(type: Exec, group: "e2e") {
 task openE2eDev(type: Exec, group: "e2e") {
     commandLine npmCommandName, "run", "cy:open"
 
-    environment "CYPRESS_HOST", "http://localhost:8081"
+    environment "CYPRESS_HOST", "http://localhost:8082"
 
     workingDir E2E_DIR
 }

--- a/webapp/src/component/common/MarkdownLink.tsx
+++ b/webapp/src/component/common/MarkdownLink.tsx
@@ -1,10 +1,7 @@
 import { Link as MuiLink } from '@mui/material';
 import { stopBubble } from 'tg.fixtures/eventHandler';
 
-type Props = React.DetailedHTMLProps<
-  React.AnchorHTMLAttributes<HTMLAnchorElement>,
-  HTMLAnchorElement
->;
+type Props = React.ComponentProps<'a'>;
 
 export const MarkdownLink = (props: Props) => {
   return (

--- a/webapp/src/component/common/MarkdownLink.tsx
+++ b/webapp/src/component/common/MarkdownLink.tsx
@@ -1,0 +1,20 @@
+import { Link as MuiLink } from '@mui/material';
+import { stopBubble } from 'tg.fixtures/eventHandler';
+
+type Props = React.DetailedHTMLProps<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  HTMLAnchorElement
+>;
+
+export const MarkdownLink = (props: Props) => {
+  return (
+    <MuiLink
+      onClick={stopBubble()}
+      href={props.href || ''}
+      target="_blank"
+      rel="nofollow noreferrer noopener"
+    >
+      {props.children}
+    </MuiLink>
+  );
+};

--- a/webapp/src/views/projects/dashboard/ProjectDescription.tsx
+++ b/webapp/src/views/projects/dashboard/ProjectDescription.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useProject } from 'tg.hooks/useProject';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
+import { MarkdownLink } from 'tg.component/common/MarkdownLink';
 
 const StyledContainer = styled('div')`
   display: grid;
@@ -52,15 +53,7 @@ export const ProjectDescription: React.FC<Props> = ({ description }) => {
       <StyledContent>
         <ReactMarkdown
           components={{
-            a: (props) => (
-              <MuiLink
-                href={props.href || ''}
-                target="_blank"
-                rel="nofollow noreferrer noopener"
-              >
-                {props.children}
-              </MuiLink>
-            ),
+            a: MarkdownLink,
           }}
         >
           {description}

--- a/webapp/src/views/projects/dashboard/ProjectDescription.tsx
+++ b/webapp/src/views/projects/dashboard/ProjectDescription.tsx
@@ -1,5 +1,5 @@
 import { Edit02 } from '@untitled-ui/icons-react';
-import { Box, IconButton, Link as MuiLink, styled } from '@mui/material';
+import { Box, IconButton, styled } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 import { Link } from 'react-router-dom';
 

--- a/webapp/src/views/projects/translations/CellKey.tsx
+++ b/webapp/src/views/projects/translations/CellKey.tsx
@@ -30,6 +30,8 @@ import { useGlobalContext } from 'tg.globalContext/GlobalContext';
 import { ScreenshotDropzone } from './Screenshots/ScreenshotDropzone';
 import { useScreenshotUpload } from './Screenshots/useScreenshotUpload';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
+import ReactMarkdown from 'react-markdown';
+import { MarkdownLink } from 'tg.component/common/MarkdownLink';
 
 type KeyWithTranslationsModel =
   components['schemas']['KeyWithTranslationsModel'];
@@ -244,7 +246,13 @@ export const CellKey: React.FC<Props> = ({
           {data.keyDescription && (
             <StyledDescription data-cy="translations-key-cell-description">
               <LimitedHeightText maxLines={5}>
-                {data.keyDescription}
+                <ReactMarkdown
+                  components={{
+                    a: MarkdownLink,
+                  }}
+                >
+                  {data.keyDescription}
+                </ReactMarkdown>
               </LimitedHeightText>
             </StyledDescription>
           )}

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -102,8 +102,8 @@ export const KeyGeneral = () => {
 
       <StyledSection>
         <FieldLabel>
-          <LabelHint title={t('translations_key_edit_label_description_hint')}>
-            {t('translations_key_edit_label_description_markdown')}
+          <LabelHint title={t('translations_key_edit_label_description_markdown_hint')}>
+            {t('translations_key_edit_label_description')}
           </LabelHint>
         </FieldLabel>
         <EditorWrapper data-cy="translations-key-edit-description-field">

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -103,7 +103,7 @@ export const KeyGeneral = () => {
       <StyledSection>
         <FieldLabel>
           <LabelHint title={t('translations_key_edit_label_description_hint')}>
-            {t('translations_key_edit_label_description')}
+            {t('translations_key_edit_label_description_markdown')}
           </LabelHint>
         </FieldLabel>
         <EditorWrapper data-cy="translations-key-edit-description-field">

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -102,7 +102,9 @@ export const KeyGeneral = () => {
 
       <StyledSection>
         <FieldLabel>
-          <LabelHint title={t('translations_key_edit_label_description_markdown_hint')}>
+          <LabelHint
+            title={t('translations_key_edit_label_description_markdown_hint')}
+          >
             {t('translations_key_edit_label_description')}
           </LabelHint>
         </FieldLabel>


### PR DESCRIPTION
- Add a new component, MarkdownLink, to address a re-render issue where the link breaks upon re-rendering
- Close https://github.com/tolgee/tolgee-platform/issues/2438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Key descriptions now support markdown formatting, allowing for styled text and links.
- **Enhancements**
  - All markdown links open in a new tab with improved security and consistent behavior via a centralized component.
  - Tooltip for the description label updated to reflect markdown support.
- **Bug Fixes**
  - Standardized link rendering within markdown content for consistency.
- **Documentation**
  - Updated end-to-end testing instructions for running the frontend.
- **Tests**
  - Added automated tests verifying correct rendering of markdown in key descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->