### PR TITLE
fix: TranslationSuggestionControllerStreamingTest - spring bug on async processing (ignore test, when it happens)

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2ExportAllFormatsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2ExportAllFormatsTest.kt
@@ -3,6 +3,7 @@ package io.tolgee.api.v2.controllers
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.development.testDataBuilder.data.NamespacesTestData
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.ignoreTestOnSpringBug
 import io.tolgee.formats.ExportFormat
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.opentest4j.TestAbortedException
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.transaction.annotation.Transactional
@@ -45,22 +45,11 @@ class V2ExportAllFormatsTest : ProjectAuthControllerTest("/v2/projects/") {
   @Transactional
   @ProjectJWTAuthTestMethod
   fun `it exports to all formats`(format: ExportFormat) {
-    val mvcResult = try {
+    val mvcResult = ignoreTestOnSpringBug {
       performProjectAuthGet("export?format=${format.name}")
         .andIsOk
         .andDo { obj: MvcResult -> obj.asyncResult }
         .andReturn()
-    } catch (e: ConcurrentModificationException) {
-      if (isSpringBug(e)) {
-        log.error(e.message, e)
-        // Retrying the request once more can still lead to the bug, plus it will hide
-        // this dirty "fix" completely. So TestAbortedException is chosen to mark the test
-        // as ignored. This way it won't fail the cicd pipeline, and you still see it in the final
-        // report, that it was ignored.
-        throw TestAbortedException("spring-security/issues/9175", e)
-      } else {
-        throw e
-      }
     }
 
     // Verify we get some content back
@@ -84,24 +73,6 @@ class V2ExportAllFormatsTest : ProjectAuthControllerTest("/v2/projects/") {
       // For single file responses, verify we have content
       assertThat(responseContent.size).isGreaterThan(0)
     }
-  }
-
-  /**
-   * Main link to the spring bug
-   * https://github.com/spring-projects/spring-security/issues/9175
-   * It doesn't seem to be fixed soon. The best explanation of what is going on is here by Rossen Stoyanchev:
-   * https://github.com/spring-projects/spring-security/issues/11452#issuecomment-1172491187
-   *
-   * You can see in this method where the ConcurrentModification actually happens ("addHeader" <-> "setHeader").
-   * Also for more details check the pull request discussion: https://github.com/tolgee/tolgee-platform/pull/3233
-   */
-  private fun isSpringBug(e: ConcurrentModificationException): Boolean {
-    return e.stackTrace.first().className.contains("HashMap") &&
-        e.stackTrace.first().methodName == "computeIfAbsent" &&
-        e.stackTrace.find {
-      it.className.contains("HttpServletResponseWrapper") &&
-          (it.methodName == "addHeader" || it.methodName == "setHeader")
-        } != null
   }
 
   private fun initTestData() {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerStreamingTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerStreamingTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.fixtures.NdJsonParser
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andPrettyPrint
+import io.tolgee.fixtures.ignoreTestOnSpringBug
 import io.tolgee.model.Language
 import io.tolgee.model.enums.LlmProviderType
 import io.tolgee.service.machineTranslation.MtService
@@ -107,15 +108,17 @@ class TranslationSuggestionControllerStreamingTest : ProjectAuthControllerTest("
   @ProjectJWTAuthTestMethod
   fun `it does not return unsupporting services`() {
     val response =
-      performProjectAuthPost(
-        "suggest/machine-translations-streaming",
-        mapOf(
-          "targetLanguageId" to hindiLanguage.id,
-          "baseText" to "text",
-        ),
-      ).andDo {
-        it.asyncResult
-      }.andReturn().response.contentAsString
+      ignoreTestOnSpringBug {
+            performProjectAuthPost(
+              "suggest/machine-translations-streaming",
+              mapOf(
+                "targetLanguageId" to hindiLanguage.id,
+                "baseText" to "text",
+              ),
+            ).andDo {
+              it.asyncResult
+            }.andReturn().response.contentAsString
+        }
 
     response.split("\n").filter { it.isNotBlank() }.map {
       jacksonObjectMapper().readValue(it, Any::class.java)

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/springBug.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/springBug.kt
@@ -1,0 +1,55 @@
+package io.tolgee.fixtures
+
+import org.opentest4j.TestAbortedException
+
+/**
+ * Main link to the spring bug
+ * https://github.com/spring-projects/spring-security/issues/9175
+ * It doesn't seem to be fixed soon. The best explanation of what is going on is here by Rossen Stoyanchev:
+ * https://github.com/spring-projects/spring-security/issues/11452#issuecomment-1172491187
+ *
+ * Happens for async request processing, for example when using StreamingResponseBody.
+ *
+ * You can see in this method where the ConcurrentModification actually happens ("addHeader" <-> "setHeader").
+ * Also for more details check the pull request discussion: https://github.com/tolgee/tolgee-platform/pull/3233
+ */
+fun <T> ignoreTestOnSpringBug(fn: () -> T): T {
+    return try {
+        fn.invoke()
+    } catch (e: Exception) {
+        if (isSpringBug(e)) {
+            org.slf4j.LoggerFactory.getLogger("springBug").error(e.message, e)
+            // Retrying the request once more can still lead to the bug, plus it will hide
+            // this dirty "fix" completely. So TestAbortedException is chosen to mark the test
+            // as ignored. This way it won't fail the cicd pipeline, and you still see it in the final
+            // report, that it was ignored.
+            throw TestAbortedException("spring-security/issues/9175", e)
+        } else {
+            throw e
+        }
+    }
+}
+
+private fun isSpringBug(e: Exception): Boolean {
+    return when (e) {
+        is ConcurrentModificationException -> {
+            return e.stackTrace.first().className.contains("HashMap") &&
+                e.stackTrace.first().methodName == "computeIfAbsent" &&
+                e.stackTrace.any {
+                    it.className.contains("HttpServletResponseWrapper") &&
+                        (it.methodName == "addHeader" || it.methodName == "setHeader")
+                }
+        }
+
+        is IllegalStateException -> {
+            // this one is thrown by mockMvc. Somewhere inside backend code, if you wrap it in try/catch,
+            // you will find the ConcurrentModificationException (e.g. MtResultStreamer when writer is flushed)
+            return e.stackTrace.any {
+                it.className.contains("HeaderValueHolder") &&
+                    it.methodName == "getStringValues"
+            }
+        }
+
+        else -> false
+    }
+}


### PR DESCRIPTION
+ refactor it to move bug detection to a separate util file, since it already happens in 2 tests

Same issue as in the https://github.com/tolgee/tolgee-platform/pull/3233.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a test helper that detects a known Spring framework bug and marks affected tests as skipped to improve CI stability.
  - Updated tests to use the new wrapper, reducing intermittent failures and simplifying error handling.
  - Removed prior ad-hoc detection and conditional logic, consolidating behavior into the shared utility.
  - No changes to user-facing behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->