### PR TITLE
fix: use projection queries in BranchMergeActivityParamsProvider

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BranchMergeActivityParamsProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BranchMergeActivityParamsProvider.kt
@@ -1,7 +1,7 @@
 package io.tolgee.batch
 
-import io.mockk.InternalPlatformDsl.toStr
 import io.tolgee.activity.PublicParamsProvider
+import io.tolgee.activity.data.EntityDescriptionRef
 import io.tolgee.model.branching.BranchMerge
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Component
@@ -10,20 +10,55 @@ import org.springframework.stereotype.Component
 class BranchMergeActivityParamsProvider(
   private val entityManager: EntityManager,
 ) : PublicParamsProvider {
+  @Suppress("UNCHECKED_CAST")
   override fun provide(revisionIds: List<Long>): Map<Long, Any?> {
-    return entityManager
-      .createQuery(
-        """select ar.id, bm.sourceBranch.name, bm.targetBranch.name from ActivityRevision ar 
-          join ar.modifiedEntities me
-          join BranchMerge bm on bm.id = me.entityId
-          where ar.id in :revisionIds and me.entityClass = :class      
-    """,
-        Array<Any?>::class.java,
-      ).setParameter("revisionIds", revisionIds)
-      .setParameter("class", BranchMerge::class.toStr())
-      .resultList
-      .associate {
-        ((it[0] as Long to mapOf("source" to it[1], "target" to it[2])))
-      }
+    val modifiedRows =
+      entityManager
+        .createQuery(
+          """
+          select me.activityRevision.id, me.describingRelations
+          from ActivityModifiedEntity me
+          where me.activityRevision.id in :revisionIds
+            and me.entityClass = :entityClass
+          """.trimIndent(),
+        ).setParameter("revisionIds", revisionIds)
+        .setParameter("entityClass", BranchMerge::class.simpleName)
+        .resultList as List<Array<Any?>>
+
+    if (modifiedRows.isEmpty()) return emptyMap()
+
+    val describingRows =
+      entityManager
+        .createQuery(
+          """
+          select ade.activityRevision.id, ade.entityId, ade.data
+          from ActivityDescribingEntity ade
+          where ade.activityRevision.id in :revisionIds
+            and ade.entityClass = :branchClass
+          """.trimIndent(),
+        ).setParameter("revisionIds", revisionIds)
+        .setParameter("branchClass", "Branch")
+        .resultList as List<Array<Any?>>
+
+    val describingIndex =
+      describingRows.associateBy { (it[0] as Long) to (it[1] as Long) }
+
+    return modifiedRows.associate { row ->
+      val revisionId = row[0] as Long
+      val relations = row[1] as? Map<String, EntityDescriptionRef> ?: emptyMap()
+
+      val sourceName =
+        relations["sourceBranch"]?.let {
+          val data = describingIndex[revisionId to it.entityId]?.get(2) as? Map<String, Any?>
+          data?.get("name")
+        }
+      val targetName =
+        relations["targetBranch"]?.let {
+          val data = describingIndex[revisionId to it.entityId]?.get(2) as? Map<String, Any?>
+          data?.get("name")
+        }
+
+      revisionId to mapOf("source" to sourceName, "target" to targetName)
+    }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/branching/BranchMerge.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/branching/BranchMerge.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.branching
 
+import io.tolgee.activity.annotation.ActivityEntityDescribingPaths
 import io.tolgee.activity.annotation.ActivityLoggedEntity
 import io.tolgee.model.EntityWithId
 import io.tolgee.model.StandardAuditModel
@@ -20,6 +21,7 @@ import java.util.Date
 @Entity
 @Table()
 @ActivityLoggedEntity
+@ActivityEntityDescribingPaths(["sourceBranch", "targetBranch"])
 class BranchMerge :
   StandardAuditModel(),
   EntityWithId {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerMergingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerMergingTest.kt
@@ -1,5 +1,6 @@
 package io.tolgee.ee.api.v2.controllers.branching
 
+import io.tolgee.ActivityTestUtil
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.constants.Feature
 import io.tolgee.constants.Message
@@ -48,6 +49,9 @@ class BranchControllerMergingTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Autowired
   lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  @Autowired
+  lateinit var activityTestUtil: ActivityTestUtil
 
   @BeforeEach
   fun setup() {
@@ -123,6 +127,44 @@ class BranchControllerMergingTest : ProjectAuthControllerTest("/v2/projects/") {
       )!!
       .text.assert
       .isEqualTo("new translation")
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `merge activity includes source and target branch names in params`() {
+    val keys = initConflicts()
+    waitForNotThrowing(timeout = 10000, pollTime = 250) {
+      testData.featureBranch
+        .refresh()
+        .revision.assert
+        .isGreaterThan(0)
+      testData.mainBranch
+        .refresh()
+        .revision.assert
+        .isGreaterThan(0)
+    }
+    val change =
+      createMergeWithConflict(
+        keys.second,
+        keys.first,
+        BranchKeyMergeResolutionType.SOURCE,
+      )
+    val mergeId = change.branchMerge.id
+
+    performProjectAuthPost("branches/merge/$mergeId/apply").andIsOk
+
+    waitForNotThrowing(timeout = 5000, pollTime = 250) {
+      performProjectAuthGet("activity")
+        .andIsOk
+        .andAssertThatJson {
+          node("_embedded.activities") {
+            isArray.isNotEmpty
+            node("[0].type").isEqualTo("BRANCH_MERGE")
+            node("[0].params.source").isEqualTo("feature")
+            node("[0].params.target").isEqualTo("main")
+          }
+        }
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Replace the broken direct-join query in `BranchMergeActivityParamsProvider` with projection queries that resolve source/target branch names via activity describing relations and entity data
- Add `@ActivityEntityDescribingPaths(["sourceBranch", "targetBranch"])` to `BranchMerge` so the activity system records branch references
- Add integration test verifying merge activity params contain correct branch names

## Test plan
- [x] `BranchControllerMergingTest` — new test `merge activity includes source and target branch names in params` passes
- [x] `ProjectActivityBranchingTest` — existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for branch merge activity logging to verify source and target branch information is properly captured.

* **Refactor**
  * Improved internal handling of branch merge activity data collection to ensure complete information is recorded in activity logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->