### PR TITLE
fix: restrict DELETE scope in removeDuplicityDescribingEntities

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActivityFinalizer.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActivityFinalizer.kt
@@ -171,7 +171,8 @@ class BatchJobActivityFinalizer(
       .createNativeQuery(
         """
         delete from activity_describing_entity
-        where (entity_class, entity_id) in
+        where (activity_revision_id in (:revisionIds) or activity_revision_id = :activityRevisionIdToMergeInto)
+        and (entity_class, entity_id) in
               (select entity_class, entity_id
                from activity_describing_entity
                where activity_revision_id in (:revisionIds)


### PR DESCRIPTION
## Summary

When a batch job completes, `BatchJobActivityFinalizer` merges activity revisions from individual chunks into a single revision. As part of this, `removeDuplicityDescribingEntities` deletes duplicate `(entity_class, entity_id)` rows to avoid PK violations before reassigning all rows to the merge target.

The DELETE query was missing an `activity_revision_id` filter on its outer `WHERE` clause:

```sql
-- before
delete from activity_describing_entity
where (entity_class, entity_id) in (...)  -- no revision scope
and (activity_revision_id, entity_class, entity_id) not in (...)
```

This caused two problems:

**1. Performance** — without `activity_revision_id` as the leading predicate, PostgreSQL cannot use the existing `(activity_revision_id, entity_class, entity_id)` index and falls back to a full sequential scan of the entire table on every batch job completion.

**2. Data correctness** — the unscoped DELETE could match and delete rows from old, unrelated activity revisions that happen to reference the same `(entity_class, entity_id)` as entities in the batch being merged, silently corrupting historical activity data.

## Fix

Add `(activity_revision_id in (:revisionIds) or activity_revision_id = :activityRevisionIdToMergeInto)` as the leading predicate on the outer DELETE. This restricts the operation strictly to the chunk revisions being merged, enables index usage, and eliminates the risk of touching unrelated historical rows.

## Test plan

- [ ] Run a batch job with multiple chunks (e.g. machine translate ≥ 6 keys) and verify it completes successfully
- [ ] Verify activity history for affected keys is intact after the job completes
- [ ] Run `EXPLAIN ANALYZE` on the DELETE query and confirm it uses an Index Scan rather than a Seq Scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch job cleanup operations now process an expanded set of entities during merge scenarios, ensuring more thorough data consolidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->