### PR TITLE
feat: limit concurrent non-exclusive batch jobs per project

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
@@ -5,6 +5,7 @@ import io.tolgee.batch.data.BatchJobType
 import io.tolgee.batch.processors.AutomationChunkProcessor
 import io.tolgee.batch.processors.DeleteKeysChunkProcessor
 import io.tolgee.batch.processors.MachineTranslationChunkProcessor
+import io.tolgee.batch.processors.NoOpChunkProcessor
 import io.tolgee.batch.processors.PreTranslationByTmChunkProcessor
 import io.tolgee.batch.request.AutomationBjRequest
 import io.tolgee.batch.request.DeleteKeysRequest
@@ -114,6 +115,10 @@ abstract class AbstractBatchJobConcurrentTest :
 
   @MockitoSpyBean
   @Autowired
+  lateinit var noOpChunkProcessor: NoOpChunkProcessor
+
+  @MockitoSpyBean
+  @Autowired
   lateinit var autoTranslationService: AutoTranslationService
 
   @BeforeEach
@@ -150,6 +155,7 @@ abstract class AbstractBatchJobConcurrentTest :
     Mockito.reset(deleteKeysChunkProcessor)
     Mockito.reset(machineTranslationChunkProcessor)
     Mockito.reset(automationChunkProcessor)
+    Mockito.reset(noOpChunkProcessor)
     Mockito.reset(autoTranslationService)
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobNonExclusiveProjectLimitTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobNonExclusiveProjectLimitTest.kt
@@ -1,0 +1,103 @@
+package io.tolgee.batch
+
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.assert
+import io.tolgee.util.logger
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ContextConfiguration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests that non-exclusive jobs are limited per project so that
+ * a single project with many non-exclusive jobs doesn't starve other projects.
+ */
+@SpringBootTest(
+  properties = [
+    "tolgee.cache.use-redis=true",
+    "tolgee.cache.enabled=true",
+    "tolgee.websocket.use-redis=true",
+    "tolgee.batch.concurrency=10",
+    "tolgee.batch.max-non-exclusive-jobs-per-project=2",
+  ],
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+)
+@ContextConfiguration(initializers = [AbstractBatchJobConcurrentTest.Companion.Initializer::class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextRecreatingTest
+class BatchJobNonExclusiveProjectLimitTest : AbstractBatchJobConcurrentTest() {
+  @Test
+  fun `limits concurrent non-exclusive jobs per project`() {
+    val concurrentJobIds = ConcurrentHashMap.newKeySet<Long>()
+    val maxConcurrentDistinctJobs = AtomicInteger(0)
+    val currentConcurrentDistinctJobs = ConcurrentHashMap<Long, AtomicInteger>()
+
+    doAnswer { invocation ->
+      val job = invocation.getArgument<io.tolgee.batch.data.BatchJobDto>(0)
+      val counter = currentConcurrentDistinctJobs.computeIfAbsent(job.id) { AtomicInteger(0) }
+      // Only count the first chunk of each job entering
+      if (counter.incrementAndGet() == 1) {
+        concurrentJobIds.add(job.id)
+        maxConcurrentDistinctJobs.updateAndGet { max -> maxOf(max, concurrentJobIds.size) }
+      }
+      try {
+        Thread.sleep(200)
+      } finally {
+        if (counter.decrementAndGet() == 0) {
+          concurrentJobIds.remove(job.id)
+        }
+      }
+    }.whenever(noOpChunkProcessor).process(any(), any(), any())
+
+    // Start 5 non-exclusive NO_OP jobs for projectA
+    val jobs = (1..5).map { runNoOpJob(testData.projectA, 3) }
+
+    jobs.forEach { waitForJobComplete(it, timeoutMs = 30_000) }
+
+    jobs.forEach { assertJobSuccess(it) }
+
+    logger.info("Max concurrent distinct non-exclusive jobs for project: ${maxConcurrentDistinctJobs.get()}")
+    maxConcurrentDistinctJobs
+      .get()
+      .assert
+      .isLessThanOrEqualTo(batchProperties.maxNonExclusiveJobsPerProject)
+  }
+
+  @Test
+  fun `non-exclusive jobs from different projects can run concurrently`() {
+    val currentConcurrency = AtomicInteger(0)
+    val maxConcurrency = AtomicInteger(0)
+
+    doAnswer {
+      val current = currentConcurrency.incrementAndGet()
+      maxConcurrency.updateAndGet { max -> maxOf(max, current) }
+      try {
+        Thread.sleep(100)
+      } finally {
+        currentConcurrency.decrementAndGet()
+      }
+    }.whenever(noOpChunkProcessor).process(any(), any(), any())
+
+    // Start non-exclusive jobs on different projects
+    val jobA = runNoOpJob(testData.projectA, 2)
+    val jobB = runNoOpJob(testData.projectB, 2)
+    val jobC = runNoOpJob(testData.projectC, 2)
+
+    waitForJobComplete(jobA, timeoutMs = 15_000)
+    waitForJobComplete(jobB, timeoutMs = 15_000)
+    waitForJobComplete(jobC, timeoutMs = 15_000)
+
+    assertJobSuccess(jobA)
+    assertJobSuccess(jobB)
+    assertJobSuccess(jobC)
+
+    // All 3 projects should be able to run concurrently (limit is per-project)
+    logger.info("Max concurrent non-exclusive chunks across projects: ${maxConcurrency.get()}")
+    maxConcurrency.get().assert.isGreaterThan(1)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
@@ -187,6 +187,21 @@ class BatchJobConcurrentLauncher(
       return false
     }
 
+    if (!canRunNonExclusiveJobForProject(batchJobDto)) {
+      logger.debug(
+        "Cannot run execution ${executionItem.chunkExecutionId}. " +
+          "Project ${batchJobDto.projectId} already has max non-exclusive jobs running, skipping",
+      )
+      batchJobChunkExecutionQueue.addItemsToLocalQueue(
+        listOf(
+          executionItem.also {
+            it.executeAfter = currentDateProvider.date.time + 1000
+          },
+        ),
+      )
+      return false
+    }
+
     /**
      * Only single job can run in project at the same time.
      * Check this BEFORE trySetRunningState to avoid mutating state for lock-rejected chunks,
@@ -288,6 +303,26 @@ class BatchJobConcurrentLauncher(
       logger.debug("Debouncing max wait time reached for job ${dto.id}")
     }
     return maxTimeReached
+  }
+
+  private fun canRunNonExclusiveJobForProject(batchJobDto: BatchJobDto): Boolean {
+    if (batchJobDto.type.exclusive) {
+      return true
+    }
+    val projectId = batchJobDto.projectId ?: return true
+    val maxNonExclusive = batchProperties.maxNonExclusiveJobsPerProject
+    if (maxNonExclusive <= 0) {
+      return true
+    }
+    val runningNonExclusiveJobIdsForProject =
+      runningJobs.values
+        .filter { !it.first.type.exclusive && it.first.projectId == projectId }
+        .mapTo(HashSet()) { it.first.id }
+    // Don't block additional chunks for a job that's already running
+    if (batchJobDto.id in runningNonExclusiveJobIdsForProject) {
+      return true
+    }
+    return runningNonExclusiveJobIdsForProject.size < maxNonExclusive
   }
 
   private fun canRunJobWithCharacter(character: JobCharacter): Boolean {

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/BatchProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/BatchProperties.kt
@@ -54,4 +54,14 @@ class BatchProperties {
     defaultExplanation = "30 seconds",
   )
   var cancellationTimeoutMs: Long = 30000
+
+  @DocProperty(
+    description =
+      "Maximum number of concurrently running non-exclusive jobs per project per instance. " +
+        "This prevents a single project with many non-exclusive jobs (e.g. AUTO_TRANSLATE) " +
+        "from monopolizing all worker coroutines and starving other projects. " +
+        "The limit is enforced locally on each Tolgee instance, not globally across the cluster.",
+    defaultExplanation = "2",
+  )
+  var maxNonExclusiveJobsPerProject: Int = 2
 }


### PR DESCRIPTION
Prevents a single project with many non-exclusive jobs (e.g. AUTO_TRANSLATE) from monopolizing all worker coroutines and starving other projects.

Adds configurable tolgee.batch.max-non-exclusive-jobs-per-project (default: 2) that limits how many distinct non-exclusive jobs from one project can run concurrently on each instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for batch job concurrency behavior, including per-project job limits and cross-project execution scenarios.

* **Chores**
  * Introduced a new configuration property to control the maximum number of concurrent non-exclusive batch jobs per project instance (default: 2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->