### PR TITLE
fix: make S3 content storage path nullable and handle default value

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/contentDelivery/S3ContentStorageConfig.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/contentDelivery/S3ContentStorageConfig.kt
@@ -33,5 +33,5 @@ class S3ContentStorageConfig(
   @field:Schema(
     description = "Specifies an optional subfolder structure within s3 bucket to which content will be stored",
   )
-  override var path: String = ""
+  override var path: String? = ""
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/ContentStorageModelAssemblerEeImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/ContentStorageModelAssemblerEeImpl.kt
@@ -25,7 +25,7 @@ class ContentStorageModelAssemblerEeImpl :
             bucketName = it.bucketName,
             endpoint = it.endpoint,
             signingRegion = it.signingRegion,
-            path = it.path,
+            path = it.path ?: "",
           )
         },
       azureContentStorageConfig =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the storage path configuration to prevent issues caused by null values. The path will now default to an empty string if not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->