### PR TITLE
fix: fallback to key if PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY unavailable

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
@@ -99,7 +99,7 @@ class PoFileExporter(
     translation: ExportTranslationView,
     converted: ToPoConversionResult,
   ) {
-    val msgIdPlural = translation.key.custom?.get(PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY) as? String ?: return
+    val msgIdPlural = translation.key.custom?.get(PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY) as? String ?: translation.key.name
     if (converted.isPlural()) {
       this.append(
         convertToPoMultilineString(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
@@ -117,7 +117,6 @@ class PoFileExporterTest {
       "Plural-Forms: nplurals = 3; plural = (n === 1 ? 0 : (n >= 2 && n <= 4) ? 1 : 2)\n"
       "X-Generator: Tolgee\n"
 
-
       msgid ""
       "I am key\n"
       "Look at me\n"

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
@@ -36,6 +36,7 @@ class PoFileExporterTest {
       "X-Generator: Tolgee\n"
 
       msgid "key"
+      msgid_plural "key"
       msgstr[0] "%d den"
       msgstr[1] "dny"
       msgstr[2] "%d dnů"${"\n"}
@@ -53,6 +54,7 @@ class PoFileExporterTest {
       "X-Generator: Tolgee\n"
 
       msgid "key"
+      msgid_plural "key"
       msgstr[0] "%d day"
       msgstr[1] "%d days"${"\n"}
       """.trimIndent(),
@@ -115,7 +117,12 @@ class PoFileExporterTest {
       "Plural-Forms: nplurals = 3; plural = (n === 1 ? 0 : (n >= 2 && n <= 4) ? 1 : 2)\n"
       "X-Generator: Tolgee\n"
 
+
       msgid ""
+      "I am key\n"
+      "Look at me\n"
+      "Hello!"
+      msgid_plural ""
       "I am key\n"
       "Look at me\n"
       "Hello!"
@@ -274,6 +281,7 @@ class PoFileExporterTest {
     |"X-Generator: Tolgee\n"
     |
     |msgid "key3"
+    |msgid_plural "key3"
     |msgstr[0] "%d den %s"
     |msgstr[1] "%d dny"
     |msgstr[2] "%d dní"
@@ -321,6 +329,7 @@ class PoFileExporterTest {
     |"X-Generator: Tolgee\n"
     |
     |msgid "key3"
+    |msgid_plural "key3"
     |msgstr[0] "# den {icuParam}"
     |msgstr[1] "# dny"
     |msgstr[2] "# dní"


### PR DESCRIPTION
Fixes one of the issues mentioned in #3011.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PO exports now include plural entries for pluralizable keys. If a custom plural identifier is missing or invalid, the exporter falls back to the key name so msgid_plural is emitted, producing more complete PO files and better compatibility with translation tools.

* **Tests**
  * Updated test expectations to reflect the new plural export behavior, including msgid_plural presence and multiline plural handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->