### PR TITLE
fix: prevent Quick Start panel from reopening after user closes it

### DIFF
--- a/webapp/src/views/projects/translations/Translations.tsx
+++ b/webapp/src/views/projects/translations/Translations.tsx
@@ -36,7 +36,7 @@ const StyledContainer = styled('div')`
 `;
 
 export const Translations = () => {
-  const { setQuickStartOpen, setQuickStartFloatingForced } = useGlobalActions();
+  const { setQuickStartFloatingForced } = useGlobalActions();
   const prefilter = useTranslationsSelector((c) => c.prefilter);
   const quickStartEnabled = useGlobalContext((c) => c.quickStartGuide.enabled);
   const { t } = useTranslate();
@@ -95,7 +95,6 @@ export const Translations = () => {
   useEffect(() => {
     if (sidePanelWidth && quickStartEnabled) {
       setQuickStartFloatingForced(true);
-      setQuickStartOpen(true);
       return () => {
         setQuickStartFloatingForced(false);
       };


### PR DESCRIPTION
## Summary

- Remove unconditional `setQuickStartOpen(true)` call in the translations view that overrode the user's manual close of the Quick Start panel
- The `floatingForced` mechanism alone correctly handles the layout transition between the Quick Start sidebar and the translation side panel
- Fixes the panel reopening when stopping translation editing or reloading the page after manually closing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quick start panel no longer automatically opens when side-panel width or quick-start settings change; only the floating state is now affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->