### PR TITLE
feat: add custom histogram buckets to Tempo span metrics

### DIFF
--- a/docker/local-observability-stack/tempo-config.yaml
+++ b/docker/local-observability-stack/tempo-config.yaml
@@ -46,6 +46,7 @@ compactor:
 metrics_generator:
   processor:
     span_metrics:
+      histogram_buckets: [0.002, 0.004, 0.008, 0.016, 0.032, 0.064, 0.128, 0.256, 0.512, 1, 2, 4, 6, 8, 10, 12, 14, 16, 20, 25, 30, 45, 60, 90, 120]
       dimensions:
         # HTTP attributes (stable semantic conventions)
         - http.request.method


### PR DESCRIPTION
## Summary

- Add custom histogram buckets to the local dev Tempo config, matching the production change in the [deployment repo PR](https://github.com/tolgee/deployment/pulls)
- Replaces Tempo's default power-of-2 histogram buckets (14 buckets, 2ms–16.384s) with a data-driven scheme (25 buckets, 2ms–120s)

## Context

The Overview dashboard's "Latency Percentiles" and "DB Query Latency" panels use `histogram_quantile(1, ...)` for their "Max" series, which always returns 16.384s (the highest default bucket boundary) regardless of actual max latency.

The new bucket scheme provides fine-grained resolution for both the fast cluster (93% of traffic, <512ms) and the slow cluster (import, auto-translate, batch jobs at 2–30s), and extends coverage to 120s for outliers.

See the deployment repo PR for full analysis and rationale.

## Test plan

- [ ] Local observability stack starts with `docker compose up`
- [ ] Tempo generates metrics with new bucket boundaries visible in local Prometheus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated histogram bucket boundaries for span metrics in the local observability stack configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->