### PR TITLE
fix: hide EUR column for fixed plans, format EUR to 2 decimals

### DIFF
--- a/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderPricingDialog.tsx
+++ b/webapp/src/ee/llm/OrganizationLLMProviders/LlmProviderPricingDialog.tsx
@@ -37,7 +37,9 @@ export const LlmProviderPricingDialog = ({
   const outputPrice = provider.tokenPriceInCreditsOutput;
   const hasPricing = inputPrice != null && outputPrice != null;
   const pricePerMtCredit =
-    perThousandMtCredits != null ? perThousandMtCredits / 1000 : null;
+    perThousandMtCredits != null && perThousandMtCredits > 0
+      ? perThousandMtCredits / 1000
+      : null;
 
   function formatCredits(value: number): string {
     return formatNumber(value, {
@@ -50,7 +52,7 @@ export const LlmProviderPricingDialog = ({
     if (pricePerMtCredit == null) return null;
     return formatMoney(credits * pricePerMtCredit, {
       currency: 'EUR',
-      maximumFractionDigits: 4,
+      maximumFractionDigits: 2,
       minimumFractionDigits: 2,
     });
   }


### PR DESCRIPTION
## Summary
- Hide EUR column in LLM pricing dialog when `perThousandMtCredits` is 0 (fixed plans) — previously showed misleading €0.00 values
- Format EUR amounts to exactly 2 decimal places (was up to 4)

## Test plan
- [ ] Fixed plan users don't see EUR column
- [ ] Pay-as-you-go users see EUR formatted as e.g. €1.23 (not €1.2345)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing calculation validation to prevent invalid values from displaying.
  * Updated currency formatting to display prices with greater precision for EUR conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->