### PR TITLE
fix: publish glossary export as business event + use enriched event for generating key for publishOnceInTime cache

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/reporting/OnBusinessEventToCaptureEvent.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/reporting/OnBusinessEventToCaptureEvent.kt
@@ -10,6 +10,7 @@ data class OnBusinessEventToCaptureEvent(
   val projectId: Long? = null,
   val organizationId: Long? = null,
   val organizationName: String? = null,
+  val glossaryId: Long? = null,
   val userAccountId: Long? = null,
   val userAccountDto: UserAccountDto? = null,
   val utmData: Map<String, Any?>? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/component/reporting/PostHogBusinessEventReporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/reporting/PostHogBusinessEventReporter.kt
@@ -64,6 +64,7 @@ class PostHogBusinessEventReporter(
           ),
         "organizationId" to data.organizationId,
         "organizationName" to data.organizationName,
+        "glossaryId" to data.glossaryId,
       ) + (data.utmData ?: emptyMap()) + (data.data ?: emptyMap()) + setEntry
 
     postHog?.capture(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Glossary export events are now tracked and reported in analytics.

* **Refactor**
  * Improved event enrichment logic for more consistent data handling across business event publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->