### PR TITLE
fix: dont count requests which result in "304 Not Modified" towards export rate limit

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/V2ExportController.kt
@@ -84,12 +84,13 @@ class V2ExportController(
     @ParameterObject params: ExportParams,
     request: WebRequest,
   ): ResponseEntity<StreamingResponseBody>? {
-    rateLimitService.checkPerUserRateLimit(
-      "export",
-      limit = tolgeeProperties.rateLimit.exportRequestLimit,
-      refillDuration = Duration.ofMillis(tolgeeProperties.rateLimit.exportRequestWindow),
-    )
     return projectLastModifiedManager.onlyWhenProjectDataChanged(request) { headersBuilder ->
+      rateLimitService.checkPerUserRateLimit(
+        "export",
+        limit = tolgeeProperties.rateLimit.exportRequestLimit,
+        refillDuration = Duration.ofMillis(tolgeeProperties.rateLimit.exportRequestWindow),
+      )
+
       params.languages =
         languageService
           .getLanguagesForExport(params.languages, projectHolder.project.id, authenticationFacade.authenticatedUser.id)

--- a/backend/api/src/main/kotlin/io/tolgee/controllers/ExportController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/controllers/ExportController.kt
@@ -58,13 +58,13 @@ class ExportController(
   @RateLimited(limit = 10, refillDurationInMs = 60_000)
   @Deprecated("Use v2 export controller")
   fun doExportJsonZip(request: WebRequest): ResponseEntity<StreamingResponseBody>? {
-    rateLimitService.checkPerUserRateLimit(
-      "export",
-      limit = tolgeeProperties.rateLimit.exportRequestLimit,
-      refillDuration = Duration.ofMillis(tolgeeProperties.rateLimit.exportRequestWindow),
-    )
-
     return projectLastModifiedManager.onlyWhenProjectDataChanged(request) { headersBuilder ->
+      rateLimitService.checkPerUserRateLimit(
+        "export",
+        limit = tolgeeProperties.rateLimit.exportRequestLimit,
+        refillDuration = Duration.ofMillis(tolgeeProperties.rateLimit.exportRequestWindow),
+      )
+
       val allLanguages =
         permissionService.getPermittedViewLanguages(
           projectHolder.project.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized export rate limiting to only apply when data changes are present, reducing unnecessary rate limit consumption for unmodified exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->