### PR TITLE
docs: Fix API key creation endpoint docs typo

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ApiKeyController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ApiKeyController.kt
@@ -69,7 +69,7 @@ class ApiKeyController(
   private val simpleProjectModelAssembler: SimpleProjectModelAssembler,
 ) {
   @PostMapping(path = ["/api-keys"])
-  @Operation(summary = "Crete API key", description = "Creates new API key with provided scopes")
+  @Operation(summary = "Create API key", description = "Creates new API key with provided scopes")
   @RequiresSuperAuthentication
   @OpenApiOrderExtension(1)
   fun create(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typo in the API documentation summary for the "Create API key" operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->