### PR TITLE
chore: include example for configuring llm providers with environment variables

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProperties.kt
@@ -24,7 +24,7 @@ class LlmProperties : MachineTranslationServiceProperties {
     description = """
     List of LLM providers. Example:
     
-    ```
+    ``` yaml
     providers:
       - name: openai-gpt-4o-mini
         type: OPENAI
@@ -32,6 +32,17 @@ class LlmProperties : MachineTranslationServiceProperties {
         api-url: "https://api.openai.com"
         model: gpt-4o-mini
         format: "json_schema"
+    ```
+    
+    or using environment variables:
+    
+    ```
+    TOLGEE_LLM_PROVIDERS_0_NAME=MySuperDuperAI
+    TOLGEE_LLM_PROVIDERS_0_TYPE=OPENAI
+    TOLGEE_LLM_PROVIDERS_0_API_KEY=myApiKey
+    TOLGEE_LLM_PROVIDERS_0_API_URL=https://api.openai.com
+    TOLGEE_LLM_PROVIDERS_0_MODEL=gpt-4o-mini
+    TOLGEE_LLM_PROVIDERS_0_FORMAT=json_schema
     ```
     
     Check [llm providers documentation](/platform/projects_and_organizations/llm-providers#self-hosted-server-configuration) for more information.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated machine translation LLM configuration guide for clarity.
  * Examples are now fenced as YAML for improved readability and syntax highlighting.
  * Added environment-variable examples (provider name, type, API key, API URL, model, format) equivalent to file-based config.
  * Notes clarify no runtime behavior or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->