### PR TITLE
fix: hide branching UI elements in tasks when branching is disabled

### DIFF
--- a/webapp/src/component/branching/useBranchLinks.ts
+++ b/webapp/src/component/branching/useBranchLinks.ts
@@ -30,7 +30,7 @@ export const useBranchLinks = (selectedBranch?: string) => {
     const url = link.build(params);
     const branchParam = branchName || branch;
 
-    if (!branchParam || !BRANCHING_LINKS.has(link)) {
+    if (!isBranchingEnabled || !branchParam || !BRANCHING_LINKS.has(link)) {
       return url;
     }
 

--- a/webapp/src/ee/task/components/PrefilterTask.tsx
+++ b/webapp/src/ee/task/components/PrefilterTask.tsx
@@ -22,6 +22,7 @@ import { TASK_ACTIVE_STATES } from 'tg.component/task/taskActiveStates';
 import { QUERY } from 'tg.constants/links';
 import { PrefilterTaskHideDoneSwitch } from './PrefilterTaskHideDoneSwitch';
 import { BranchNameChip } from 'tg.component/branching/BranchNameChip';
+import { useIsBranchingEnabled } from 'tg.component/branching/useIsBranchingEnabled';
 
 const StyledWarning = styled('div')`
   display: flex;
@@ -41,6 +42,7 @@ const StyledTaskId = styled('span')`
 
 export const PrefilterTask = ({ taskNumber }: PrefilterTaskProps) => {
   const project = useProject();
+  const isBranchingEnabled = useIsBranchingEnabled();
   const { t } = useTranslate();
   const currentUser = useUser();
 
@@ -115,7 +117,7 @@ export const PrefilterTask = ({ taskNumber }: PrefilterTaskProps) => {
             pr={2}
           >
             <TaskLabel task={data} />
-            {data.branchName && (
+            {isBranchingEnabled && data.branchName && (
               <BranchNameChip name={data.branchName!} size={'small'} />
             )}
             <Tooltip title={t('task_detail_tooltip')} disableInteractive>


### PR DESCRIPTION
## Summary
- Skip branch parameter in URL building when branching is disabled (`useBranchLinks.ts`)
- Hide branch name chip in task prefilter when branching is disabled (`PrefilterTask.tsx`)

## Test plan
- [ ] Verify tasks section renders correctly without branch chips when branching is disabled
- [ ] Verify branch links don't include branch params when branching is disabled
- [ ] Verify both features still work correctly when branching is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Improvements**
* Branching functionality now integrates with feature flag controls to ensure consistent availability across the application.
* URL generation and branch name display now properly validate feature flag state before enabling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->