### PR TITLE
perf: allow concurrent MACHINE_TRANSLATE batch jobs across projects

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/data/BatchJobType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/data/BatchJobType.kt
@@ -47,6 +47,7 @@ enum class BatchJobType(
     activityType = ActivityType.BATCH_MACHINE_TRANSLATE,
     maxRetries = 3,
     processor = MachineTranslationChunkProcessor::class,
+    exclusive = false
   ),
   AUTO_TRANSLATE(
     activityType = ActivityType.AUTO_TRANSLATE,


### PR DESCRIPTION
MACHINE_TRANSLATE was exclusive by default, meaning only one job could run at a time per project. Setting `exclusive = false` allows multiple jobs to run concurrently, improving throughput when several projects trigger machine translation at the same time.

Closes: https://github.com/tolgee/tolgee-platform/issues/3482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Machine translation jobs can now execute concurrently, allowing multiple translation operations to run simultaneously without blocking other processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->