### PR TITLE
Limit batch queue size to prevent CPU waste during MACHINE_TRANSLATE processing

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -109,7 +109,7 @@ class BatchJobChunkExecutionQueue(
         ).setParameter("executionStatus", BatchJobChunkExecutionStatus.PENDING)
         .setParameter("runningStatus", BatchJobStatus.RUNNING)
         // Limit to get pending batches faster
-        .setMaxResults(500)
+        .setMaxResults(batchProperties.queuePopulateLimit)
         .resultList
 
     if (data.size > 0) {

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/BatchProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/BatchProperties.kt
@@ -1,9 +1,13 @@
 package io.tolgee.configuration.tolgee
 
 import io.tolgee.configuration.annotations.DocProperty
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
 @ConfigurationProperties(prefix = "tolgee.batch")
+@Validated
 @DocProperty(description = "Configuration of batch operations.", displayName = "Batch operations")
 class BatchProperties {
   @DocProperty(description = "How many parallel jobs can be run at once on single Tolgee instance")
@@ -54,4 +58,14 @@ class BatchProperties {
     defaultExplanation = "30 seconds",
   )
   var cancellationTimeoutMs: Long = 30000
+
+  @DocProperty(
+    description =
+      "Maximum number of pending batch job chunk executions to load into the in-memory queue " +
+        "on each scheduled populate run. Limits CPU and memory usage when the queue grows large.",
+    defaultValue = "500",
+  )
+  @field:Min(10)
+  @field:Max(5000)
+  var queuePopulateLimit: Int = 500
 }


### PR DESCRIPTION
When the batch queue grows very large with many pending items, iterating through
the entire queue to fetch pending batches consumes significant CPU and memory resources
without providing any performance benefit. The queue traversal becomes a bottleneck
that slows down MACHINE_TRANSLATE batch processing.

Set max result limit to 500 items to fetch pending batches efficiently and prevent
the queue from degrading system performance. This ensures batch processing remains
responsive even with high workloads.

Closes: https://github.com/tolgee/tolgee-platform/issues/3480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Pending batch selection now respects a configurable maximum (default 500), reducing load and improving queue predictability and latency.

* **Configuration**
  * New validated setting to adjust the batch queue populate limit per run (range constrained, default 500).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->