### PR TITLE
fix: Export -> escape newlines in Apple .strings files

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/StringsWriter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/StringsWriter.kt
@@ -27,7 +27,7 @@ class StringsWriter {
       escapeApos = false,
       keepPercentSignEscaped = true,
       quoteMoreWhitespaces = false,
-      escapeNewLines = false,
+      escapeNewLines = true,
       escapeQuotes = true,
       utfSymbolCharacter = 'U',
     ).escape()

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/StringsStringsdictFileExporterTest.kt
@@ -28,6 +28,8 @@ class StringsStringsdictFileExporterTest {
       """
     |"key" = "Hello! I am great today! There you have some params %lld, %@, %e, %f";
     |
+    |"key" = "String\nwith\nnewlines";
+    |
     |
       """.trimMargin(),
     )
@@ -66,9 +68,9 @@ class StringsStringsdictFileExporterTest {
     |        <key>NSStringFormatValueTypeKey</key>
     |        <string>lld</string>
     |        <key>one</key>
-    |        <string>Today we had a very nice workout at %2$@, where we did one push up.</string>
+    |        <string>Today we had a very nice workout at %2${'$'}@, where we did one push up.</string>
     |        <key>other</key>
-    |        <string>Today we had a very nice workout at %2$@, where we did %3$@ push ups.</string>
+    |        <string>Today we had a very nice workout at %2${'$'}@, where we did %3${'$'}@ push ups.</string>
     |      </dict>
     |    </dict>
     |  </dict>
@@ -346,6 +348,13 @@ class StringsStringsdictFileExporterTest {
           "{count, plural, one {# day} other {# days}}",
           TranslationState.TRANSLATED,
           ExportKeyView(1, "key", namespace = "homepage", isPlural = true),
+          "en",
+        ),
+        ExportTranslationView(
+          1,
+          "String\nwith\nnewlines",
+          TranslationState.TRANSLATED,
+          ExportKeyView(1, "key"),
           "en",
         ),
         ExportTranslationView(


### PR DESCRIPTION
Closes #3322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed escaping of newline characters in exported Apple strings files to ensure multiline strings are properly preserved.
  * Corrected escaping of dollar-sign placeholders in plural form translations to prevent formatting errors in localized content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->