### PR TITLE
feat: support exporting json, yaml and xliff with all message formats from web ui

### DIFF
--- a/e2e/cypress/common/export.ts
+++ b/e2e/cypress/common/export.ts
@@ -97,12 +97,41 @@ export const testExportFormats = (
   };
 
   testFormat(interceptFn, submitFn, clearCheckboxesAfter, afterFn, {
-    format: 'JSON',
+    format: 'Native JSON',
     expectedParams: {
       format: 'JSON',
       supportArrays: false,
     },
   });
+
+  testFormat(interceptFn, submitFn, clearCheckboxesAfter, afterFn, {
+    format: 'Flat JSON',
+    messageFormat: 'Java String.format',
+    expectedParams: {
+      format: 'JSON',
+      structureDelimiter: '.',
+      supportArrays: false,
+    },
+  });
+
+  testFormatWithMessageFormats(
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
+    {
+      format: 'Flat JSON',
+      expectedParams: {
+        format: 'JSON',
+        structureDelimiter: '.',
+        supportArrays: false,
+      },
+    }
+  );
 
   testFormat(interceptFn, submitFn, clearCheckboxesAfter, afterFn, {
     format: 'Structured JSON',
@@ -115,7 +144,14 @@ export const testExportFormats = (
   });
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Ruby Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'Structured JSON',
       expectedParams: {
@@ -127,7 +163,14 @@ export const testExportFormats = (
   );
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Ruby Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'XLIFF',
       expectedParams: {
@@ -138,7 +181,14 @@ export const testExportFormats = (
   );
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'Flat YAML',
       expectedParams: {
@@ -148,7 +198,14 @@ export const testExportFormats = (
   );
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'Structured YAML',
       expectedParams: {
@@ -241,7 +298,14 @@ export const testExportFormats = (
   });
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Ruby Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'CSV',
       expectedParams: {
@@ -251,7 +315,14 @@ export const testExportFormats = (
   );
 
   testFormatWithMessageFormats(
-    ['ICU', 'PHP Sprintf', 'C Sprintf', 'Ruby Sprintf', 'Java String.format'],
+    [
+      'ICU',
+      'PHP Sprintf',
+      'C Sprintf',
+      'Ruby Sprintf',
+      'Java String.format',
+      'Python Percent',
+    ],
     {
       format: 'XLSX',
       expectedParams: {

--- a/e2e/cypress/common/export.ts
+++ b/e2e/cypress/common/export.ts
@@ -116,7 +116,6 @@ export const testExportFormats = (
 
   testFormatWithMessageFormats(
     [
-      'ICU',
       'PHP Sprintf',
       'C Sprintf',
       'Ruby Sprintf',

--- a/e2e/cypress/common/export.ts
+++ b/e2e/cypress/common/export.ts
@@ -109,7 +109,7 @@ export const testExportFormats = (
     messageFormat: 'Java String.format',
     expectedParams: {
       format: 'JSON',
-      structureDelimiter: '.',
+      structureDelimiter: '',
       supportArrays: false,
     },
   });
@@ -127,7 +127,7 @@ export const testExportFormats = (
       format: 'Flat JSON',
       expectedParams: {
         format: 'JSON',
-        structureDelimiter: '.',
+        structureDelimiter: '',
         supportArrays: false,
       },
     }

--- a/webapp/src/views/projects/export/ExportFormContent.tsx
+++ b/webapp/src/views/projects/export/ExportFormContent.tsx
@@ -44,7 +44,7 @@ export const ExportFormContent = ({
       <StateSelector className="states" />
       <LanguageSelector className="langs" languages={allLanguages} />
       <FormatSelector className="format" />
-      {getFormatById(values.format).defaultSupportArrays && (
+      {getFormatById(values.format).showSupportArrays && (
         <>
           <StyledOptions className="options">
             <SupportArraysSelector />

--- a/webapp/src/views/projects/export/components/formatGroups.tsx
+++ b/webapp/src/views/projects/export/components/formatGroups.tsx
@@ -33,7 +33,7 @@ export const formatGroups: FormatGroup[] = [
       {
         id: 'native_json',
         extension: 'json',
-        name: <T keyName="export-format-flat-json" />,
+        name: <T keyName="export-format-native-flat-json" />,
         defaultStructureDelimiter: '',
         structured: false,
         showSupportArrays: false,
@@ -43,7 +43,8 @@ export const formatGroups: FormatGroup[] = [
           params.format === 'JSON' &&
           (params.structureDelimiter === '' ||
             params.structureDelimiter == null) &&
-          !params.supportArrays,
+          !params.supportArrays &&
+          params.messageFormat === undefined,
       },
     ],
   },
@@ -62,6 +63,33 @@ export const formatGroups: FormatGroup[] = [
           'PHP_SPRINTF',
           'C_SPRINTF',
           'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
+        ],
+      },
+      {
+        id: 'generic_flat_json',
+        extension: 'json',
+        name: <T keyName="export-format-flat-json" />,
+        format: 'JSON',
+        defaultStructureDelimiter: '',
+        structured: false,
+        showSupportArrays: true,
+        defaultSupportArrays: false,
+        matchByExportParams: (params) => {
+          return (
+            params.format === 'JSON' &&
+            (params.structureDelimiter === '' ||
+              params.structureDelimiter == null) &&
+            (params.supportArrays || params.messageFormat !== undefined)
+          );
+        },
+        supportedMessageFormats: [
+          'ICU',
+          'JAVA_STRING_FORMAT',
+          'PHP_SPRINTF',
+          'C_SPRINTF',
+          'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
       {
@@ -81,6 +109,7 @@ export const formatGroups: FormatGroup[] = [
           'PHP_SPRINTF',
           'C_SPRINTF',
           'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
       {
@@ -111,14 +140,13 @@ export const formatGroups: FormatGroup[] = [
         format: 'YAML',
         defaultStructureDelimiter: '',
         structured: false,
-        showSupportArrays: false,
+        showSupportArrays: true,
         defaultSupportArrays: false,
         matchByExportParams: (params) => {
           return (
             params.format === 'YAML' &&
             (params.structureDelimiter === '' ||
-              params.structureDelimiter == null) &&
-            !params.supportArrays
+              params.structureDelimiter == null)
           );
         },
         supportedMessageFormats: [
@@ -126,6 +154,8 @@ export const formatGroups: FormatGroup[] = [
           'JAVA_STRING_FORMAT',
           'PHP_SPRINTF',
           'C_SPRINTF',
+          'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
       {
@@ -144,6 +174,8 @@ export const formatGroups: FormatGroup[] = [
           'JAVA_STRING_FORMAT',
           'PHP_SPRINTF',
           'C_SPRINTF',
+          'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
       {
@@ -157,6 +189,7 @@ export const formatGroups: FormatGroup[] = [
           'PHP_SPRINTF',
           'C_SPRINTF',
           'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
       {
@@ -170,6 +203,7 @@ export const formatGroups: FormatGroup[] = [
           'PHP_SPRINTF',
           'C_SPRINTF',
           'RUBY_SPRINTF',
+          'PYTHON_PERCENT',
         ],
       },
     ],

--- a/webapp/src/views/projects/export/components/formatGroups.tsx
+++ b/webapp/src/views/projects/export/components/formatGroups.tsx
@@ -44,7 +44,8 @@ export const formatGroups: FormatGroup[] = [
           (params.structureDelimiter === '' ||
             params.structureDelimiter == null) &&
           !params.supportArrays &&
-          params.messageFormat === undefined,
+          (params.messageFormat === undefined ||
+            params.messageFormat === 'ICU'),
       },
     ],
   },
@@ -80,7 +81,9 @@ export const formatGroups: FormatGroup[] = [
             params.format === 'JSON' &&
             (params.structureDelimiter === '' ||
               params.structureDelimiter == null) &&
-            (params.supportArrays || params.messageFormat !== undefined)
+            (params.supportArrays ||
+              (params.messageFormat !== undefined &&
+                params.messageFormat !== 'ICU'))
           );
         },
         supportedMessageFormats: [


### PR DESCRIPTION
Note: We have a bug (or is it intended?) in the CD and Export form. The form ignores the `defaultSupportArrays` when switching between formats, but it doesn't ignore it when reloading the web page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Flat JSON" export format supporting arrays and multiple message formats, including ICU, Java, PHP, C, Ruby, and Python Percent.
  * Expanded support for the Python Percent message format across various export formats (JSON, YAML, CSV, XLSX, PO, XLIFF).

* **Improvements**
  * Updated export form logic to better control when support array options are shown.
  * Improved matching and display logic for native and flat JSON export formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->