### PR TITLE
fix: change base for UnsupportedXliffVersionException to avoid 500

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/exceptions/UnsupportedXliffVersionException.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/exceptions/UnsupportedXliffVersionException.kt
@@ -1,5 +1,4 @@
 package io.tolgee.exceptions
 
-class UnsupportedXliffVersionException(version: String) : Exception() {
-  override val message: String = "XLIFF version $version not supported."
-}
+class UnsupportedXliffVersionException(version: String) :
+  Exception("XLIFF version $version not supported.")


### PR DESCRIPTION
Changed base of the `UnsupportedXliffVersionException` to Exception. This way, it should get caught and converted to `ImportCannotParseFileException`, avoiding a 500 error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized internal error handling to use platform-standard exceptions for a specific XLIFF version error. No changes to behavior, APIs, or settings; users will see unchanged functionality. Improves consistency, logging clarity, and future maintainability. No action required by administrators or end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->