### PR TITLE
feat: administration plans UI improvements

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/SelfHostedEePlanModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/SelfHostedEePlanModel.kt
@@ -21,6 +21,7 @@ open class SelfHostedEePlanModel(
   val free: Boolean,
   val nonCommercial: Boolean,
   val isPayAsYouGo: Boolean,
+  val archived: Boolean = false,
 ) : RepresentationModel<SelfHostedEePlanModel>() {
   /**
    * We need to provide this setter so unrecognized features are ignored in situation

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/SelfHostedEePlanModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/ee/SelfHostedEePlanModel.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonSetter
 import io.tolgee.constants.Feature
 import org.springframework.hateoas.RepresentationModel
 import org.springframework.hateoas.server.core.Relation
+import java.util.Date
 
 @Suppress("unused")
 @Relation(collectionRelation = "plans", itemRelation = "plan")
@@ -21,7 +22,7 @@ open class SelfHostedEePlanModel(
   val free: Boolean,
   val nonCommercial: Boolean,
   val isPayAsYouGo: Boolean,
-  val archived: Boolean = false,
+  val archivedAt: Date? = null,
 ) : RepresentationModel<SelfHostedEePlanModel>() {
   /**
    * We need to provide this setter so unrecognized features are ignored in situation

--- a/backend/api/src/main/kotlin/io/tolgee/publicBilling/PublicCloudPlanModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/publicBilling/PublicCloudPlanModel.kt
@@ -2,6 +2,7 @@ package io.tolgee.publicBilling
 
 import io.tolgee.constants.Feature
 import io.tolgee.hateoas.ee.PlanIncludedUsageModel
+import java.util.Date
 
 interface PublicCloudPlanModel {
   val id: Long
@@ -13,5 +14,5 @@ interface PublicCloudPlanModel {
   val nonCommercial: Boolean
   val includedUsage: PlanIncludedUsageModel
   val metricType: MetricType
-  val archived: Boolean
+  val archivedAt: Date?
 }

--- a/backend/api/src/main/kotlin/io/tolgee/publicBilling/PublicCloudPlanModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/publicBilling/PublicCloudPlanModel.kt
@@ -13,4 +13,5 @@ interface PublicCloudPlanModel {
   val nonCommercial: Boolean
   val includedUsage: PlanIncludedUsageModel
   val metricType: MetricType
+  val archived: Boolean
 }

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,10 @@ project(':server-app').afterEvaluate {
     task startDbChangelogContainer {
         doLast {
             exec {
+                ignoreExitValue = true
+                commandLine "docker", "rm", "--force", "--volumes", dbSchemaContainerName
+            }
+            exec {
                 commandLine "docker", "run", "-e", "POSTGRES_PASSWORD=postgres", "-d", "-p55538:5432", "--name", dbSchemaContainerName, "postgres:13"
             }
             Thread.sleep(5000)

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -40,6 +40,8 @@ declare namespace DataCy {
         "administration-cloud-plan-field-type" |
         "administration-cloud-plan-field-type-item" |
         "administration-cloud-plans-item" |
+        "administration-cloud-plans-item-archive" |
+        "administration-cloud-plans-item-archived-badge" |
         "administration-cloud-plans-item-delete" |
         "administration-cloud-plans-item-edit" |
         "administration-cloud-plans-item-public-badge" |
@@ -52,6 +54,7 @@ declare namespace DataCy {
         "administration-ee-license-release-key-button" |
         "administration-ee-plan-cancel-button" |
         "administration-ee-plans-item" |
+        "administration-ee-plans-item-archive" |
         "administration-ee-plans-item-delete" |
         "administration-ee-plans-item-edit" |
         "administration-ee-plans-item-public-badge" |
@@ -65,6 +68,7 @@ declare namespace DataCy {
         "administration-organizations-list-item" |
         "administration-organizations-projects-button" |
         "administration-organizations-settings-button" |
+        "administration-plan-field-archived" |
         "administration-plan-field-feature" |
         "administration-plan-field-name" |
         "administration-plan-field-non-commercial" |
@@ -210,9 +214,6 @@ declare namespace DataCy {
         "cell-key-screenshot-dropzone" |
         "cell-key-screenshot-file-input" |
         "checkbox-group-multiselect" |
-        "color-palette-field" |
-        "color-palette-popover" |
-        "color-preview" |
         "comment" |
         "comment-menu" |
         "comment-menu-delete" |
@@ -261,7 +262,6 @@ declare namespace DataCy {
         "developer-menu-content-delivery" |
         "developer-menu-storage" |
         "developer-menu-webhooks" |
-        "disabled-feature-banner" |
         "dropzone" |
         "dropzone-inner" |
         "edit-pat-dialog-content" |
@@ -413,9 +413,6 @@ declare namespace DataCy {
         "key-plural-checkbox" |
         "key-plural-checkbox-expand" |
         "key-plural-variable-name" |
-        "label-autocomplete-option" |
-        "label-modal" |
-        "label-selector-autocomplete" |
         "language-ai-prompt-dialog-description-input" |
         "language-ai-prompt-dialog-save" |
         "language-delete-button" |
@@ -528,7 +525,6 @@ declare namespace DataCy {
         "organization-switch-item" |
         "organization-switch-new" |
         "organization-switch-search" |
-        "palette-color" |
         "pat-expiry-info" |
         "pat-list-item" |
         "pat-list-item-alert" |
@@ -610,21 +606,12 @@ declare namespace DataCy {
         "project-settings-button" |
         "project-settings-delete-button" |
         "project-settings-description" |
-        "project-settings-label-item" |
-        "project-settings-label-item-description" |
-        "project-settings-label-item-label" |
-        "project-settings-label-item-name" |
-        "project-settings-labels-add-button" |
-        "project-settings-labels-edit-button" |
-        "project-settings-labels-list" |
-        "project-settings-labels-remove-button" |
         "project-settings-languages" |
         "project-settings-languages-add" |
         "project-settings-languages-list-edit-button" |
         "project-settings-languages-list-name" |
         "project-settings-menu-advanced" |
         "project-settings-menu-general" |
-        "project-settings-menu-labels" |
         "project-settings-name" |
         "project-settings-suggestions-mode-switch" |
         "project-settings-transfer-button" |
@@ -772,10 +759,6 @@ declare namespace DataCy {
         "translation-editor" |
         "translation-field-label" |
         "translation-history-item" |
-        "translation-label" |
-        "translation-label-add" |
-        "translation-label-control" |
-        "translation-label-delete" |
         "translation-panel" |
         "translation-panel-content" |
         "translation-panel-items-count" |

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -214,6 +214,9 @@ declare namespace DataCy {
         "cell-key-screenshot-dropzone" |
         "cell-key-screenshot-file-input" |
         "checkbox-group-multiselect" |
+        "color-palette-field" |
+        "color-palette-popover" |
+        "color-preview" |
         "comment" |
         "comment-menu" |
         "comment-menu-delete" |
@@ -262,6 +265,7 @@ declare namespace DataCy {
         "developer-menu-content-delivery" |
         "developer-menu-storage" |
         "developer-menu-webhooks" |
+        "disabled-feature-banner" |
         "dropzone" |
         "dropzone-inner" |
         "edit-pat-dialog-content" |
@@ -413,6 +417,9 @@ declare namespace DataCy {
         "key-plural-checkbox" |
         "key-plural-checkbox-expand" |
         "key-plural-variable-name" |
+        "label-autocomplete-option" |
+        "label-modal" |
+        "label-selector-autocomplete" |
         "language-ai-prompt-dialog-description-input" |
         "language-ai-prompt-dialog-save" |
         "language-delete-button" |
@@ -525,6 +532,7 @@ declare namespace DataCy {
         "organization-switch-item" |
         "organization-switch-new" |
         "organization-switch-search" |
+        "palette-color" |
         "pat-expiry-info" |
         "pat-list-item" |
         "pat-list-item-alert" |
@@ -606,12 +614,21 @@ declare namespace DataCy {
         "project-settings-button" |
         "project-settings-delete-button" |
         "project-settings-description" |
+        "project-settings-label-item" |
+        "project-settings-label-item-description" |
+        "project-settings-label-item-label" |
+        "project-settings-label-item-name" |
+        "project-settings-labels-add-button" |
+        "project-settings-labels-edit-button" |
+        "project-settings-labels-list" |
+        "project-settings-labels-remove-button" |
         "project-settings-languages" |
         "project-settings-languages-add" |
         "project-settings-languages-list-edit-button" |
         "project-settings-languages-list-name" |
         "project-settings-menu-advanced" |
         "project-settings-menu-general" |
+        "project-settings-menu-labels" |
         "project-settings-name" |
         "project-settings-suggestions-mode-switch" |
         "project-settings-transfer-button" |
@@ -759,6 +776,10 @@ declare namespace DataCy {
         "translation-editor" |
         "translation-field-label" |
         "translation-history-item" |
+        "translation-label" |
+        "translation-label-add" |
+        "translation-label-control" |
+        "translation-label-delete" |
         "translation-panel" |
         "translation-panel-content" |
         "translation-panel-items-count" |

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -220,6 +220,7 @@ declare namespace DataCy {
         "comment-menu-needs-resolution" |
         "comment-resolve" |
         "comment-text" |
+        "confirmation-dialog-checkbox" |
         "content-delivery-add-button" |
         "content-delivery-auto-publish-checkbox" |
         "content-delivery-delete-button" |

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -220,7 +220,6 @@ declare namespace DataCy {
         "comment-menu-needs-resolution" |
         "comment-resolve" |
         "comment-text" |
-        "confirmation-dialog-checkbox" |
         "content-delivery-add-button" |
         "content-delivery-auto-publish-checkbox" |
         "content-delivery-delete-button" |

--- a/webapp/src/ee/billing/Subscriptions/cloud/useCloudPlans.tsx
+++ b/webapp/src/ee/billing/Subscriptions/cloud/useCloudPlans.tsx
@@ -62,7 +62,7 @@ export const useCloudPlans = () => {
       mtCredits: -2,
       translations: -2,
     },
-    archived: false,
+    archivedAt: undefined,
   });
 
   const parentForPublic: PlanType[] = [];

--- a/webapp/src/ee/billing/Subscriptions/cloud/useCloudPlans.tsx
+++ b/webapp/src/ee/billing/Subscriptions/cloud/useCloudPlans.tsx
@@ -62,6 +62,7 @@ export const useCloudPlans = () => {
       mtCredits: -2,
       translations: -2,
     },
+    archived: false,
   });
 
   const parentForPublic: PlanType[] = [];

--- a/webapp/src/ee/billing/Subscriptions/selfHosted/PlansSelfHostedList.tsx
+++ b/webapp/src/ee/billing/Subscriptions/selfHosted/PlansSelfHostedList.tsx
@@ -66,7 +66,7 @@ export const PlansSelfHostedList: FC<BillingPlansProps> = ({
     public: true,
     nonCommercial: false,
     metricType: 'KEYS_SEATS',
-    archived: false,
+    archivedAt: undefined,
   });
 
   const parentForPublic: PlanType[] = [];

--- a/webapp/src/ee/billing/Subscriptions/selfHosted/PlansSelfHostedList.tsx
+++ b/webapp/src/ee/billing/Subscriptions/selfHosted/PlansSelfHostedList.tsx
@@ -66,6 +66,7 @@ export const PlansSelfHostedList: FC<BillingPlansProps> = ({
     public: true,
     nonCommercial: false,
     metricType: 'KEYS_SEATS',
+    archived: false,
   });
 
   const parentForPublic: PlanType[] = [];

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/CloudPlanForm.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/CloudPlanForm.tsx
@@ -7,6 +7,7 @@ import { CloudPlanFormData } from './types';
 import { useUrlSearch } from 'tg.hooks/useUrlSearch';
 import { Form, Formik } from 'formik';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
+import { PlanArchivedSwitch } from 'tg.ee.module/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch';
 
 type Props = {
   isUpdate?: boolean;
@@ -63,8 +64,10 @@ export function CloudPlanForm({
       <Form>
         {beforeFields}
         <Box mb={3} pt={2}>
-          <PlanPublicSwitchField {...publicSwitchFieldProps} />
-
+          <Box display="grid">
+            <PlanArchivedSwitch isUpdate={isUpdate} />
+            <PlanPublicSwitchField {...publicSwitchFieldProps} />
+          </Box>
           <CloudPlanFields isUpdate={isUpdate} canEditPrices={canEditPrices} />
 
           <PlanSaveButton loading={loading} />

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/getCloudPlanInitialValues.ts
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/getCloudPlanInitialValues.ts
@@ -19,6 +19,7 @@ export const getCloudPlanInitialValues = (
         ...planData.includedUsage,
         translations: planData.includedUsage.translations,
       },
+      archived: planData.archivedAt != null,
     } as CloudPlanFormData;
   }
 
@@ -46,5 +47,6 @@ export const getCloudPlanInitialValues = (
     forOrganizationIds: [],
     free: false,
     nonCommercial: false,
+    archived: false,
   } as CloudPlanFormData;
 };

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
@@ -18,7 +18,7 @@ export interface GenericPlanFormData {
   public: boolean;
   free: boolean;
   nonCommercial: boolean;
-  archived: boolean;
+  archived?: boolean;
 }
 
 export interface CloudPlanFormData extends GenericPlanFormData {

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
@@ -18,6 +18,7 @@ export interface GenericPlanFormData {
   public: boolean;
   free: boolean;
   nonCommercial: boolean;
+  archived: boolean;
 }
 
 export interface CloudPlanFormData extends GenericPlanFormData {

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/cloud/types.ts
@@ -26,5 +26,8 @@ export interface CloudPlanFormData extends GenericPlanFormData {
   metricType: MetricType;
 }
 
-export type SelfHostedEePlanFormData =
-  components['schemas']['SelfHostedEePlanRequest'];
+export interface SelfHostedEePlanFormData extends SelfHostedEePlanRequest {
+  canEditPrices: boolean;
+}
+
+type SelfHostedEePlanRequest = components['schemas']['SelfHostedEePlanRequest'];

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
@@ -20,7 +20,7 @@ export const PlanArchivedSwitch: FC<{ isUpdate?: boolean }> = ({
       <FormControlLabel
         control={
           <Switch
-            checked={values.archived}
+            checked={values.archived ?? false}
             onChange={() => setFieldValue('archived', !values.archived)}
           />
         }

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
@@ -2,12 +2,12 @@ import React, { FC } from 'react';
 import { Alert, FormControlLabel, Switch } from '@mui/material';
 import { useFormikContext } from 'formik';
 import { T, useTranslate } from '@tolgee/react';
-import { CloudPlanFormData } from '../cloud/types';
+import { GenericPlanFormData } from '../cloud/types';
 
 export const PlanArchivedSwitch: FC<{ isUpdate?: boolean }> = ({
   isUpdate,
 }) => {
-  const { setFieldValue, values } = useFormikContext<CloudPlanFormData>();
+  const { setFieldValue, values } = useFormikContext<GenericPlanFormData>();
 
   const { t } = useTranslate();
 

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch.tsx
@@ -1,0 +1,37 @@
+import React, { FC } from 'react';
+import { Alert, FormControlLabel, Switch } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { T, useTranslate } from '@tolgee/react';
+import { CloudPlanFormData } from '../cloud/types';
+
+export const PlanArchivedSwitch: FC<{ isUpdate?: boolean }> = ({
+  isUpdate,
+}) => {
+  const { setFieldValue, values } = useFormikContext<CloudPlanFormData>();
+
+  const { t } = useTranslate();
+
+  if (!isUpdate) {
+    return null;
+  }
+
+  return (
+    <>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={values.archived}
+            onChange={() => setFieldValue('archived', !values.archived)}
+          />
+        }
+        data-cy="administration-plan-field-archived"
+        label={t('administration_cloud_plan_field_archived')}
+      />
+      {values.archived && (
+        <Alert severity="warning" sx={{ mt: 1, mb: 4 }}>
+          <T keyName={'admin_billing_plan_archived_warning'} />
+        </Alert>
+      )}
+    </>
+  );
+};

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanStripeProductSelectField.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanStripeProductSelectField.tsx
@@ -41,6 +41,14 @@ export const PlanStripeProductSelectField: FC<
             onChange={(val) => form.setFieldValue(field.name, val)}
             items={[
               { value: '', name: 'None' },
+              ...(!products?.find((product) => product.id === field.value)
+                ? [
+                    {
+                      value: field.value,
+                      name: `${field.value}`,
+                    },
+                  ]
+                : []),
               ...(products?.map(({ id, name }) => ({
                 value: id,
                 name: `${id} ${name}`,

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanStripeProductSelectField.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanStripeProductSelectField.tsx
@@ -41,7 +41,8 @@ export const PlanStripeProductSelectField: FC<
             onChange={(val) => form.setFieldValue(field.name, val)}
             items={[
               { value: '', name: 'None' },
-              ...(!products?.find((product) => product.id === field.value)
+              ...(!products?.find((product) => product.id === field.value) &&
+              field.value
                 ? [
                     {
                       value: field.value,

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/SelfHostedEePlanEditForm.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/SelfHostedEePlanEditForm.tsx
@@ -9,6 +9,7 @@ import {
 import { useMessage } from 'tg.hooks/useSuccessMessage';
 import { useHistory } from 'react-router-dom';
 import { SpinnerProgress } from 'tg.component/SpinnerProgress';
+import { getSelfHostedPlanInitialValues } from 'tg.ee.module/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/getSelfHostedPlanInitialValues';
 
 type EditSelfHostedEePlanFormProps = { planId: number };
 
@@ -34,7 +35,7 @@ export const SelfHostedEePlanEditForm: FC<EditSelfHostedEePlanFormProps> = ({
     return <SpinnerProgress />;
   }
 
-  const planData = planLoadable.data;
+  const planData = getSelfHostedPlanInitialValues(planLoadable.data, true);
 
   const onSubmit: React.ComponentProps<
     typeof SelfHostedEePlanForm

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/SelfHostedEePlanForm.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/SelfHostedEePlanForm.tsx
@@ -12,6 +12,7 @@ import { SelfHostedEePlanFormData } from '../cloud/types';
 import { SelfHostedEePlanTypeSelectField } from './fields/SelfHostedEePlanTypeSelectField';
 import { PlanSaveButton } from '../genericFields/PlanSaveButton';
 import { SelfHostedEePlanPricesAndLimits } from './fields/SelfHostedEePlanPricesAndLimits';
+import { PlanArchivedSwitch } from 'tg.ee.module/billing/administration/subscriptionPlans/components/planForm/genericFields/PlanArchivedSwitch';
 
 type Props = {
   initialData: SelfHostedEePlanFormData;
@@ -39,7 +40,10 @@ export function SelfHostedEePlanForm({
     >
       <Form>
         <Box mb={3} mt={3}>
-          <PlanPublicSwitchField />
+          <Box display="grid">
+            <PlanArchivedSwitch isUpdate={isUpdate} />
+            <PlanPublicSwitchField />
+          </Box>
 
           {beforeFields}
 

--- a/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/getSelfHostedPlanInitialValues.ts
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/components/planForm/selfHostedEe/getSelfHostedPlanInitialValues.ts
@@ -2,7 +2,8 @@ import { SelfHostedEePlanFormData } from '../cloud/types';
 import { components } from 'tg.service/billingApiSchema.generated';
 
 export function getSelfHostedPlanInitialValues(
-  planData?: components['schemas']['SelfHostedEePlanAdministrationModel']
+  planData?: components['schemas']['SelfHostedEePlanAdministrationModel'],
+  withOrganizationIds: boolean = false
 ): SelfHostedEePlanFormData {
   if (planData) {
     return {
@@ -10,12 +11,16 @@ export function getSelfHostedPlanInitialValues(
       stripeProductId: planData.stripeProductId,
       prices: planData.prices,
       includedUsage: planData.includedUsage,
-      forOrganizationIds: [],
+      forOrganizationIds: withOrganizationIds
+        ? planData.forOrganizationIds
+        : [],
       enabledFeatures: planData.enabledFeatures,
       public: planData.public,
       free: planData.free,
       nonCommercial: planData.nonCommercial,
       isPayAsYouGo: planData.isPayAsYouGo,
+      canEditPrices: planData.canEditPrices,
+      archived: planData.archivedAt != null,
     };
   }
 
@@ -40,5 +45,7 @@ export function getSelfHostedPlanInitialValues(
     free: false,
     nonCommercial: false,
     isPayAsYouGo: true,
+    archived: false,
+    canEditPrices: true,
   };
 }

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
@@ -21,6 +21,8 @@ import { useMessage } from 'tg.hooks/useSuccessMessage';
 import { confirmation } from 'tg.hooks/confirmation';
 import { components } from 'tg.service/billingApiSchema.generated';
 import { PlanPublicChip } from '../../../component/Plan/PlanPublicChip';
+import { PlanSubscriptionCount } from 'tg.ee.module/billing/component/Plan/PlanSubscriptionCount';
+import { PlanListPriceInfo } from 'tg.ee.module/billing/component/Plan/PlanListPriceInfo';
 
 type CloudPlanModel = components['schemas']['CloudPlanModel'];
 
@@ -89,24 +91,37 @@ export const AdministrationCloudPlansView = () => {
                   <ListItemText>{plan.name}</ListItemText>
                   <PlanPublicChip isPublic={plan.public} />
                 </Box>
-                <Box>
-                  <Button
-                    size="small"
-                    component={Link}
-                    to={LINKS.ADMINISTRATION_BILLING_CLOUD_PLAN_EDIT.build({
-                      [PARAMS.PLAN_ID]: plan.id,
-                    })}
-                    data-cy="administration-cloud-plans-item-edit"
-                  >
-                    {t('administration_cloud_plan_edit_button')}
-                  </Button>
-                  <IconButton
-                    size="small"
-                    onClick={() => deletePlan(plan)}
-                    data-cy="administration-cloud-plans-item-delete"
-                  >
-                    <X />
-                  </IconButton>
+                <Box display="flex">
+                  <Box display="flex" gap={2} alignItems="center">
+                    <ListItemText>
+                      <PlanSubscriptionCount count={plan.subscriptionCount} />
+                    </ListItemText>
+                    <PlanListPriceInfo prices={plan.prices} period="MONTHLY" />
+                    <PlanListPriceInfo
+                      prices={plan.prices}
+                      period="YEARLY"
+                      bold
+                    />
+                  </Box>
+                  <Box>
+                    <Button
+                      size="small"
+                      component={Link}
+                      to={LINKS.ADMINISTRATION_BILLING_CLOUD_PLAN_EDIT.build({
+                        [PARAMS.PLAN_ID]: plan.id,
+                      })}
+                      data-cy="administration-cloud-plans-item-edit"
+                    >
+                      {t('administration_cloud_plan_edit_button')}
+                    </Button>
+                    <IconButton
+                      size="small"
+                      onClick={() => deletePlan(plan)}
+                      data-cy="administration-cloud-plans-item-delete"
+                    >
+                      <X />
+                    </IconButton>
+                  </Box>
                 </Box>
               </Box>
             </ListItem>

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
@@ -124,11 +124,11 @@ export const AdministrationCloudPlansView = () => {
               >
                 <Box display="flex" gap={2} alignItems="center">
                   <StyledListItemText
-                    className={clsx(plan.archived && 'archived')}
+                    className={clsx(plan.archivedAt != null && 'archived')}
                   >
                     {plan.name}
                   </StyledListItemText>
-                  <PlanArchivedChip isArchived={plan.archived} />
+                  <PlanArchivedChip isArchived={plan.archivedAt != null} />
                   <PlanPublicChip isPublic={plan.public} />
                 </Box>
                 <Box display="flex" gap={2}>
@@ -139,7 +139,7 @@ export const AdministrationCloudPlansView = () => {
                     <PlanListPriceInfo prices={plan.prices} bold />
                   </Box>
                   <Box display="flex">
-                    {!plan.archived && (
+                    {!plan.archivedAt && (
                       <Button
                         size="small"
                         onClick={() => archivePlan(plan)}

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsCloud/AdministrationCloudPlansView.tsx
@@ -136,12 +136,7 @@ export const AdministrationCloudPlansView = () => {
                     <ListItemText>
                       <PlanSubscriptionCount count={plan.subscriptionCount} />
                     </ListItemText>
-                    <PlanListPriceInfo prices={plan.prices} period="MONTHLY" />
-                    <PlanListPriceInfo
-                      prices={plan.prices}
-                      period="YEARLY"
-                      bold
-                    />
+                    <PlanListPriceInfo prices={plan.prices} bold />
                   </Box>
                   <Box display="flex">
                     {!plan.archived && (

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
@@ -8,6 +8,7 @@ import {
   ListItem,
   ListItemText,
   Paper,
+  styled,
 } from '@mui/material';
 import { X } from '@untitled-ui/icons-react';
 
@@ -23,8 +24,17 @@ import { confirmation } from 'tg.hooks/confirmation';
 import { components } from 'tg.service/billingApiSchema.generated';
 import { PlanSubscriptionCount } from 'tg.ee.module/billing/component/Plan/PlanSubscriptionCount';
 import { PlanListPriceInfo } from 'tg.ee.module/billing/component/Plan/PlanListPriceInfo';
+import { PlanArchivedChip } from 'tg.ee.module/billing/component/Plan/PlanArchivedChip';
+import clsx from 'clsx';
 
-type SelfHostedEePlanModel = components['schemas']['SelfHostedEePlanModel'];
+type SelfHostedEePlanAdministrationModel =
+  components['schemas']['SelfHostedEePlanAdministrationModel'];
+
+const StyledListItemText = styled(ListItemText)(({ theme }) => ({
+  '&.archived': {
+    color: theme.palette.text.disabled,
+  },
+}));
 
 export const AdministrationEePlansView = () => {
   const messaging = useMessage();
@@ -36,13 +46,39 @@ export const AdministrationEePlansView = () => {
     query: {},
   });
 
+  const archivePlanLoadable = useBillingApiMutation({
+    url: '/v2/administration/billing/self-hosted-ee-plans/{planId}/archive',
+    method: 'put',
+    invalidatePrefix: '/v2/administration/billing/self-hosted-ee-plans',
+  });
+
   const deletePlanLoadable = useBillingApiMutation({
     url: '/v2/administration/billing/self-hosted-ee-plans/{planId}',
     method: 'delete',
     invalidatePrefix: '/v2/administration/billing/self-hosted-ee-plans',
   });
 
-  function deletePlan(plan: SelfHostedEePlanModel) {
+  function archivePlan(plan: SelfHostedEePlanAdministrationModel) {
+    confirmation({
+      message: <T keyName="administration_plan_archive_message" />,
+      confirmButtonText: <T keyName="general_archive" />,
+      onConfirm: () =>
+        archivePlanLoadable.mutate(
+          {
+            path: { planId: plan.id },
+          },
+          {
+            onSuccess() {
+              messaging.success(
+                <T keyName="administration_plan_archived_success" />
+              );
+            },
+          }
+        ),
+    });
+  }
+
+  function deletePlan(plan: SelfHostedEePlanAdministrationModel) {
     confirmation({
       hardModeText: plan.name,
       message: <T keyName="administration_ee_plan_delete_message" />,
@@ -88,7 +124,12 @@ export const AdministrationEePlansView = () => {
                 alignItems="center"
               >
                 <Box display="flex" gap={2} alignItems="center">
-                  <ListItemText>{plan.name}</ListItemText>
+                  <StyledListItemText
+                    className={clsx(plan.archived && 'archived')}
+                  >
+                    {plan.name}
+                  </StyledListItemText>
+                  <PlanArchivedChip isArchived={plan.archived} />
                   {plan.public && (
                     <Chip
                       data-cy="administration-ee-plans-item-public-badge"
@@ -97,7 +138,7 @@ export const AdministrationEePlansView = () => {
                     />
                   )}
                 </Box>
-                <Box display="flex">
+                <Box display="flex" gap={2}>
                   <Box display="flex" gap={2} alignItems="center">
                     <PlanSubscriptionCount count={plan.subscriptionCount} />
                     <PlanListPriceInfo prices={plan.prices} period="MONTHLY" />
@@ -107,7 +148,17 @@ export const AdministrationEePlansView = () => {
                       bold
                     />
                   </Box>
-                  <Box>
+                  <Box display="flex">
+                    {!plan.archived && (
+                      <Button
+                        size="small"
+                        onClick={() => archivePlan(plan)}
+                        data-cy="administration-ee-plans-item-archive"
+                        style={{ padding: '6px 8px' }}
+                      >
+                        {t('administration_plan_archive_button')}
+                      </Button>
+                    )}
                     <Button
                       size="small"
                       component={Link}

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
@@ -154,7 +154,6 @@ export const AdministrationEePlansView = () => {
                         size="small"
                         onClick={() => archivePlan(plan)}
                         data-cy="administration-ee-plans-item-archive"
-                        style={{ padding: '6px 8px' }}
                       >
                         {t('administration_plan_archive_button')}
                       </Button>

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
@@ -125,11 +125,11 @@ export const AdministrationEePlansView = () => {
               >
                 <Box display="flex" gap={2} alignItems="center">
                   <StyledListItemText
-                    className={clsx(plan.archived && 'archived')}
+                    className={clsx(plan.archivedAt != null && 'archived')}
                   >
                     {plan.name}
                   </StyledListItemText>
-                  <PlanArchivedChip isArchived={plan.archived} />
+                  <PlanArchivedChip isArchived={plan.archivedAt != null} />
                   {plan.public && (
                     <Chip
                       data-cy="administration-ee-plans-item-public-badge"
@@ -144,7 +144,7 @@ export const AdministrationEePlansView = () => {
                     <PlanListPriceInfo prices={plan.prices} bold />
                   </Box>
                   <Box display="flex">
-                    {!plan.archived && (
+                    {!plan.archivedAt && (
                       <Button
                         size="small"
                         onClick={() => archivePlan(plan)}

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
@@ -21,6 +21,8 @@ import { BaseAdministrationView } from 'tg.views/administration/components/BaseA
 import { useMessage } from 'tg.hooks/useSuccessMessage';
 import { confirmation } from 'tg.hooks/confirmation';
 import { components } from 'tg.service/billingApiSchema.generated';
+import { PlanSubscriptionCount } from 'tg.ee.module/billing/component/Plan/PlanSubscriptionCount';
+import { PlanListPriceInfo } from 'tg.ee.module/billing/component/Plan/PlanListPriceInfo';
 
 type SelfHostedEePlanModel = components['schemas']['SelfHostedEePlanModel'];
 
@@ -95,24 +97,35 @@ export const AdministrationEePlansView = () => {
                     />
                   )}
                 </Box>
-                <Box>
-                  <Button
-                    size="small"
-                    component={Link}
-                    to={LINKS.ADMINISTRATION_BILLING_EE_PLAN_EDIT.build({
-                      [PARAMS.PLAN_ID]: plan.id,
-                    })}
-                    data-cy="administration-ee-plans-item-edit"
-                  >
-                    {t('administration_ee_plan_edit_button')}
-                  </Button>
-                  <IconButton
-                    size="small"
-                    onClick={() => deletePlan(plan)}
-                    data-cy="administration-ee-plans-item-delete"
-                  >
-                    <X />
-                  </IconButton>
+                <Box display="flex">
+                  <Box display="flex" gap={2} alignItems="center">
+                    <PlanSubscriptionCount count={plan.subscriptionCount} />
+                    <PlanListPriceInfo prices={plan.prices} period="MONTHLY" />
+                    <PlanListPriceInfo
+                      prices={plan.prices}
+                      period="YEARLY"
+                      bold
+                    />
+                  </Box>
+                  <Box>
+                    <Button
+                      size="small"
+                      component={Link}
+                      to={LINKS.ADMINISTRATION_BILLING_EE_PLAN_EDIT.build({
+                        [PARAMS.PLAN_ID]: plan.id,
+                      })}
+                      data-cy="administration-ee-plans-item-edit"
+                    >
+                      {t('administration_ee_plan_edit_button')}
+                    </Button>
+                    <IconButton
+                      size="small"
+                      onClick={() => deletePlan(plan)}
+                      data-cy="administration-ee-plans-item-delete"
+                    >
+                      <X />
+                    </IconButton>
+                  </Box>
                 </Box>
               </Box>
             </ListItem>

--- a/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
+++ b/webapp/src/ee/billing/administration/subscriptionPlans/viewsSelfHostedEe/AdministrationEePlansView.tsx
@@ -141,12 +141,7 @@ export const AdministrationEePlansView = () => {
                 <Box display="flex" gap={2}>
                   <Box display="flex" gap={2} alignItems="center">
                     <PlanSubscriptionCount count={plan.subscriptionCount} />
-                    <PlanListPriceInfo prices={plan.prices} period="MONTHLY" />
-                    <PlanListPriceInfo
-                      prices={plan.prices}
-                      period="YEARLY"
-                      bold
-                    />
+                    <PlanListPriceInfo prices={plan.prices} bold />
                   </Box>
                   <Box display="flex">
                     {!plan.archived && (

--- a/webapp/src/ee/billing/component/Plan/PlanArchivedChip.tsx
+++ b/webapp/src/ee/billing/component/Plan/PlanArchivedChip.tsx
@@ -1,0 +1,15 @@
+import { Chip } from '@mui/material';
+import { T } from '@tolgee/react';
+
+export function PlanArchivedChip({ isArchived }: { isArchived?: boolean }) {
+  if (!isArchived) {
+    return null;
+  }
+  return (
+    <Chip
+      data-cy="administration-cloud-plans-item-archived-badge"
+      size="small"
+      label={<T keyName="administration_plan_archived_badge" />}
+    />
+  );
+}

--- a/webapp/src/ee/billing/component/Plan/PlanListPriceInfo.tsx
+++ b/webapp/src/ee/billing/component/Plan/PlanListPriceInfo.tsx
@@ -1,0 +1,32 @@
+import { PricePrimary } from 'tg.ee.module/billing/component/Price/PricePrimary';
+import { styled, useTheme } from '@mui/material';
+import { components } from 'tg.service/billingApiSchema.generated';
+
+type PlanPricesModel = components['schemas']['PlanPricesModel'];
+export type BillingPeriodType =
+  components['schemas']['CloudSubscribeRequest']['period'];
+
+const StyledPricePrimary = styled(PricePrimary)<{ bold?: boolean }>`
+  font-size: 15px;
+  font-weight: ${({ bold }) => (bold ? 'bold' : 'inherit')};
+`;
+
+export const PlanListPriceInfo = ({
+  prices,
+  period,
+  bold,
+}: {
+  prices: PlanPricesModel;
+  period: BillingPeriodType;
+  bold?: boolean;
+}) => {
+  const theme = useTheme();
+  return (
+    <StyledPricePrimary
+      prices={prices}
+      period={period}
+      highlightColor={theme.palette.primaryText}
+      bold={bold}
+    />
+  );
+};

--- a/webapp/src/ee/billing/component/Plan/PlanListPriceInfo.tsx
+++ b/webapp/src/ee/billing/component/Plan/PlanListPriceInfo.tsx
@@ -1,6 +1,8 @@
 import { PricePrimary } from 'tg.ee.module/billing/component/Price/PricePrimary';
 import { styled, useTheme } from '@mui/material';
 import { components } from 'tg.service/billingApiSchema.generated';
+import { Tooltip } from '@mui/material';
+import { T } from '@tolgee/react';
 
 type PlanPricesModel = components['schemas']['PlanPricesModel'];
 export type BillingPeriodType =
@@ -13,20 +15,52 @@ const StyledPricePrimary = styled(PricePrimary)<{ bold?: boolean }>`
 
 export const PlanListPriceInfo = ({
   prices,
-  period,
   bold,
 }: {
   prices: PlanPricesModel;
-  period: BillingPeriodType;
   bold?: boolean;
 }) => {
   const theme = useTheme();
+
+  const tooltipContent = (
+    <div>
+      <div>
+        <T keyName="administration_cloud_plan_field_price_yearly" />:
+        <StyledPricePrimary
+          prices={prices}
+          period="YEARLY"
+          highlightColor={theme.palette.primaryText}
+          bold={bold}
+          noPeriodSwitch={true}
+        />
+      </div>
+      <div>
+        <T keyName="administration_cloud_plan_field_price_monthly" />:
+        <StyledPricePrimary
+          prices={prices}
+          period="MONTHLY"
+          highlightColor={theme.palette.primaryText}
+          bold={bold}
+          noPeriodSwitch={true}
+        />
+      </div>
+    </div>
+  );
+
   return (
-    <StyledPricePrimary
-      prices={prices}
-      period={period}
-      highlightColor={theme.palette.primaryText}
-      bold={bold}
-    />
+    <Tooltip
+      title={tooltipContent}
+      componentsProps={{ tooltip: { sx: { minWidth: '150px' } } }}
+    >
+      <span>
+        <StyledPricePrimary
+          prices={prices}
+          period="YEARLY"
+          highlightColor={theme.palette.primaryText}
+          bold={bold}
+          noPeriodSwitch={true}
+        />
+      </span>
+    </Tooltip>
   );
 };

--- a/webapp/src/ee/billing/component/Plan/PlanSubscriptionCount.tsx
+++ b/webapp/src/ee/billing/component/Plan/PlanSubscriptionCount.tsx
@@ -1,0 +1,16 @@
+import { ListItemText } from '@mui/material';
+import { T } from '@tolgee/react';
+
+export const PlanSubscriptionCount = ({ count }: { count: number }) => {
+  if (count == 0) {
+    return null;
+  }
+  return (
+    <ListItemText>
+      <T
+        keyName="administration_subscription_count"
+        params={{ count: count }}
+      />
+    </ListItemText>
+  );
+};

--- a/webapp/src/ee/billing/component/Price/PricePrimary.tsx
+++ b/webapp/src/ee/billing/component/Price/PricePrimary.tsx
@@ -22,6 +22,7 @@ type Props = {
   highlightColor: string;
   sx?: SxProps;
   className?: string;
+  noPeriodSwitch?: boolean;
 };
 
 export const PricePrimary = ({
@@ -30,11 +31,12 @@ export const PricePrimary = ({
   highlightColor,
   sx,
   className,
+  noPeriodSwitch = false,
 }: Props) => {
   const { subscriptionMonthly, subscriptionYearly } = prices;
   const formatMoney = useMoneyFormatter();
 
-  const needsPeriodSwitch = isPlanPeriodDependant(prices);
+  const needsPeriodSwitch = !noPeriodSwitch && isPlanPeriodDependant(prices);
 
   const subscriptionPrice =
     period === 'MONTHLY' ? subscriptionMonthly : subscriptionYearly / 12;

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -4490,6 +4490,8 @@ export interface components {
       enabled: boolean;
     };
     PublicCloudPlanModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
         | "PRIORITIZED_FEATURE_REQUESTS"
@@ -4805,6 +4807,8 @@ export interface components {
       ids: number[];
     };
     SelfHostedEePlanModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
         | "PRIORITIZED_FEATURE_REQUESTS"

--- a/webapp/src/service/billingApiSchema.generated.ts
+++ b/webapp/src/service/billingApiSchema.generated.ts
@@ -364,6 +364,7 @@ export interface components {
       type: "PAY_AS_YOU_GO" | "FIXED";
     };
     CloudPlanRequest: {
+      archived?: boolean;
       /** Format: date-time */
       availableUntil?: string;
       enabledFeatures: (
@@ -1193,6 +1194,7 @@ export interface components {
       public: boolean;
     };
     SelfHostedEePlanRequest: {
+      archived?: boolean;
       /** Format: date-time */
       availableUntil?: string;
       enabledFeatures: (

--- a/webapp/src/service/billingApiSchema.generated.ts
+++ b/webapp/src/service/billingApiSchema.generated.ts
@@ -24,6 +24,9 @@ export interface paths {
     put: operations["updatePlan_1"];
     delete: operations["deletePlan_1"];
   };
+  "/v2/administration/billing/cloud-plans/{planId}/archive": {
+    put: operations["archivePlan_1"];
+  };
   "/v2/administration/billing/cloud-plans/{planId}/organizations": {
     get: operations["getPlanOrganizations_1"];
   };
@@ -45,6 +48,9 @@ export interface paths {
     get: operations["getPlan"];
     put: operations["updatePlan"];
     delete: operations["deletePlan"];
+  };
+  "/v2/administration/billing/self-hosted-ee-plans/{planId}/archive": {
+    put: operations["archivePlan"];
   };
   "/v2/administration/billing/self-hosted-ee-plans/{planId}/organizations": {
     get: operations["getPlanOrganizations"];
@@ -212,6 +218,8 @@ export interface paths {
 export interface components {
   schemas: {
     AdministrationCloudPlanModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       canEditPrices: boolean;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
@@ -252,6 +260,8 @@ export interface components {
       prices: components["schemas"]["PlanPricesModel"];
       public: boolean;
       stripeProductId: string;
+      /** Format: int64 */
+      subscriptionCount: number;
       type: "PAY_AS_YOU_GO" | "FIXED";
     };
     AdministrationCloudSubscriptionModel: {
@@ -329,6 +339,8 @@ export interface components {
       ids: components["schemas"]["SubscriptionId"][];
     };
     CloudPlanModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
         | "PRIORITIZED_FEATURE_REQUESTS"
@@ -1118,6 +1130,8 @@ export interface components {
       planId: number;
     };
     SelfHostedEePlanAdministrationModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       canEditPrices: boolean;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
@@ -1158,8 +1172,12 @@ export interface components {
       prices: components["schemas"]["PlanPricesModel"];
       public: boolean;
       stripeProductId: string;
+      /** Format: int64 */
+      subscriptionCount: number;
     };
     SelfHostedEePlanModel: {
+      /** Format: date-time */
+      archivedAt?: string;
       enabledFeatures: (
         | "GRANULAR_PERMISSIONS"
         | "PRIORITIZED_FEATURE_REQUESTS"
@@ -1801,6 +1819,53 @@ export interface operations {
       };
     };
   };
+  archivePlan_1: {
+    parameters: {
+      path: {
+        planId: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["AdministrationCloudPlanModel"];
+        };
+      };
+      /** Bad Request */
+      400: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Unauthorized */
+      401: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Forbidden */
+      403: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Not Found */
+      404: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+    };
+  };
   getPlanOrganizations_1: {
     parameters: {
       path: {
@@ -2229,6 +2294,53 @@ export interface operations {
     responses: {
       /** OK */
       200: unknown;
+      /** Bad Request */
+      400: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Unauthorized */
+      401: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Forbidden */
+      403: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+      /** Not Found */
+      404: {
+        content: {
+          "application/json":
+            | components["schemas"]["ErrorResponseTyped"]
+            | components["schemas"]["ErrorResponseBody"];
+        };
+      };
+    };
+  };
+  archivePlan: {
+    parameters: {
+      path: {
+        planId: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SelfHostedEePlanAdministrationModel"];
+        };
+      };
       /** Bad Request */
       400: {
         content: {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to archive cloud and self-hosted EE plans from Administration with confirmation, archive endpoint integration, and success feedback.
  * Visual indicators for archived plans: badge, disabled styling, and conditional Archive button.
  * Show subscription counts and richer price info per plan in administration lists.
  * Add archived toggle to plan edit forms.

* **Chores**
  * Extend API/schema and form data to support archived state and subscription counts.
  * Add test identifiers for archived-plan UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->