### PR TITLE
fix: increase length limit for llm provider url and api key

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/llmProvider/LlmProviderRequest.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/llmProvider/LlmProviderRequest.kt
@@ -3,17 +3,26 @@ package io.tolgee.dtos.request.llmProvider
 import com.fasterxml.jackson.annotation.JsonSetter
 import io.tolgee.model.enums.LlmProviderPriority
 import io.tolgee.model.enums.LlmProviderType
+import jakarta.validation.constraints.Size
 
 data class LlmProviderRequest(
+  @field:Size(max = 255)
   var name: String,
   var type: LlmProviderType,
+  @field:Size(max = 2047)
   var apiUrl: String,
+  @field:Size(max = 511)
   var apiKey: String? = null,
   var priority: LlmProviderPriority? = null,
+  @field:Size(max = 255)
   var model: String? = null,
+  @field:Size(max = 255)
   var deployment: String? = null,
+  @field:Size(max = 255)
   var keepAlive: String? = null,
+  @field:Size(max = 255)
   var format: String? = null,
+  @field:Size(max = 255)
   var reasoningEffort: String? = null,
 ) {
   @JsonSetter("type")

--- a/backend/data/src/main/kotlin/io/tolgee/model/LlmProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LlmProvider.kt
@@ -3,6 +3,7 @@ package io.tolgee.model
 import io.tolgee.dtos.LlmProviderDto
 import io.tolgee.model.enums.LlmProviderPriority
 import io.tolgee.model.enums.LlmProviderType
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -31,7 +32,9 @@ class LlmProvider(
   var type: LlmProviderType = LlmProviderType.OPENAI,
   @field:Enumerated(EnumType.STRING)
   var priority: LlmProviderPriority? = null,
+  @Column(length = 511)
   var apiKey: String? = null,
+  @Column(length = 2047)
   var apiUrl: String = "",
   var model: String? = null,
   var deployment: String? = null,

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4637,4 +4637,10 @@
             <column name="key_id"/>
         </createIndex>
     </changeSet>
+    <changeSet author="anty (generated)" id="1762964560931-1">
+        <modifyDataType columnName="api_key" newDataType="varchar(511)" tableName="llm_provider"/>
+    </changeSet>
+    <changeSet author="anty (generated)" id="1762964560931-2">
+        <modifyDataType columnName="api_url" newDataType="varchar(2047)" tableName="llm_provider"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Fixes #3295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased maximum field size limits for LLM provider configuration, allowing longer API keys and URLs to be stored and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->