### PR TITLE
fix: add validCheckSum for modified index changesets

### DIFF
--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -4655,6 +4655,7 @@
     </changeSet>
     <changeSet author="gabriel.shanahan (generated)" id="1769694787155-164"
                runInTransaction="false" failOnError="false">
+        <validCheckSum>9:cd29e48b8d2b7bc2fe7cc462945e2a72</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="IDXcg7y08d599p7jxdebbxwavak0"/>
@@ -4667,6 +4668,7 @@
     </changeSet>
     <changeSet author="gabriel.shanahan (generated)" id="1769694787155-144"
                runInTransaction="false" failOnError="false">
+        <validCheckSum>9:4c6a8f0ac5e40cb7577ffe67c385137f</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>
                 <indexExists indexName="IDX71c7yr8a185u5jsdyndom5fa7"/>


### PR DESCRIPTION
## Summary
- Adds `<validCheckSum>` entries for the original checksums of changesets `1769694787155-164` and `1769694787155-144`
- These changesets were modified in v3.151.1 (PR #3436) to use `CREATE INDEX CONCURRENTLY`, which changed their checksums
- Users who successfully deployed v3.151.0 (where the original `<createIndex>` ran fine) get a checksum mismatch error on upgrade to v3.151.1+, preventing startup

Fixes #3439

## Test plan
- [ ] Self-hosted instance that previously ran v3.151.0 successfully can upgrade to this version without checksum errors
- [ ] Fresh install still works (preConditions + CONCURRENTLY path)
- [ ] Instance that never completed the original changesets (like our testing env) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database schema validation to ensure integrity and consistency across deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->