### PR TITLE
fix: Optimize batch queue population

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -20,7 +20,6 @@ import org.hibernate.LockMode
 import org.hibernate.LockOptions
 import org.hibernate.Session
 import org.springframework.beans.factory.InitializingBean
-import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -51,12 +50,6 @@ class BatchJobChunkExecutionQueue(
       QueueEventType.ADD -> this.addItemsToLocalQueue(event.items)
       QueueEventType.REMOVE -> queue.removeAll(event.items.toSet())
     }
-  }
-
-  @EventListener
-  @Transactional
-  fun onApplicationReady(event: ApplicationReadyEvent) {
-    populateQueue()
   }
 
   @Scheduled(fixedDelay = 60000)


### PR DESCRIPTION
These changes were actually a result of investigation why `BatchJobManagementControllerCancellationTest` sometimes fails. Now it doesn't, plus it has much more influence on the whole batch processing mechanism

Having just LockOptions.SKIP_LOCKED actually does nothing. In the postgres docs https://www.postgresql.org/docs/current/sql-select.html
it can be found that "SKIP LOCKED" is always used with "FOR { UPDATE | NO KEY UPDATE |...". Moreover, hibernate is smart enough and didn't
even add SKIP LOCKED, when there was not LockModeType.PESSIMISTIC_WRITE (instruction for "FOR UPDATE"). It can be seen by turning on the
hibernate's "showSql=true"

Without this, there were rare cases when LOCKED chunks were returned from database and sent processing again. During processing in the
`BatchJobActionService.handleItem` it was found out that row is locked, then coroutine is finished and `BatchJobConcurrentLauncher.onJobCompleted`
removed the coroutine job from `runningJobs`. Now cancelling is coming - doesn't find it in the `runningJobs` and the coroutine is no cancelled.

Probably, it also led to conflicts when running on multiple k8s pods - same chunks could be selected simultaneously and sent for processing.
These changes don't fully solve it, because it still can happen, when this transaction in one pod is finished and in another one started. This
will be fixed next (probably by introducing a new chunk status, "NEW", which will be updated in this transaction to "PENDING")

Setting `LockModeType.PESSIMISTIC_WRITE` also required to make it Transactional, because rows are locked only within transaction

Moreover, the queue was populated simultaneously from 2 threads on start of the app. One of them, ApplicationReadyEvent, is removed, because @Scheduled(fixedDelay = 60000) actually does the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced transaction handling for batch job queue processing
  * Improved database locking strategy for batch job execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->