### PR TITLE
chore: allow for custom gradle scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ ngrok.local.yml
 
 # Local developer workstuff
 /.local
+
+# IDEs and tools
+.cursorrules
+.cursorignore

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -279,3 +279,10 @@ normalization {
         ignore '**/build-info.properties'
     }
 }
+
+// ===== Apply custom tasks, if exist, from gitignored .local directory =====
+def customTasksFile = rootProject.file('.local/gradle/backend-app.gradle')
+if (customTasksFile.exists()) {
+    logger.lifecycle("Applying custom local Gradle script: ${customTasksFile}")
+    apply from: customTasksFile
+}


### PR DESCRIPTION
- Allows developers to include custom gradle-scripts from the gitignored .local directory.

- ignore some cursor IDE files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the `.gitignore` file to exclude additional tool-specific files.
  - Enhanced backend build configuration to support local, gitignored Gradle customizations without affecting the main build script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->