### PR TITLE
fix: sync MCP sessions to Redis for multi-replica deployments

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-properties-migrator"
 
     implementation libs.springDocOpenApiCommon
-    testApi libs.redissonSpringBootStarter
+    implementation libs.redissonSpringBootStarter
 
     /**
      * OPENTELEMETRY

--- a/backend/app/src/main/kotlin/io/tolgee/mcp/McpConfig.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/mcp/McpConfig.kt
@@ -1,10 +1,13 @@
 package io.tolgee.mcp
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.modelcontextprotocol.server.McpServer
 import io.modelcontextprotocol.server.McpSyncServer
 import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider
 import io.modelcontextprotocol.spec.McpSchema
 import io.tolgee.util.VersionProvider
+import org.redisson.api.RedissonClient
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.function.RouterFunction
@@ -49,5 +52,17 @@ class McpConfig {
     @Suppress("unused") mcpServer: McpSyncServer,
   ): RouterFunction<ServerResponse> {
     return transportProvider.routerFunction
+  }
+
+  @Bean
+  fun mcpSessionRedisFilter(
+    transportProvider: WebMvcStreamableServerTransportProvider,
+    redissonClient: RedissonClient?,
+    objectMapper: ObjectMapper,
+  ): FilterRegistrationBean<McpSessionRedisFilter> {
+    val filter = McpSessionRedisFilter(transportProvider, redissonClient, objectMapper)
+    val registration = FilterRegistrationBean(filter)
+    registration.addUrlPatterns("/mcp/*")
+    return registration
   }
 }

--- a/backend/app/src/main/kotlin/io/tolgee/mcp/McpSessionData.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/mcp/McpSessionData.kt
@@ -1,0 +1,6 @@
+package io.tolgee.mcp
+
+data class McpSessionData(
+  val clientCapabilitiesJson: String?,
+  val clientInfoJson: String?,
+)

--- a/backend/app/src/main/kotlin/io/tolgee/mcp/McpSessionRedisFilter.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/mcp/McpSessionRedisFilter.kt
@@ -1,0 +1,250 @@
+package io.tolgee.mcp
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.modelcontextprotocol.server.McpNotificationHandler
+import io.modelcontextprotocol.server.McpRequestHandler
+import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider
+import io.modelcontextprotocol.spec.DefaultMcpStreamableServerSessionFactory
+import io.modelcontextprotocol.spec.McpSchema
+import io.modelcontextprotocol.spec.McpStreamableServerSession
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponseWrapper
+import org.redisson.api.RedissonClient
+import org.slf4j.LoggerFactory
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Servlet filter that syncs MCP sessions to Redis for multi-replica deployments.
+ *
+ * The MCP Java SDK's [WebMvcStreamableServerTransportProvider] stores sessions in an in-memory
+ * `ConcurrentHashMap`. When running multiple replicas behind a load balancer, requests with an
+ * `Mcp-Session-Id` header may land on a replica that doesn't have the session, resulting in
+ * 404 "Session not found" errors.
+ *
+ * This filter works around the issue by:
+ * - **Before handler**: If the request carries an `Mcp-Session-Id` not present in the local map,
+ *   reconstructs the session from Redis and injects it into the transport provider's sessions map.
+ * - **After handler**: If the response sets a new `Mcp-Session-Id` (initialize), persists the
+ *   session metadata to Redis.
+ *
+ * Uses reflection because [WebMvcStreamableServerTransportProvider] has a private constructor and
+ * all private fields/methods — it cannot be extended or configured with custom session storage.
+ *
+ * When Redis is unavailable (e.g. single-instance deployment), the filter is a no-op.
+ *
+ * This is a temporary workaround until the SDK provides a proper session storage API.
+ * Tracked upstream: https://github.com/modelcontextprotocol/java-sdk/issues/201
+ * SDK maintainer confirmed persistent session storage is planned:
+ * https://github.com/modelcontextprotocol/java-sdk/issues/201#issuecomment-3915069460
+ */
+class McpSessionRedisFilter(
+  private val transportProvider: WebMvcStreamableServerTransportProvider,
+  private val redissonClient: RedissonClient?,
+  private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+  private val log = LoggerFactory.getLogger(McpSessionRedisFilter::class.java)
+
+  private val sessionsMap: ConcurrentHashMap<String, McpStreamableServerSession> by lazy {
+    loadSessionsMap()
+  }
+
+  private val factoryFields: FactoryFields by lazy {
+    loadFactoryFields()
+  }
+
+  override fun doFilterInternal(
+    request: HttpServletRequest,
+    response: HttpServletResponse,
+    filterChain: FilterChain,
+  ) {
+    if (redissonClient == null) {
+      filterChain.doFilter(request, response)
+      return
+    }
+
+    val sessionId = request.getHeader(MCP_SESSION_ID_HEADER)
+
+    // Pre-handle: recover session from Redis if not in local map
+    if (sessionId != null && !sessionsMap.containsKey(sessionId)) {
+      recoverSessionFromRedis(sessionId)
+    }
+
+    // Wrap response to capture new session ID from initialize responses
+    val responseWrapper = SessionIdCapturingResponseWrapper(response)
+    filterChain.doFilter(request, responseWrapper)
+
+    // Post-handle: persist new session to Redis
+    val newSessionId = responseWrapper.capturedSessionId
+    if (newSessionId != null) {
+      persistSessionToRedis(newSessionId)
+    }
+  }
+
+  private fun recoverSessionFromRedis(sessionId: String) {
+    try {
+      val bucket = redissonClient!!.getBucket<String>("$REDIS_KEY_PREFIX$sessionId")
+      val json = bucket.get() ?: return
+
+      val sessionData = objectMapper.readValue(json, McpSessionData::class.java)
+
+      val clientCapabilities =
+        sessionData.clientCapabilitiesJson?.let {
+          objectMapper.readValue(it, McpSchema.ClientCapabilities::class.java)
+        }
+      val clientInfo =
+        sessionData.clientInfoJson?.let {
+          objectMapper.readValue(it, McpSchema.Implementation::class.java)
+        }
+
+      @Suppress("UNCHECKED_CAST")
+      val session =
+        McpStreamableServerSession(
+          sessionId,
+          clientCapabilities,
+          clientInfo,
+          factoryFields.requestTimeout,
+          factoryFields.requestHandlers as Map<String, McpRequestHandler<*>>,
+          factoryFields.notificationHandlers as Map<String, McpNotificationHandler>,
+        )
+
+      val existing = sessionsMap.putIfAbsent(sessionId, session)
+      if (existing != null) {
+        log.debug("MCP session {} was already recovered by another thread", sessionId)
+      } else {
+        log.debug("Recovered MCP session {} from Redis", sessionId)
+      }
+    } catch (e: Exception) {
+      log.warn("Failed to recover MCP session {} from Redis", sessionId, e)
+    }
+  }
+
+  private fun persistSessionToRedis(sessionId: String) {
+    try {
+      val session = sessionsMap[sessionId] ?: return
+
+      val clientCapabilities = getPrivateField<Any?>(session, "clientCapabilities")
+      val clientInfo = getPrivateField<Any?>(session, "clientInfo")
+
+      val capabilitiesValue = unwrapField(clientCapabilities, "clientCapabilities")
+      val infoValue = unwrapField(clientInfo, "clientInfo")
+
+      val sessionData =
+        McpSessionData(
+          clientCapabilitiesJson = capabilitiesValue?.let { objectMapper.writeValueAsString(it) },
+          clientInfoJson = infoValue?.let { objectMapper.writeValueAsString(it) },
+        )
+
+      val bucket = redissonClient!!.getBucket<String>("$REDIS_KEY_PREFIX$sessionId")
+      bucket.set(objectMapper.writeValueAsString(sessionData), SESSION_TTL)
+      log.debug("Persisted MCP session {} to Redis", sessionId)
+    } catch (e: Exception) {
+      log.warn("Failed to persist MCP session {} to Redis", sessionId, e)
+    }
+  }
+
+  private fun unwrapField(
+    fieldValue: Any?,
+    fieldName: String,
+  ): Any? {
+    if (fieldValue == null) return null
+    if (fieldValue is java.util.concurrent.atomic.AtomicReference<*>) {
+      return fieldValue.get()
+    }
+    log.warn(
+      "Expected AtomicReference for field '{}' but got {}; using value directly",
+      fieldName,
+      fieldValue.javaClass.name,
+    )
+    return fieldValue
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun loadSessionsMap(): ConcurrentHashMap<String, McpStreamableServerSession> {
+    val field = WebMvcStreamableServerTransportProvider::class.java.getDeclaredField("sessions")
+    field.isAccessible = true
+    return field.get(transportProvider) as ConcurrentHashMap<String, McpStreamableServerSession>
+  }
+
+  private fun loadFactoryFields(): FactoryFields {
+    val factoryField = WebMvcStreamableServerTransportProvider::class.java.getDeclaredField("sessionFactory")
+    factoryField.isAccessible = true
+    val factory = factoryField.get(transportProvider)
+
+    if (factory !is DefaultMcpStreamableServerSessionFactory) {
+      throw IllegalStateException(
+        "Expected DefaultMcpStreamableServerSessionFactory but got ${factory?.javaClass?.name}",
+      )
+    }
+
+    val timeoutField = DefaultMcpStreamableServerSessionFactory::class.java.getDeclaredField("requestTimeout")
+    timeoutField.isAccessible = true
+    val requestTimeout = timeoutField.get(factory) as Duration
+
+    val handlersField = DefaultMcpStreamableServerSessionFactory::class.java.getDeclaredField("requestHandlers")
+    handlersField.isAccessible = true
+
+    @Suppress("UNCHECKED_CAST")
+    val requestHandlers = handlersField.get(factory) as Map<String, Any>
+
+    val notifField = DefaultMcpStreamableServerSessionFactory::class.java.getDeclaredField("notificationHandlers")
+    notifField.isAccessible = true
+
+    @Suppress("UNCHECKED_CAST")
+    val notificationHandlers = notifField.get(factory) as Map<String, Any>
+
+    return FactoryFields(requestTimeout, requestHandlers, notificationHandlers)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun <T> getPrivateField(
+    obj: Any,
+    fieldName: String,
+  ): T {
+    val field = obj.javaClass.getDeclaredField(fieldName)
+    field.isAccessible = true
+    return field.get(obj) as T
+  }
+
+  private class SessionIdCapturingResponseWrapper(
+    response: HttpServletResponse,
+  ) : HttpServletResponseWrapper(response) {
+    var capturedSessionId: String? = null
+      private set
+
+    override fun setHeader(
+      name: String,
+      value: String?,
+    ) {
+      if (name == MCP_SESSION_ID_HEADER && value != null) {
+        capturedSessionId = value
+      }
+      super.setHeader(name, value)
+    }
+
+    override fun addHeader(
+      name: String,
+      value: String?,
+    ) {
+      if (name == MCP_SESSION_ID_HEADER && value != null) {
+        capturedSessionId = value
+      }
+      super.addHeader(name, value)
+    }
+  }
+
+  private data class FactoryFields(
+    val requestTimeout: Duration,
+    val requestHandlers: Map<String, Any>,
+    val notificationHandlers: Map<String, Any>,
+  )
+
+  companion object {
+    private const val MCP_SESSION_ID_HEADER = "Mcp-Session-Id"
+    private const val REDIS_KEY_PREFIX = "mcp_session:"
+    private val SESSION_TTL = Duration.ofHours(48)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/McpRedisSessionRecoveryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/McpRedisSessionRecoveryTest.kt
@@ -1,0 +1,108 @@
+package io.tolgee.mcp
+
+import io.modelcontextprotocol.server.transport.WebMvcStreamableServerTransportProvider
+import io.modelcontextprotocol.spec.McpStreamableServerSession
+import io.tolgee.AbstractMcpTest
+import io.tolgee.fixtures.RedisRunner
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ContextConfiguration
+import java.util.concurrent.ConcurrentHashMap
+
+@SpringBootTest(
+  properties = [
+    "tolgee.cache.use-redis=true",
+    "tolgee.cache.enabled=true",
+  ],
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+)
+@ContextConfiguration(initializers = [McpRedisSessionRecoveryTest.Companion.Initializer::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextRecreatingTest
+class McpRedisSessionRecoveryTest : AbstractMcpTest() {
+  companion object {
+    val redisRunner = RedisRunner()
+
+    @AfterAll
+    @JvmStatic
+    fun stopRedis() {
+      redisRunner.stop()
+    }
+
+    class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+      override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
+        redisRunner.run()
+        TestPropertyValues
+          .of("spring.data.redis.port=${RedisRunner.port}")
+          .applyTo(configurableApplicationContext)
+      }
+    }
+  }
+
+  @Autowired
+  lateinit var transportProvider: WebMvcStreamableServerTransportProvider
+
+  @Autowired
+  lateinit var redissonClient: RedissonClient
+
+  lateinit var data: McpPatTestData
+
+  @BeforeEach
+  fun setup() {
+    data = createTestDataWithPat()
+  }
+
+  @AfterEach
+  fun clean() {
+    testDataService.cleanTestData(data.testData.root)
+  }
+
+  @Test
+  fun `session is recovered from Redis after local eviction`() {
+    // 1. Initialize MCP client — this creates a session and the filter persists it to Redis
+    val client = createMcpClientWithPat(data.pat.token!!)
+
+    // Verify the tool call works before eviction
+    val resultBefore = callTool(client, "list_projects")
+    assertThat(resultBefore.isError).isFalse()
+
+    // 2. Get the sessions map via reflection and find the session ID
+    val sessionsMap = getSessionsMap()
+    assertThat(sessionsMap).isNotEmpty
+
+    val sessionId = sessionsMap.keys().toList().first()
+
+    // Verify session data is in Redis
+    val bucket = redissonClient.getBucket<String>("mcp_session:$sessionId")
+    assertThat(bucket.get()).isNotNull
+
+    // 3. Remove session from local map to simulate request landing on a different replica
+    sessionsMap.remove(sessionId)
+    assertThat(sessionsMap.containsKey(sessionId)).isFalse()
+
+    // 4. Call a tool — the filter should recover the session from Redis
+    val resultAfter = callTool(client, "list_projects")
+    assertThat(resultAfter.isError).isFalse()
+
+    // 5. Verify session is back in local map
+    assertThat(sessionsMap.containsKey(sessionId)).isTrue()
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun getSessionsMap(): ConcurrentHashMap<String, McpStreamableServerSession> {
+    val field = WebMvcStreamableServerTransportProvider::class.java.getDeclaredField("sessions")
+    field.isAccessible = true
+    return field.get(transportProvider) as ConcurrentHashMap<String, McpStreamableServerSession>
+  }
+}


### PR DESCRIPTION
WebMvcStreamableServerTransportProvider stores sessions in an in-memory ConcurrentHashMap, causing 404 "Session not found" errors when requests scatter across replicas. Add a servlet filter that persists session metadata to Redis and reconstructs sessions on replicas that haven't seen the client.

Tracked upstream: https://github.com/modelcontextprotocol/java-sdk/issues/201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP sessions are now optionally persisted to Redis and synchronized across instances, enabling automatic session recovery and continuity for up to 48 hours (no-op when Redis is not configured).

* **Tests**
  * Added integration tests validating end-to-end Redis-backed session persistence and recovery across replicas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->