### PR TITLE
fix: prevent LazyInitializationException in the MCP tools

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -65,6 +65,7 @@ class TagService(
   /**
    * @param map key entity to list of tags
    */
+  @Transactional
   fun tagKeys(map: Map<Key, List<String>>) {
     if (map.isEmpty()) {
       return
@@ -77,6 +78,7 @@ class TagService(
   /**
    * @param map keyId entity to list of tags
    */
+  @Transactional
   fun tagKeysById(
     projectId: Long,
     map: Map<Long, List<String>>,
@@ -129,6 +131,7 @@ class TagService(
       }.toMap()
   }
 
+  @Transactional
   fun untagKeys(
     projectId: Long,
     map: Map<Long, List<String>>,

--- a/backend/testing/src/main/kotlin/io/tolgee/AbstractMcpTest.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/AbstractMcpTest.kt
@@ -14,10 +14,14 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.TestInstance
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.TestPropertySource
 import java.time.Duration
 
+// OSIV is disabled to replicate production MCP environment where tool handlers
+// run without an open Hibernate session spanning the request.
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestPropertySource(properties = ["spring.jpa.open-in-view=false"])
 abstract class AbstractMcpTest : AbstractSpringTest() {
   @LocalServerPort
   protected val port: Int = 0


### PR DESCRIPTION
MCP tool handlers run without OpenSessionInView, so multiple service calls within a single handler need an explicit transaction. Without it, entities become detached between calls and lazy field access fails.

Wrapped all multi-service-call MCP tool handlers in executeInNewTransaction and added @Transactional to TagService methods that were missing it. Disabled OSIV in all MCP tests to replicate production behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced transactional integrity across machine translation, key management, project creation, and branch operations.
  * Strengthened data consistency for tagging and bulk operations through improved transaction boundaries.
  * Updated service layer with explicit transaction management for critical data modifications.

* **Tests**
  * Updated test configuration to better align with production environment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->