### PR TITLE
feat: add indexes on activity_revision and batch_job timestamps

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/activity/ActivityRevision.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/activity/ActivityRevision.kt
@@ -36,6 +36,7 @@ import java.util.Date
     Index(columnList = "authorId"),
     Index(columnList = "type"),
     Index(columnList = "organizationId"),
+    Index(columnList = "timestamp"),
   ],
 )
 @EntityListeners(ActivityRevision.Companion.ActivityRevisionListener::class)

--- a/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJob.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJob.kt
@@ -27,6 +27,7 @@ import java.util.Date
     Index(columnList = "project_id"),
     Index(columnList = "author_id"),
     Index(columnList = "debouncing_key"),
+    Index(columnList = "created_at"),
   ],
 )
 class BatchJob :

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4653,4 +4653,14 @@
             <column name="storage_json" type="JSONB"/>
         </addColumn>
     </changeSet>
+    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-164">
+        <createIndex indexName="IDXcg7y08d599p7jxdebbxwavak0" tableName="activity_revision">
+            <column name="timestamp"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-144">
+        <createIndex indexName="IDX71c7yr8a185u5jsdyndom5fa7" tableName="tolgee_batch_job">
+            <column name="created_at"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- Add B-tree index on `activity_revision.timestamp` for efficient time-range queries on the activity audit trail
- Add B-tree index on `tolgee_batch_job.created_at` for efficient time-range queries on batch job history

These are standard indexes on timestamp columns of append-mostly tables and carry negligible write overhead.

## Test plan
- [ ] Verify Liquibase migration applies cleanly on a fresh database
- [ ] Verify migration applies cleanly on existing production database
- [ ] Confirm indexes exist after migration: `\di IDXcg7y08d599p7jxdebbxwavak0` and `\di IDX71c7yr8a185u5jsdyndom5fa7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)