### PR TITLE
feat: make LLM provider temperature configurable

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/llmProvider/LlmProviderModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/llmProvider/LlmProviderModel.kt
@@ -17,4 +17,5 @@ open class LlmProviderModel(
   var deployment: String?,
   var format: String?,
   var reasoningEffort: String?,
+  var temperature: Double?,
 ) : RepresentationModel<LlmProviderModel>()

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProperties.kt
@@ -74,6 +74,8 @@ class LlmProperties : MachineTranslationServiceProperties {
     override var maxTokens: Long = MAX_TOKENS_DEFAULT,
     @DocProperty(description = "ChatGPT reasoning effort")
     override var reasoningEffort: String? = null,
+    @DocProperty(description = "LLM sampling temperature")
+    override var temperature: Double? = null,
     @DocProperty(description = "Set to `json_schema` if the API supports JSON Schema")
     override var format: String? = null,
     @DocProperty(
@@ -102,6 +104,7 @@ class LlmProperties : MachineTranslationServiceProperties {
         deployment = deployment,
         format = format,
         reasoningEffort = reasoningEffort,
+        temperature = temperature,
         tokenPriceInCreditsInput = tokenPriceInCreditsInput,
         tokenPriceInCreditsOutput = tokenPriceInCreditsOutput,
         attempts = attempts,

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProviderInterface.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/machineTranslation/LlmProviderInterface.kt
@@ -35,6 +35,9 @@ interface LlmProviderInterface {
   @DocProperty(description = "ChatGPT reasoning effort")
   var reasoningEffort: String?
 
+  @DocProperty(description = "LLM sampling temperature")
+  var temperature: Double?
+
   var maxTokens: Long
 
   // pricing

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/LlmProviderDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/LlmProviderDto.kt
@@ -16,6 +16,7 @@ data class LlmProviderDto(
   override var deployment: String?,
   override var format: String?,
   override var reasoningEffort: String?,
+  override var temperature: Double?,
   override var tokenPriceInCreditsInput: Double?,
   override var tokenPriceInCreditsOutput: Double?,
   override var attempts: List<Int>?,

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/llmProvider/LlmProviderRequest.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/llmProvider/LlmProviderRequest.kt
@@ -24,6 +24,7 @@ data class LlmProviderRequest(
   var format: String? = null,
   @field:Size(max = 255)
   var reasoningEffort: String? = null,
+  var temperature: Double? = null,
 ) {
   @JsonSetter("type")
   fun setType(type: String) {

--- a/backend/data/src/main/kotlin/io/tolgee/model/LlmProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LlmProvider.kt
@@ -42,6 +42,7 @@ class LlmProvider(
   var keepAlive: String? = null,
   var format: String? = null,
   var reasoningEffort: String? = null,
+  var temperature: Double? = null,
   @ManyToOne
   var organization: Organization,
 ) : AuditModel() {
@@ -57,6 +58,7 @@ class LlmProvider(
       deployment = deployment,
       format = format,
       reasoningEffort = reasoningEffort,
+      temperature = temperature,
       attempts = null,
       tokenPriceInCreditsInput = null,
       tokenPriceInCreditsOutput = null,

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5057,4 +5057,14 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet author="anty (generated)" id="1770379929953-1">
+        <addColumn tableName="llm_provider">
+            <column name="temperature" type="FLOAT(53)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="anty (generated)" id="1770379929953-2">
+        <createIndex indexName="IDX7ofy2tesqs3c5b8j1us8ajtjd" tableName="activity_modified_entity">
+            <column name="branch_id"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/LlmProviderModelAssembler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/LlmProviderModelAssembler.kt
@@ -24,6 +24,7 @@ class LlmProviderModelAssembler :
       deployment = entity.deployment,
       format = entity.format,
       reasoningEffort = entity.reasoningEffort,
+      temperature = entity.temperature,
     )
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/AnthropicApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/AnthropicApiService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.component.llm
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.tolgee.configuration.tolgee.machineTranslation.LlmProviderInterface
 import io.tolgee.dtos.LlmParams
 import io.tolgee.dtos.PromptResult
@@ -34,6 +35,7 @@ class AnthropicApiService :
         messages = messages,
         model = config.model,
         max_tokens = config.maxTokens,
+        temperature = config.temperature,
       )
 
     val request = HttpEntity(requestBody, headers)
@@ -119,7 +121,8 @@ class AnthropicApiService :
       val stream: Boolean = false,
       val messages: List<RequestMessage>,
       val model: String?,
-      val temperature: Long? = 0,
+      @JsonInclude(JsonInclude.Include.NON_NULL)
+      val temperature: Double? = null,
     )
 
     class RequestMessage(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/GoogleAiApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/GoogleAiApiService.kt
@@ -35,6 +35,7 @@ class GoogleAiApiService :
         generationConfig =
           RequestGenerationConfig(
             responseMimeType = if (params.shouldOutputJson) "application/json" else null,
+            temperature = config.temperature,
           ),
       )
 
@@ -126,6 +127,8 @@ class GoogleAiApiService :
 
     class RequestGenerationConfig(
       val responseMimeType: String? = null,
+      @JsonInclude(JsonInclude.Include.NON_NULL)
+      val temperature: Double? = null,
     )
 
     class RequestPart(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OllamaApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OllamaApiService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.component.llm
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.sentry.Sentry
 import io.tolgee.configuration.tolgee.machineTranslation.LlmProviderInterface
 import io.tolgee.dtos.LlmParams
@@ -36,6 +37,7 @@ class OllamaApiService :
         model = config.model!!,
         messages = messages,
         format = if (params.shouldOutputJson && config.format == "json") "json" else null,
+        temperature = config.temperature,
       )
 
     val request = HttpEntity(requestBody, headers)
@@ -89,6 +91,8 @@ class OllamaApiService :
       val messages: List<RequestMessage>,
       val stream: Boolean = false,
       val format: String? = "json",
+      @JsonInclude(JsonInclude.Include.NON_NULL)
+      val temperature: Double? = null,
     )
 
     class RequestMessage(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
@@ -57,6 +57,7 @@ class OpenaiApiService :
           },
         model = config.model,
         reasoning_effort = config.reasoningEffort,
+        temperature = config.temperature,
       )
 
     val request = HttpEntity(requestBody, headers)
@@ -156,7 +157,7 @@ class OpenaiApiService :
       @JsonInclude(JsonInclude.Include.NON_NULL)
       val reasoning_effort: String? = null,
       @JsonInclude(JsonInclude.Include.NON_NULL)
-      val temperature: Long? = null,
+      val temperature: Double? = null,
     )
 
     class RequestMessage(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/LlmProviderService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/LlmProviderService.kt
@@ -91,6 +91,7 @@ class LlmProviderService(
         keepAlive = dto.keepAlive,
         format = dto.format,
         reasoningEffort = dto.reasoningEffort,
+        temperature = dto.temperature,
         organization = organizationService.get(organizationId),
       )
     llmProviderRepository.save(provider)
@@ -114,6 +115,7 @@ class LlmProviderService(
     provider.keepAlive = dto.keepAlive
     provider.format = dto.format
     provider.reasoningEffort = dto.reasoningEffort
+    provider.temperature = dto.temperature
     provider.organization = organizationService.get(organizationId)
     llmProviderRepository.save(provider)
     return provider.toDto()

--- a/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/LlmProviderForm.tsx
+++ b/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/LlmProviderForm.tsx
@@ -87,7 +87,9 @@ export const LlmProviderForm = ({ type, onTypeChange }: Props) => {
               label={labelWithHint}
               data-cy="llm-provider-form-text-field"
               data-cy-name={name}
-              {...(options.numeric ? { type: 'number', inputProps: { step: 0.1, min: 0, max: 2 } } : {})}
+              {...(options.numeric
+                ? { type: 'number', inputProps: { step: 0.1, min: 0, max: 2 } }
+                : {})}
             />
           );
         }

--- a/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/LlmProviderForm.tsx
+++ b/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/LlmProviderForm.tsx
@@ -87,6 +87,7 @@ export const LlmProviderForm = ({ type, onTypeChange }: Props) => {
               label={labelWithHint}
               data-cy="llm-provider-form-text-field"
               data-cy-name={name}
+              {...(options.numeric ? { type: 'number', inputProps: { step: 0.1, min: 0, max: 2 } } : {})}
             />
           );
         }

--- a/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/llmProvidersConfig.ts
+++ b/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/llmProvidersConfig.ts
@@ -12,6 +12,7 @@ export type ProviderOptions = {
   enum?: (string | undefined)[];
   optional?: boolean;
   defaultValue?: string;
+  numeric?: boolean;
 };
 
 type ProvidersConfig = Record<
@@ -31,6 +32,11 @@ export const llmProvidersDefaults = (
   model: { label: t('llm_provider_form_model') },
   format: { label: t('llm_provider_form_format') },
   deployment: { label: t('llm_provider_form_deployment') },
+  temperature: {
+    label: t('llm_provider_form_temperature'),
+    hint: t('llm_provider_form_temperature_hint'),
+    numeric: true,
+  },
 });
 
 export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
@@ -40,6 +46,9 @@ export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
     optional: true,
     enum: [undefined, 'minimal', 'low', 'medium', 'high'],
     defaultValue: undefined,
+  };
+  const temperature: Partial<ProviderOptions> = {
+    optional: true,
   };
   return {
     OPENAI: {
@@ -60,6 +69,7 @@ export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
         defaultValue: 'json_schema',
       },
       reasoningEffort,
+      temperature,
     },
     OPENAI_AZURE: {
       name: {},
@@ -75,6 +85,7 @@ export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
         defaultValue: 'json_schema',
       },
       reasoningEffort,
+      temperature,
     },
     ANTHROPIC: {
       name: {},
@@ -85,6 +96,7 @@ export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
       model: {
         hint: t('llm_provider_form_anthropic_model_hint'),
       },
+      temperature,
     },
     GOOGLE_AI: {
       name: {},
@@ -95,6 +107,7 @@ export const llmProvidersConfig = (t: TranslateFunction): ProvidersConfig => {
       model: {
         hint: t('llm_provider_form_google_ai_model_hint'),
       },
+      temperature,
     },
   };
 };
@@ -106,7 +119,12 @@ export const getValidationSchema = (
   const fields: Record<string, Yup.AnySchema> = {};
   Object.entries(llmProvidersConfig(t)[type]).forEach(([name, o]) => {
     const options: ProviderOptions = { ...llmProvidersDefaults(t)[name], ...o };
-    let field: Yup.AnySchema = Yup.string();
+    let field: Yup.AnySchema;
+    if (options.numeric) {
+      field = Yup.number().nullable().transform((value) => (value === '' || isNaN(value) ? undefined : value));
+    } else {
+      field = Yup.string();
+    }
     if (!options.optional) {
       field = field.required();
     }
@@ -131,7 +149,7 @@ export const getInitialValues = (
   };
   if (existingData?.type === type) {
     Object.entries(existingData).forEach(([name, value]) => {
-      result[name] = value ?? undefined;
+      result[name] = value != null ? value : undefined;
     });
   } else {
     Object.entries(llmProvidersConfig(t)[type]).forEach(([name, o]) => {

--- a/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/llmProvidersConfig.ts
+++ b/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderEdit/llmProvidersConfig.ts
@@ -121,7 +121,11 @@ export const getValidationSchema = (
     const options: ProviderOptions = { ...llmProvidersDefaults(t)[name], ...o };
     let field: Yup.AnySchema;
     if (options.numeric) {
-      field = Yup.number().nullable().transform((value) => (value === '' || isNaN(value) ? undefined : value));
+      field = Yup.number()
+        .nullable()
+        .transform((value) =>
+          value === '' || isNaN(value) ? undefined : value
+        );
     } else {
       field = Yup.string();
     }

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -3955,6 +3955,8 @@ export interface components {
       /** @enum {string} */
       priority?: "LOW" | "HIGH";
       reasoningEffort?: string;
+      /** Format: double */
+      temperature?: number;
       /** @enum {string} */
       type: "OPENAI" | "OPENAI_AZURE" | "TOLGEE" | "ANTHROPIC" | "GOOGLE_AI";
     };
@@ -3969,6 +3971,8 @@ export interface components {
       /** @enum {string} */
       priority?: "LOW" | "HIGH";
       reasoningEffort?: string;
+      /** Format: double */
+      temperature?: number;
       /** @enum {string} */
       type: "OPENAI" | "OPENAI_AZURE" | "TOLGEE" | "ANTHROPIC" | "GOOGLE_AI";
     };


### PR DESCRIPTION
## Summary

- Adds a configurable `temperature` field (`Double?`) to LLM provider configuration
- Temperature is passed to all 4 provider APIs: OpenAI, Anthropic, Google AI, and Ollama
- When not set, temperature is omitted from API requests (preserving provider defaults)
- Previously, Anthropic hardcoded temperature to 0 and OpenAI/others left it null — both now read from config
- Includes UI field in the LLM provider create/edit form for all provider types

Closes #3297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temperature configuration now available for LLM providers. Users can set temperature values between 0 and 2 using 0.1 increments. Configuration supported across OpenAI, Anthropic, Google AI, and Ollama integrations. Temperature settings are stored with provider configuration and applied to all requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->