### PR TITLE
feat: add OpenTelemetry tracing to branching operations

### DIFF
--- a/ee/backend/app/build.gradle
+++ b/ee/backend/app/build.gradle
@@ -63,6 +63,12 @@ dependencies {
 
 
     /**
+     * OpenTelemetry for distributed tracing
+     */
+    implementation libs.opentelemetryApi
+    implementation libs.opentelemetryInstrumentationAnnotations
+
+    /**
      * MISC
      */
     implementation libs.jjwtApi

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCleanupService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCleanupService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.service.branching
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.Metrics
 import io.tolgee.ee.repository.branching.BranchMergeRepository
 import io.tolgee.ee.repository.branching.BranchRepository
@@ -52,6 +53,7 @@ class BranchCleanupService(
    * Uses bulk SQL for high-volume tables (translations, key metadata, keys)
    * and delegates to services for business logic (screenshots, namespaces, tasks).
    */
+  @WithSpan
   @Transactional
   fun cleanupBranch(
     projectId: Long,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
@@ -87,6 +87,7 @@ class BranchMergeService(
     }!!
   }
 
+  @WithSpan
   @Transactional
   fun refresh(branchMerge: BranchMerge) {
     val resolvedConflicts =
@@ -283,6 +284,7 @@ class BranchMergeService(
     }
   }
 
+  @WithSpan
   @Transactional
   fun resolveConflict(
     projectId: Long,
@@ -295,6 +297,7 @@ class BranchMergeService(
     metrics.branchMergeConflictCounter(resolution.name).increment()
   }
 
+  @WithSpan
   @Transactional
   fun resolveAllConflicts(
     projectId: Long,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -1,5 +1,7 @@
 package io.tolgee.ee.service.branching
 
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.Metrics
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.activity.data.RevisionType
@@ -24,6 +26,7 @@ import io.tolgee.model.enums.BranchKeyMergeChangeType
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.branching.AbstractBranchService
 import io.tolgee.service.branching.BranchCopyService
+import io.tolgee.tracing.TolgeeTracingContext
 import jakarta.persistence.EntityManager
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Primary
@@ -48,6 +51,7 @@ class BranchServiceImpl(
   private val branchCleanupService: BranchCleanupService,
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val metrics: Metrics,
+  private val tracingContext: TolgeeTracingContext,
 ) : AbstractBranchService(branchRepository, branchMergeService) {
   override fun getBranches(
     projectId: Long,
@@ -108,6 +112,7 @@ class BranchServiceImpl(
       ?: throw NotFoundException(Message.BRANCH_NOT_FOUND)
   }
 
+  @WithSpan
   @Transactional
   override fun createBranch(
     projectId: Long,
@@ -121,11 +126,15 @@ class BranchServiceImpl(
           Message.ORIGIN_BRANCH_NOT_FOUND,
         )
 
+      setCreateBranchTracingAttributes(projectId, name, originBranch)
+
       val branch =
         createBranch(projectId, name, author).also {
           it.originBranch = originBranch
         }
       branchRepository.save(branch)
+
+      Span.current().setAttribute("tolgee.branch.id", branch.id)
 
       branchCopyService.copy(projectId, originBranch, branch)
       branchSnapshotService.createInitialSnapshot(projectId, originBranch, branch)
@@ -148,6 +157,36 @@ class BranchServiceImpl(
       this.name = name
       this.author = author
     }
+  }
+
+  private fun setCreateBranchTracingAttributes(
+    projectId: Long,
+    name: String,
+    originBranch: Branch,
+  ) {
+    tracingContext.setContext(projectId, null)
+
+    val span = Span.current()
+    span.setAttribute("tolgee.branch.name", name)
+    span.setAttribute("tolgee.branch.origin.id", originBranch.id)
+    span.setAttribute("tolgee.branch.origin.name", originBranch.name)
+  }
+
+  private fun setApplyMergeTracingAttributes(
+    projectId: Long,
+    mergeId: Long,
+    deleteBranch: Boolean?,
+    merge: BranchMerge,
+  ) {
+    tracingContext.setContext(projectId, null)
+
+    val span = Span.current()
+    span.setAttribute("tolgee.branch.merge.id", mergeId)
+    span.setAttribute("tolgee.branch.merge.deleteBranch", deleteBranch ?: true)
+    span.setAttribute("tolgee.branch.source.id", merge.sourceBranch.id)
+    span.setAttribute("tolgee.branch.source.name", merge.sourceBranch.name)
+    span.setAttribute("tolgee.branch.target.id", merge.targetBranch.id)
+    span.setAttribute("tolgee.branch.target.name", merge.targetBranch.name)
   }
 
   @Transactional
@@ -189,6 +228,7 @@ class BranchServiceImpl(
     return branchMergeService.dryRun(sourceBranch, targetBranch)
   }
 
+  @WithSpan
   @Transactional
   override fun applyMerge(
     projectId: Long,
@@ -198,6 +238,9 @@ class BranchServiceImpl(
     val merge =
       branchMergeService.findActiveMergeFull(projectId, mergeId)
         ?: throw NotFoundException(Message.BRANCH_MERGE_NOT_FOUND)
+
+    setApplyMergeTracingAttributes(projectId, mergeId, deleteBranch, merge)
+
     if (!merge.isReadyToMerge) {
       if (!merge.isRevisionValid) {
         throw BadRequestException(Message.BRANCH_MERGE_REVISION_NOT_VALID)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -189,6 +189,7 @@ class BranchServiceImpl(
     span.setAttribute("tolgee.branch.target.name", merge.targetBranch.name)
   }
 
+  @WithSpan
   @Transactional
   override fun deleteBranch(
     projectId: Long,
@@ -209,6 +210,7 @@ class BranchServiceImpl(
     )
   }
 
+  @WithSpan
   @Transactional
   override fun dryRunMerge(
     projectId: Long,
@@ -220,6 +222,7 @@ class BranchServiceImpl(
     return dryRunMerge(sourceBranch, targetBranch)
   }
 
+  @WithSpan
   @Transactional
   fun dryRunMerge(
     sourceBranch: Branch,
@@ -275,6 +278,7 @@ class BranchServiceImpl(
     return branchMergeService.getMergeView(projectId, mergeId)
   }
 
+  @WithSpan
   @Transactional
   override fun refreshMerge(
     projectId: Long,
@@ -328,6 +332,7 @@ class BranchServiceImpl(
     return branchMergeService.getChange(project, branchMergeId, changeId, user.id)
   }
 
+  @WithSpan
   @Transactional
   override fun resolveConflict(
     projectId: Long,
@@ -337,6 +342,7 @@ class BranchServiceImpl(
     branchMergeService.resolveConflict(projectId, mergeId, request.changeId, request.resolve)
   }
 
+  @WithSpan
   @Transactional
   override fun resolveAllConflicts(
     projectId: Long,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchSnapshotService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchSnapshotService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.service.branching
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.ee.repository.branching.KeySnapshotRepository
 import io.tolgee.model.branching.Branch
 import io.tolgee.model.branching.snapshot.KeySnapshot
@@ -12,6 +13,7 @@ class BranchSnapshotService(
   private val keySnapshotRepository: KeySnapshotRepository,
   private val entityManager: EntityManager,
 ) {
+  @WithSpan
   @Transactional
   fun createInitialSnapshot(
     projectId: Long,
@@ -143,6 +145,7 @@ class BranchSnapshotService(
     entityManager.createNativeQuery(sql).setParameter("branchId", branchId).executeUpdate()
   }
 
+  @WithSpan
   @Transactional
   fun rebuildSnapshotFromSource(
     projectId: Long,
@@ -204,8 +207,10 @@ class BranchSnapshotService(
       .executeUpdate()
   }
 
+  @WithSpan
   fun getSnapshotKeys(branchId: Long): List<KeySnapshot> = keySnapshotRepository.findAllByBranchId(branchId)
 
+  @WithSpan
   fun getSnapshotKeysByOriginalKeyIdIn(
     branchId: Long,
     originalKeyIds: Collection<Long>,
@@ -216,6 +221,7 @@ class BranchSnapshotService(
     return keySnapshotRepository.findAllByBranchIdAndOriginalKeyIdIn(branchId, originalKeyIds)
   }
 
+  @WithSpan
   fun deleteSnapshots(branchId: Long) {
     entityManager
       .createNativeQuery(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/DefaultBranchCreator.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/DefaultBranchCreator.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.service.branching
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.model.Project
 import io.tolgee.model.branching.Branch
 import jakarta.persistence.EntityManager
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service
 class DefaultBranchCreator(
   private val entityManager: EntityManager,
 ) {
+  @WithSpan
   @Transactional
   fun create(project: Project): Branch {
     val branch = Branch.createMainBranch(project)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/ProjectBranchingMigrationService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/ProjectBranchingMigrationService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.service.branching
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.repository.ProjectRepository
 import jakarta.persistence.EntityManager
@@ -12,6 +13,7 @@ class ProjectBranchingMigrationService(
   private val entityManager: EntityManager,
   private val defaultBranchCreator: DefaultBranchCreator,
 ) {
+  @WithSpan
   @Transactional
   fun enableBranching(projectId: Long) {
     val project =

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeAnalyzer.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeAnalyzer.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.service.branching.merging
 
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.ee.service.branching.BranchSnapshotService
 import io.tolgee.model.branching.BranchMerge
 import io.tolgee.model.branching.BranchMergeChange
@@ -19,6 +20,7 @@ class BranchMergeAnalyzer(
     val name: String,
   )
 
+  @WithSpan
   @Transactional
   fun compute(merge: BranchMerge): MutableList<BranchMergeChange> {
     val snapshots = branchSnapshotService.getSnapshotKeys(merge.sourceBranch.id)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
@@ -1,5 +1,7 @@
 package io.tolgee.ee.service.branching.merging
 
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.ee.exceptions.BranchMergeConflictNotResolvedException
 import io.tolgee.ee.service.branching.BranchSnapshotService
@@ -16,6 +18,7 @@ import io.tolgee.repository.KeyRepository
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.translation.TranslationService
+import io.tolgee.tracing.TolgeeTracingContext
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.LinkedHashMap
@@ -28,9 +31,12 @@ class BranchMergeExecutor(
   private val translationService: TranslationService,
   private val currentDateProvider: CurrentDateProvider,
   private val branchSnapshotService: BranchSnapshotService,
+  private val tracingContext: TolgeeTracingContext,
 ) {
+  @WithSpan
   @Transactional
   fun execute(merge: BranchMerge) {
+    setTracingAttributes(merge)
     attachKeysForMerge(merge)
     val snapshotKeys by lazy {
       branchSnapshotService.getSnapshotKeys(merge.sourceBranch.id).associateBy { it.originalKeyId }
@@ -62,6 +68,29 @@ class BranchMergeExecutor(
     merge.mergedAt = currentDateProvider.date
   }
 
+  private fun setTracingAttributes(merge: BranchMerge) {
+    tracingContext.setContext(merge.sourceBranch.project.id, null)
+
+    val span = Span.current()
+    span.setAttribute("tolgee.branch.merge.id", merge.id)
+    span.setAttribute("tolgee.branch.merge.changesCount", merge.changes.size.toLong())
+
+    val changesByType = merge.changes.groupingBy { it.change }.eachCount()
+    changesByType[BranchKeyMergeChangeType.ADD]?.let {
+      span.setAttribute("tolgee.branch.merge.additions", it.toLong())
+    }
+    changesByType[BranchKeyMergeChangeType.UPDATE]?.let {
+      span.setAttribute("tolgee.branch.merge.updates", it.toLong())
+    }
+    changesByType[BranchKeyMergeChangeType.DELETE]?.let {
+      span.setAttribute("tolgee.branch.merge.deletions", it.toLong())
+    }
+    changesByType[BranchKeyMergeChangeType.CONFLICT]?.let {
+      span.setAttribute("tolgee.branch.merge.conflicts", it.toLong())
+    }
+  }
+
+  @WithSpan
   private fun attachKeysForMerge(merge: BranchMerge) {
     val sourceIds = merge.changes.mapNotNull { it.sourceKey?.id }.toSet()
     val targetIds = merge.changes.mapNotNull { it.targetKey?.id }.toSet()
@@ -81,6 +110,7 @@ class BranchMergeExecutor(
     }
   }
 
+  @WithSpan
   private fun applyConflict(
     change: BranchMergeChange,
     keySnapshot: KeySnapshot,
@@ -92,6 +122,7 @@ class BranchMergeExecutor(
     }
   }
 
+  @WithSpan
   private fun applyUpdate(
     change: BranchMergeChange,
     snapshotKey: KeySnapshot,
@@ -107,6 +138,7 @@ class BranchMergeExecutor(
     persistAfterMerge(targetKey)
   }
 
+  @WithSpan
   private fun applyAddition(
     change: BranchMergeChange,
     targetBranch: Branch,
@@ -165,6 +197,7 @@ class BranchMergeExecutor(
     }
   }
 
+  @WithSpan
   private fun applyDeletion(change: BranchMergeChange) {
     if (change.resolution != BranchKeyMergeResolutionType.SOURCE) {
       return
@@ -174,6 +207,7 @@ class BranchMergeExecutor(
     keyService.hardDelete(targetKey.id)
   }
 
+  @WithSpan
   private fun persistAfterMerge(key: Key) {
     key.translations.filter { it.id == 0L }.forEach { translationService.save(it) }
   }


### PR DESCRIPTION
Add distributed tracing with @WithSpan annotations and span attributes to branch creation, merge preview, and merge execution. This enables performance analysis to identify bottlenecks in branching operations.

Traced operations include:
- Branch creation (BranchServiceImpl.createBranch)
- Branch copy with batched SQL operations (BranchCopyServiceSql)
- Merge dry-run/preview (BranchMergeService.dryRun)
- Merge execution (BranchMergeExecutor.execute)
- Snapshot management (BranchSnapshotService)
- Merge analysis (BranchMergeAnalyzer.compute)

Span attributes capture project/branch IDs, branch names, key counts, and merge change breakdowns (additions, updates, deletions, conflicts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added distributed tracing infrastructure across branch management services for enhanced system observability
  * Implemented comprehensive operation tracking and performance instrumentation for branch creation, merging, copying, and snapshot management
  * Enhanced monitoring capabilities to improve diagnostic visibility and performance analysis of branch-related workflows
  * Improved system instrumentation for better troubleshooting and operational insights

<!-- end of auto-generated comment: release notes by coderabbit.ai -->