### PR TITLE
chore: fix intermittent WebsocketAuthenticationTest and ScheduledUsageReportingTest

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -192,7 +192,7 @@ class WebsocketTestHelper(
 
   fun waitForAuthenticationStatus(status: MySessionHandler.AuthenticationStatus) {
     try {
-      waitFor(500) {
+      waitFor(5000) {
         sessionHandler?.authenticationStatus == status
       }
     } catch (e: WaitNotSatisfiedException) {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/selfHostedLimitsAndReporting/ScheduledUsageReportingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/selfHostedLimitsAndReporting/ScheduledUsageReportingTest.kt
@@ -119,31 +119,34 @@ class ScheduledUsageReportingTest : AbstractSpringTest() {
       }
 
       verify {
+        // Record baseline captor size to avoid race condition: the scheduler (100ms interval)
+        // may fire between mock setup and this point, producing extra captures.
+        val baseSize = captor.allValues.size
         usageToReportService.delete()
         waitForNotThrowing(timeout = 10_000, pollTime = 100) {
-          captor.allValues.assert.hasSize(1)
+          captor.allValues.assert.hasSize(baseSize + 1)
         }
 
         keyService.create(testData.project, "key1", null)
 
         // It doesn't report until we move time
         Thread.sleep(200)
-        captor.allValues.assert.hasSize(1)
+        captor.allValues.assert.hasSize(baseSize + 1)
 
         currentDateProvider.move(Duration.ofDays(1))
         waitForNotThrowing(timeout = 10_000, pollTime = 100) {
-          captor.allValues.assert.hasSize(2)
+          captor.allValues.assert.hasSize(baseSize + 2)
         }
 
         createUser(1)
 
         // It doesn't report until we move time
         Thread.sleep(200)
-        captor.allValues.assert.hasSize(2)
+        captor.allValues.assert.hasSize(baseSize + 2)
 
         currentDateProvider.move(Duration.ofDays(1))
         waitForNotThrowing(timeout = 10_000, pollTime = 100) {
-          captor.allValues.assert.hasSize(3)
+          captor.allValues.assert.hasSize(baseSize + 3)
         }
       }
     }


### PR DESCRIPTION
## Summary
- **WebsocketTestHelper**: increase `waitForAuthenticationStatus` timeout from 500ms to 5000ms — too tight for CI runners under load
- **ScheduledUsageReportingTest**: use relative captor sizes (`baseSize + N`) instead of absolute counts to avoid race condition where the scheduler fires between mock setup and the verify block

## Test plan
- [x] WebsocketAuthenticationTest: 100/100 passed locally with `@RepeatedTest(100)`
- [x] ScheduledUsageReportingTest: 3/3 passed with context recreation (CI-style)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by increasing authentication status timeout and making test assertions more robust against race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->