### PR TITLE
feat: add GET /branches/find endpoint for SDK branch protection

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchController.kt
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.activity.RequestActivity
 import io.tolgee.activity.data.ActivityType
 import io.tolgee.constants.Feature
+import io.tolgee.constants.Message
+import io.tolgee.exceptions.NotFoundException
 import io.tolgee.dtos.queryResults.branching.BranchMergeChangeView
 import io.tolgee.dtos.queryResults.branching.BranchMergeConflictView
 import io.tolgee.dtos.queryResults.branching.BranchMergeView
@@ -112,6 +114,20 @@ class BranchController(
     projectFeatureGuard.checkEnabled(Feature.BRANCHING)
     val branches = branchService.getBranches(projectHolder.project.id, pageable, search)
     return pagedBranchResourceAssembler.toModel(branches, branchModelAssembler)
+  }
+
+  @GetMapping(value = ["/find"])
+  @Operation(summary = "Get branch by name, or the default branch if name is not provided")
+  @AllowApiAccess
+  @UseDefaultPermissions
+  @OpenApiOrderExtension(2)
+  fun find(
+    @RequestParam("name", required = false) name: String?,
+  ): BranchModel {
+    projectFeatureGuard.checkEnabled(Feature.BRANCHING)
+    val branch = branchService.getActiveOrDefault(projectHolder.project.id, name)
+      ?: throw NotFoundException(Message.BRANCH_NOT_FOUND)
+    return branchModelAssembler.toModel(branch)
   }
 
   @DeleteMapping(value = ["/{branchId}"])

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerTest.kt
@@ -433,6 +433,33 @@ class BranchControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   }
 
   @Test
+  @ProjectApiKeyAuthTestMethod
+  fun `finds branch by name`() {
+    performProjectAuthGet("branches/find?name=feature-branch").andIsOk.andAssertThatJson {
+      node("name").isEqualTo("feature-branch")
+      node("isProtected").isEqualTo(false)
+      node("isDefault").isEqualTo(false)
+    }
+  }
+
+  @Test
+  @ProjectApiKeyAuthTestMethod
+  fun `find returns default branch when name not provided`() {
+    performProjectAuthGet("branches/find").andIsOk.andAssertThatJson {
+      node("name").isEqualTo("main")
+      node("isDefault").isEqualTo(true)
+      node("isProtected").isEqualTo(true)
+    }
+  }
+
+  @Test
+  @ProjectApiKeyAuthTestMethod
+  fun `find returns 404 for non-existent branch`() {
+    performProjectAuthGet("branches/find?name=non-existent").andIsNotFound
+      .andHasErrorMessage(Message.BRANCH_NOT_FOUND)
+  }
+
+  @Test
   @ProjectApiKeyAuthTestMethod(scopes = [Scope.BRANCH_MANAGEMENT])
   fun `accepts valid branch names`() {
     val validNames =


### PR DESCRIPTION
## Summary

- Users couldn't tell upfront if a branch was protected when using the in-context SDK editor
- Adds a new `GET /v2/projects/branches/find?name=<name>` endpoint that returns a single branch by name, or the default branch when no name is provided
- Used by tolgee-js SDK to proactively detect protected branches and show read-only mode before the user attempts to save

## Related

tolgee-js PR: https://github.com/tolgee/tolgee-js/pull/3495

## Test plan

- [ ] `BranchControllerTest` — finds branch by name
- [ ] `BranchControllerTest` — returns default branch when name not provided
- [ ] `BranchControllerTest` — returns 404 for non-existent branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a new branch lookup endpoint that retrieves branches by name or returns the default branch when no name is specified, with comprehensive error handling for non-existent branches.

## Tests
- Added test coverage validating the branch lookup functionality across multiple scenarios including named branch retrieval, default branch resolution, and error cases for missing branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->