### PR TITLE
feat: add support for additional locales and translations

### DIFF
--- a/library/src/constants/locales.ts
+++ b/library/src/constants/locales.ts
@@ -7,6 +7,14 @@ import ptDateLocale from 'date-fns/locale/pt';
 import daDateLocale from 'date-fns/locale/da';
 import jaDateLocale from 'date-fns/locale/ja';
 import zhCNDateLocale from 'date-fns/locale/zh-CN';
+import ukrDateLocale from 'date-fns/locale/uk';
+import huDateLocale from 'date-fns/locale/hu';
+import itDateLocale from 'date-fns/locale/it';
+import nlDateLocale from 'date-fns/locale/nl';
+import noDateLocale from 'date-fns/locale/nb';
+import plDateLocale from 'date-fns/locale/pl';
+import roDateLocale from 'date-fns/locale/ro';
+import ruDateLocale from 'date-fns/locale/ru';
 
 export const locales = {
   en: {
@@ -71,5 +79,61 @@ export const locales = {
     dateFnsLocale: zhCNDateLocale,
     translations: () =>
       import('../../../webapp/src/i18n/zh.json').then((m) => m.default),
+  },
+  uk: {
+    name: 'Українська',
+    flag: '🇺🇦',
+    dateFnsLocale: ukrDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/uk-UA.json').then((m) => m.default),
+  },
+  hu: {
+    name: 'Magyar',
+    flag: '🇭🇺',
+    dateFnsLocale: huDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/hu.json').then((m) => m.default),
+  },
+  it: {
+    name: 'Italiano',
+    flag: '🇮🇹',
+    dateFnsLocale: itDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/it-IT.json').then((m) => m.default),
+  },
+  nl: {
+    name: 'Nederlands',
+    flag: '🇳🇱',
+    dateFnsLocale: nlDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/nl.json').then((m) => m.default),
+  },
+  no: {
+    name: 'Norsk',
+    flag: '🇳🇴',
+    dateFnsLocale: noDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/no.json').then((m) => m.default),
+  },
+  pl: {
+    name: 'Polski',
+    flag: '🇵🇱',
+    dateFnsLocale: plDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/pl.json').then((m) => m.default),
+  },
+  ro: {
+    name: 'Română',
+    flag: '🇷🇴',
+    dateFnsLocale: roDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/ro.json').then((m) => m.default),
+  },
+  ru: {
+    name: 'Русский',
+    flag: '🇷🇺',
+    dateFnsLocale: ruDateLocale,
+    translations: () =>
+      import('../../../webapp/src/i18n/ru.json').then((m) => m.default),
   },
 };

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -58,6 +58,14 @@ const tolgee = Tolgee()
       da: () => import('./i18n/da.json').then((m) => m.default),
       ja: () => import('./i18n/ja.json').then((m) => m.default),
       zh: () => import('./i18n/zh.json').then((m) => m.default),
+      uk: () => import('./i18n/uk-UA.json').then((m) => m.default),
+      hu: () => import('./i18n/hu.json').then((m) => m.default),
+      it: () => import('./i18n/it-IT.json').then((m) => m.default),
+      nl: () => import('./i18n/nl.json').then((m) => m.default),
+      no: () => import('./i18n/no.json').then((m) => m.default),
+      pl: () => import('./i18n/pl.json').then((m) => m.default),
+      ro: () => import('./i18n/ro.json').then((m) => m.default),
+      ru: () => import('./i18n/ru.json').then((m) => m.default),
     },
   });
 


### PR DESCRIPTION
Fix [#3289](https://github.com/tolgee/tolgee-platform/issues/3289)

## Summary

Adds missing interface language support for multiple languages (Ukrainian, Hungarian, Italian, Dutch, Norwegian, Polish, Romanian, Russian) to the language selector

- Translation files existed but languages were not fully configured
- Added language entries to Tolgee's staticData configuration in `webapp/src/index.tsx` for translation loading
- Added language entries to `library/src/constants/locales.ts` with proper metadata (name, flag, date-fns locale, translation import) for UI selector
- Languages now appear in both the top bar language menu and user settings language selector

## Test Plan

- Verify all languages appear in language selector
- Select each language from language menu - interface should switch correctly
- Verify date formatting works correctly with each locale

---

### Bug Fixes

- Fixed missing interface languages by adding entries to both Tolgee's staticData configuration and locales constants
- Languages now properly load translations and appear in the language selector UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for 8 new languages: Ukrainian, Hungarian, Italian, Dutch, Norwegian, Polish, Romanian, and Russian. Users can now use the application interface and view localized content in their preferred language, with region-specific date and time formatting for enhanced usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->