### PR TITLE
fix: env variable name for API url in DEVELOPMENT.md file

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -116,7 +116,7 @@ Create a file `webapp/.env.development.local` with following content.
 Don't forget to supply it with your API key generated in the Tolgee app:
 
 ```properties
-VITE_APP_TOLGEE_API_URL=https://app.tolgee.io
+VITE_APP_API_URL=https://app.tolgee.io
 VITE_APP_TOLGEE_API_KEY=your-tolgee-api-key
 ```
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example environment variable name for the Tolgee API URL in the development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->