### PR TITLE
fix: ImportFile issue: handle propely when empty string is passed as issue param value

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportFile.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportFile.kt
@@ -63,7 +63,7 @@ class ImportFile(
     return ImportFileIssue(file = this, type = type).apply {
       this.params =
         params.map {
-          ImportFileIssueParam(this, it.key, it.value.shortenWithEllipsis().withEmptyPlaceholder())
+          ImportFileIssueParam(this, it.key, it.value.shortenWithEllipsis())
         }.toMutableList()
     }
   }
@@ -126,13 +126,6 @@ class ImportFile(
   private fun String.shortenWithEllipsis(): String {
     if (this.length > 255) {
       return this.substring(0..100) + "..."
-    }
-    return this
-  }
-
-  private fun String.withEmptyPlaceholder(): String {
-    if (this.isEmpty()) {
-      return "<empty>"
     }
     return this
   }

--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportFile.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/ImportFile.kt
@@ -63,7 +63,7 @@ class ImportFile(
     return ImportFileIssue(file = this, type = type).apply {
       this.params =
         params.map {
-          ImportFileIssueParam(this, it.key, it.value.shortenWithEllipsis())
+          ImportFileIssueParam(this, it.key, it.value.shortenWithEllipsis().withEmptyPlaceholder())
         }.toMutableList()
     }
   }
@@ -126,6 +126,13 @@ class ImportFile(
   private fun String.shortenWithEllipsis(): String {
     if (this.length > 255) {
       return this.substring(0..100) + "..."
+    }
+    return this
+  }
+
+  private fun String.withEmptyPlaceholder(): String {
+    if (this.isEmpty()) {
+      return "<empty>"
     }
     return this
   }

--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/ImportFileIssueParam.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/ImportFileIssueParam.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.Index
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.validation.constraints.NotBlank
 
 @Entity
 @Table(
@@ -20,6 +19,5 @@ class ImportFileIssueParam(
   val issue: ImportFileIssue,
   @Enumerated
   val type: FileIssueParamType,
-  @field:NotBlank
   val value: String,
 ) : StandardAuditModel()


### PR DESCRIPTION
I'm split on the best solution for this. Currently, `ImportFileIssueParam` doesn't allow an empty `value`, and passing an empty value will fail the import completely. I'm split between allowing it or replacing it with some constant value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed validation rules to allow blank values in certain import file issue parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->