### PR TITLE
fix: Revert "fix: send temperature as 0 for OpenaiApi LLM providers (#3308)"

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
@@ -154,7 +154,7 @@ class OpenaiApiService(
       @JsonInclude(JsonInclude.Include.NON_NULL)
       val reasoning_effort: String? = null,
       @JsonInclude(JsonInclude.Include.NON_NULL)
-      val temperature: Long? = 0,
+      val temperature: Long? = null,
     )
 
     class RequestMessage(


### PR DESCRIPTION
This reverts commit 762621d4321f16bafdd088f765eb180d0bf0880f.

Turns out some models don't support a temperature set to 0. We need to make this configurable instead.
Viz: https://tolgee.sentry.io/issues/5832051236/events/?cursor=0%3A250%3A0&query=is%3Aunresolved%20temperature&referrer=issue-stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted AI temperature default setting to utilize platform defaults instead of a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->