### PR TITLE
chore: Test postgres cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ backend/app/src/main/resources/application-js-e2e.properties
 
 ngrok.yml
 ngrok.local.yml
+
+# Local developer workstuff
+/.local

--- a/ee/backend/tests/src/test/resources/application.yaml
+++ b/ee/backend/tests/src/test/resources/application.yaml
@@ -35,10 +35,10 @@ spring:
 tolgee:
   postgres-autostart:
     enabled: true
-    container-name: tolgee_backend_tests_postgres_main
-    port: 55433
+    container-name: tolgee_backend_tests_postgres_ee
+    port: 55434
     stop: false
-  data-path: ./build/test_data
+  data-path: ./build/test_data_ee
   authentication:
     native-enabled: true
     registrationsAllowed: true


### PR DESCRIPTION
- re #2970

## Dedicated Resources for ee-test:test

f2add566f86525aeb88d9d0362708dfa8fb18612 avoids errors like this (from docker logs) :

```
2025-05-09 03:59:12 2025-05-09 00:59:12.338 UTC [191] ERROR:  deadlock detected at character 137
2025-05-09 03:59:12 2025-05-09 00:59:12.338 UTC [191] DETAIL:  Process 191 waits for AccessShareLock on relation 16452 of database 5; blocked by process 197.
```

An alternative would be to setup 2 separate databases. A dedicated container was choosen because it is super-straightforward, with near-zero risks to introduce side-effects.

Behaviour on a Ryzen 2700X Win10 machine became much better (nearly 100 less test-failures)

### :server-app:test

![image](https://github.com/user-attachments/assets/f404b5c4-0a50-4701-9c9f-a1a6de56b0c4)

![image](https://github.com/user-attachments/assets/6321f9e9-6bf7-4e47-8e5c-8a10dfd5a876)


##  gitignored .local

This is to allow developers to keep files locally. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude the `.local/` directory for local developer files.
  - Adjusted test configuration with new database container names, ports, and test data directories to enhance the test environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->