### PR TITLE
fix: optimize tagging memory

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -35,7 +35,8 @@ class TagService(
     val tag =
       find(key.project, tagName)?.let {
         if (!keyMeta.tags.contains(it)) {
-          it.keyMetas.add(keyMeta)
+          // Don't access it.keyMetas - triggers lazy load of all KeyMeta for this tag
+          // Only update owning side (keyMeta.tags) - JPA will sync the join table
           keyMeta.tags.add(it)
         }
         it
@@ -103,7 +104,8 @@ class TagService(
             val tag =
               existingTags[tagToAdd]?.let {
                 if (!keyMeta.tags.contains(it)) {
-                  it.keyMetas.add(keyMeta)
+                  // Don't access it.keyMetas directly - it triggers massive query for all KeyMeta on this tag
+                  // Instead, just update the owning side (keyMeta.tags)
                   keyMeta.tags.add(it)
                 }
                 it


### PR DESCRIPTION
Sharing this commit here and suggesting this might make sense if upstreamed.

At Rakuten France, we have on our database some tags that are linked to more than 10k translations.

As our database grew, so did memory usage, until we had to allocate 10Gb of java memory to the tolgee JVM (`Xmx`).

After some heap dump and thread dump analysis, we pinpointed the root cause in the tagging code that does standard Hibernate many-to-many mapping between translations and tags. 

We have been running with the attached patch for a few weeks in QA and a few days in production and see no adverse effect.
Original commit was on `v3.123.13` and was forward ported to main. 

Note: this can also be solved by doing the update with raw sql... I'm not attached to this patch, but I wish for upstream to efficiently tag translations with little memory usage.

Attached: graph of the memory consumption of one of our servers in production. It shows clearly when the new version with this patch was introduced, and then when we finally tweaked `Xmx` from 10 Gb back to 2 Gb

<img width="3144" height="1712" alt="image" src="https://github.com/user-attachments/assets/e6791baf-569f-49df-adf8-780ac0951b85" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized tag management operations to reduce unnecessary database queries and improve performance when applying tags to content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->