### PR TITLE
feat: add glossary_id for deepl usage

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
@@ -34,7 +34,9 @@ class DeeplApiService(
     requestBody.add("text", text)
     requestBody.add("source_lang", sourceTag.uppercase())
     requestBody.add("target_lang", targetTag.uppercase())
-
+    deeplMachineTranslationProperties.glossaryId?.let {
+      requestBody.add("glossary_id", it)
+    }
     addFormality(requestBody, formality)
 
     val response =

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
@@ -34,7 +34,7 @@ class DeeplApiService(
     requestBody.add("text", text)
     requestBody.add("source_lang", sourceTag.uppercase())
     requestBody.add("target_lang", targetTag.uppercase())
-    deeplMachineTranslationProperties.optionalParameters?.map {
+    deeplMachineTranslationProperties.optionalParameters?.forEach {
       requestBody.add(it.key, it.value)
     }
     addFormality(requestBody, formality)

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
@@ -34,8 +34,8 @@ class DeeplApiService(
     requestBody.add("text", text)
     requestBody.add("source_lang", sourceTag.uppercase())
     requestBody.add("target_lang", targetTag.uppercase())
-    deeplMachineTranslationProperties.glossaryId?.let {
-      requestBody.add("glossary_id", it)
+    deeplMachineTranslationProperties.optionalParameters?.map {
+      requestBody.add(it.key, it.value)
     }
     addFormality(requestBody, formality)
 

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/DeeplMachineTranslationProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/DeeplMachineTranslationProperties.kt
@@ -15,6 +15,6 @@ open class DeeplMachineTranslationProperties(
   override var defaultPrimary: Boolean = false,
   @DocProperty(description = "DeepL auth key. Both key types (commercial and free) are supported.")
   var authKey: String? = null,
-  @DocProperty(description = "DeepL glossaryId (Optional)")
-  var glossaryId: String? = null,
+  @DocProperty(description = "DeepL parameters which should be set for deepl api usage (Optional)")
+  var optionalParameters: Map<String, String>? = null,
 ) : MachineTranslationServiceProperties

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/DeeplMachineTranslationProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/DeeplMachineTranslationProperties.kt
@@ -15,4 +15,6 @@ open class DeeplMachineTranslationProperties(
   override var defaultPrimary: Boolean = false,
   @DocProperty(description = "DeepL auth key. Both key types (commercial and free) are supported.")
   var authKey: String? = null,
+  @DocProperty(description = "DeepL glossaryId (Optional)")
+  var glossaryId: String? = null,
 ) : MachineTranslationServiceProperties


### PR DESCRIPTION
Added the ability to configure a glossary_id in the server config for deepl. This is needed to translate texts with a custom configured glossory from deepl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a DeepL glossary ID when using machine translation, allowing users to leverage custom glossaries for improved translation accuracy.
  - Introduced the ability to include optional DeepL API parameters to customize translation requests further.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->