### PR TITLE
chore: normalize line endings for exporter tests

### DIFF
--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
@@ -141,7 +141,7 @@ class AndroidXmlFileExporterTest {
     file: String,
     content: String,
   ) {
-    this[file]!!.assert.isEqualTo(content)
+    this[file]!!.assert.isEqualToNormalizingNewlines(content)
   }
 
   private fun getExporter(params: ExportParams = getExportParams()): XmlResourcesExporter {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
@@ -313,7 +313,7 @@ class AppleXliffFileExporterTest {
     file: String,
     content: String,
   ) {
-    this[file]!!.assert.isEqualTo(content)
+    this[file]!!.assert.isEqualToNormalizingNewlines(content)
   }
 
   private fun getExporter(params: ExportParams = getExportParams()): AppleXliffExporter {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
@@ -141,7 +141,7 @@ class ComposeXmlFileExporterTest {
     file: String,
     content: String,
   ) {
-    this[file]!!.assert.isEqualTo(content)
+    this[file]!!.assert.isEqualToNormalizingNewlines(content)
   }
 
   private fun getExporter(params: ExportParams = getExportParams()): XmlResourcesExporter {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/fluttter/out/FlutterArbFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/fluttter/out/FlutterArbFileExporterTest.kt
@@ -137,7 +137,7 @@ class FlutterArbFileExporterTest {
     file: String,
     content: String,
   ) {
-    this[file]!!.assert.isEqualTo(content)
+    this[file]!!.assert.isEqualToNormalizingNewlines(content)
   }
 
   private fun getExporter(params: ExportParams = getExportParams()): FlutterArbFileExporter {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
@@ -151,7 +151,7 @@ class ResxExporterTest {
     file: String,
     content: String,
   ) {
-    this[file]!!.assert.isEqualTo(content)
+    this[file]!!.assert.isEqualToNormalizingNewlines(content)
   }
 
   private fun getExporter(params: ExportParams = getExportParams()): ResxExporter {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/util/exportAssertUtil.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/util/exportAssertUtil.kt
@@ -8,7 +8,7 @@ fun Map<String, String>.assertFile(
   file: String,
   content: String,
 ) {
-  this[file]!!.assert.isEqualTo(content)
+  this[file]!!.assert.isEqualToNormalizingNewlines(content)
 }
 
 fun getExported(exporter: FileExporter): Map<String, String> {


### PR DESCRIPTION
this came up during

- https://github.com/tolgee/tolgee-platform/issues/2970

on a windows 10 machine

## Compatibility

Behaviour on linux/mac should be unchanged

Maintainer should check:

- [ ] Line Endings are of no relevance within the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test robustness by updating file content comparisons to ignore differences in newline characters. This ensures tests pass regardless of newline formatting variations in exported files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->