### PR TITLE
fix: Configure YAML ObjectMapper with custom settings: disable doc start markers and line splitting, enable literal block style

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/YamlObjectMapperConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/YamlObjectMapperConfiguration.kt
@@ -2,6 +2,7 @@ package io.tolgee.configuration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -9,6 +10,10 @@ import org.springframework.context.annotation.Configuration
 class YamlObjectMapperConfiguration {
   @Bean("yamlObjectMapper")
   fun yamlObjectMapper(): ObjectMapper {
-    return ObjectMapper(YAMLFactory())
+    val factory = YAMLFactory()
+      .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
+      .disable(YAMLGenerator.Feature.SPLIT_LINES)
+      .enable(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE)
+    return ObjectMapper(factory)
   }
 }


### PR DESCRIPTION
# Disable line splitting in YAML export and enable literal block style

Resolves #3020

## Changes
- Modified YamlObjectMapperConfiguration to disable the SPLIT_LINES feature in the YAML generator
- Enabled LITERAL_BLOCK_STYLE for better readability of multi-line strings
- Disabled WRITE_DOC_START_MARKER to produce cleaner YAML output

This PR addresses the issue where Structured YAML exports would wrap long strings with no option to control or disable this behavior. By disabling line splitting and enabling literal block style, the output will be more readable and maintain long strings without unwanted line breaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved YAML export formatting by removing the document start marker, preventing automatic line splitting, and using literal block style for multiline strings. This results in cleaner and more readable YAML outputs for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->