### PR TITLE
fix: batch IN clause in LanguageStatsListener to avoid PostgreSQL parameter limit

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
@@ -80,8 +80,8 @@ class LanguageStatsListener(
     val keyIds = event.modifiedEntities[Key::class]?.keys.orEmpty()
     if (keyIds.isEmpty()) return
 
-    keyRepository.getBranchIdsByIds(keyIds).forEach { branchId ->
-      branchIds.add(branchId)
+    keyIds.chunked(IN_CLAUSE_BATCH_SIZE).forEach { chunk ->
+      branchIds.addAll(keyRepository.getBranchIdsByIds(chunk))
     }
   }
 
@@ -92,8 +92,12 @@ class LanguageStatsListener(
     val translationIds = event.modifiedEntities[Translation::class]?.keys.orEmpty()
     if (translationIds.isEmpty()) return
 
-    translationRepository.getBranchIdsByIds(translationIds).forEach { branchId ->
-      branchIds.add(branchId)
+    translationIds.chunked(IN_CLAUSE_BATCH_SIZE).forEach { chunk ->
+      branchIds.addAll(translationRepository.getBranchIdsByIds(chunk))
     }
+  }
+
+  companion object {
+    private const val IN_CLAUSE_BATCH_SIZE = 30_000
   }
 }


### PR DESCRIPTION
## Summary
- `LanguageStatsListener.collectBranchIdsForTranslations` passes all modified translation IDs in a single `WHERE IN (...)` clause to PostgreSQL
- When a large activity event modifies >65K translations, this exceeds PostgreSQL's 65,535 PreparedStatement parameter limit
- Fix: chunk IDs into batches of 30,000 before querying (applies to both `collectBranchIdsForKeys` and `collectBranchIdsForTranslations`)

Fixes TOLGEE-BACKEND-3GT

## Test plan
- [ ] Verify the fix compiles and existing tests pass
- [ ] Optionally test with a large project import that modifies >65K translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved language statistics refresh performance by processing ID lookups in large batched chunks and aggregating results to reduce per-item overhead.
  * Added internal batching controls to handle high-volume datasets more efficiently.
  * No changes to public APIs or external behavior; existing fallback to full refresh remains when unresolved data is encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->