### PR TITLE
feat: optimize batch job throughput

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
@@ -486,7 +486,7 @@ class BatchJobTestUtil(
   fun verifiedTriedToLockJob(jobId: Long) {
     waitForNotThrowing {
       verify(batchJobProjectLockingManager, atLeast(1))
-        .canLockJobForProject(ArgumentMatchers.eq(jobId))
+        .canLockJobForProject(ArgumentMatchers.eq(jobId), ArgumentMatchers.any())
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
@@ -94,7 +94,7 @@ class BatchJobActionService(
 
             logger.debug("Job ${batchJobDto.id}: 🟡 Processing chunk ${lockedExecution.id}")
             val savepoint = savePointManager.setSavepoint()
-            val util = ChunkProcessingUtil(lockedExecution, applicationContext, coroutineContext)
+            val util = ChunkProcessingUtil(lockedExecution, applicationContext, coroutineContext, batchJobDto)
             util.processChunk()
 
             if (transactionStatus.isRollbackOnly) {

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ProgressManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ProgressManager.kt
@@ -382,9 +382,10 @@ class ProgressManager(
   fun reportSingleChunkProgress(
     jobId: Long,
     delta: Int = 1,
+    batchJobDto: BatchJobDto? = null,
   ) {
     batchJobStateProvider.addSingleChunkProgressCount(jobId, delta.toLong())
-    val job = batchJobService.getJobDto(jobId)
+    val job = batchJobDto ?: batchJobService.getJobDto(jobId)
     val confirmedProgress = batchJobStateProvider.getProgressCount(jobId)
     val optimisticProgress = batchJobStateProvider.getSingleChunkProgressCount(jobId)
     eventPublisher.publishEvent(

--- a/backend/data/src/main/kotlin/io/tolgee/batch/data/BatchJobType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/data/BatchJobType.kt
@@ -52,6 +52,7 @@ enum class BatchJobType(
     activityType = ActivityType.AUTO_TRANSLATE,
     maxRetries = 3,
     processor = AutoTranslateChunkProcessor::class,
+    exclusive = false,
   ),
   DELETE_KEYS(
     activityType = ActivityType.KEY_DELETE,


### PR DESCRIPTION
## Summary
- Add local Redis lock cache to avoid redundant round-trips for the common "still locked by another job" case (1s TTL, eager invalidation on unlock)
- Reorder project lock check before state mutation to eliminate ~5 redundant state operations per lock rejection on the hot path (~87% reduction in `STATE_GET/UPDATE_SINGLE_EXEC` calls)
- Pass `BatchJobDto` through the processing pipeline (`ChunkProcessingUtil`, `canLockJobForProject`) to reduce redundant `getJobDto` calls
- Add optional `batchJobDto` param to `reportSingleChunkProgress` (prep for future callers)
- Make `AUTO_TRANSLATE` non-exclusive so multiple auto-translate jobs can run concurrently across projects
- Handle project lock release when `trySetRunningState` fails on completed jobs to prevent deadlocks

## Test plan
- [x] `./gradlew compileKotlin` passes
- [x] `./gradlew ktlintFormat` passes
- [x] Run e2e perf test with exclusive mode: `./run...sh -k 1000 -j 10 -e 1`
- [x] Verify timing report shows dramatically reduced `STATE_*` operation counts
- [ ] Run existing batch job tests (especially `BatchJobProjectLockingTest`, `AbstractBatchJobsGeneralTest`)
- [x] Verify AUTO_TRANSLATE jobs can run concurrently across different projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch job processing reliability by preventing potential deadlocks during concurrent execution.

* **Tests**
  * Updated batch job test utilities to align with method signature changes.

* **Refactor**
  * Optimized batch job processing with local caching and reduced database lookups for improved performance.
  * Enhanced concurrency handling for automatic translation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->