### PR TITLE
chore: existing symlink not removed properly

### DIFF
--- a/webapp/scripts/prepareEe.js
+++ b/webapp/scripts/prepareEe.js
@@ -17,10 +17,10 @@ const eeModuleLocal = path.join(
   '../src/eeSetup/eeModule.current.tsx'
 );
 
-try {
-  lstatSync(eeModuleLocal);
+// remove the symlink if it exists
+if (!!lstatSync(eeModuleLocal, { throwIfNoEntry: false })) {
   unlinkSync(eeModuleLocal);
-} catch {}
+}
 
 if (existsSync(srcDir)) {
   symlinkSync(eeModuleEe, eeModuleLocal);


### PR DESCRIPTION
## problem

When doing `npm install` in the webapp folder, the following error pops up as the symlink is not deleted.

<img width="1280" height="1088" alt="image" src="https://github.com/user-attachments/assets/1d102352-cca8-46d3-a89e-bbf947bfdda1" />

## solution

`existsSync()` returns false for broken/existing symlinks. `lstatSync` throws error if the path does not exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of the module preparation script: safer handling of file operations to avoid race conditions and transient errors during initialization, reducing spurious failures in setup and the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->