### PR TITLE
chore: Cleanup unpack task to avoid duplicated deps or classes

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -259,24 +259,6 @@ bootJar {
     }
 }
 
-def unpackTarget = "build/dependency"
-
-task unpack(type: Copy) {
-    from(zipTree(project.tasks.findByName("bootJar").outputs.files.singleFile))
-    into(unpackTarget)
-    if (System.getenv("SKIP_SERVER_BUILD") != "true") {
-        dependsOn "bootJar"
-    }
-}
-
-task addVersionFile(type: Task) {
-    mustRunAfter unpack
-    doLast {
-        def file = new File("${project.buildDir}/dependency/BOOT-INF/classes/.VERSION")
-        file.write(project.version.toString())
-    }
-}
-
 sourceSets {
     main.kotlin.srcDirs = ['src/main/kotlin', 'src/main/java']
     test.kotlin.srcDirs = ['src/test/kotlin', 'src/test/java']

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,11 @@ def unpackTarget = "${project.buildDir}/dependency"
 
 project(':server-app').afterEvaluate {
     task unpack(type: Copy) {
+        // cleanup the unpackTarget first so we don't have duplicated dependencies or other files, which
+        // can be there from previous builds
+        doFirst {
+            delete(unpackTarget)
+        }
         from(zipTree(project(':server-app').tasks.findByName("bootJar").outputs.files.singleFile))
         into(unpackTarget)
         if (System.getenv("SKIP_SERVER_BUILD") != "true") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined the server build process by removing obsolete build steps.
  - Added automatic cleanup during build to avoid leftover files between builds.
  - No changes to application behavior or public APIs.

- Refactor
  - Simplified build workflow for improved reliability and maintainability.

- Documentation
  - N/A

- Tests
  - N/A

- Style
  - N/A

- Bug Fixes
  - N/A

<!-- end of auto-generated comment: release notes by coderabbit.ai -->