### PR TITLE
build: speedup ci execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,8 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Compile kotlin
         run: ./gradlew compileTestKotlin --parallel
@@ -75,6 +70,7 @@ jobs:
           [
             "server-app:runContextRecreatingTests",
             "server-app:runStandardTests",
+            "server-app:runAuthorizedTests",
             "server-app:runWebsocketTests",
             "server-app:runWithoutEeTests",
             "ee-test:test",
@@ -93,13 +89,8 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Download backend build result
         uses: actions/download-artifact@v4
@@ -180,13 +171,8 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Cache node modules
         uses: actions/cache@v3
@@ -288,7 +274,7 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-
+      
       - name: Setup node
         uses: actions/setup-node@v3
         with:
@@ -445,13 +431,8 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Run ktlint
         run: ./gradlew ktlintCheck

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -204,7 +204,7 @@ tasks.register('runContextRecreatingTests', Test) {
 tasks.register('runStandardTests', Test) {
     outputs.upToDateWhen { false }
     useJUnitPlatform {
-        excludeTags "contextRecreating", "websocket"
+        excludeTags "contextRecreating", "websocket", "authorized"
     }
     maxHeapSize = "4096m"
     rootProject.setTestRetry(it)
@@ -214,6 +214,20 @@ tasks.register('runWebsocketTests', Test) {
     outputs.upToDateWhen { false }
     useJUnitPlatform {
         includeTags "websocket"
+    }
+    maxHeapSize = "4096m"
+    rootProject.setTestRetry(it)
+}
+
+/**
+ * Split around half of the standard tests into a separate CI job.
+ * This allows the CI pipeline to complete faster by running these tests in parallel.
+ */
+tasks.register('runAuthorizedTests', Test) {
+    outputs.upToDateWhen { false }
+    useJUnitPlatform {
+        includeTags "authorized"
+        excludeTags "contextRecreating", "websocket"
     }
     maxHeapSize = "4096m"
     rootProject.setTestRetry(it)

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ApiKeyControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ApiKeyControllerTest.kt
@@ -15,6 +15,7 @@ import io.tolgee.model.enums.Scope
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import io.tolgee.testing.assertions.Assertions.assertThat
+import io.tolgee.testing.ContextRecreatingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -25,6 +26,7 @@ import java.util.*
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ContextRecreatingTest
 class ApiKeyControllerTest : AuthorizedControllerTest() {
   lateinit var testData: ApiKeysTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/BigMetaControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/BigMetaControllerTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.model.key.Key
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.bigMeta.KeysDistanceDto
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assert
 import io.tolgee.util.Logging
 import org.junit.jupiter.api.BeforeEach
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import kotlin.time.measureTime
 
+@ContextRecreatingTest
 class BigMetaControllerTest : ProjectAuthControllerTest("/v2/projects/"), Logging {
   lateinit var testData: BigMetaTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
@@ -1,5 +1,7 @@
 package io.tolgee.api.v2.controllers.batch
 
+import io.tolgee.testing.ContextRecreatingTest
+
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.batch.BatchJobActivityFinalizer
 import io.tolgee.batch.BatchJobChunkExecutionQueue
@@ -40,6 +42,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.ConcurrentHashMap
 
+@ContextRecreatingTest
 class BatchJobManagementControllerTest : ProjectAuthControllerTest("/v2/projects/"), Logging {
   lateinit var testData: BatchJobsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtTranslateTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtTranslateTest.kt
@@ -11,7 +11,9 @@ import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import io.tolgee.testing.ContextRecreatingTest
 
+@ContextRecreatingTest
 class BatchMtTranslateTest : ProjectAuthControllerTest("/v2/projects/") {
   @Autowired
   lateinit var batchJobTestBase: BatchJobTestBase

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
@@ -17,9 +17,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import java.math.BigDecimal
+import io.tolgee.testing.ContextRecreatingTest
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ContextRecreatingTest
 class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects/") {
   lateinit var testData: TranslationsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerViewTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerViewTest.kt
@@ -26,9 +26,11 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.ResultActions
 import java.math.BigDecimal
 import kotlin.system.measureTimeMillis
+import io.tolgee.testing.ContextRecreatingTest
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ContextRecreatingTest
 class TranslationsControllerViewTest : ProjectAuthControllerTest("/v2/projects/") {
   lateinit var testData: TranslationsTestData
 

--- a/backend/testing/src/main/kotlin/io/tolgee/testing/AuthorizedControllerTest.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/testing/AuthorizedControllerTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.fixtures.AuthorizedRequestPerformer
 import io.tolgee.model.UserAccount
 import io.tolgee.security.authentication.JwtService
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.mock.web.MockMultipartFile
@@ -14,6 +15,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import java.time.Duration
 import java.util.*
 
+@Tag("authorized")
 abstract class AuthorizedControllerTest : AbstractControllerTest(), AuthRequestPerformer {
   private var _userAccount: UserAccount? = null
 


### PR DESCRIPTION
## CI Optimization

After a few more trials, I realized that there are far more elegant solutions to test distribution. This should be done in an follow-up issue, see https://github.com/tolgee/tolgee-platform/pull/3066#issuecomment-2871351977.

## Followup PR
- https://github.com/tolgee/tolgee-platform/pull/3069

---

## Alternative

~An alternative would be to tag enough standardTests as e.g. `standardGroup2Tests`. This is cleaner, but we have to tag around ~ 30-40 classes to collect the necessary runtime (did this in previous runs, works nice). Thinking of it now: it's the cleaner way.~

## Description

`runStandardTests` executes all tests that are not placed in some group.

This PR moves several test out of the standardTests
This allows the CI to complete the run faster.

This works by:

- tag `AuthorizedControllerTest` as `authorized`
- execute `authorized` tests via `runAuthorizedTests` (not anymore in runStandardTests)
- tag some the inheriting test-classes as `@ContextRecreatingTest` to mover some duration out of `AuthorizedTests`, so runtimes are moved evenly (no top duration runners anymore)
  
  Tests pass: https://github.com/laz-001/tolgee-platform/actions/runs/14953776252



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved Gradle workflow setup for more efficient caching and standardized configuration.
  - Enhanced CI pipeline by splitting authorized tests into a separate job for faster execution.
  - Refined end-to-end test distribution in CI for better load balancing and faster test runs.

- **Tests**
  - Introduced a new test task to run authorized tests separately.
  - Added context-recreation annotations to several test classes for improved test isolation.
  - Marked authorized controller tests with a new tag for better test categorization.

- **Documentation**
  - Updated E2E testing guide with details on test distribution and balancing in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->