### PR TITLE
test: fix flaky SlackWithAutoTranslationTest race condition

### DIFF
--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/slack/SlackWithAutoTranslationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/slack/SlackWithAutoTranslationTest.kt
@@ -1,7 +1,7 @@
 package io.tolgee.ee.slack
 
 import com.slack.api.Slack
-import com.slack.api.methods.request.chat.ChatPostMessageRequest
+import com.slack.api.model.Attachment
 import com.slack.api.model.block.SectionBlock
 import io.tolgee.development.testDataBuilder.data.SlackTestData
 import io.tolgee.dtos.request.translation.SetTranslationsWithKeyDto
@@ -55,10 +55,9 @@ class SlackWithAutoTranslationTest : MachineTranslationTest() {
     val mockedSlackClient = MockedSlackClient.mockSlackClient(slackClient)
 
     performCreateKey("new key", mapOf(BASE_LANGUAGE_TAG to BASE_LANGUAGE_TRANSLATION)).andIsCreated
-    waitForNotThrowing(timeout = 3_000) {
-      mockedSlackClient.chatPostMessageRequests.assert.hasSize(1)
-      val request = mockedSlackClient.chatPostMessageRequests.first()
-      assertThatActualTranslationsEqualToExpected(request)
+    waitForNotThrowing(timeout = 10_000) {
+      assertThat(mockedSlackClient.chatPostMessageRequests).isNotEmpty()
+      assertThatLatestSlackStateHasExpectedTranslations(mockedSlackClient)
     }
   }
 
@@ -69,16 +68,28 @@ class SlackWithAutoTranslationTest : MachineTranslationTest() {
     val mockedSlackClient = MockedSlackClient.mockSlackClient(slackClient)
 
     performSetBaseTranslation(testData.baseTranslationNotExistKey.name)
-    waitForNotThrowing(timeout = 3_000) {
-      mockedSlackClient.chatPostMessageRequests.assert.hasSize(1)
-      val request = mockedSlackClient.chatPostMessageRequests.first()
-      assertThatActualTranslationsEqualToExpected(request)
+    waitForNotThrowing(timeout = 10_000) {
+      assertThat(mockedSlackClient.chatPostMessageRequests).isNotEmpty()
+      assertThatLatestSlackStateHasExpectedTranslations(mockedSlackClient)
     }
   }
 
-  private fun assertThatActualTranslationsEqualToExpected(request: ChatPostMessageRequest) {
+  private fun assertThatLatestSlackStateHasExpectedTranslations(mockedSlackClient: MockedSlackClient) {
+    // The auto-translated content may arrive via chatUpdate if the AUTOMATION batch job
+    // sent the initial message before the AUTO_TRANSLATE batch job completed (both are
+    // non-exclusive and can run concurrently with no ordering guarantee).
+    val attachments =
+      if (mockedSlackClient.chatUpdateRequests.isNotEmpty()) {
+        mockedSlackClient.chatUpdateRequests.last().attachments
+      } else {
+        mockedSlackClient.chatPostMessageRequests.first().attachments
+      }
+    assertThatAttachmentsHaveExpectedTranslations(attachments)
+  }
+
+  private fun assertThatAttachmentsHaveExpectedTranslations(attachments: List<Attachment>) {
     val actualMap =
-      request.attachments
+      attachments
         .dropLast(1)
         .associate {
           val keyLanguage = ((it.blocks[0] as SectionBlock).text.text).removePrefix("null ").trim()


### PR DESCRIPTION
Both AUTO_TRANSLATE and AUTOMATION batch jobs are non-exclusive, so they run concurrently with no ordering guarantee. When the automation sends the Slack message before auto-translation completes, the chatPostMessage only contains the base translation. The auto-translated text then arrives via chatUpdate. Assert against the latest Slack state (chatUpdate if present, otherwise chatPostMessage) and increase the timeout from 3s to 10s for CI resilience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for Slack auto-translation integration by implementing more flexible assertion mechanisms and extending timeout thresholds to better handle concurrent operations. Enhanced test validation to accurately verify translation content across different messaging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->