### PR TITLE
fix: stop escaping percent signs in Compose Multiplatform XML export

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/MobileStringEscaper.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/MobileStringEscaper.kt
@@ -14,6 +14,7 @@ class MobileStringEscaper(
   private val escapeQuotes: Boolean,
   // Android need 'u' and iOS 'U'
   private val utfSymbolCharacter: Char,
+  private val escapePercentWithBackslash: Boolean = true,
 ) {
   private enum class State {
     DEFAULT,
@@ -135,7 +136,8 @@ class MobileStringEscaper(
 
   private fun handlePercentEnd(char: Char?) {
     if (!keepPercentSignEscaped) {
-      val unescaped = percents.toString().replace("%%", "\\%")
+      val replacement = if (escapePercentWithBackslash) "\\%" else "%"
+      val unescaped = percents.toString().replace("%%", replacement)
       stringBuilder.append(unescaped)
     } else {
       stringBuilder.append(percents)

--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -223,6 +223,7 @@ class TextToXmlResourcesConvertor(
       escapeNewLines = isAndroid && escapeNewLines,
       utfSymbolCharacter = 'u',
       escapeQuotes = isAndroid,
+      escapePercentWithBackslash = isAndroid,
     ).escape()
   }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
@@ -24,7 +24,7 @@ class ComposeXmlFileExporterTest {
     |<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     |<resources>
     |  <string name="key1">Ahoj! I%d, %s, %e, %f</string>
-    |  <string name="percent_no_placeholders">I am just a percent \% sign!</string>
+    |  <string name="percent_no_placeholders">I am just a percent % sign!</string>
     |  <!-- This is a description -->
     |  <string name="percent_and_placeholders">I am not just a percent %s %% sign!</string>
     |  <string name="percent_and_placeholders_and_tags">I am not just a percent <![CDATA[<b>%s</b>]]> %% sign!</string>

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
@@ -44,7 +44,7 @@ class TextToComposeXmlConvertorTest {
         .toList()
     nodes[0].assertTextContent("What a ")
     nodes[1].nodeAssertCdataNodeText(
-      "<unsupported attr=\"https://example.com\">link \' \\% \" " +
+      "<unsupported attr=\"https://example.com\">link \' % \" " +
         "</unsupported>",
     )
     nodes[2].assertTextContent(".")
@@ -79,7 +79,7 @@ class TextToComposeXmlConvertorTest {
 
   @Test
   fun `percent signs are escaped`() {
-    "I am just a %% sign".assertSingleTextNode("I am just a \\% sign")
+    "I am just a %% sign".assertSingleTextNode("I am just a % sign")
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Fixes #3368 — Compose Multiplatform XML export was incorrectly escaping `%` as `\%`
- Compose Multiplatform does not use backslash-escaping for special characters (unlike Android XML)
- Added `escapePercentWithBackslash` parameter to `MobileStringEscaper`, gated on `isAndroid` in `TextToXmlResourcesConvertor` — following the same pattern used for 4 other escaping flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable percent sign escaping behavior for Android and Compose XML resource exports.

* **Bug Fixes**
  * Improved handling of percent signs in exported text content to better align with XML standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->