### PR TITLE
fix: stop doubling percent signs in Compose Multiplatform XML export

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -63,7 +63,7 @@ class TextToXmlResourcesConvertor(
         document.createCDATASection(
           string.escape(
             escapeApos = true,
-            keepPercentSignEscaped = true,
+            keepPercentSignEscaped = isAndroid,
             quoteMoreWhitespaces = false,
             escapeNewLines = true,
           ),
@@ -73,7 +73,10 @@ class TextToXmlResourcesConvertor(
 
   private fun escapeTextNodes() {
     analysisResult.textNodes.forEach { node ->
-      node.escapeText(keepPercentSignEscaped = analysisResult.containsPlaceholders, quoteMoreWhitespaces = true)
+      node.escapeText(
+        keepPercentSignEscaped = isAndroid && analysisResult.containsPlaceholders,
+        quoteMoreWhitespaces = true,
+      )
     }
   }
 
@@ -86,7 +89,7 @@ class TextToXmlResourcesConvertor(
         doc.createCDATASection(
           node.writeToString().escape(
             escapeApos = true,
-            keepPercentSignEscaped = analysisResult.containsPlaceholders,
+            keepPercentSignEscaped = isAndroid && analysisResult.containsPlaceholders,
             quoteMoreWhitespaces = false,
             escapeNewLines = true,
           ),

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/ComposeXmlFileExporterTest.kt
@@ -26,8 +26,8 @@ class ComposeXmlFileExporterTest {
     |  <string name="key1">Ahoj! I%d, %s, %e, %f</string>
     |  <string name="percent_no_placeholders">I am just a percent % sign!</string>
     |  <!-- This is a description -->
-    |  <string name="percent_and_placeholders">I am not just a percent %s %% sign!</string>
-    |  <string name="percent_and_placeholders_and_tags">I am not just a percent <![CDATA[<b>%s</b>]]> %% sign!</string>
+    |  <string name="percent_and_placeholders">I am not just a percent %s % sign!</string>
+    |  <string name="percent_and_placeholders_and_tags">I am not just a percent <![CDATA[<b>%s</b>]]> % sign!</string>
     |  <string name="forced_CDATA"><![CDATA[Forced CDATA <b>Hey!</b> sign!]]></string>
     |  <plurals name="Empty_plural">
     |    <item quantity="one"/>

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/compose/out/TextToComposeXmlConvertorTest.kt
@@ -33,7 +33,7 @@ class TextToComposeXmlConvertorTest {
 
   @Test
   fun `trailing percents are handled`() {
-    "%s %%".assertSingleTextNode().isEqualTo("%s %%")
+    "%s %%".assertSingleTextNode().isEqualTo("%s %")
   }
 
   @Test
@@ -56,7 +56,7 @@ class TextToComposeXmlConvertorTest {
       ).convertedNodes().toList()
     nodes[0].assertTextContent("What a ")
     nodes[1].nodeAssertCdataNodeText(
-      "<unsupported attr=\"https://example.com\">link \' %% %s \"    " +
+      "<unsupported attr=\"https://example.com\">link \' % %s \"    " +
         "</unsupported>",
     )
     nodes[2].assertTextContent(".")


### PR DESCRIPTION
## Summary
- Follow-up to #3457 which fixed `\%` escaping but left `%%` doubling for strings with placeholders
- Compose Multiplatform's [`replaceWithArgs`](https://github.com/JetBrains/compose-multiplatform/blob/master/components/resources/library/src/commonMain/kotlin/org/jetbrains/compose/resources/StringResourcesUtils.kt) does **not** use `String.format()` — it uses a simple regex `%(\d+)\$[ds]` that does not interpret `%%` as an escaped percent sign
- Gates `keepPercentSignEscaped` on `isAndroid` in all 3 locations in `TextToXmlResourcesConvertor` so Compose exports always convert `%%` back to `%`

Fixes #3368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved percent-sign escaping in XML resource conversion. Escaping behavior now intelligently adapts based on Android targeting and placeholder detection, ensuring more accurate text content rendering when converting resources to XML format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->