### PR TITLE
fix: use CREATE INDEX CONCURRENTLY for large table migrations

### DIFF
--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4653,14 +4653,28 @@
             <column name="storage_json" type="JSONB"/>
         </addColumn>
     </changeSet>
-    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-164">
-        <createIndex indexName="IDXcg7y08d599p7jxdebbxwavak0" tableName="activity_revision">
-            <column name="timestamp"/>
-        </createIndex>
+    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-164"
+               runInTransaction="false" failOnError="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="IDXcg7y08d599p7jxdebbxwavak0"/>
+            </not>
+        </preConditions>
+        <sql dbms="postgresql">
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDXcg7y08d599p7jxdebbxwavak0"
+            ON activity_revision (timestamp);
+        </sql>
     </changeSet>
-    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-144">
-        <createIndex indexName="IDX71c7yr8a185u5jsdyndom5fa7" tableName="tolgee_batch_job">
-            <column name="created_at"/>
-        </createIndex>
+    <changeSet author="gabriel.shanahan (generated)" id="1769694787155-144"
+               runInTransaction="false" failOnError="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="IDX71c7yr8a185u5jsdyndom5fa7"/>
+            </not>
+        </preConditions>
+        <sql dbms="postgresql">
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX71c7yr8a185u5jsdyndom5fa7"
+            ON tolgee_batch_job (created_at);
+        </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

- The v3.151.0 deploy to testing caused a crash loop because `CREATE INDEX` on `activity_revision` (4.4M rows, 755MB in testing / 6.2M rows, 1.4GB in production) took longer than the liveness probe timeout, killing the pod mid-migration and leaving a stale Liquibase changelog lock
- Switches both index changesets to `CREATE INDEX CONCURRENTLY` which builds the index without blocking reads/writes
- Adds `runInTransaction="false"` (required for `CONCURRENTLY`), `failOnError="false"` (safety net since no transaction rollback), and `preConditions`/`IF NOT EXISTS` guards for idempotent re-runs

## Test plan

- [x] Verify neither index exists in testing or production (confirmed via Grafana Explore + kubectl)
- [x] Verify the changesets were never recorded in `databasechangelog` (pod was killed before completion, transaction rolled back)
- [ ] Merge and monitor deployment through the pipeline to testing
- [ ] Verify indexes are created successfully after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database index creation now operates more efficiently with significantly reduced lock contention, improving application performance during updates and deployments while preventing unnecessary duplicate index creation.

* **Chores**
  * Enhanced database maintenance procedures to ensure greater robustness and efficiency, improving system reliability and stability during schema updates and production deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->