### PR TITLE
fix: count per-job executions for maxPerJobConcurrency check

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
@@ -269,13 +269,8 @@ class BatchJobConcurrentLauncher(
       if (maxPerJobConcurrency == -1) {
         return@trySetExecutionRunning true
       }
-      // before (look back to the git log) number of running executions was counted based on
-      // executions in Map<Long, ExecutionState> in status RUNNING
-      // it.values.count { executionState -> executionState.status == BatchJobChunkExecutionStatus.RUNNING },
-      // which led to more couroutines actually launched, because there can be executions in the SUCCESS
-      // state that are not finalized yet and are not removed from that map
-      // see io.tolgee.batch.AbstractBatchJobsGeneralTest.`mt job respects maxPerJobConcurrency`
-      runningJobs.size < maxPerJobConcurrency
+      // Count only executions for THIS specific job, not all running executions globally
+      runningJobs.values.count { it.first.id == this.jobId } < maxPerJobConcurrency
     }
   }
 }


### PR DESCRIPTION
## Summary
Fix flaky test `BatchJobsGeneralWithoutRedisTest > mt job respects maxPerJobConcurrency()`

## Problem
The `maxPerJobConcurrency` limit was incorrectly checking `runningJobs.size` which counts **ALL** running executions globally across all batch jobs. This should only count executions for the specific job being checked.

## Fix
Changed from:
```kotlin
runningJobs.size < maxPerJobConcurrency
```

To:
```kotlin
runningJobs.values.count { it.first.id == this.jobId } < maxPerJobConcurrency
```

## Test plan
- [x] Ran the flaky test 5 times - all passed
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch job concurrency handling to evaluate limits on a per-job basis rather than system-wide, enabling more efficient parallel execution of multiple batch jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->