### PR TITLE
feat: count unique keys by name across branches

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/OrganizationStatsServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/OrganizationStatsServiceTest.kt
@@ -1,0 +1,77 @@
+package io.tolgee.service
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.OrganizationStatsTestData
+import io.tolgee.service.organization.OrganizationStatsService
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class OrganizationStatsServiceTest : AbstractSpringTest() {
+  @Autowired
+  lateinit var organizationStatsService: OrganizationStatsService
+
+  lateinit var testData: OrganizationStatsTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = OrganizationStatsTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @Test
+  fun `getProjectKeyCount counts unique keys across branches`() {
+    // First project has:
+    // - key1 (main only) = 1 unique key
+    // - key2 (main and feature) = 1 unique key
+    // - key3 (feature only) = 1 unique key
+    // - key4 with namespace1 (main and feature) = 1 unique key
+    // - key4 with namespace2 (main only) = 1 unique key
+    // - key4 without namespace (main only) = 1 unique key
+    // Total: 6 unique keys
+    val projectKeyCount = organizationStatsService.getProjectKeyCount(testData.project.id)
+    assertThat(projectKeyCount).isEqualTo(6)
+  }
+
+  @Test
+  fun `getProjectKeyCount counts unique keys in second project`() {
+    // Second project has:
+    // - key1 (main and feature) = 1 unique key
+    // - key5 (main only) = 1 unique key
+    // Total: 2 unique keys
+    val projectKeyCount = organizationStatsService.getProjectKeyCount(testData.secondProject.id)
+    assertThat(projectKeyCount).isEqualTo(2)
+  }
+
+  @Test
+  fun `getKeyCount counts unique keys across all projects in organization`() {
+    // Organization total:
+    // First project: 6 unique keys
+    // Second project: 2 unique keys
+    // Total: 8 unique keys
+    val orgKeyCount = organizationStatsService.getKeyCount(testData.organization.id)
+    assertThat(orgKeyCount).isEqualTo(8)
+  }
+
+  @Test
+  fun `getTranslationCount counts unique translations across branches`() {
+    // First project translations (unique key+language combinations with non-empty text):
+    // - key1 (main): EN = 1
+    // - key2 (main and feature, counted once): EN, DE = 2
+    // - key3 (feature): EN = 1
+    // - key4/namespace1 (main and feature, counted once): DE = 1
+    // - key4/namespace2: no translations = 0
+    // - key4/no namespace: empty translation = 0
+    // First project total: 5
+    //
+    // Second project translations:
+    // - key1 (main and feature, counted once): EN = 1
+    // - key5 (main): EN, DE = 2
+    // Second project total: 3
+    //
+    // Organization total: 8
+    val translationCount = organizationStatsService.getTranslationCount(testData.organization.id)
+    assertThat(translationCount).isEqualTo(8)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OrganizationStatsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OrganizationStatsTestData.kt
@@ -1,0 +1,196 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.model.Language
+import io.tolgee.model.Organization
+import io.tolgee.model.Project
+import io.tolgee.model.branching.Branch
+
+class OrganizationStatsTestData : BaseTestData("org-stats", "Stats Project") {
+  lateinit var organization: Organization
+  lateinit var mainBranch: Branch
+  lateinit var featureBranch: Branch
+  lateinit var secondProject: Project
+  lateinit var secondProjectMainBranch: Branch
+  lateinit var secondProjectFeatureBranch: Branch
+  lateinit var germanLanguage: Language
+  lateinit var secondProjectGermanLanguage: Language
+
+  init {
+    root.apply {
+      organization = projectBuilder.self.organizationOwner
+
+      projectBuilder.apply {
+        self.useBranching = true
+        addGermanLanguage()
+        addBranchesAndKeys()
+      }
+
+      addSecondProject()
+    }
+  }
+
+  private fun ProjectBuilder.addGermanLanguage() {
+    addLanguage {
+      name = "German"
+      tag = "de"
+      originalName = "Deutsch"
+      germanLanguage = this
+    }
+  }
+
+  private fun ProjectBuilder.addBranchesAndKeys() {
+    addBranch {
+      name = "main"
+      project = projectBuilder.self
+      isDefault = true
+    }.build {
+      mainBranch = self
+    }
+
+    addBranch {
+      name = "feature"
+      project = projectBuilder.self
+      originBranch = mainBranch
+    }.build {
+      featureBranch = self
+    }
+
+    // Key "key1" exists only in main branch - has EN translation
+    addKey {
+      name = "key1"
+      branch = mainBranch
+    }.build {
+      addTranslation("en", "Key 1 English")
+    }
+
+    // Key "key2" exists in both branches (should be counted once) - has EN and DE translations in both branches
+    addKey {
+      name = "key2"
+      branch = mainBranch
+    }.build {
+      addTranslation("en", "Key 2 English Main")
+      addTranslation("de", "Key 2 German Main")
+    }
+    addKey {
+      name = "key2"
+      branch = featureBranch
+    }.build {
+      addTranslation("en", "Key 2 English Feature")
+      addTranslation("de", "Key 2 German Feature")
+    }
+
+    // Key "key3" exists only in feature branch - has EN translation
+    addKey {
+      name = "key3"
+      branch = featureBranch
+    }.build {
+      addTranslation("en", "Key 3 English")
+    }
+
+    // Key "key4" with namespace in main branch - has DE translation
+    val namespace1 = addNamespace {
+      name = "namespace1"
+    }.self
+
+    addKey {
+      name = "key4"
+      branch = mainBranch
+      namespace = namespace1
+    }.build {
+      addTranslation("de", "Key 4 NS1 German Main")
+    }
+
+    // Key "key4" with same namespace in feature branch (should be counted once) - has DE translation
+    addKey {
+      name = "key4"
+      branch = featureBranch
+      namespace = namespace1
+    }.build {
+      addTranslation("de", "Key 4 NS1 German Feature")
+    }
+
+    // Key "key4" with different namespace (should be counted as separate) - no translations
+    val namespace2 = addNamespace {
+      name = "namespace2"
+    }.self
+
+    addKey {
+      name = "key4"
+      branch = mainBranch
+      namespace = namespace2
+    }
+
+    // Key "key4" without namespace (should be counted as separate from namespaced ones) - has empty translation (should not count)
+    addKey {
+      name = "key4"
+      branch = mainBranch
+    }.build {
+      addTranslation("en", "")
+    }
+  }
+
+  private fun TestDataBuilder.addSecondProject() {
+    secondProject = addProject {
+      name = "Second Project"
+      organizationOwner = this@OrganizationStatsTestData.organization
+      useBranching = true
+    }.build {
+      addLanguage {
+        name = "English"
+        tag = "en"
+        originalName = "English"
+        this@build.self.baseLanguage = this
+      }
+
+      addLanguage {
+        name = "German"
+        tag = "de"
+        originalName = "Deutsch"
+        secondProjectGermanLanguage = this
+      }
+
+      addBranch {
+        name = "main"
+        project = self
+        isDefault = true
+      }.build {
+        secondProjectMainBranch = self
+      }
+
+      addBranch {
+        name = "feature"
+        project = self
+        originBranch = secondProjectMainBranch
+      }.build {
+        secondProjectFeatureBranch = self
+      }
+
+      // Key "key1" in second project (same name as first project, should be counted separately) - has EN translation
+      addKey {
+        name = "key1"
+        branch = secondProjectMainBranch
+      }.build {
+        addTranslation("en", "Second Project Key 1 English Main")
+      }
+
+      // Key "key1" in second project feature branch (should NOT be counted separately) - has EN translation
+      addKey {
+        name = "key1"
+        branch = secondProjectFeatureBranch
+      }.build {
+        addTranslation("en", "Second Project Key 1 English Feature")
+      }
+
+      // Key "key5" only in second project - has EN and DE translations
+      addKey {
+        name = "key5"
+        branch = secondProjectMainBranch
+      }.build {
+        addTranslation("en", "Key 5 English")
+        addTranslation("de", "Key 5 German")
+      }
+    }.self
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationStatsService.kt
@@ -23,7 +23,7 @@ class OrganizationStatsService(
     return entityManager
       .createQuery(
         """
-        select count(k) from Key k
+        select count(distinct k.name, k.namespace) from Key k
         where k.project.id = :projectId and k.project.deletedAt is null
         """.trimIndent(),
       ).setParameter("projectId", projectId)
@@ -44,7 +44,7 @@ class OrganizationStatsService(
     return entityManager
       .createQuery(
         """
-        select count(t.id) from Translation t
+        select count(distinct k.project.id, k.name, k.namespace, t.language) from Translation t
         join t.key k
         join k.project p on p.deletedAt is null
         join t.language l on l.deletedAt is null
@@ -58,7 +58,7 @@ class OrganizationStatsService(
     return entityManager
       .createQuery(
         """
-        select count(k.id) from Key k
+        select count(distinct k.project.id, k.name, k.namespace) from Key k
         join k.project p on p.deletedAt is null
         where p.organizationOwner.id = :organizationId
         """.trimIndent(),


### PR DESCRIPTION
@marketachalupnikova @ZuzanaOdstrcilova adding you here to to be on the same page regarding billing, when branching is finished. Please check the comments in the `OrganizationStatsServiceTest`, which describes it well, when a key is considered unique or not
```kt
    // - key1 (main only) = 1 unique key
    // - key2 (main and feature) = 1 unique key
    // - key3 (feature only) = 1 unique key
    // - key4 with namespace1 (main and feature) = 1 unique key
    // - key4 with namespace2 (main only) = 1 unique key
    // - key4 without namespace (main only) = 1 unique key
```