### PR TITLE
fix: prevent NonUniqueObjectException on duplicate screenshot references

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -214,6 +214,7 @@ class ResolvingKeyImporter(
         ).toMutableList()
 
     val referencesToDelete = mutableListOf<KeyScreenshotReference>()
+    val addedReferences = mutableSetOf<Pair<Long, Long>>()
 
     keysToImport.forEach {
       val key = getOrCreateKey(it)
@@ -222,6 +223,11 @@ class ResolvingKeyImporter(
           createdScreenshots[screenshot.uploadedImageId]
             ?: throw NotFoundException(Message.ONE_OR_MORE_IMAGES_NOT_FOUND)
         val info = ScreenshotInfoDto(screenshot.text, screenshot.positions)
+
+        val referenceKey = key.first.id to screenshotResult.screenshot.id
+        if (!addedReferences.add(referenceKey)) {
+          return@forEach
+        }
 
         screenshotService.addReference(
           key = key.first,


### PR DESCRIPTION
## Summary

- Fix `NonUniqueObjectException` in `ResolvingKeyImporter.importScreenshots()` when the same `(key, screenshot)` pair is persisted twice in the same Hibernate session
- This happens when the API request contains duplicate `uploadedImageId` entries for the same key (either repeated in the screenshots array, or across multiple items resolving to the same key)
- Added deduplication tracking via a `Set<Pair<Long, Long>>` to skip already-processed references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Import operations now prevent duplicate screenshot references from being created during file processing, ensuring cleaner imports and improved data consistency without redundant entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->