### PR TITLE
fix: open import translations help links in new tab

### DIFF
--- a/webapp/src/views/projects/import/component/ImportSettingsPanel.tsx
+++ b/webapp/src/views/projects/import/component/ImportSettingsPanel.tsx
@@ -110,7 +110,11 @@ export const ImportSettingsPanel: FC = (props) => {
           checked={state?.convertPlaceholdersToIcu}
           {...additionalCheckboxProps}
           customHelpIcon={
-            <StyledLink href={DOCS_LINKS.importingPlaceholders}>
+            <StyledLink
+              href={DOCS_LINKS.importingPlaceholders}
+              rel="noreferrer noopener"
+              target="_blank"
+            >
               <HelpCircle className="icon" />
             </StyledLink>
           }
@@ -126,7 +130,11 @@ export const ImportSettingsPanel: FC = (props) => {
         label={t('import_override_key_descriptions_label')}
         checked={state?.overrideKeyDescriptions}
         customHelpIcon={
-          <StyledLink href={DOCS_LINKS.importOverridingDescriptions}>
+          <StyledLink
+            href={DOCS_LINKS.importOverridingDescriptions}
+            rel="noreferrer noopener"
+            target="_blank"
+          >
             <HelpCircle className="icon" />
           </StyledLink>
         }


### PR DESCRIPTION
Open the help icons beside the checkboxes in import translations page in a new tab. Also make them all of equal size.

| before | after |
|--------|--------|
| <img width="2080" height="271" alt="image" src="https://github.com/user-attachments/assets/5ff8a7da-f459-4315-bcd1-801befda0186" /> | <img width="2097" height="328" alt="image" src="https://github.com/user-attachments/assets/eef2af29-fdde-40be-8781-180e3fa7fe01" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External help documentation links now open in a new browser tab, allowing you to reference documentation while continuing your work.
  * Enhanced security attributes for external resource links.

* **UI Improvements**
  * Improved visual consistency of help icons throughout the import settings panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->