### PR TITLE
chore: add metrics - locked and already queued executions of batch jobs

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -18,6 +18,21 @@ class Metrics(
       .register(meterRegistry)
   }
 
+  val batchJobManagementItemAlreadyQueuedCounter: Counter by lazy {
+    Counter
+      .builder("tolgee.batch.job.execution.queue.already_queued")
+      .description("Number of executions that were already queued, but retrieved again from db")
+      .register(meterRegistry)
+  }
+
+  val batchJobManagementItemAlreadyLockedCounter: Counter by lazy {
+    Counter
+      .builder("tolgee.batch.job.execution.queue.already_locked")
+      .description(
+        "Number of executions that were already locked (by scheduled db retrieved or other pod) and are preprocessed redundantly",
+      ).register(meterRegistry)
+  }
+
   val batchJobManagementFailureWithRetryCounter: Counter by lazy {
     Counter
       .builder("tolgee.batch.job.execution.management.failure.retried")

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
@@ -123,6 +123,7 @@ class BatchJobActionService(
     val lockedExecution = getExecutionIfCanAcquireLockInDb(executionItem.chunkExecutionId)
 
     if (lockedExecution == null) {
+      metrics.batchJobManagementItemAlreadyLockedCounter.increment()
       logger.debug("⚠️ Chunk ${executionItem.chunkExecutionId} (job: ${executionItem.jobId}) is locked, skipping")
       progressManager.finalizeIfCompleted(executionItem.jobId)
       return null

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -104,7 +104,7 @@ class BatchJobChunkExecutionQueue(
         count++
       }
     }
-
+    metrics.batchJobManagementItemAlreadyQueuedCounter.increment(data.size - count.toDouble())
     logger.debug("Added $count new items to queue ${System.identityHashCode(this)}")
   }
 
@@ -119,7 +119,7 @@ class BatchJobChunkExecutionQueue(
         filteredOut.add(it)
       }
     }
-
+    metrics.batchJobManagementItemAlreadyQueuedCounter.increment(filteredOut.size.toDouble())
     logger.trace {
       val itemsString = toAdd.joinToString(", ") { it.chunkExecutionId.toString() }
       val filteredOutString = filteredOut.joinToString(", ") { it.chunkExecutionId.toString() }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced monitoring metrics for batch job processing to track duplicate queue attempts and locked items, enabling better visibility into batch job execution status and potential bottlenecks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->