### PR TITLE
feat: rate limit translation and activity endpoints

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/RateLimitProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/RateLimitProperties.kt
@@ -62,6 +62,20 @@ class RateLimitProperties(
   var exportRequestLimit: Int = 100,
   @DocProperty(description = "Size, in milliseconds, of the time window for export-based limiting.")
   var exportRequestWindow: Long = 5 * 60 * 1000,
+  @DocProperty(description = "Amount of translation requests a user can do in a single time window.")
+  var translationRequestLimit: Int = 100,
+  @DocProperty(
+    description = "Size, in milliseconds, of the time window for translation-based limiting.",
+    defaultExplanation = "= 5 minutes",
+  )
+  var translationRequestWindow: Long = 5 * 60 * 1000,
+  @DocProperty(description = "Amount of activity requests a user can do in a single time window.")
+  var activityRequestLimit: Int = 100,
+  @DocProperty(
+    description = "Size, in milliseconds, of the time window for activity-based limiting.",
+    defaultExplanation = "= 5 minutes",
+  )
+  var activityRequestWindow: Long = 5 * 60 * 1000,
   @DocProperty(
     description =
       "Number of rate limit violations before the server stops responding to the client.\n" +


### PR DESCRIPTION
## Summary
- Add per-user rate limits to translation GET endpoints (`/{languages}` and paginated `/`) and activity GET endpoint, preventing database overload from excessive API usage
- Mirror the existing export rate limit pattern: 100 requests per 5-minute window per user, configurable via `tolgee.rate-limits.translation-request-limit`, `translation-request-window`, `activity-request-limit`, `activity-request-window`
- Translation `/{languages}` endpoint rate limit is inside the `onlyWhenProjectDataChanged` block so 304 responses don't count against the limit

## Test plan
- [ ] Verify translation endpoints return 429 after exceeding 100 requests in 5 minutes
- [ ] Verify activity endpoint returns 429 independently of translation limit
- [ ] Verify rate limits are configurable via YAML properties
- [ ] Verify existing export rate limits are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)