### PR TITLE
fix: don't rate limit export endpoint twice

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
@@ -15,7 +15,6 @@ import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authentication.ReadOnlyOperation
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.ratelimit.RateLimitService
-import io.tolgee.security.ratelimit.RateLimited
 import io.tolgee.service.export.ExportService
 import io.tolgee.service.language.LanguageService
 import io.tolgee.util.StreamingResponseBodyProvider
@@ -81,7 +80,6 @@ class V2ExportController(
   @RequiresProjectPermissions([Scope.TRANSLATIONS_VIEW])
   @AllowApiAccess
   @ExportApiResponse
-  @RateLimited(limit = 10, refillDurationInMs = 60_000)
   fun exportData(
     @ParameterObject params: ExportParams,
     request: WebRequest,
@@ -106,7 +104,6 @@ class V2ExportController(
     }
   }
 
-  @RateLimited(limit = 10, refillDurationInMs = 60_000)
   @PostMapping(value = [""])
   @Operation(
     summary = "Export data (post)",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Refactor**
  * Removed rate limiting from data export endpoints, allowing for unrestricted export operations.
  * Updated endpoint classifications to reflect the read-only nature of export functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->