### PR TITLE
fix: show project description activity and difference

### DIFF
--- a/webapp/src/component/activity/configuration.tsx
+++ b/webapp/src/component/activity/configuration.tsx
@@ -148,7 +148,7 @@ export const actionsConfiguration: Partial<
     label(params) {
       return <T keyName="activity_edit_project" params={params} />;
     },
-    entities: { Project: ['name'] },
+    entities: { Project: ['name', 'description'] },
   },
   NAMESPACE_EDIT: {
     label(params) {


### PR DESCRIPTION
Project description activity was blank although changes were made. This PR fixes that behaviour.

| before | after |
|--------|--------|
| <img width="1996" height="1794" alt="image" src="https://github.com/user-attachments/assets/0c04a360-47ac-4d7f-82d1-fe2da63d3669" /> | <img width="2160" height="1794" alt="image" src="https://github.com/user-attachments/assets/4fe78b3e-a5ca-4496-894f-72f69919dceb" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Project activity tracking now records description field changes in addition to name changes, providing more comprehensive visibility into project modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->