### PR TITLE
fix: ContentDeliveryConfig: missing migration for structure delimiter

### DIFF
--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4482,4 +4482,7 @@
             <column name="organization_id"/>
         </createIndex>
     </changeSet>
+    <changeSet author="anty (generated)" id="1751022945678-1">
+        <modifyDataType columnName="structure_delimiter" newDataType="char(1)" tableName="content_delivery_config"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database schema to change the data type of the `structure_delimiter` column to `char(1)` in the content delivery configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->