### PR TITLE
chore: DirtiesContext tests must be marked with ContextRecreatingTest

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -213,6 +213,7 @@ tasks.register('runContextRecreatingTests', Test) {
     useJUnitPlatform {
         includeTags "contextRecreating"
     }
+    systemProperties['spring.test.context.cache.maxSize'] = 1
     maxHeapSize = "4096m"
     rootProject.setTestRetry(it)
 }

--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobsCleanerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobsCleanerTest.kt
@@ -5,6 +5,7 @@ import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.batch.BatchJobChunkExecutionStatus
 import io.tolgee.model.batch.BatchJobStatus
+import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assert
 import io.tolgee.util.StuckBatchJobTestUtil
 import org.junit.jupiter.api.AfterEach
@@ -18,6 +19,7 @@ import org.springframework.test.annotation.DirtiesContext
   properties = ["tolgee.batch.scheduled-handle-stuck-job-delay=200"],
 )
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextRecreatingTest
 class BatchJobsCleanerTest : AbstractSpringTest() {
   @Autowired
   lateinit var jobConcurrentLauncher: BatchJobConcurrentLauncher

--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobsGeneralWithRedisTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobsGeneralWithRedisTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.batch.events.JobQueueItemsEvent
 import io.tolgee.fixtures.RedisRunner
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.pubSub.RedisPubSubReceiverConfiguration.Companion.JOB_QUEUE_TOPIC
+import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
@@ -34,6 +35,7 @@ import org.springframework.test.context.ContextConfiguration
 )
 @ContextConfiguration(initializers = [BatchJobsGeneralWithRedisTest.Companion.Initializer::class])
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextRecreatingTest
 class BatchJobsGeneralWithRedisTest : AbstractBatchJobsGeneralTest() {
   companion object {
     val redisRunner = RedisRunner()

--- a/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/TolgeeRulesProvider.kt
+++ b/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/TolgeeRulesProvider.kt
@@ -19,6 +19,7 @@ package io.tolgee.testing.ktlint
 import com.pinterest.ktlint.cli.ruleset.core.api.RuleSetProviderV3
 import com.pinterest.ktlint.rule.engine.core.api.RuleProvider
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId
+import io.tolgee.testing.ktlint.rules.DirtiesContextTagRule
 import io.tolgee.testing.ktlint.rules.JakartaTransientInEntities
 
 class TolgeeRulesProvider : RuleSetProviderV3(RULE_SET_ID) {
@@ -26,6 +27,9 @@ class TolgeeRulesProvider : RuleSetProviderV3(RULE_SET_ID) {
     setOf(
       RuleProvider {
         JakartaTransientInEntities()
+      },
+      RuleProvider {
+        DirtiesContextTagRule()
       },
     )
 

--- a/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/rules/DirtiesContextTagRule.kt
+++ b/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/rules/DirtiesContextTagRule.kt
@@ -1,0 +1,80 @@
+package io.tolgee.testing.ktlint.rules
+
+import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
+import com.pinterest.ktlint.rule.engine.core.api.Rule
+import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
+import com.pinterest.ktlint.rule.engine.core.api.RuleId
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+
+/**
+ * A ktlint rule that ensures that any test annotated with @DirtiesContext also has the @ContextRecreatingTest annotation.
+ * This rule checks both class-level and method-level annotations.
+ *
+ * @ContextRecreatingTest annotation was added to mark tests to run separately in the ci/cd pipelines,
+ * because they don't share the application context with other tests. @DirtiesContext has the same purpose,
+ * but can't be tagged easily (gradle junit plugin would require to load a whole class to find that test is annotated).
+ * Alternatively a new wrapper annotation could be added which leads to even more annotations with the same purpose.
+ * So lint is actually a good option to just control that.
+ *
+ * However, this rule still leaves a possibility to have @ContextRecreatingTest annotation without @DirtiesContext.
+ * You can use it if you want to run the test in the ci/cd pipeline in a fresh context, even though
+ * the test itself doesn't dirty the context.
+ */
+class DirtiesContextTagRule :
+  Rule(RULE_ID, About(maintainer = "Tolgee Team")),
+  RuleAutocorrectApproveHandler {
+  override fun beforeVisitChildNodes(
+    node: ASTNode,
+    emit: (Int, String, Boolean) -> AutocorrectDecision,
+  ) {
+    when (val psi = node.psi) {
+      is KtNamedFunction -> {
+        val functionAnnotations = psi.annotationEntries
+
+        val hasDirtiesContext =
+          functionAnnotations.any {
+            it.shortName?.asString() == "DirtiesContext"
+          }
+
+        if (hasDirtiesContext) {
+          val hasClassContextRecreatingTag =
+            psi.containingClass()?.annotationEntries?.any {
+              it.shortName?.asString() == "ContextRecreatingTest"
+            } ?: false
+
+          if (!hasClassContextRecreatingTag) {
+            emit(node.startOffset, ERROR_MESSAGE, false)
+          }
+        }
+      }
+      is KtClass -> {
+        val annotations = psi.annotationEntries
+
+        val hasDirtiesContext =
+          annotations.any {
+            it.shortName?.asString() == "DirtiesContext"
+          }
+
+        if (hasDirtiesContext) {
+          val hasContextRecreatingTag =
+            annotations.any {
+              it.shortName?.asString() == "ContextRecreatingTest"
+            }
+
+          if (!hasContextRecreatingTag) {
+            emit(node.startOffset, ERROR_MESSAGE, false)
+          }
+        }
+      }
+    }
+  }
+
+  companion object {
+    val RULE_ID = RuleId(RULE_ID_STR)
+    const val ERROR_MESSAGE = "Tests annotated with @DirtiesContext must also include @ContextRecreatingTest"
+    const val RULE_ID_STR = "tolgee:dirties-context-test-without-tag"
+  }
+}

--- a/backend/ktlint/src/test/kotlin/io/tolgee/testing/ktlint/DirtiesContextTagRuleTest.kt
+++ b/backend/ktlint/src/test/kotlin/io/tolgee/testing/ktlint/DirtiesContextTagRuleTest.kt
@@ -1,0 +1,71 @@
+package io.tolgee.testing.ktlint
+
+import com.pinterest.ktlint.test.KtLintAssertThat.Companion.assertThatRule
+import io.tolgee.testing.ktlint.rules.DirtiesContextTagRule
+import org.junit.jupiter.api.Test
+
+class DirtiesContextTagRuleTest {
+  private val wrappingRuleAssertThat = assertThatRule { DirtiesContextTagRule() }
+
+  @Test
+  fun `raises an error if DirtiesContext class test doesn't have ContextRecreatingTest annotation`() {
+    val code =
+      """
+      @DirtiesContext
+      class MyTest {
+      }
+      """.trimIndent()
+    wrappingRuleAssertThat(code)
+      .hasLintViolationWithoutAutoCorrect(
+        1,
+        1,
+        DirtiesContextTagRule.ERROR_MESSAGE,
+      )
+  }
+
+  @Test
+  fun `raises an error if DirtiesContext method isn't inside the class with ContextRecreatingTest annotation`() {
+    val code =
+      """
+      class MyTest {
+        @Test
+        @DirtiesContext
+        fun myTestMethod() {
+        }
+      }
+      """.trimIndent()
+    wrappingRuleAssertThat(code)
+      .hasLintViolationWithoutAutoCorrect(
+        2,
+        3,
+        DirtiesContextTagRule.ERROR_MESSAGE,
+      )
+  }
+
+  @Test
+  fun `no error if DirtiesContext test has ContextRecreatingTest annotation`() {
+    val code =
+      """
+      @DirtiesContext
+      @ContextRecreatingTest
+      class MyTest {
+      }
+      """.trimIndent()
+    wrappingRuleAssertThat(code).hasNoLintViolations()
+  }
+
+  @Test
+  fun `no error if DirtiesContext method is inside the class with ContextRecreatingTest annotation`() {
+    val code =
+      """
+      @ContextRecreatingTest
+      class MyTest {
+        @Test
+        @DirtiesContext
+        fun myTestMethod() {
+        }
+      }
+      """.trimIndent()
+    wrappingRuleAssertThat(code).hasNoLintViolations()
+  }
+}


### PR DESCRIPTION
Also set spring.test.context.cache.maxSize=1 for ContextRecreatingTest-s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage enforcing consistent test annotations and a lint rule to catch missing annotations.
  * Enhanced test infrastructure so tests can recreate application context between runs for more reliable isolation.

* **Chores**
  * Added automated quality checks to validate test annotation usage.
  * Adjusted test runtime configuration to limit test-context caching for more predictable test behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->