### PR TITLE
Update AGENTS.md for wrapper repo changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,12 @@ This file provides Tolgee-specific guidance for AI coding agents working on the 
 This project uses a multi-repository setup managed by a wrapper repository:
 
 ```
-tolgee-platform/                    # platform-dev-start (wrapper repo)
+tolgee-company/                     # platform-dev-start (wrapper repo)
 ├── .git/                           # git@github.com:tolgee/platform-dev-start.git
 ├── start.sh                        # Development startup script
-├── public/                         # tolgee-platform (main repo)
+├── CLAUDE.md                       # Shared Claude Code config
+├── .claude/                        # Shared Claude Code config dir
+├── tolgee-platform/                # tolgee-platform (main repo)
 │   ├── .git/                       # git@github.com:tolgee/tolgee-platform.git
 │   ├── backend/                    # Kotlin/Spring Boot backend
 │   ├── webapp/                     # React frontend
@@ -20,9 +22,9 @@ tolgee-platform/                    # platform-dev-start (wrapper repo)
 ```
 
 **Important**: When working with git commands, ensure you're in the correct repository:
-- For platform code changes: `cd public/` then run git commands
+- For platform code changes: `cd tolgee-platform/` then run git commands
 - For billing changes: `cd billing/` then run git commands
-- The wrapper repo (`platform-dev-start`) ignores `public/` and `billing/` in its `.gitignore`
+- The wrapper repo (`platform-dev-start`) ignores everything except its own tracked files in `.gitignore`
 
 ## Backend Development
 


### PR DESCRIPTION
## Summary
- The `platform-dev-start` wrapper repo now clones `tolgee-platform` into `tolgee-platform/` instead of `public/`, and ships shared Claude Code configuration (`CLAUDE.md`, `.claude/`).
- This PR updates `AGENTS.md` to match, so AI agents have accurate directory references when navigating the multi-repo setup.

## Changes
- `public/` → `tolgee-platform/` in the directory tree and git instructions
- Added `CLAUDE.md` and `.claude/` to the directory tree
- Updated the `.gitignore` description (deny-all pattern instead of listing ignored dirs)

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm directory references match the current wrapper repo layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated repository structure and developer workflow guidance.
  * Added new documentation for CLAUDE and a companion directory for related assets.
  * Noted addition of an end-to-end test directory under the platform workspace.
  * Documented the inclusion of a billing repository in the wrapper tree and revised gitignore guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->