### PR TITLE
chore: Explicitly define cleanup dependencies

### DIFF
--- a/.github/workflows/reportIntermittentTests.yml
+++ b/.github/workflows/reportIntermittentTests.yml
@@ -202,7 +202,7 @@ jobs:
 
   cleanup:
     if: always()
-    needs: [e2e]
+    needs: [e2e, frontend-build, backend-build, e2e-install-deps]
     name: Delete artifacts 🧹
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Explicitly defines dependencies for the cleanup job as [e2e, frontend-build, backend-build, e2e-install-deps], fixing the failing cleanup job for the reportIntermittentTests workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to ensure the cleanup job runs only after additional build and setup jobs have completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->