### PR TITLE
fix: handle numbered placeholders when exporting Apple Stringsdict plurals

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/util/nullIfEmpty.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/nullIfEmpty.kt
@@ -3,3 +3,7 @@ package io.tolgee.util
 fun <T : Iterable<*>> T.nullIfEmpty(): T? {
   return if (this.none()) null else this
 }
+
+fun <T : CharSequence> T.nullIfEmpty(): T? {
+  return if (this.none()) null else this
+}

--- a/backend/data/src/main/kotlin/io/tolgee/util/regexReplaceEntire.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/regexReplaceEntire.kt
@@ -1,0 +1,12 @@
+package io.tolgee.util
+
+fun Regex.replaceEntire(
+  input: CharSequence,
+  replacement: String,
+): String? {
+  if (!matches(input)) {
+    return null
+  }
+
+  return replaceFirst(input, replacement)
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
@@ -55,6 +55,22 @@ class StringsStringsdictFileExporterTest {
     |        <string>%lld days</string>
     |      </dict>
     |    </dict>
+    |    <key>plural_numbered_placeholders</key>
+    |    <dict>
+    |      <key>NSStringLocalizedFormatKey</key>
+    |      <string>%#@format@</string>
+    |      <key>format</key>
+    |      <dict>
+    |        <key>NSStringFormatSpecTypeKey</key>
+    |        <string>NSStringPluralRuleType</string>
+    |        <key>NSStringFormatValueTypeKey</key>
+    |        <string>lld</string>
+    |        <key>one</key>
+    |        <string>Today we had a very nice workout at %2$@, where we did one push up.</string>
+    |        <key>other</key>
+    |        <string>Today we had a very nice workout at %2$@, where we did %3$@ push ups.</string>
+    |      </dict>
+    |    </dict>
     |  </dict>
     |</plist>
     |
@@ -367,6 +383,13 @@ class StringsStringsdictFileExporterTest {
           ExportKeyView(1, "escaping_singular"),
           "cs",
         ),
+        ExportTranslationView(
+          1,
+          "{value, plural, one {Today we had a very nice workout at {1}, where we did one push up.} other {Today we had a very nice workout at {1}, where we did {2} push ups.}}",
+          TranslationState.TRANSLATED,
+          ExportKeyView(1, "plural_numbered_placeholders", isPlural = true),
+          "en",
+        ),
       ),
       params = params,
     )
@@ -381,25 +404,6 @@ class StringsStringsdictFileExporterTest {
       translations = translations,
       exportParams = params,
       isProjectIcuPlaceholdersEnabled = isProjectIcuPlaceholdersEnabled,
-      stringsFilePathProvider =
-        ExportFilePathProvider(
-          template = template,
-          extension = "strings",
-        ),
-      stringsdictFilePathProvider =
-        ExportFilePathProvider(
-          template = template,
-          extension = "stringsdict",
-        ),
-    )
-  }
-
-  private fun getExporter(translations: List<ExportTranslationView>): AppleStringsStringsdictExporter {
-    val params = getExportParams()
-    val template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate()
-    return AppleStringsStringsdictExporter(
-      translations = translations,
-      exportParams = params,
       stringsFilePathProvider =
         ExportFilePathProvider(
           template = template,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined Apple format export handling with enhanced placeholder specification extraction, improving support for numbered placeholders in plural forms.
  * Added utility functions for improved null-safety and regex pattern matching.

* **Tests**
  * Expanded test coverage for plural forms with numbered placeholders in Apple format exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->