### PR TITLE
fix: update glossary documentation links and temporarily hide import section

### DIFF
--- a/webapp/src/ee/glossary/components/AddFirstGlossaryMessage.tsx
+++ b/webapp/src/ee/glossary/components/AddFirstGlossaryMessage.tsx
@@ -51,7 +51,7 @@ export const AddFirstGlossaryMessage: React.VFC<
             keyName="glossaries_list_empty_message"
             params={{
               bestPractice: (
-                <Link href="https://docs.tolgee.io/platform/projects_and_organizations/glossary" />
+                <Link href="https://docs.tolgee.io/platform/projects_and_organizations/managing_glossaries" />
               ),
             }}
           />

--- a/webapp/src/ee/glossary/components/GlossaryEmptyListMessage.tsx
+++ b/webapp/src/ee/glossary/components/GlossaryEmptyListMessage.tsx
@@ -79,7 +79,7 @@ export const GlossaryEmptyListMessage: React.VFC<Props> = ({
             <T keyName="glossary_empty_placeholder_add_term_button" />
           </Button>
           <Link
-            href="https://docs.tolgee.io/platform/projects_and_organizations/glossary"
+            href="https://docs.tolgee.io/platform/projects_and_organizations/managing_glossaries"
             sx={{ visibility: 'hidden' }}
           >
             <Typography variant="body2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated in-app glossary links to point to the “Managing glossaries” documentation.

* **Bug Fixes**
  * Corrected outdated documentation URLs shown in empty-glossary and add-first-glossary messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->