### PR TITLE
feat: close search field on escape key

### DIFF
--- a/webapp/src/component/layout/HeaderSearchField.tsx
+++ b/webapp/src/component/layout/HeaderSearchField.tsx
@@ -10,11 +10,12 @@ export const HeaderSearchField = (
     value: string;
     onSearchChange: (value: string) => void;
     style?: React.CSSProperties;
+    setSearchOpen?: (open: boolean) => void;
   }
 ) => {
   const theme = useTheme();
 
-  const { value, onSearchChange, ...otherProps } = props;
+  const { value, onSearchChange, setSearchOpen, ...otherProps } = props;
 
   return (
     <TextField
@@ -53,6 +54,12 @@ export const HeaderSearchField = (
       value={value}
       style={{ flexBasis: 200 }}
       onChange={(e) => onSearchChange(e.target.value)}
+      onKeyUp={(e) => {
+        if (e.key === 'Escape') {
+          onSearchChange('');
+          setSearchOpen?.(false);
+        }
+      }}
       {...otherProps}
     />
   );

--- a/webapp/src/views/projects/translations/TranslationHeader/TranslationControlsCompact.tsx
+++ b/webapp/src/views/projects/translations/TranslationHeader/TranslationControlsCompact.tsx
@@ -163,6 +163,7 @@ export const TranslationControlsCompact: React.FC<Props> = ({
               maxWidth: 'unset',
               width: '100%',
             }}
+            setSearchOpen={setSearchOpen}
           />
           <StyledIconButton size="small" onClick={() => setSearchOpen(false)}>
             <XClose />


### PR DESCRIPTION
I usually press escape key to clear the search bar and close it. Added that feature in this PR

https://github.com/user-attachments/assets/4422311d-ac6e-4da6-8093-52be348887f4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search field now closes and clears when the Escape key is pressed, improving keyboard navigation and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->