### PR TITLE
feat: store msgctxt from Gettext (.po) files

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/contsants.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/contsants.kt
@@ -1,3 +1,5 @@
 package io.tolgee.formats.po
 
 const val PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY = "_poFileMsgIdPlural"
+const val PO_FILE_MSG_CTXT_CUSTOM_KEY = "_poFileMsgCtxt"
+const val PO_MSGCTXT_SEPARATOR = "\u0004"

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/data/PoParsedTranslation.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/data/PoParsedTranslation.kt
@@ -1,6 +1,7 @@
 package io.tolgee.formats.po.`in`.data
 
 class PoParsedTranslation {
+  var msgctxt: StringBuilder = StringBuilder()
   var msgid: StringBuilder = StringBuilder()
   var msgidPlural: StringBuilder = StringBuilder()
   var msgstr: StringBuilder = StringBuilder()

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
@@ -30,4 +30,36 @@ class PoParserTest {
     assertThat(result.translations[10].msgstr.toString()).isEqualTo("This\nis\na\nmultiline\nstring")
     assertThat(result.translations[11].msgstr.toString()).isEqualTo("This\r\nis\r\na\r\nmultiline\r\nstring")
   }
+
+  @Test
+  fun `parses msgctxt correctly`() {
+    mockUtil = FileProcessorContextMockUtil()
+    mockUtil.mockIt("example.po", "src/test/resources/import/po/example_msgctxt.po")
+    val result = PoParser(mockUtil.fileProcessorContext)()
+    // header + 5 entries (menu/Open, menu/Close, Hello, dialog/Open, stats/%d file plural)
+    assertThat(result.translations).hasSize(6)
+
+    // msgctxt "menu", msgid "Open"
+    assertThat(result.translations[1].msgctxt.toString()).isEqualTo("menu")
+    assertThat(result.translations[1].msgid.toString()).isEqualTo("Open")
+    assertThat(result.translations[1].msgstr.toString()).isEqualTo("Öffnen")
+
+    // msgctxt "menu", msgid "Close"
+    assertThat(result.translations[2].msgctxt.toString()).isEqualTo("menu")
+    assertThat(result.translations[2].msgid.toString()).isEqualTo("Close")
+
+    // no msgctxt, msgid "Hello"
+    assertThat(result.translations[3].msgctxt.toString()).isEqualTo("")
+    assertThat(result.translations[3].msgid.toString()).isEqualTo("Hello")
+
+    // msgctxt "dialog", msgid "Open"
+    assertThat(result.translations[4].msgctxt.toString()).isEqualTo("dialog")
+    assertThat(result.translations[4].msgid.toString()).isEqualTo("Open")
+
+    // msgctxt "stats", plural entry
+    assertThat(result.translations[5].msgctxt.toString()).isEqualTo("stats")
+    assertThat(result.translations[5].msgid.toString()).isEqualTo("%d file")
+    assertThat(result.translations[5].msgidPlural.toString()).isEqualTo("%d files")
+    assertThat(result.translations[5].msgstrPlurals).hasSize(2)
+  }
 }

--- a/backend/data/src/test/resources/import/po/example_msgctxt.po
+++ b/backend/data/src/test/resources/import/po/example_msgctxt.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+msgctxt "menu"
+msgid "Open"
+msgstr "Öffnen"
+
+msgctxt "menu"
+msgid "Close"
+msgstr "Schließen"
+
+#. This is a greeting
+msgid "Hello"
+msgstr "Hallo"
+
+msgctxt "dialog"
+msgid "Open"
+msgstr "Datei öffnen"
+
+#, c-format
+msgctxt "stats"
+msgid "%d file"
+msgid_plural "%d files"
+msgstr[0] "%d Datei"
+msgstr[1] "%d Dateien"

--- a/webapp/src/views/projects/translations/CellKey.tsx
+++ b/webapp/src/views/projects/translations/CellKey.tsx
@@ -133,6 +133,31 @@ const StyledBolt = styled(Zap)`
   height: 14px;
 `;
 
+const MSGCTXT_SEPARATOR = '\u0004';
+
+const StyledMsgctxt = styled('span')`
+  color: ${({ theme }) => theme.palette.text.secondary};
+  &::after {
+    content: ' | ';
+    color: ${({ theme }) => theme.palette.divider};
+  }
+`;
+
+const KeyNameWithContext: React.FC<{ keyName: string }> = ({ keyName }) => {
+  const separatorIndex = keyName.indexOf(MSGCTXT_SEPARATOR);
+  if (separatorIndex === -1) {
+    return <>{keyName}</>;
+  }
+  const context = keyName.substring(0, separatorIndex);
+  const msgid = keyName.substring(separatorIndex + 1);
+  return (
+    <>
+      <StyledMsgctxt>{context}</StyledMsgctxt>
+      {msgid}
+    </>
+  );
+};
+
 type Props = {
   data: KeyWithTranslationsModel;
   widthPercent?: string | number;
@@ -240,7 +265,7 @@ export const CellKey: React.FC<Props> = ({
               maxLines={3}
               wrap="break-all"
             >
-              {data.keyName}
+              <KeyNameWithContext keyName={data.keyName} />
             </LimitedHeightText>
           </StyledKey>
           {data.keyDescription && (


### PR DESCRIPTION
## Summary
- Parse and store `msgctxt` from PO files instead of ignoring it with a warning
- Combine `msgctxt` + `\u0004` (EOT) separator + `msgid` as the key name, following the GNU gettext standard
- Store raw `msgctxt` in key custom metadata (`_poFileMsgCtxt`)
- Export `msgctxt` line before `msgid` when the custom value is present
- Display msgctxt visually in the translations UI with a dimmed prefix and `|` separator

Closes #3053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added full support for PO file message contexts (msgctxt). Translations with context information can now be properly imported, stored, and exported while maintaining all context metadata
* Translation keys with message context are now visually distinguished in the interface, making it easier to identify and manage contextual translations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->