### PR TITLE
fix: correct typo in API key endpoint and improve test

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ApiKeyController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ApiKeyController.kt
@@ -69,7 +69,7 @@ class ApiKeyController(
   private val simpleProjectModelAssembler: SimpleProjectModelAssembler,
 ) {
   @PostMapping(path = ["/api-keys"])
-  @Operation(summary = "Crete API key", description = "Creates new API key with provided scopes")
+  @Operation(summary = "Create API key", description = "Creates new API key with provided scopes")
   @RequiresSuperAuthentication
   @OpenApiOrderExtension(1)
   fun create(

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/tags/TagsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/tags/TagsControllerTest.kt
@@ -29,7 +29,7 @@ class TagsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   @ProjectJWTAuthTestMethod
   fun `project tags are returned correctly`() {
-    performProjectAuthGet("tags").andAssertThatJson {
+    performProjectAuthGet("tags").andPrettyPrint.andAssertThatJson {
       node("_embedded.tags") {
         isArray.hasSize(20)
         node("[0].id").isValidId
@@ -94,7 +94,7 @@ class TagsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   @ProjectJWTAuthTestMethod
   fun `tags key with existing tag`() {
-    performProjectAuthPut("keys/${testData.noTagKey.id}/tags", TagKeyDto(name = testData.existingTag.name))
+    performProjectAuthPut("keys/${testData.noTagKey.id}/tags", mapOf("name"  to testData.existingTag.name))
       .andPrettyPrint.andAssertThatJson {
         node("id").isEqualTo(testData.existingTag.id)
         node("name").isEqualTo(testData.existingTag.name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the OpenAPI summary for API key creation.

- **Tests**
  - Improved test output readability with pretty-printed JSON responses.
  - Adjusted test payload construction for tag-related requests without altering test outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->