### PR TITLE
fix: Merge duplicate screenshot references during key import

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerResolvableImportTest.kt
@@ -10,6 +10,7 @@ import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.generateImage
 import io.tolgee.fixtures.node
+import io.tolgee.model.key.screenshotReference.KeyInScreenshotPosition
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
@@ -147,6 +148,251 @@ class KeyControllerResolvableImportTest : ProjectAuthControllerTest("/v2/project
       assertTranslationText("namespace-1", "key-1", "de", "changed")
       assertTranslationText("namespace-1", "key-1", "en", "new")
       assertTranslationText("namespace-1", "key-2", "en", "existing translation")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `merges positions of duplicate screenshot references for the same key`() {
+    val imageId = storeUnscaledImage()
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "text" to "First text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                        mapOf("x" to 500, "y" to 200, "width" to 30, "height" to 20),
+                      ),
+                  ),
+                  mapOf(
+                    "text" to "Second text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 10, "y" to 20, "width" to 5, "height" to 5),
+                      ),
+                  ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      val references = getReferences("namespace-1", "merge-key")
+      references.assert.hasSize(1)
+      val reference = references.single()
+      reference.originalText.assert.isEqualTo("First text")
+      reference.positions.assert.isEqualTo(
+        listOf(
+          KeyInScreenshotPosition(100, 150, 80, 100),
+          KeyInScreenshotPosition(500, 200, 30, 20),
+          KeyInScreenshotPosition(10, 20, 5, 5),
+        ),
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `keeps first non-null text when merging duplicate screenshot references`() {
+    val imageId = storeUnscaledImage()
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                      ),
+                  ),
+                  mapOf(
+                    "text" to "Second text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 10, "y" to 20, "width" to 5, "height" to 5),
+                      ),
+                  ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      val reference = getReferences("namespace-1", "merge-key").single()
+      reference.originalText.assert.isEqualTo("Second text")
+      reference.positions.assert.isEqualTo(
+        listOf(
+          KeyInScreenshotPosition(100, 150, 80, 100),
+          KeyInScreenshotPosition(10, 20, 5, 5),
+        ),
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `merges duplicate screenshot references across separate key entries with the same name`() {
+    val imageId = storeUnscaledImage()
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "text" to "First text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                      ),
+                  ),
+                ),
+            ),
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "text" to "Second text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 10, "y" to 20, "width" to 5, "height" to 5),
+                      ),
+                  ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      val references = getReferences("namespace-1", "merge-key")
+      references.assert.hasSize(1)
+      val reference = references.single()
+      reference.originalText.assert.isEqualTo("First text")
+      reference.positions.assert.isEqualTo(
+        listOf(
+          KeyInScreenshotPosition(100, 150, 80, 100),
+          KeyInScreenshotPosition(10, 20, 5, 5),
+        ),
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `merging a duplicate reference with no positions keeps the existing positions`() {
+    val imageId = storeUnscaledImage()
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "text" to "First text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                      ),
+                  ),
+                  mapOf(
+                    "text" to "Second text",
+                    "uploadedImageId" to imageId,
+                  ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      val reference = getReferences("namespace-1", "merge-key").single()
+      reference.originalText.assert.isEqualTo("First text")
+      reference.positions.assert.isEqualTo(
+        listOf(
+          KeyInScreenshotPosition(100, 150, 80, 100),
+        ),
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `does not duplicate identical positions when merging duplicate references`() {
+    val imageId = storeUnscaledImage()
+    performProjectAuthPost(
+      "keys/import-resolvable",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf(
+              "name" to "merge-key",
+              "namespace" to "namespace-1",
+              "screenshots" to
+                listOf(
+                  mapOf(
+                    "text" to "First text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                      ),
+                  ),
+                  mapOf(
+                    "text" to "Second text",
+                    "uploadedImageId" to imageId,
+                    "positions" to
+                      listOf(
+                        mapOf("x" to 100, "y" to 150, "width" to 80, "height" to 100),
+                      ),
+                  ),
+                ),
+            ),
+          ),
+      ),
+    ).andIsOk
+
+    executeInNewTransaction {
+      val reference = getReferences("namespace-1", "merge-key").single()
+      reference.positions.assert.isEqualTo(
+        listOf(
+          KeyInScreenshotPosition(100, 150, 80, 100),
+        ),
+      )
     }
   }
 
@@ -413,6 +659,25 @@ class KeyControllerResolvableImportTest : ProjectAuthControllerTest("/v2/project
       assertTranslationText("namespace-1", "key-2", "en", "existing translation")
     }
   }
+
+  // 1000x1000 stays under ImageConverter's 3MP resize threshold, so the stored screenshot keeps
+  // the source dimensions and screenshot positions are persisted without coordinate scaling.
+  private fun storeUnscaledImage() =
+    imageUploadService
+      .store(
+        generateImage(1000, 1000),
+        userAccount!!,
+        ImageUploadInfoDto(location = "merge frame"),
+      ).id
+
+  fun getReferences(
+    namespace: String?,
+    keyName: String,
+  ) = projectService
+    .get(testData.projectBuilder.self.id)
+    .keys
+    .find { it.name == keyName && it.namespace?.name == namespace }!!
+    .keyScreenshotReferences
 
   fun assertTranslationText(
     namespace: String?,

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -1,8 +1,10 @@
 package io.tolgee.service.key
 
 import io.tolgee.constants.Message
+import io.tolgee.dtos.CreateScreenshotResult
 import io.tolgee.dtos.KeyImportResolvableResult
 import io.tolgee.dtos.cacheable.LanguageDto
+import io.tolgee.dtos.request.KeyInScreenshotPositionDto
 import io.tolgee.dtos.request.ScreenshotInfoDto
 import io.tolgee.dtos.request.translation.importKeysResolvable.ImportKeysResolvableItemDto
 import io.tolgee.dtos.request.translation.importKeysResolvable.ImportTranslationResolution
@@ -214,7 +216,14 @@ class ResolvingKeyImporter(
         ).toMutableList()
 
     val referencesToDelete = mutableListOf<KeyScreenshotReference>()
-    val addedReferences = mutableSetOf<Pair<Long, Long>>()
+
+    data class MergedReferenceData(
+      val key: Pair<Key, Boolean>,
+      val screenshotResult: CreateScreenshotResult,
+      val mergedInfo: ScreenshotInfoDto,
+    )
+
+    val mergedReferences = linkedMapOf<Pair<Long, Long>, MergedReferenceData>()
 
     keysToImport.forEach {
       val key = getOrCreateKey(it)
@@ -222,20 +231,28 @@ class ResolvingKeyImporter(
         val screenshotResult =
           createdScreenshots[screenshot.uploadedImageId]
             ?: throw NotFoundException(Message.ONE_OR_MORE_IMAGES_NOT_FOUND)
-        val info = ScreenshotInfoDto(screenshot.text, screenshot.positions)
 
         val referenceKey = key.first.id to screenshotResult.screenshot.id
-        if (!addedReferences.add(referenceKey)) {
+        val existing = mergedReferences[referenceKey]
+        if (existing != null) {
+          screenshot.positions?.let { newPositions ->
+            val combined: MutableList<KeyInScreenshotPositionDto> =
+              existing.mergedInfo.positions?.toMutableList() ?: mutableListOf()
+            combined.addAll(newPositions)
+            existing.mergedInfo.positions = combined
+          }
+          if (existing.mergedInfo.text == null) {
+            existing.mergedInfo.text = screenshot.text
+          }
           return@forEach
         }
 
-        screenshotService.addReference(
-          key = key.first,
-          screenshot = screenshotResult.screenshot,
-          info = info,
-          originalDimension = screenshotResult.originalDimension,
-          targetDimension = screenshotResult.targetDimension,
-        )
+        mergedReferences[referenceKey] =
+          MergedReferenceData(
+            key = key,
+            screenshotResult = screenshotResult,
+            mergedInfo = ScreenshotInfoDto(screenshot.text, screenshot.positions?.toMutableList()),
+          )
 
         val toDelete =
           allReferences.filter { reference ->
@@ -245,6 +262,16 @@ class ResolvingKeyImporter(
 
         referencesToDelete.addAll(toDelete)
       }
+    }
+
+    mergedReferences.values.forEach { refData ->
+      screenshotService.addReference(
+        key = refData.key.first,
+        screenshot = refData.screenshotResult.screenshot,
+        info = refData.mergedInfo,
+        originalDimension = refData.screenshotResult.originalDimension,
+        targetDimension = refData.screenshotResult.targetDimension,
+      )
     }
 
     screenshotService.removeScreenshotReferences(referencesToDelete)

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -1,8 +1,10 @@
 package io.tolgee.service.key
 
 import io.tolgee.constants.Message
+import io.tolgee.dtos.CreateScreenshotResult
 import io.tolgee.dtos.KeyImportResolvableResult
 import io.tolgee.dtos.cacheable.LanguageDto
+import io.tolgee.dtos.request.KeyInScreenshotPositionDto
 import io.tolgee.dtos.request.ScreenshotInfoDto
 import io.tolgee.dtos.request.translation.importKeysResolvable.ImportKeysResolvableItemDto
 import io.tolgee.dtos.request.translation.importKeysResolvable.ImportTranslationResolution
@@ -214,37 +216,56 @@ class ResolvingKeyImporter(
         ).toMutableList()
 
     val referencesToDelete = mutableListOf<KeyScreenshotReference>()
-    val addedReferences = mutableSetOf<Pair<Long, Long>>()
+
+    val mergedReferences = linkedMapOf<Pair<Long, Long>, MergedReferenceData>()
 
     keysToImport.forEach {
-      val key = getOrCreateKey(it)
+      val (key, _) = getOrCreateKey(it)
       it.screenshots?.forEach { screenshot ->
         val screenshotResult =
           createdScreenshots[screenshot.uploadedImageId]
             ?: throw NotFoundException(Message.ONE_OR_MORE_IMAGES_NOT_FOUND)
-        val info = ScreenshotInfoDto(screenshot.text, screenshot.positions)
 
-        val referenceKey = key.first.id to screenshotResult.screenshot.id
-        if (!addedReferences.add(referenceKey)) {
+        val referenceKey = key.id to screenshotResult.screenshot.id
+        val existing = mergedReferences[referenceKey]
+        if (existing != null) {
+          screenshot.positions?.let { newPositions ->
+            val combined: MutableList<KeyInScreenshotPositionDto> =
+              existing.mergedInfo.positions?.toMutableList() ?: mutableListOf()
+            combined.addAll(newPositions.filter { it !in combined })
+            existing.mergedInfo.positions = combined
+          }
+          if (existing.mergedInfo.text == null) {
+            existing.mergedInfo.text = screenshot.text
+          }
           return@forEach
         }
 
-        screenshotService.addReference(
-          key = key.first,
-          screenshot = screenshotResult.screenshot,
-          info = info,
-          originalDimension = screenshotResult.originalDimension,
-          targetDimension = screenshotResult.targetDimension,
-        )
+        mergedReferences[referenceKey] =
+          MergedReferenceData(
+            key = key,
+            screenshotResult = screenshotResult,
+            mergedInfo = ScreenshotInfoDto(screenshot.text, screenshot.positions?.toMutableList()),
+          )
 
         val toDelete =
           allReferences.filter { reference ->
-            reference.key.id == key.first.id &&
+            reference.key.id == key.id &&
               reference.screenshot.location == screenshotResult.screenshot.location
           }
 
         referencesToDelete.addAll(toDelete)
       }
+    }
+
+    mergedReferences.values.forEach { refData ->
+      screenshotService.addReference(
+        key = refData.key,
+        screenshot = refData.screenshotResult.screenshot,
+        info = refData.mergedInfo,
+        originalDimension = refData.screenshotResult.originalDimension,
+        targetDimension = refData.screenshotResult.targetDimension,
+      )
     }
 
     screenshotService.removeScreenshotReferences(referencesToDelete)
@@ -384,4 +405,10 @@ class ResolvingKeyImporter(
         key to translations.associateBy { it.language.tag }
       }.toMap()
   }
+
+  private data class MergedReferenceData(
+    val key: Key,
+    val screenshotResult: CreateScreenshotResult,
+    val mergedInfo: ScreenshotInfoDto,
+  )
 }


### PR DESCRIPTION
## Summary
- Fix `NonUniqueObjectException` crash on the deprecated `POST keys/import-resolvable` endpoint when the same `(key, screenshot)` pair appears more than once in a single import (reported via Sentry).
- `ResolvingKeyImporter.importScreenshots()` now accumulates references and merges duplicates instead of persisting one per entry: positions are combined (identical positions are deduplicated, so a repeated submit stays idempotent) and the first non-null text is kept. Each `(key, screenshot)` reference is persisted once after the whole import is processed.
- Scope: merge applies only to this endpoint; the standard data-import path (`ScreenshotImporter`) is intentionally unchanged.
- Tests cover within-entry merge (position contents + order), cross-entry merge (same key name across separate entries), first-non-null text, a duplicate with no positions, and identical-position deduplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Importer now merges duplicate screenshot references (including across separate key entries), concatenates position data, avoids duplicate positions, and preserves the first available reference text; duplicates without positions retain existing positions.
* **Chores**
  * Consolidated reference handling during import to ensure a single merged reference per screenshot/key and more reliable cleanup of obsolete references.
* **Tests**
  * Added integration tests validating merged positions, text-selection rules, cross-entry merging, and deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->