### PR TITLE
fix: conditional glossaries load only if the feature is available

### DIFF
--- a/webapp/src/ee/glossary/components/GlossaryCreateEditForm.tsx
+++ b/webapp/src/ee/glossary/components/GlossaryCreateEditForm.tsx
@@ -60,7 +60,7 @@ export const GlossaryCreateEditForm = ({
   const { t } = useTranslate();
 
   const { isEnabled } = useEnabledFeatures();
-  const glossaryFeature = isEnabled('GLOSSARY');
+  const glossaryFeatureEnabled = isEnabled('GLOSSARY');
 
   if (initialValues === undefined) {
     return (
@@ -81,7 +81,7 @@ export const GlossaryCreateEditForm = ({
         return (
           <StyledContainer>
             <GlossaryCreateEditFields
-              disabled={!glossaryFeature}
+              disabled={!glossaryFeatureEnabled}
               withAssignedProjects
             />
             <StyledActions>
@@ -89,7 +89,7 @@ export const GlossaryCreateEditForm = ({
                 {t('global_cancel_button')}
               </Button>
               <LoadingButton
-                disabled={!glossaryFeature}
+                disabled={!glossaryFeatureEnabled}
                 onClick={submitForm}
                 color="primary"
                 variant="contained"

--- a/webapp/src/ee/glossary/hooks/useGlossaryTermHighlights.ts
+++ b/webapp/src/ee/glossary/hooks/useGlossaryTermHighlights.ts
@@ -12,7 +12,7 @@ export const useGlossaryTermHighlights = ({
   enabled = true,
 }: GlossaryTermHighlightsProps): GlossaryTermHighlightModel[] => {
   const { isEnabled } = useEnabledFeatures();
-  const glossaryFeature = isEnabled('GLOSSARY');
+  const glossaryFeatureEnabled = isEnabled('GLOSSARY');
   const project = useProject();
   const hasText = text !== undefined && text !== null && text.length > 0;
   const highlights = useApiQuery({
@@ -28,13 +28,13 @@ export const useGlossaryTermHighlights = ({
       },
     },
     options: {
-      enabled: glossaryFeature && hasText && enabled,
+      enabled: glossaryFeatureEnabled && hasText && enabled,
       keepPreviousData: true,
       noGlobalLoading: true,
     },
   });
 
-  if (!glossaryFeature || !hasText || !enabled || !highlights.data) {
+  if (!glossaryFeatureEnabled || !hasText || !enabled || !highlights.data) {
     return [];
   }
 

--- a/webapp/src/ee/glossary/views/GlossariesListView.tsx
+++ b/webapp/src/ee/glossary/views/GlossariesListView.tsx
@@ -45,6 +45,7 @@ export const GlossariesListView = () => {
       sort: ['id,desc'],
     },
     options: {
+      enabled: glossaryFeature,
       keepPreviousData: true,
     },
   });
@@ -76,7 +77,7 @@ export const GlossariesListView = () => {
             }),
           ],
         ]}
-        loading={glossaries.isLoading}
+        loading={glossaryFeature && glossaries.isLoading}
         hideChildrenOnLoading={false}
         maxWidth={1000}
         allCentered

--- a/webapp/src/ee/glossary/views/GlossariesListView.tsx
+++ b/webapp/src/ee/glossary/views/GlossariesListView.tsx
@@ -28,7 +28,7 @@ export const GlossariesListView = () => {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const { isEnabled } = useEnabledFeatures();
-  const glossaryFeature = isEnabled('GLOSSARY');
+  const glossaryFeatureEnabled = isEnabled('GLOSSARY');
 
   const organization = useOrganization();
 
@@ -45,7 +45,7 @@ export const GlossariesListView = () => {
       sort: ['id,desc'],
     },
     options: {
-      enabled: glossaryFeature,
+      enabled: glossaryFeatureEnabled,
       keepPreviousData: true,
     },
   });
@@ -77,7 +77,7 @@ export const GlossariesListView = () => {
             }),
           ],
         ]}
-        loading={glossaryFeature && glossaries.isLoading}
+        loading={glossaryFeatureEnabled && glossaries.isLoading}
         hideChildrenOnLoading={false}
         maxWidth={1000}
         allCentered
@@ -91,7 +91,7 @@ export const GlossariesListView = () => {
             onFinished={() => setCreateDialogOpen(false)}
           />
         )}
-        {glossaryFeature ? (
+        {glossaryFeatureEnabled ? (
           <PaginatedHateoasList
             wrapperComponentProps={{ className: 'listWrapper' }}
             onPageChange={setPage}

--- a/webapp/src/ee/glossary/views/GlossaryCreateDialog.tsx
+++ b/webapp/src/ee/glossary/views/GlossaryCreateDialog.tsx
@@ -37,7 +37,7 @@ export const GlossaryCreateDialog = ({ open, onClose, onFinished }: Props) => {
   const { preferredOrganization } = usePreferredOrganization();
 
   const { isEnabled } = useEnabledFeatures();
-  const glossaryFeature = isEnabled('GLOSSARY');
+  const glossaryFeatureEnabled = isEnabled('GLOSSARY');
 
   const mutation = useApiMutation({
     url: '/v2/organizations/{organizationId}/glossaries',
@@ -85,7 +85,7 @@ export const GlossaryCreateDialog = ({ open, onClose, onFinished }: Props) => {
       maxWidth="sm"
       onClick={(e) => e.stopPropagation()}
     >
-      {!glossaryFeature && (
+      {!glossaryFeatureEnabled && (
         <DisabledFeatureBanner
           customMessage={t('glossaries_feature_description')}
         />

--- a/webapp/src/ee/glossary/views/GlossaryEditDialog.tsx
+++ b/webapp/src/ee/glossary/views/GlossaryEditDialog.tsx
@@ -32,7 +32,7 @@ export const GlossaryEditDialog = ({ open, onClose, onFinished }: Props) => {
   const { preferredOrganization } = usePreferredOrganization();
 
   const { isEnabled } = useEnabledFeatures();
-  const glossaryFeature = isEnabled('GLOSSARY');
+  const glossaryFeatureEnabled = isEnabled('GLOSSARY');
 
   const mutation = useApiMutation({
     url: '/v2/organizations/{organizationId}/glossaries/{glossaryId}',
@@ -93,7 +93,7 @@ export const GlossaryEditDialog = ({ open, onClose, onFinished }: Props) => {
       maxWidth="sm"
       onClick={(e) => e.stopPropagation()}
     >
-      {!glossaryFeature && (
+      {!glossaryFeatureEnabled && (
         <DisabledFeatureBanner
           customMessage={t('glossaries_feature_description')}
         />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Loading indicators for glossaries are now only shown when the glossary feature is enabled, preventing unnecessary loading states when the feature is disabled.  
- **Chores**
  - Improved clarity by renaming the glossary feature flag variable throughout the glossary-related components and hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->