### PR TITLE
fix: missing error translation when third party provider doesn't send over user e-mail

### DIFF
--- a/webapp/src/translationTools/useErrorTranslation.ts
+++ b/webapp/src/translationTools/useErrorTranslation.ts
@@ -27,6 +27,8 @@ export function useErrorTranslation() {
         return t('key_exists');
       case 'third_party_auth_error_message':
         return t('third_party_auth_error_message');
+      case 'third_party_auth_no_email':
+        return t('third_party_auth_no_email');
       case 'third_party_auth_non_matching_email':
         return t('third_party_auth_non_matching_email');
       case 'third_party_switch_initiated':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for third-party authentication error messaging when email information is unavailable, ensuring users receive appropriate translated error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->