### PR TITLE
build: update ktlint and ktlintGradlePlugin versions

### DIFF
--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -96,7 +96,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
     }
 }
 

--- a/backend/data/build.gradle
+++ b/backend/data/build.gradle
@@ -244,7 +244,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
         mavenBom 'org.junit:junit-bom:5.11.4'
     }
 }

--- a/backend/development/build.gradle
+++ b/backend/development/build.gradle
@@ -88,7 +88,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
     }
 }
 

--- a/backend/security/build.gradle
+++ b/backend/security/build.gradle
@@ -95,7 +95,9 @@ sourceSets {
 dependencyManagement {
     applyMavenExclusions = false
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
         mavenBom 'org.junit:junit-bom:5.11.4'
     }
 }

--- a/backend/testing/build.gradle
+++ b/backend/testing/build.gradle
@@ -145,7 +145,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
     }
 }
 

--- a/ee/backend/app/build.gradle
+++ b/ee/backend/app/build.gradle
@@ -124,7 +124,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
     }
 }
 

--- a/ee/backend/tests/build.gradle
+++ b/ee/backend/tests/build.gradle
@@ -79,7 +79,9 @@ dependencyManagement {
     applyMavenExclusions = false
 
     imports {
-        mavenBom org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES
+        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES) {
+            bomProperty "kotlin.version", "${kotlinVersion}"
+        }
         mavenBom 'org.junit:junit-bom:5.11.4'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ jacksonVersion=2.17.2
 slackSdkVersion=1.37.0
 commonsLang3Version=3.18.0
 org.gradle.caching=true
-ktlintVersion=1.5.0
-ktlintGradlePluginVersion=12.2.0
+ktlintVersion=1.7.1
+ktlintGradlePluginVersion=13.1.0


### PR DESCRIPTION
Initially these changes must have a part of the 61f7b543287c239b9b62a43abd04006343d81889. However, there was a problem, described here: https://github.com/pinterest/ktlint/issues/3162. It turned out that the spring dependency management plugin affects the classpath used by ktlint. It was reported in the plugin issues too: https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/407. The solution was also taken from there - explicitly specify the "kotlin.version", when importing mavenBom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin linting tool (ktlint) from version 1.5.0 to 1.7.1 and its Gradle plugin from 12.2.0 to 13.1.0 to enhance code quality analysis.
  * Optimized build configuration for dependency management across backend modules to ensure consistent Kotlin version handling and build stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->