### PR TITLE
fix: make extension placeholder for fileStructureTemplate optional

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/ExportFormat.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/ExportFormat.kt
@@ -7,6 +7,7 @@ enum class ExportFormat(
   val mediaType: String,
   val defaultFileStructureTemplate: String = ExportFilePathProvider.DEFAULT_TEMPLATE,
   val multiLanguage: Boolean = false,
+  val fileStructureExtensionRequired: Boolean = false,
 ) {
   JSON("json", "application/json"),
   JSON_TOLGEE("json", "application/json"),
@@ -16,6 +17,7 @@ enum class ExportFormat(
     "",
     "",
     defaultFileStructureTemplate = "{namespace}/{languageTag}.lproj/Localizable.{extension}",
+    fileStructureExtensionRequired = true,
   ),
   APPLE_XLIFF(
     "xliff",

--- a/backend/data/src/main/kotlin/io/tolgee/service/export/ExportFileStructureTemplateProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/export/ExportFileStructureTemplateProvider.kt
@@ -8,7 +8,6 @@ import io.tolgee.service.export.dataProvider.ExportTranslationView
 class ExportFileStructureTemplateProvider(
   val params: IExportParams,
   translations: List<ExportTranslationView>,
-  val extensionPlaceholderRequired: Boolean = false,
 ) {
   fun validateAndGetTemplate(): String {
     validateTemplate()
@@ -64,7 +63,7 @@ class ExportFileStructureTemplateProvider(
 
   private fun validateExtensionInTemplate() {
     val containsExtension = getTemplate().contains(ExportFilePathPlaceholder.EXTENSION.placeholder)
-    if (!containsExtension && extensionPlaceholderRequired) {
+    if (!containsExtension && params.format.fileStructureExtensionRequired) {
       throw getMissingPlaceholderException(ExportFilePathPlaceholder.EXTENSION)
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
@@ -116,18 +116,8 @@ class FileExporterFactory(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
-          stringsFilePathProvider = getFilePathProvider(
-            exportParams,
-            data,
-            "strings",
-            extensionPlaceholderRequired = true
-          ),
-          stringsdictFilePathProvider = getFilePathProvider(
-            exportParams,
-            data,
-            "stringsdict",
-            extensionPlaceholderRequired = true
-          )
+          stringsFilePathProvider = getFilePathProvider(exportParams, data, "strings"),
+          stringsdictFilePathProvider = getFilePathProvider(exportParams, data, "stringsdict")
         )
 
       ExportFormat.APPLE_XCSTRINGS ->
@@ -180,13 +170,11 @@ class FileExporterFactory(
     exportParams: IExportParams,
     translations: List<ExportTranslationView>,
     extension: String = exportParams.format.extension,
-    extensionPlaceholderRequired: Boolean = false,
   ): ExportFilePathProvider {
     return ExportFilePathProvider(
       template = ExportFileStructureTemplateProvider(
         exportParams,
-        translations,
-        extensionPlaceholderRequired
+        translations
       ).validateAndGetTemplate(),
       extension = extension,
     )

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
@@ -376,8 +376,7 @@ class StringsStringsdictFileExporterTest {
     isProjectIcuPlaceholdersEnabled: Boolean = true,
     params: ExportParams = getExportParams(),
   ): AppleStringsStringsdictExporter {
-    val template = ExportFileStructureTemplateProvider(params, translations, extensionPlaceholderRequired = true)
-      .validateAndGetTemplate()
+    val template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate()
     return AppleStringsStringsdictExporter(
       translations = translations,
       exportParams = params,


### PR DESCRIPTION
- Most formats have an extension constant, making the placeholder optional allows overriding this extension
- APPLE_STRINGS_STRINGSDICT format is an exception – it exports multiple formats, so this one will still require an extension placeholder in the fileStructureTemplate

Fixes #3291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced export validation to conditionally require extension placeholders based on export format configuration.
  * Improved Apple Strings Stringsdict format handling with updated file structure extension requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->