### PR TITLE
chore: apply readOnly transactions in batch jobs, where possible

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
@@ -136,7 +136,7 @@ class BatchJobCancellationManager(
 
   private fun tryWaitForBatchJobCompletedStatus(jobId: Long) {
     waitFor(pollTime = 200, timeout = 2000) {
-      executeInNewTransaction(transactionManager) {
+      executeInNewTransaction(transactionManager, readOnly = true) {
         batchJobService.getJobDto(jobId).status.completed
       }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/state/BatchJobStateProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/state/BatchJobStateProvider.kt
@@ -94,6 +94,7 @@ class BatchJobStateProvider(
       executeInNewTransaction(
         platformTransactionManager,
         isolationLevel = TransactionDefinition.ISOLATION_READ_COMMITTED,
+        readOnly = true,
       ) {
         entityManager.createQuery(
           """

--- a/backend/data/src/main/kotlin/io/tolgee/util/transactionUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/transactionUtil.kt
@@ -12,11 +12,13 @@ fun <T> executeInNewTransaction(
   transactionManager: PlatformTransactionManager,
   isolationLevel: Int = TransactionDefinition.ISOLATION_READ_COMMITTED,
   propagationBehavior: Int = TransactionDefinition.PROPAGATION_REQUIRES_NEW,
+  readOnly: Boolean = false,
   fn: (ts: TransactionStatus) -> T,
 ): T {
   val tt = TransactionTemplate(transactionManager)
   tt.propagationBehavior = propagationBehavior
   tt.isolationLevel = isolationLevel
+  tt.isReadOnly = readOnly
 
   return tt.execute { ts ->
     fn(ts)
@@ -25,12 +27,14 @@ fun <T> executeInNewTransaction(
 
 fun <T> executeInNewTransaction(
   transactionManager: PlatformTransactionManager,
+  readOnly: Boolean = false,
   fn: (ts: TransactionStatus) -> T,
 ): T {
   return executeInNewTransaction(
     transactionManager = transactionManager,
     fn = fn,
     propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW,
+    readOnly = readOnly
   )
 }
 


### PR DESCRIPTION
Postgres does some optimizations in the locks and logs, when dealing with readOnly transactions. Might be helpful in problems, which are currently experienced in the batch jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved transaction handling to run certain background checks in read-only mode, reducing contention and smoothing batch job completion under load. No visible behavior changes.

* **Chores**
  * Added a read-only option to internal transaction utilities to better align background tasks with best practices and improve reliability. No user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->