### PR TITLE
feat: select/deselect all languages in translations language selector

### DIFF
--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -64,7 +64,8 @@ export const getLanguagesContent = ({
   );
 
   // Показываем кнопки "All" и "None" только для batch операций
-  const isBatchOperation = context === 'batch-operations';
+  const isBatchOperation =
+    context === 'batch-operations' || context === 'translations';
 
   const languageItems = languages.map((lang) => (
     <MenuItem

--- a/webapp/src/views/projects/translations/TranslationHeader/TranslationControls.tsx
+++ b/webapp/src/views/projects/translations/TranslationHeader/TranslationControls.tsx
@@ -121,6 +121,7 @@ export const TranslationControls: React.FC<Props> = ({ onDialogOpen }) => {
           value={selectedLanguages || []}
           languages={languages || []}
           context="translations"
+          enableEmpty
         />
         <ButtonGroup>
           <StyledToggleButton

--- a/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
@@ -177,12 +177,15 @@ export const useTranslationsService = (props: Props) => {
       onSuccess(data) {
         const flatKeys = flattenKeys(data);
 
-        const selectedLanguages = languages?.length
-          ? shaveBy(
-              data.pages[0].selectedLanguages.map((l) => l.tag),
-              languages
-            )
-          : data.pages[0].selectedLanguages.map((l) => l.tag);
+        const selectedLanguages =
+          languages !== undefined
+            ? languages.length === 0
+              ? []
+              : shaveBy(
+                  data.pages[0].selectedLanguages.map((l) => l.tag),
+                  languages
+                )
+            : data.pages[0].selectedLanguages.map((l) => l.tag);
         if (query.languages?.toString() !== selectedLanguages?.toString()) {
           // update language selection to the fetched one
           // if there are some languages which are not permitted or were deleted
@@ -301,7 +304,7 @@ export const useTranslationsService = (props: Props) => {
     }
     // override url languages
     setUrlLanguages(undefined);
-    _setLanguages(value?.length ? value : undefined);
+    _setLanguages(value);
   };
 
   const updateQuery = (q: Partial<typeof query>) => {


### PR DESCRIPTION
Allow to select all and deselect all when in the translations multi-selector.


https://github.com/user-attachments/assets/f70451a8-ea96-432e-b061-302e612e1d99


closes https://github.com/tolgee/tolgee-platform/issues/3336



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Users can now select an empty language option in the language selector.
- Batch operation controls ("All" and "None") are now available in translation contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->