### PR TITLE
feat: Build docker images using Gradle

### DIFF
--- a/.github/workflows/prerelease-alpha.yml
+++ b/.github/workflows/prerelease-alpha.yml
@@ -50,21 +50,15 @@ jobs:
         if: ${{ steps.version.outputs.VERSION != '' }}
         run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p "${{ secrets.DOCKERHUB_PASSWORD }}"
 
-      - name: Prepare for docker build
+      - name: Create docker image
         if: ${{ steps.version.outputs.VERSION != '' }}
-        run: ./gradlew dockerPrepare
+        run: |
+          docker buildx create --use
+          ./gradlew dockerPublish
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
-
-      - name: Create docker image
-        if: ${{ steps.version.outputs.VERSION != '' }}
-        run: |
-          OTEL_VERSION=$(grep '^opentelemetryJavaagentVersion=' ../../gradle.properties | cut -d'=' -f2)
-          docker buildx create --use
-          docker buildx build . -t tolgee/tolgee:${{ steps.version.outputs.VERSION }} --build-arg OTEL_AGENT_VERSION=$OTEL_VERSION --platform linux/arm64,linux/amd64 --push
-        working-directory: build/docker
 
       - name: Pack with webapp
         if: ${{ steps.version.outputs.VERSION != '' }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -42,18 +42,15 @@ jobs:
         id: version
         run: echo "VERSION=$(echo $GITHUB_REF | sed -e 's/refs\/tags\///g' -e 's/\//-/g')" >> $GITHUB_OUTPUT
 
-      - name: Prepare for docker build
-        run: ./gradlew dockerPrepare
-        env:
-          TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
-          TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
-
       - name: Create docker image
         run: |
-          OTEL_VERSION=$(grep '^opentelemetryJavaagentVersion=' ../../gradle.properties | cut -d'=' -f2)
           docker buildx create --use
-          docker buildx build . -t tgint/tgpreview:${{ steps.version.outputs.VERSION }} --build-arg OTEL_AGENT_VERSION=$OTEL_VERSION --platform linux/arm64,linux/amd64 --push
-        working-directory: build/docker
+          ./gradlew dockerPublish
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          DOCKER_IMAGE: tgint/tgpreview
+          TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
+          TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
 
       - name: Deploy
         uses: nickgronow/kubectl@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,22 +54,18 @@ jobs:
         if: ${{ steps.version.outputs.VERSION != '' }}
         run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p "${{ secrets.DOCKERHUB_PASSWORD }}"
 
-      - name: Prepare for docker build
+      - name: Create docker image
         if: ${{ steps.version.outputs.VERSION != '' }}
-        run: ./gradlew dockerPrepare
+        run: |
+          docker buildx create --use
+          ./gradlew dockerPublish
+          VERSION=latest ./gradlew dockerPublish
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
-
-      - name: Create docker image
-        if: ${{ steps.version.outputs.VERSION != '' }}
-        run: |
-          OTEL_VERSION=$(grep '^opentelemetryJavaagentVersion=' ../../gradle.properties | cut -d'=' -f2)
-          docker buildx create --use
-          docker buildx build . -t tolgee/tolgee:${{ steps.version.outputs.VERSION }} --build-arg OTEL_AGENT_VERSION=$OTEL_VERSION --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
-          docker buildx build . -t tolgee/tolgee:latest --build-arg OTEL_AGENT_VERSION=$OTEL_VERSION --platform linux/arm64,linux/amd64 --cache-from type=registry,ref=tolgee/tolgee:latest --cache-to type=inline --push
-        working-directory: build/docker
+          DOCKER_CACHE_FROM: type=registry,ref=tolgee/tolgee:latest
+          DOCKER_CACHE_TO: type=inline
 
       - name: Pack with webapp
         if: ${{ steps.version.outputs.VERSION != '' }}

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -17,7 +17,8 @@ task dockerPrepare {
     dependsOn("unpack", "copyDist", "copyDockerIgnore", "addVersionFile")
 }
 
-// Builds Docker image with OpenTelemetry agent. See: docs/observability/
+// Builds Docker image for local development.
+// Single platform, no push, tagged as tolgee/tolgee.
 task docker {
     doLast {
         exec {
@@ -31,31 +32,41 @@ task docker {
     dependsOn("dockerPrepare")
 }
 
-void createDockerBuildxTask(String taskName, boolean isPush) {
-    task(taskName) {
-        doLast {
-            if (project.hasProperty('dockerImageTag')) {
-                def commandParams = ["docker", "buildx", "build", ".",
-                    "-t", project.property('dockerImageTag'),
-                    "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
-                    "--platform", "linux/arm64,linux/amd64"]
-                if (isPush) {
-                    commandParams += ["--push"]
-                }
-                exec {
-                    workingDir dockerPath
-                    commandLine commandParams
-                }
-            } else {
-                throw new GradleException('A "dockerImageTag" project property must be defined! e.g. ./gradlew dockerBuildx -PdockerImageTag=myImageTag');
-            }
-        }
-        dependsOn("dockerPrepare")
-    }
-}
+// Builds and pushes multi-platform Docker image for CI.
+// Reads configuration from environment variables:
+//   - VERSION: image tag version (default: 'latest')
+//   - DOCKER_IMAGE: image name (default: 'tolgee/tolgee')
+//   - DOCKER_CACHE_FROM: cache source (optional, e.g., 'type=registry,ref=tolgee/tolgee:latest')
+//   - DOCKER_CACHE_TO: cache destination (optional, e.g., 'type=inline')
+// Requires: docker buildx create --use (run once before calling this task)
+task dockerPublish {
+    doLast {
+        def version = System.getenv('VERSION') ?: 'latest'
+        def imageName = System.getenv('DOCKER_IMAGE') ?: 'tolgee/tolgee'
+        def tag = "${imageName}:${version}"
+        def cacheFrom = System.getenv('DOCKER_CACHE_FROM')
+        def cacheTo = System.getenv('DOCKER_CACHE_TO')
 
-createDockerBuildxTask("dockerBuildxPush", true)
-createDockerBuildxTask("dockerBuildx", false)
+        def commandParams = ["docker", "buildx", "build", ".",
+            "-t", tag,
+            "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
+            "--platform", "linux/arm64,linux/amd64",
+            "--push"]
+
+        if (cacheFrom) {
+            commandParams += ["--cache-from", cacheFrom]
+        }
+        if (cacheTo) {
+            commandParams += ["--cache-to", cacheTo]
+        }
+
+        exec {
+            workingDir dockerPath
+            commandLine commandParams
+        }
+    }
+    dependsOn("dockerPrepare")
+}
 
 task cleanDocker{
     delete(dockerPath)


### PR DESCRIPTION
## Summary

Consolidates Docker image building logic into Gradle, replacing inline shell commands in GitHub workflows with a single `dockerPublish` Gradle task.

## Changes

### New `dockerPublish` Gradle task
- Builds and pushes multi-platform Docker images (linux/arm64, linux/amd64)
- Configurable via environment variables:
  - `VERSION` - image tag (default: `latest`)
  - `DOCKER_IMAGE` - image name (default: `tolgee/tolgee`)
  - `DOCKER_CACHE_FROM` - cache source (optional)
  - `DOCKER_CACHE_TO` - cache destination (optional)
- Automatically reads OpenTelemetry agent version from `gradle.properties`

### Simplified GitHub workflows
- **prerelease-alpha.yml**: Merged `dockerPrepare` and `docker buildx build` steps into single `dockerPublish` call
- **preview.yml**: Same simplification, now uses `DOCKER_IMAGE` env var for custom image name
- **release.yml**: Same simplification, runs `dockerPublish` twice (versioned + latest tags)

### Removed
- `dockerBuildx` and `dockerBuildxPush` tasks (replaced by `dockerPublish`)
- Manual OTEL version extraction via `grep` in workflows (now handled by Gradle)

## Benefits
- Single source of truth for Docker build configuration
- Cleaner, more maintainable CI workflows
- Consistent behavior across all release pipelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Docker image build and publishing process across CI/CD workflows
  * Implemented unified publishing configuration using environment variables
  * Improved build workflow consistency and reduced complexity in deployment pipeline

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->