### PR TITLE
fix: properly format plural C-like placeholders

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/BaseToCLikePlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/BaseToCLikePlaceholderConvertor.kt
@@ -73,6 +73,12 @@ class BaseToCLikePlaceholderConvertor(
     return ""
   }
 
+  fun convertReplaceNumber(argNum: Int?): String {
+    argIndex++
+    val argNumString = getArgNumString(argNum)
+    return "%${argNumString}$numberSpecifier"
+  }
+
   private val MessagePatternUtil.ArgNode.argNumOrNull get() = this.name?.toLongOrNull()
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToApplePlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToApplePlaceholderConvertor.kt
@@ -26,6 +26,6 @@ class IcuToApplePlaceholderConvertor : FromIcuPlaceholderConvertor {
     node: MessagePatternUtil.MessageContentsNode,
     argName: String?,
   ): String {
-    return "%lld"
+    return baseToCLikePlaceholderConvertor.convertReplaceNumber(argName?.toIntOrNull())
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToCPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToCPlaceholderConvertor.kt
@@ -26,6 +26,6 @@ class IcuToCPlaceholderConvertor : FromIcuPlaceholderConvertor {
     node: MessagePatternUtil.MessageContentsNode,
     argName: String?,
   ): String {
-    return "%d"
+    return baseToCLikePlaceholderConvertor.convertReplaceNumber(argName?.toIntOrNull())
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToJavaPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToJavaPlaceholderConvertor.kt
@@ -25,6 +25,6 @@ class IcuToJavaPlaceholderConvertor : FromIcuPlaceholderConvertor {
     node: MessagePatternUtil.MessageContentsNode,
     argName: String?,
   ): String {
-    return "%d"
+    return baseToCLikePlaceholderConvertor.convertReplaceNumber(argName?.toIntOrNull())
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPhpPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPhpPlaceholderConvertor.kt
@@ -26,6 +26,6 @@ class IcuToPhpPlaceholderConvertor : FromIcuPlaceholderConvertor {
     node: MessagePatternUtil.MessageContentsNode,
     argName: String?,
   ): String {
-    return "%d"
+    return baseToCLikePlaceholderConvertor.convertReplaceNumber(argName?.toIntOrNull())
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/out/IcuToPoMessageConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/out/IcuToPoMessageConvertor.kt
@@ -11,7 +11,7 @@ import io.tolgee.formats.pluralData.PluralData
 
 class IcuToPoMessageConvertor(
   val message: String,
-  val placeholderConvertor: FromIcuPlaceholderConvertor,
+  val placeholderConvertorFactory: (() -> FromIcuPlaceholderConvertor),
   val languageTag: String = "en",
   private val forceIsPlural: Boolean,
   private val projectIcuPlaceholdersSupport: Boolean = true,
@@ -44,9 +44,8 @@ class IcuToPoMessageConvertor(
         message,
         forceIsPlural,
         projectIcuPlaceholdersSupport,
-      ) {
-        placeholderConvertor
-      }.create().convert()
+        placeholderConvertorFactory,
+      ).create().convert()
     val poPluralResult = getPluralResult(result.formsResult ?: mutableMapOf())
     return ToPoConversionResult(null, poPluralResult)
   }
@@ -57,9 +56,8 @@ class IcuToPoMessageConvertor(
         message,
         forceIsPlural = false,
         projectIcuPlaceholdersSupport,
-      ) {
-        placeholderConvertor
-      }.create().convert()
+        placeholderConvertorFactory,
+      ).create().convert()
     return ToPoConversionResult(result.singleResult, null)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
@@ -43,7 +43,7 @@ class PoFileExporter(
     return IcuToPoMessageConvertor(
       message = translation.text ?: "",
       languageTag = translation.languageTag,
-      placeholderConvertor = messageFormat.paramConvertorFactory(),
+      placeholderConvertorFactory = messageFormat.paramConvertorFactory,
       forceIsPlural = translation.key.isPlural,
       projectIcuPlaceholdersSupport = projectIcuPlaceholdersSupport,
     ).convert()

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formatConversions/CPoConversionTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formatConversions/CPoConversionTest.kt
@@ -33,7 +33,7 @@ class CPoConversionTest {
       IcuToPoMessageConvertor(
         icuString!!,
         forceIsPlural = false,
-        placeholderConvertor = IcuToCPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToCPlaceholderConvertor() },
       ).convert().singleResult
     cString.assert
       .describedAs("Input:\n${string}\nICU:\n$icuString\nC String:\n$cString")

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formatConversions/PhpPoConversionTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formatConversions/PhpPoConversionTest.kt
@@ -31,7 +31,7 @@ class PhpPoConversionTest {
       IcuToPoMessageConvertor(
         icuString!!,
         forceIsPlural = false,
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
       ).convert().singleResult
     phpString.assert
       .describedAs("Input:\n${string}\nICU:\n$icuString\nPhpString:\n$phpString")

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
@@ -64,6 +64,10 @@ class AndroidXmlFileExporterTest {
     |    <item quantity="one">%1${'$'}s dog</item>
     |    <item quantity="other">%1${'$'}s dogs</item>
     |  </plurals>
+    |  <plurals name="numbered_plural">
+    |    <item quantity="one">%2${'$'}d store selected</item>
+    |    <item quantity="other">%2${'$'}d stores selected</item>
+    |  </plurals>
     |</resources>
     |
       """.trimMargin(),
@@ -266,6 +270,13 @@ class AndroidXmlFileExporterTest {
           languageTag = "en",
           keyName = "plural with placeholders",
           text = "{count, plural, one {{0} dog} other {{0} dogs}}",
+        ) {
+          key.isPlural = true
+        }
+        add(
+          languageTag = "en",
+          keyName = "numbered_plural",
+          text = "{1, plural, one {# store selected} other {# stores selected}}",
         ) {
           key.isPlural = true
         }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleSdkFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleSdkFileExporterTest.kt
@@ -71,7 +71,7 @@ class AppleSdkFileExporterTest {
     |  "key3": {
     |    "variations": {
     |      "plural": {
-    |        "one": "%lld den %2${'$'}lld",
+    |        "one": "%lld den %lld",
     |        "few": "%lld dny",
     |        "other": "%lld dní"
     |      }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
@@ -64,6 +64,10 @@ class ComposeXmlFileExporterTest {
     |    <item quantity="one">%1${'$'}s dog</item>
     |    <item quantity="other">%1${'$'}s dogs</item>
     |  </plurals>
+    |  <plurals name="numbered_plural">
+    |    <item quantity="one">%2${'$'}d store selected</item>
+    |    <item quantity="other">%2${'$'}d stores selected</item>
+    |  </plurals>
     |</resources>
     |
       """.trimMargin(),
@@ -266,6 +270,13 @@ class ComposeXmlFileExporterTest {
           languageTag = "en",
           keyName = "plural with placeholders",
           text = "{count, plural, one {{0} dog} other {{0} dogs}}",
+        ) {
+          key.isPlural = true
+        }
+        add(
+          languageTag = "en",
+          keyName = "numbered_plural",
+          text = "{1, plural, one {# store selected} other {# stores selected}}",
         ) {
           key.isPlural = true
         }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/IcuToPoMessageConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/IcuToPoMessageConvertorTest.kt
@@ -10,7 +10,7 @@ class IcuToPoMessageConvertorTest {
   fun `converts simple message`() {
     IcuToPoMessageConvertor(
       "Hello {hello} {hello, number} {hello, number, .00}",
-      IcuToPhpPlaceholderConvertor(),
+      { IcuToPhpPlaceholderConvertor() },
       forceIsPlural = false,
     ).convert().singleResult.assert.isEqualTo("Hello %s %d %.2f")
   }
@@ -19,7 +19,7 @@ class IcuToPoMessageConvertorTest {
   fun `converts message with complex escape sequences`() {
     IcuToPoMessageConvertor(
       "Normal hashtag # and escaped hashtag '#' and double escaped hashtag '''#'''",
-      IcuToPhpPlaceholderConvertor(),
+      { IcuToPhpPlaceholderConvertor() },
       forceIsPlural = false,
     ).convert().singleResult.assert.isEqualTo(
       "Normal hashtag # and escaped hashtag '#' and double escaped hashtag ''#''",
@@ -30,7 +30,7 @@ class IcuToPoMessageConvertorTest {
   fun `converts message with complex escape sequences and icu disabled`() {
     IcuToPoMessageConvertor(
       "Normal hashtag # and escaped hashtag '#' and double escaped hashtag '''#'''",
-      IcuToPhpPlaceholderConvertor(),
+      { IcuToPhpPlaceholderConvertor() },
       forceIsPlural = false,
       projectIcuPlaceholdersSupport = false,
     ).convert().singleResult.assert.isEqualTo(
@@ -43,7 +43,7 @@ class IcuToPoMessageConvertorTest {
     val forms =
       IcuToPoMessageConvertor(
         "{0, plural, one {# dog} other {# dogs}}",
-        IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
       ).convert()
         .formsResult
@@ -58,7 +58,7 @@ class IcuToPoMessageConvertorTest {
       IcuToPoMessageConvertor(
         message = "{0, plural, one {# pes} few {# psi} other {# psů}}",
         languageTag = "cs",
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
       ).convert().formsResult
 
@@ -78,7 +78,7 @@ class IcuToPoMessageConvertorTest {
             " other {# znaků '''''#''''' a '#' pro psi}" +
             "}",
         languageTag = "cs",
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
       ).convert().formsResult
 
@@ -98,7 +98,7 @@ class IcuToPoMessageConvertorTest {
             " other {'#' znaků '''''#''''' a '#' pro psi}" +
             "}",
         languageTag = "cs",
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
         projectIcuPlaceholdersSupport = false,
       ).convert().formsResult
@@ -114,7 +114,7 @@ class IcuToPoMessageConvertorTest {
       IcuToPoMessageConvertor(
         message = "{0, plural, one {# pes} other {# psů}}",
         languageTag = "cs",
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
       ).convert().formsResult
 
@@ -129,7 +129,7 @@ class IcuToPoMessageConvertorTest {
       IcuToPoMessageConvertor(
         message = "{0, plural, one {# pes} many {# pesos} other {# psů}}",
         languageTag = "cs",
-        placeholderConvertor = IcuToPhpPlaceholderConvertor(),
+        placeholderConvertorFactory = { IcuToPhpPlaceholderConvertor() },
         forceIsPlural = true,
       ).convert().formsResult
 


### PR DESCRIPTION
Fixes #3409

### Bugs:

1. The `convertReplaceNumber()` method in `IcuToJavaPlaceholderConvertor.kt` always returns `%d` without using the `argName` parameter to generate a numbered format specifier, even in cases when the `argName` is a number. 
2. The `BaseToCLikePlaceholderConvertor` maintains `argIndex` and `wasNumberedArg` state. The `convertReplaceNumber` bypasses this, so subsequent placeholders doesn't know a numbered arg was used.
3. The `IcuToPoMessageConvertor.kt` doesn't create new instance of placeholder convertor for each plural form - a state is shared across plural forms.

### Impact:

Affects Compose Multiplatform, Android XML, Apple stringsdict, PHP, and C exports when using `#` (replace number) in ICU plurals.

### Fix:

- Added `convertReplaceNumber` method to `BaseToCLikePlaceholderConvertor.kt`
  - New method that properly tracks state (argIndex, wasNumberedArg)
- Updated placeholder convertors to delegate to the base convertor
  - `IcuToJavaPlaceholderConvertor.kt`
  - `IcuToApplePlaceholderConvertor.kt`
  - `IcuToPhpPlaceholderConvertor.kt`
  - `IcuToCPlaceholderConvertor.kt`
- Fixed `IcuToPoMessageConvertor.kt` to use the factory pattern



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Improved consistency in message placeholder formatting across multiple language export formats

## Tests
* Added test coverage for numbered plural message formatting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->