### PR TITLE
feat: add manifest in generated files by exporter for Android SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,15 @@ Tests are split into multiple categories that run in parallel in CI:
 ./gradlew security:test
 ```
 
+Don't use the bare test task (it doesn't work) – always run a specific test suite even when running a single test, e.g:
+```bash
+# Don't do this
+./gradlew test --tests "io.tolgee.unit.formats.android.out.AndroidSdkFileExporterTest"
+
+# Do this
+./gradlew :data:test --tests "io.tolgee.unit.formats.android.out.AndroidSdkFileExporterTest"
+```
+
 **TestData Pattern**: Use TestData classes for test setup:
 ```kotlin
 class YourControllerTest {

--- a/backend/data/src/main/kotlin/io/tolgee/formats/json/out/JsonFileExporterWithManifest.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/json/out/JsonFileExporterWithManifest.kt
@@ -1,0 +1,49 @@
+package io.tolgee.formats.json.out
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.dtos.IExportParams
+import io.tolgee.formats.genericStructuredFile.out.CustomPrettyPrinter
+import io.tolgee.service.export.ExportFilePathProvider
+import io.tolgee.service.export.dataProvider.ExportTranslationView
+import io.tolgee.service.export.exporters.FileExporter
+import java.io.InputStream
+
+class JsonFileExporterWithManifest(
+  private val translations: List<ExportTranslationView>,
+  private val exportParams: IExportParams,
+  private val projectIcuPlaceholdersSupport: Boolean,
+  private val objectMapper: ObjectMapper,
+  private val customPrettyPrinter: CustomPrettyPrinter,
+  private val filePathProvider: ExportFilePathProvider,
+) : FileExporter {
+  private val jsonExporter =
+    JsonFileExporter(
+      translations = translations,
+      exportParams = exportParams,
+      projectIcuPlaceholdersSupport = projectIcuPlaceholdersSupport,
+      objectMapper = objectMapper,
+      customPrettyPrinter = customPrettyPrinter,
+      filePathProvider = filePathProvider,
+    )
+
+  override fun produceFiles(): Map<String, InputStream> {
+    val jsonFiles = jsonExporter.produceFiles()
+    val manifestFile = generateManifestFile()
+    return jsonFiles + ("manifest.json" to manifestFile)
+  }
+
+  private fun generateManifestFile(): InputStream {
+    val locales =
+      translations
+        .map { it.languageTag }
+        .distinct()
+        .sorted()
+
+    val manifest = mapOf("locales" to locales)
+
+    return objectMapper
+      .writer(customPrettyPrinter)
+      .writeValueAsBytes(manifest)
+      .inputStream()
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
@@ -12,6 +12,7 @@ import io.tolgee.formats.csv.out.CsvFileExporter
 import io.tolgee.formats.flutter.out.FlutterArbFileExporter
 import io.tolgee.formats.genericStructuredFile.out.CustomPrettyPrinter
 import io.tolgee.formats.json.out.JsonFileExporter
+import io.tolgee.formats.json.out.JsonFileExporterWithManifest
 import io.tolgee.formats.po.out.PoFileExporter
 import io.tolgee.formats.properties.out.PropertiesFileExporter
 import io.tolgee.formats.resx.out.ResxExporter
@@ -40,17 +41,18 @@ class FileExporterFactory(
     projectIcuPlaceholdersSupport: Boolean,
   ): FileExporter {
     return when (exportParams.format) {
-      ExportFormat.CSV ->
+      ExportFormat.CSV -> {
         CsvFileExporter(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
           getFilePathProvider(exportParams, data),
         )
+      }
 
       ExportFormat.JSON, ExportFormat.JSON_TOLGEE, ExportFormat.JSON_I18NEXT,
-      ExportFormat.ANDROID_SDK, ExportFormat.APPLE_SDK,
-      ->
+      ExportFormat.APPLE_SDK,
+      -> {
         JsonFileExporter(
           data,
           exportParams,
@@ -59,8 +61,20 @@ class FileExporterFactory(
           customPrettyPrinter = customPrettyPrinter,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.YAML_RUBY, ExportFormat.YAML ->
+      ExportFormat.ANDROID_SDK -> {
+        JsonFileExporterWithManifest(
+          translations = data,
+          exportParams = exportParams,
+          projectIcuPlaceholdersSupport = projectIcuPlaceholdersSupport,
+          objectMapper = objectMapper,
+          customPrettyPrinter = customPrettyPrinter,
+          filePathProvider = getFilePathProvider(exportParams, data),
+        )
+      }
+
+      ExportFormat.YAML_RUBY, ExportFormat.YAML -> {
         YamlFileExporter(
           data,
           exportParams,
@@ -69,8 +83,9 @@ class FileExporterFactory(
           customPrettyPrinter,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.XLIFF ->
+      ExportFormat.XLIFF -> {
         XliffFileExporter(
           data,
           exportParams,
@@ -79,8 +94,9 @@ class FileExporterFactory(
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.APPLE_XLIFF ->
+      ExportFormat.APPLE_XLIFF -> {
         AppleXliffExporter(
           data,
           baseTranslationsProvider,
@@ -88,24 +104,27 @@ class FileExporterFactory(
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.ANDROID_XML ->
+      ExportFormat.ANDROID_XML -> {
         XmlResourcesExporter(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.COMPOSE_XML ->
+      ExportFormat.COMPOSE_XML -> {
         XmlResourcesExporter(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.PO ->
+      ExportFormat.PO -> {
         PoFileExporter(
           data,
           exportParams,
@@ -113,8 +132,9 @@ class FileExporterFactory(
           projectIcuPlaceholdersSupport,
           getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.APPLE_STRINGS_STRINGSDICT ->
+      ExportFormat.APPLE_STRINGS_STRINGSDICT -> {
         AppleStringsStringsdictExporter(
           data,
           exportParams,
@@ -122,8 +142,9 @@ class FileExporterFactory(
           stringsFilePathProvider = getFilePathProvider(exportParams, data, "strings"),
           stringsdictFilePathProvider = getFilePathProvider(exportParams, data, "stringsdict"),
         )
+      }
 
-      ExportFormat.APPLE_XCSTRINGS ->
+      ExportFormat.APPLE_XCSTRINGS -> {
         AppleXcstringsExporter(
           translations = data,
           exportParams = exportParams,
@@ -131,8 +152,9 @@ class FileExporterFactory(
           isProjectIcuPlaceholdersEnabled = projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.FLUTTER_ARB ->
+      ExportFormat.FLUTTER_ARB -> {
         FlutterArbFileExporter(
           data,
           exportParams,
@@ -141,24 +163,27 @@ class FileExporterFactory(
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.PROPERTIES ->
+      ExportFormat.PROPERTIES -> {
         PropertiesFileExporter(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
           filePathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.RESX_ICU ->
+      ExportFormat.RESX_ICU -> {
         ResxExporter(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
           pathProvider = getFilePathProvider(exportParams, data),
         )
+      }
 
-      ExportFormat.XLSX ->
+      ExportFormat.XLSX -> {
         XlsxFileExporter(
           currentDateProvider.date,
           data,
@@ -166,6 +191,7 @@ class FileExporterFactory(
           projectIcuPlaceholdersSupport,
           pathProvider = getFilePathProvider(exportParams, data),
         )
+      }
     }
   }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidSdkFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidSdkFileExporterTest.kt
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.tolgee.dtos.request.export.ExportParams
 import io.tolgee.formats.ExportFormat
 import io.tolgee.formats.genericStructuredFile.out.CustomPrettyPrinter
-import io.tolgee.formats.json.out.JsonFileExporter
+import io.tolgee.formats.json.out.JsonFileExporterWithManifest
 import io.tolgee.service.export.ExportFilePathProvider
 import io.tolgee.service.export.ExportFileStructureTemplateProvider
 import io.tolgee.service.export.dataProvider.ExportTranslationView
 import io.tolgee.unit.util.assertFile
 import io.tolgee.unit.util.getExported
 import io.tolgee.util.buildExportTranslationList
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class AndroidSdkFileExporterTest {
@@ -33,7 +34,7 @@ class AndroidSdkFileExporterTest {
     )
   }
 
-  private fun getIcuPlaceholdersDisabledExporter(): JsonFileExporter {
+  private fun getIcuPlaceholdersDisabledExporter(): JsonFileExporterWithManifest {
     val built =
       buildExportTranslationList {
         add(
@@ -93,6 +94,110 @@ class AndroidSdkFileExporterTest {
     )
   }
 
+  @Test
+  fun `generates manifest json with single locale`() {
+    val built =
+      buildExportTranslationList {
+        add(languageTag = "en", keyName = "key1", text = "text")
+      }
+    val exporter =
+      getExporter(
+        built.translations,
+        exportParams = ExportParams(format = ExportFormat.ANDROID_SDK),
+      )
+    val data = getExported(exporter)
+    data.assertFile(
+      "manifest.json",
+      """
+    |{
+    |  "locales": [ "en" ]
+    |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `generates manifest json with multiple locales sorted`() {
+    val built =
+      buildExportTranslationList {
+        add(languageTag = "de", keyName = "key1", text = "text")
+        add(languageTag = "en-US", keyName = "key1", text = "text")
+        add(languageTag = "en", keyName = "key1", text = "text")
+      }
+    val exporter =
+      getExporter(
+        built.translations,
+        exportParams = ExportParams(format = ExportFormat.ANDROID_SDK),
+      )
+    val data = getExported(exporter)
+    data.assertFile(
+      "manifest.json",
+      """
+    |{
+    |  "locales": [ "de", "en", "en-US" ]
+    |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `generates all translation JSON files alongside manifest`() {
+    val built =
+      buildExportTranslationList {
+        add(languageTag = "en", keyName = "key1", text = "Hello")
+        add(languageTag = "de", keyName = "key1", text = "Hallo")
+      }
+    val exporter =
+      getExporter(
+        built.translations,
+        exportParams = ExportParams(format = ExportFormat.ANDROID_SDK),
+      )
+    val data = getExported(exporter)
+
+    assertThat(data).containsKeys("en.json", "de.json", "manifest.json")
+
+    data.assertFile(
+      "en.json",
+      """
+    |{
+    |  "key1": "Hello"
+    |}
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `manifest placed at root with namespaces`() {
+    val built =
+      buildExportTranslationList {
+        add(languageTag = "en", keyName = "common:key1", text = "text")
+        add(languageTag = "de", keyName = "common:key1", text = "text")
+      }
+    val exporter =
+      getExporter(
+        built.translations,
+        exportParams =
+          ExportParams(
+            format = ExportFormat.ANDROID_SDK,
+            fileStructureTemplate = "{namespace}/{languageTag}.{extension}",
+          ),
+      )
+    val data = getExported(exporter)
+
+    // Manifest should be at the root level (not inside a namespace folder)
+    assertThat(data).containsKey("manifest.json")
+
+    // Verify the manifest contains both locales
+    data.assertFile(
+      "manifest.json",
+      """
+    |{
+    |  "locales": [ "de", "en" ]
+    |}
+      """.trimMargin(),
+    )
+  }
+
   private fun getTranslationWithColon(): MutableList<ExportTranslationView> {
     val built =
       buildExportTranslationList {
@@ -105,7 +210,7 @@ class AndroidSdkFileExporterTest {
     return built.translations
   }
 
-  private fun getIcuPlaceholdersEnabledExporter(): JsonFileExporter {
+  private fun getIcuPlaceholdersEnabledExporter(): JsonFileExporterWithManifest {
     val built =
       buildExportTranslationList {
         add(
@@ -132,8 +237,8 @@ class AndroidSdkFileExporterTest {
     translations: List<ExportTranslationView>,
     isProjectIcuPlaceholdersEnabled: Boolean = true,
     exportParams: ExportParams = ExportParams(),
-  ): JsonFileExporter {
-    return JsonFileExporter(
+  ): JsonFileExporterWithManifest {
+    return JsonFileExporterWithManifest(
       translations = translations,
       exportParams = exportParams,
       projectIcuPlaceholdersSupport = isProjectIcuPlaceholdersEnabled,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android SDK exports now generate a manifest.json file documenting all supported language locales included in the export package.

* **Documentation**
  * Backend testing guidelines updated with guidance on running targeted test suites for more efficient test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->