### PR TITLE
Fix: Pre-Translate and Auto Translate via Translation Memory Fails to Apply Matches with Trailing Spaces or Case Differences

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -125,7 +125,7 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
             target.text <> '' and
             target.text is not null
       where baseTranslation.language = p.baseLanguage and
-        baseTranslation.text = :baseTranslationText and
+        LOWER(TRIM(baseTranslation.text)) = LOWER(TRIM(:baseTranslationText)) and
         k <> :key
       """,
   )


### PR DESCRIPTION
## 🐛 Bug Fix: Improve TM Matching by Ignoring Case and Whitespace

### 📖 Description

This PR addresses an issue where **Translation Memory (TM) matches were not applied** during pre-translate or auto-translate if:

* The source text had **leading/trailing whitespace**
* The case of the source text differed from the TM entry (e.g., `"Hello World"` vs `"hello world"`)

While TM suggestions appeared correctly, the translation was not automatically applied, leading to user confusion.

---

### ✅ What’s Changed

Updated the matching condition in the TM query:

```sql
LOWER(TRIM(baseTranslation.text)) = LOWER(TRIM(:baseTranslationText))
```

This ensures TM matching is:

* **Case-insensitive**
* **Whitespace-tolerant** (ignores leading and trailing spaces)

---

### 🔍 Steps to Reproduce (Before Fix)

1. Create a key with source string `"Welcome to Tolgee"` and add a translation.
2. Create another key with `"Welcome to Tolgee "` (note trailing space).
3. Attempt to pre-translate using TM.
4. **Observed:** TM suggests the correct translation, but it is **not applied automatically**.

Same issue occurs with:

* `"Welcome to Tolgee"` vs `"welcome to tolgee"`

---

### ✅ Expected Behavior (After Fix)

* TM should **apply the correct translation automatically** even if:

  * The source string has trailing/leading whitespace
  * The source string has a different case than the TM entry

---

### 🔗 Related Issue

Closes https://github.com/tolgee/tolgee-platform/issues/3086

---

### 🙌 Additional Notes

Let me know if this behavior should be configurable or if you'd prefer this logic be handled in application code instead of the query.

@JanCizmar Thanks again for the quick feedback and for maintaining such a helpful platform! 😊

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved translation memory matching to ignore differences in letter case and leading/trailing spaces, resulting in more accurate and user-friendly search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->