### PR TITLE
feat: Add version-aware cache clearing mechanism

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/CacheCleaner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/CacheCleaner.kt
@@ -4,8 +4,16 @@ import io.tolgee.configuration.tolgee.TolgeeProperties
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.cache.CacheManager
 import org.springframework.context.event.EventListener
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
+/**
+ * Clears all caches on startup when configured via [TolgeeProperties.cache.cleanOnStartup].
+ *
+ * This runs with @Order(100) to ensure [CacheSchemaCleaner] runs first (@Order(50)).
+ * The schema cleaner handles revision-based cache clearing, while this component
+ * provides a way to force-clear all caches if needed.
+ */
 @Component
 class CacheCleaner(
   private val allCachesProvider: AllCachesProvider,
@@ -13,6 +21,7 @@ class CacheCleaner(
   private val tolgeeProperties: TolgeeProperties,
 ) {
   @EventListener
+  @Order(100)
   fun onAppStartup(event: ApplicationReadyEvent) {
     if (tolgeeProperties.cache.cleanOnStartup) {
       cleanCaches()

--- a/backend/data/src/main/kotlin/io/tolgee/component/cache/CacheSchemaCleaner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/cache/CacheSchemaCleaner.kt
@@ -1,0 +1,124 @@
+package io.tolgee.component.cache
+
+import io.tolgee.util.Logging
+import io.tolgee.util.logger
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.cache.CacheManager
+import org.springframework.context.event.EventListener
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+
+/**
+ * Clears caches that have had schema changes since last startup.
+ *
+ * ## How It Works
+ * On startup, this component:
+ * 1. Gets current schema revisions from [CacheSchemaRegistry]
+ * 2. Gets stored revisions from [SchemaRevisionStore]
+ * 3. Compares them to find caches where current > stored
+ * 4. Clears only those affected caches
+ * 5. Updates stored revisions to current values
+ *
+ * ## Example
+ * ```
+ * Registry: { rateLimits: 2, userAccounts: 1 }
+ * Stored:   { rateLimits: 1 }
+ *
+ * Result:
+ *   - rateLimits: 2 > 1 → CLEAR
+ *   - userAccounts: 1 > 0 (not stored) → CLEAR
+ *
+ * After: stored = { rateLimits: 2, userAccounts: 1 }
+ * Next restart: no clearing needed (revisions match)
+ * ```
+ *
+ * ## Edge Cases
+ * - **First run / no stored revisions:** Clears all tracked caches (safe default)
+ * - **New cache added to registry:** Cleared on first run (stored revision = 0)
+ * - **Cache removed from registry:** Ignored (no harm, old revision stays in storage)
+ *
+ * ## Concurrency Note
+ * In distributed deployments, multiple instances may race during startup and all
+ * clear the same caches. This is harmless - clearing a cache twice has no ill effects,
+ * just a minor performance impact while caches warm up.
+ *
+ * @see CacheSchemaRegistry
+ * @see SchemaRevisionStore
+ */
+@Component
+class CacheSchemaCleaner(
+  private val schemaRegistry: CacheSchemaRegistry,
+  private val revisionStore: SchemaRevisionStore,
+  private val cacheManager: CacheManager,
+) : Logging {
+  /**
+   * Runs on application startup, before the general [CacheCleaner].
+   *
+   * Uses @Order(50) to ensure it runs before CacheCleaner's @Order(100).
+   */
+  @EventListener
+  @Order(50)
+  fun onApplicationReady(event: ApplicationReadyEvent) {
+    val currentRevisions = schemaRegistry.getSchemaRevisions()
+    val storedRevisions = revisionStore.getStoredRevisions()
+
+    val cachesToClear = schemaRegistry.getCachesToClear(storedRevisions)
+
+    var allCachesCleared = true
+
+    if (cachesToClear.isNotEmpty()) {
+      logger.info(
+        "Cache schema changes detected, clearing caches: {} (stored: {}, current: {})",
+        cachesToClear,
+        storedRevisions,
+        currentRevisions,
+      )
+      val failedCaches = clearCaches(cachesToClear)
+      if (failedCaches.isNotEmpty()) {
+        allCachesCleared = false
+        logger.warn(
+          "Some caches failed to clear: {}. Will retry on next startup.",
+          failedCaches,
+        )
+      }
+    } else if (storedRevisions.isEmpty() && currentRevisions.isEmpty()) {
+      logger.debug("No cache schemas tracked, nothing to clear")
+    } else {
+      logger.debug("Cache schema revisions unchanged, no clearing needed")
+    }
+
+    // Only update stored revisions if all caches cleared successfully
+    // This ensures failed clears will be retried on next startup
+    if (currentRevisions.isNotEmpty() && allCachesCleared) {
+      revisionStore.storeRevisions(currentRevisions)
+    }
+  }
+
+  /**
+   * Clears the specified caches.
+   *
+   * @return Set of cache names that failed to clear
+   */
+  private fun clearCaches(cacheNames: Collection<String>): Set<String> {
+    val failedCaches = mutableSetOf<String>()
+    cacheNames.forEach { cacheName ->
+      try {
+        val cache = cacheManager.getCache(cacheName)
+        if (cache == null) {
+          failedCaches.add(cacheName)
+          logger.warn(
+            "Cache {} not found in CacheManager (check CacheSchemaRegistry and Caches.caches are in sync)",
+            cacheName,
+          )
+          return@forEach
+        }
+        cache.clear()
+        logger.debug("Cleared cache: {}", cacheName)
+      } catch (e: Exception) {
+        failedCaches.add(cacheName)
+        logger.warn("Failed to clear cache {}", cacheName, e)
+      }
+    }
+    return failedCaches
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/cache/CacheSchemaRegistry.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/cache/CacheSchemaRegistry.kt
@@ -1,0 +1,84 @@
+package io.tolgee.component.cache
+
+import io.tolgee.constants.Caches
+import org.springframework.stereotype.Component
+
+/**
+ * Registry of cache schema revisions for automatic cache clearing on upgrade.
+ *
+ * ## Purpose
+ * When a cached object's class structure changes (fields added/removed/renamed),
+ * old serialized entries in Redis become incompatible with the new code.
+ * This causes deserialization errors like KryoBufferUnderflowException.
+ *
+ * This registry tracks schema revisions for each cache, allowing the application
+ * to clear only affected caches when their schema has changed.
+ *
+ * ## How It Works
+ * Each cache has a schema revision number (simple integer). On startup,
+ * [CacheSchemaCleaner] compares each cache's current revision against the
+ * last-seen revision stored in Redis/local file. If current > stored, clear that cache.
+ *
+ * ## Adding a New Schema Change
+ * When you modify a class that gets cached (e.g., adding a field to a data class
+ * stored in Redis), increment that cache's revision number:
+ *
+ * ```kotlin
+ * Caches.RATE_LIMITS to 2,  // Was 1, bumped for new field
+ * ```
+ *
+ * Or add a new entry if the cache wasn't tracked before:
+ *
+ * ```kotlin
+ * Caches.USER_ACCOUNTS to 1,  // First tracked schema change
+ * ```
+ *
+ * ### Important Notes
+ * - Just increment the number - no need to know the release version
+ * - Only add/increment for caches with actual schema changes
+ * - A "breaking change" is anything causing deserialization to fail:
+ *   adding fields, removing fields, changing types, renaming fields
+ * - Clearing a cache is safe but may cause temporary performance impact
+ * - When in doubt, bump the revision - it's better than deserialization crashes
+ *
+ * @see CacheSchemaCleaner
+ * @see Caches
+ */
+@Component
+class CacheSchemaRegistry {
+  companion object {
+    /**
+     * Map of cache name to its current schema revision.
+     *
+     * Format: `Caches.CACHE_NAME to <revision_number>`
+     *
+     * When you make a breaking change to a cached class, increment its revision.
+     * If the cache isn't listed yet, add it with revision 1.
+     */
+    private val SCHEMA_REVISIONS =
+      mapOf(
+        // Revision 1: Added strikeCount and lastStrikeAt fields to Bucket class
+        Caches.RATE_LIMITS to 1,
+      )
+  }
+
+  /**
+   * Returns the current schema revisions for all tracked caches.
+   */
+  fun getSchemaRevisions(): Map<String, Int> = SCHEMA_REVISIONS
+
+  /**
+   * Returns caches that need clearing based on stored revisions.
+   *
+   * @param storedRevisions Map of cache name to last-seen revision (from storage)
+   * @return List of cache names where current revision > stored revision
+   */
+  fun getCachesToClear(storedRevisions: Map<String, Int>): List<String> {
+    return SCHEMA_REVISIONS
+      .filter { (cache, currentRevision) ->
+        val storedRevision = storedRevisions[cache] ?: 0
+        currentRevision > storedRevision
+      }.keys
+      .toList()
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/cache/LocalSchemaRevisionStore.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/cache/LocalSchemaRevisionStore.kt
@@ -1,0 +1,59 @@
+package io.tolgee.component.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.util.Logging
+import io.tolgee.util.logger
+import org.springframework.stereotype.Component
+import java.io.File
+
+/**
+ * Local file-based implementation of [SchemaRevisionStore].
+ *
+ * Stores schema revisions as JSON in a file within Tolgee's data directory.
+ * This is used as a fallback when Redis is not available.
+ *
+ * The file is stored at: `{tolgee.file-storage.fs-data-path}/.cache_schema_revisions`
+ */
+@Component
+class LocalSchemaRevisionStore(
+  private val tolgeeProperties: TolgeeProperties,
+  private val objectMapper: ObjectMapper,
+) : SchemaRevisionStore,
+  Logging {
+  companion object {
+    private const val REVISIONS_FILE_NAME = ".cache_schema_revisions"
+  }
+
+  private val revisionsFile: File
+    get() = File(tolgeeProperties.fileStorage.fsDataPath, REVISIONS_FILE_NAME)
+
+  override fun getStoredRevisions(): Map<String, Int> {
+    return try {
+      if (revisionsFile.exists()) {
+        val json = revisionsFile.readText().trim()
+        if (json.isNotEmpty()) {
+          objectMapper.readValue(json)
+        } else {
+          emptyMap()
+        }
+      } else {
+        emptyMap()
+      }
+    } catch (e: Exception) {
+      logger.warn("Failed to read schema revisions from file", e)
+      emptyMap()
+    }
+  }
+
+  override fun storeRevisions(revisions: Map<String, Int>) {
+    try {
+      revisionsFile.parentFile?.mkdirs()
+      val json = objectMapper.writeValueAsString(revisions)
+      revisionsFile.writeText(json)
+    } catch (e: Exception) {
+      logger.warn("Failed to write schema revisions to file", e)
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/cache/RedisSchemaRevisionStore.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/cache/RedisSchemaRevisionStore.kt
@@ -1,0 +1,55 @@
+package io.tolgee.component.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.tolgee.util.Logging
+import io.tolgee.util.logger
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.context.annotation.Primary
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * Redis-based implementation of [SchemaRevisionStore].
+ *
+ * Stores schema revisions as a JSON object in a Redis key, suitable for
+ * distributed deployments where multiple instances share the same Redis.
+ *
+ * This implementation is used when Redis is available; otherwise
+ * [LocalSchemaRevisionStore] is used as a fallback.
+ */
+@Component
+@Primary
+@ConditionalOnBean(StringRedisTemplate::class)
+class RedisSchemaRevisionStore(
+  private val redisTemplate: StringRedisTemplate,
+  private val objectMapper: ObjectMapper,
+) : SchemaRevisionStore,
+  Logging {
+  companion object {
+    private const val REVISIONS_KEY = "tolgee:cache:schema_revisions"
+  }
+
+  override fun getStoredRevisions(): Map<String, Int> {
+    return try {
+      val json = redisTemplate.opsForValue().get(REVISIONS_KEY)
+      if (json.isNullOrBlank()) {
+        emptyMap()
+      } else {
+        objectMapper.readValue(json)
+      }
+    } catch (e: Exception) {
+      logger.warn("Failed to read schema revisions from Redis", e)
+      emptyMap()
+    }
+  }
+
+  override fun storeRevisions(revisions: Map<String, Int>) {
+    try {
+      val json = objectMapper.writeValueAsString(revisions)
+      redisTemplate.opsForValue().set(REVISIONS_KEY, json)
+    } catch (e: Exception) {
+      logger.warn("Failed to store schema revisions to Redis", e)
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/cache/SchemaRevisionStore.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/cache/SchemaRevisionStore.kt
@@ -1,0 +1,30 @@
+package io.tolgee.component.cache
+
+/**
+ * Interface for storing and retrieving cache schema revisions.
+ *
+ * This is used by [CacheSchemaCleaner] to track which schema revisions
+ * have been seen, so caches are only cleared when their schema changes.
+ *
+ * Implementations can store revisions in different backends:
+ * - Redis for distributed deployments
+ * - Local file system for single-node deployments
+ *
+ * @see RedisSchemaRevisionStore
+ * @see LocalSchemaRevisionStore
+ */
+interface SchemaRevisionStore {
+  /**
+   * Gets the stored schema revisions for all caches.
+   *
+   * @return Map of cache name to last-seen revision, empty map if no revisions stored yet
+   */
+  fun getStoredRevisions(): Map<String, Int>
+
+  /**
+   * Stores the current schema revisions.
+   *
+   * @param revisions Map of cache name to revision number
+   */
+  fun storeRevisions(revisions: Map<String, Int>)
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cache/CacheSchemaRegistryTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cache/CacheSchemaRegistryTest.kt
@@ -1,0 +1,69 @@
+package io.tolgee.unit.cache
+
+import io.tolgee.component.cache.CacheSchemaRegistry
+import io.tolgee.constants.Caches
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CacheSchemaRegistryTest {
+  private val registry = CacheSchemaRegistry()
+
+  @Test
+  fun `getSchemaRevisions returns all tracked caches`() {
+    val revisions = registry.getSchemaRevisions()
+
+    assertThat(revisions).containsKey(Caches.RATE_LIMITS)
+    assertThat(revisions[Caches.RATE_LIMITS]).isEqualTo(1)
+  }
+
+  @Test
+  fun `getCachesToClear returns caches with newer revisions`() {
+    val storedRevisions = mapOf(Caches.RATE_LIMITS to 0)
+
+    val cachesToClear = registry.getCachesToClear(storedRevisions)
+
+    assertThat(cachesToClear).contains(Caches.RATE_LIMITS)
+  }
+
+  @Test
+  fun `getCachesToClear returns empty when revisions match`() {
+    val storedRevisions = mapOf(Caches.RATE_LIMITS to 1)
+
+    val cachesToClear = registry.getCachesToClear(storedRevisions)
+
+    assertThat(cachesToClear).isEmpty()
+  }
+
+  @Test
+  fun `getCachesToClear returns empty when stored revision is higher`() {
+    val storedRevisions = mapOf(Caches.RATE_LIMITS to 999)
+
+    val cachesToClear = registry.getCachesToClear(storedRevisions)
+
+    assertThat(cachesToClear).isEmpty()
+  }
+
+  @Test
+  fun `getCachesToClear treats missing stored revision as zero`() {
+    val storedRevisions = emptyMap<String, Int>()
+
+    val cachesToClear = registry.getCachesToClear(storedRevisions)
+
+    // All tracked caches should be cleared since stored = 0 for all
+    assertThat(cachesToClear).contains(Caches.RATE_LIMITS)
+  }
+
+  @Test
+  fun `getCachesToClear ignores unknown stored revisions`() {
+    val storedRevisions =
+      mapOf(
+        Caches.RATE_LIMITS to 1,
+        "unknown-cache" to 5,
+      )
+
+    val cachesToClear = registry.getCachesToClear(storedRevisions)
+
+    // Unknown cache should not cause any issues
+    assertThat(cachesToClear).isEmpty()
+  }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cache/LocalSchemaRevisionStoreTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cache/LocalSchemaRevisionStoreTest.kt
@@ -1,0 +1,78 @@
+package io.tolgee.unit.cache
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.tolgee.component.cache.LocalSchemaRevisionStore
+import io.tolgee.configuration.tolgee.FileStorageProperties
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class LocalSchemaRevisionStoreTest {
+  @TempDir
+  lateinit var tempDir: File
+
+  private lateinit var store: LocalSchemaRevisionStore
+  private val objectMapper = jacksonObjectMapper()
+
+  @BeforeEach
+  fun setUp() {
+    val properties = TolgeeProperties()
+    properties.fileStorage =
+      FileStorageProperties().apply {
+        fsDataPath = tempDir.absolutePath
+      }
+    store = LocalSchemaRevisionStore(properties, objectMapper)
+  }
+
+  @Test
+  fun `getStoredRevisions returns empty map when file does not exist`() {
+    val revisions = store.getStoredRevisions()
+
+    assertThat(revisions).isEmpty()
+  }
+
+  @Test
+  fun `storeRevisions creates file and getStoredRevisions reads it`() {
+    val revisions = mapOf("cache1" to 1, "cache2" to 2)
+
+    store.storeRevisions(revisions)
+    val retrieved = store.getStoredRevisions()
+
+    assertThat(retrieved).isEqualTo(revisions)
+  }
+
+  @Test
+  fun `storeRevisions overwrites existing file`() {
+    val initial = mapOf("cache1" to 1)
+    val updated = mapOf("cache1" to 2, "cache2" to 1)
+
+    store.storeRevisions(initial)
+    store.storeRevisions(updated)
+    val retrieved = store.getStoredRevisions()
+
+    assertThat(retrieved).isEqualTo(updated)
+  }
+
+  @Test
+  fun `getStoredRevisions returns empty map for empty file`() {
+    val file = File(tempDir, ".cache_schema_revisions")
+    file.writeText("")
+
+    val revisions = store.getStoredRevisions()
+
+    assertThat(revisions).isEmpty()
+  }
+
+  @Test
+  fun `getStoredRevisions returns empty map for invalid JSON`() {
+    val file = File(tempDir, ".cache_schema_revisions")
+    file.writeText("not valid json")
+
+    val revisions = store.getStoredRevisions()
+
+    assertThat(revisions).isEmpty()
+  }
+}


### PR DESCRIPTION
## Summary
- Replace brute-force rate limit cache clearing with a revision-based system
- Only clears caches when their schema revision has changed
- Uses simple monotonically increasing integers (no version guessing needed)
- Generic/reusable mechanism for future cache schema changes

## Changes
**New components:**
- `CacheSchemaRegistry`: Tracks schema revisions for each cache (simple integers: 1, 2, 3...)
- `SchemaRevisionStore`: Interface for storing last-seen revisions
- `RedisSchemaRevisionStore`: Redis-based implementation (stores JSON map)
- `LocalSchemaRevisionStore`: File-based fallback for non-Redis deployments
- `CacheSchemaCleaner`: Main orchestrator that runs on startup

**Other changes:**
- Add `@Order(100)` to `CacheCleaner` so it runs after schema cleaner
- Delete `RateLimitCacheCleanup` (replaced by new mechanism)

## How it works
On startup:
1. Get current revisions from `CacheSchemaRegistry`
2. Get stored revisions from `SchemaRevisionStore`
3. Clear caches where `current_revision > stored_revision`
4. Update stored revisions

Example:
```
Registry: { rateLimits: 2, userAccounts: 1 }
Stored:   { rateLimits: 1 }

Result:
  - rateLimits: 2 > 1 → CLEAR
  - userAccounts: 1 > 0 → CLEAR (new entry)
```

## Future usage
When a cache schema changes, just increment its revision:
```kotlin
Caches.RATE_LIMITS to 2,  // Was 1, bumped for new field
```

Or add a new entry:
```kotlin
Caches.USER_ACCOUNTS to 1,  // First tracked schema change
```

No need to know the release version - just increment the number.

## Test plan
- [ ] Deploy to testing
- [ ] Verify logs show cache clearing on first run
- [ ] Restart same version - verify no cache clearing
- [ ] Check Redis for `tolgee:cache:schema_revisions` key
- [ ] Run existing rate limit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent cache invalidation with versioned cache schema tracking.
  * Automatic clearing of outdated caches on startup; schema-based clearing now runs before general cache cleanup to ensure correct ordering.
  * Supports storing cache revision state in Redis or a local file fallback; failures are logged and handled safely.
* **Tests**
  * Unit tests added for schema registry and local revision store behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->