### PR TITLE
fix: properly remove related import conflicts when deleting language

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
@@ -13,6 +13,8 @@ import io.tolgee.development.testDataBuilder.data.TranslationsTestData
 import io.tolgee.development.testDataBuilder.data.dataImport.ImportTestData
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.model.Language
+import io.tolgee.model.UserAccount
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authentication.TolgeeAuthentication
 import io.tolgee.testing.assert
@@ -54,6 +56,19 @@ class LanguageServiceTest : AbstractSpringTest() {
 
   @Test
   @Transactional
+  fun `remove of language removes existing translation conflict references from import translations`() {
+    val testData = ImportTestData()
+    testDataService.saveTestData(testData.root)
+
+    assertThat(importService.findTranslation(testData.translationWithConflict.id)!!.conflict).isNotNull()
+    languageService.deleteLanguage(testData.english.id)
+    entityManager.flush()
+    entityManager.clear()
+    assertThat(importService.findTranslation(testData.translationWithConflict.id)!!.conflict).isNull()
+  }
+
+  @Test
+  @Transactional
   fun `deletes language with MT Service Config`() {
     val testData = MtSettingsTestData()
     testDataService.saveTestData(testData.root)
@@ -86,14 +101,31 @@ class LanguageServiceTest : AbstractSpringTest() {
     testDataService.saveTestData(testData.root)
 
     executeInNewTransaction {
-      setAuthentication(testData)
+      setAuthentication(testData.user)
       languageService.deleteLanguage(testData.germanLanguage.id)
     }
 
     executeInNewTransaction {
       waitForNotThrowing(timeout = 10000, pollTime = 100) {
-        assertLanguageDeleted(testData)
+        assertLanguageDeleted(testData.germanLanguage)
         assertActivityCreated()
+      }
+    }
+  }
+
+  @Test
+  fun `hard deletes language with conflicts`() {
+    val testData = ImportTestData()
+    testDataService.saveTestData(testData.root)
+
+    executeInNewTransaction {
+      setAuthentication(testData.userAccount)
+      languageService.deleteLanguage(testData.english.id)
+    }
+
+    executeInNewTransaction {
+      waitForNotThrowing(timeout = 10000, pollTime = 100) {
+        assertLanguageDeleted(testData.english)
       }
     }
   }
@@ -106,29 +138,29 @@ class LanguageServiceTest : AbstractSpringTest() {
 
     sessionFactory.statistics.clear()
     executeInNewTransaction {
-      setAuthentication(testData)
+      setAuthentication(testData.user)
       languageService.hardDeleteLanguage(testData.germanLanguage.id)
     }
     val count = sessionFactory.statistics.prepareStatementCount
     count.assert.isLessThan(20)
 
     executeInNewTransaction {
-      assertLanguageDeleted(testData)
+      assertLanguageDeleted(testData.germanLanguage)
     }
   }
 
-  private fun setAuthentication(testData: TranslationsTestData) {
+  private fun setAuthentication(user: UserAccount) {
     SecurityContextHolder.getContext().authentication =
       TolgeeAuthentication(
         null,
-        UserAccountDto.fromEntity(testData.user),
+        UserAccountDto.fromEntity(user),
         null,
       )
   }
 
-  private fun assertLanguageDeleted(testData: TranslationsTestData) {
+  private fun assertLanguageDeleted(language: Language) {
     entityManager.createQuery("select 1 from Language l where l.id = :id")
-      .setParameter("id", testData.germanLanguage.id)
+      .setParameter("id", language.id)
       .resultList.assert.isEmpty()
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
@@ -116,6 +116,7 @@ class LanguageServiceTest : AbstractSpringTest() {
   @Test
   fun `hard deletes language with conflicts`() {
     val testData = ImportTestData()
+    testData.useCzechBaseLanguage()
     testDataService.saveTestData(testData.root)
 
     executeInNewTransaction {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportTestData.kt
@@ -190,6 +190,7 @@ class ImportTestData {
               }
             }
           import = importBuilder.self
+          self.baseLanguage = czech
         }.self
     }
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportTestData.kt
@@ -190,7 +190,6 @@ class ImportTestData {
               }
             }
           import = importBuilder.self
-          self.baseLanguage = czech
         }.self
     }
 
@@ -455,6 +454,10 @@ class ImportTestData {
         language = importEnglish
       }
     }
+  }
+
+  fun useCzechBaseLanguage() {
+    project.baseLanguage = czech
   }
 
   data class AddFilesWithNamespacesResult(

--- a/backend/data/src/main/kotlin/io/tolgee/repository/dataImport/ImportTranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/dataImport/ImportTranslationRepository.kt
@@ -1,5 +1,6 @@
 package io.tolgee.repository.dataImport
 
+import io.tolgee.model.Language
 import io.tolgee.model.dataImport.Import
 import io.tolgee.model.dataImport.ImportLanguage
 import io.tolgee.model.dataImport.ImportTranslation
@@ -34,6 +35,11 @@ interface ImportTranslationRepository : JpaRepository<ImportTranslation, Long> {
   @Transactional
   @Query("update ImportTranslation it set it.conflict = null where it.conflict.id in :translationIds")
   fun removeExistingTranslationConflictReferences(translationIds: Collection<Long>)
+
+  @Modifying
+  @Transactional
+  @Query("update ImportTranslation it set it.conflict = null where it.language.existingLanguage = :language")
+  fun removeExistingLanguageConflictReferences(language: Language)
 
   @Query(
     """ select it.id as id, it.text as text, ik.name as keyName, ik.id as keyId,

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
@@ -325,6 +325,7 @@ class ImportService(
   }
 
   fun onExistingLanguageRemoved(language: Language) {
+    this.importTranslationRepository.removeExistingLanguageConflictReferences(language)
     this.importLanguageRepository.removeExistingLanguageReference(language)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageHardDeleter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageHardDeleter.kt
@@ -28,8 +28,8 @@ class LanguageHardDeleter(
     val tasks = getAllTasks(languageWithData)
     translationRepository.deleteAll(allTranslations)
     taskService.deleteAll(tasks)
-    languageRepository.delete(languageWithData)
     aiPlaygroundResultService.deleteResultsByLanguage(language.id)
+    languageRepository.delete(languageWithData)
     entityManager.flush()
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved issues where deleting a language did not clear related translation conflicts, ensuring all references are properly removed upon deletion.

- **Tests**
	- Added new tests to verify that translation conflicts are removed when a language is deleted and that languages with conflicts can be hard deleted.
	- Improved test clarity and coverage for language deletion scenarios.

- **New Features**
	- Introduced a method to set the base language to Czech in import data configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->