### PR TITLE
feat(import): add pagination to ImportResult table for better perform…

### DIFF
--- a/webapp/src/views/projects/import/component/ImportResult.tsx
+++ b/webapp/src/views/projects/import/component/ImportResult.tsx
@@ -73,7 +73,7 @@ export const ImportResult: FunctionComponent<ImportResultProps> = (props) => {
     setCurrentPage(page);
   };
 
-  // Keep previous behavior: render nothing when there are no rows
+  // Render nothing when there are no rows
   if (totalItems === 0) {
     return null;
   }


### PR DESCRIPTION
##Summary

Fixes performance of #3175 – Add pagination to ImportResult

https://www.loom.com/share/0aad1864952547f8bc6ba259fc3c834a

Added pagination (20 rows per page) to the import results table.

Prevents rendering all rows at once, improving performance for large imports.

Verified that with correct i18next structure, Tolgee preselects namespaces and languages.

Testing

✅ Tested with ~50 namespaces → works, but still feels slow/laggy.

✅ Checked namespace-related issues but could not reproduce.

✅ Used test files will be added in a comment.

Screenshots
<img width="689" height="592" alt="ImportResult Pagination" src="https://github.com/user-attachments/assets/5dba5ed9-aad7-4394-8f62-3fa0cffbc330" /> <img width="638" height="650" alt="Namespaces Import" src="https://github.com/user-attachments/assets/081414d3-db99-45b3-b446-4b449997b919" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side pagination for import results (20 rows per page) with right-aligned page selector and navigation controls.
  * Pagination shown only when multiple pages exist; page selection updates displayed rows and stays in sync with data changes.

* **Bug Fixes**
  * Empty result sets treated as no data, showing a clear empty state and avoiding invalid page views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->