### PR TITLE
refactor: centralize branch tracing into BranchTracing helper

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/tracing/BranchTracing.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/tracing/BranchTracing.kt
@@ -1,0 +1,98 @@
+package io.tolgee.tracing
+
+import io.opentelemetry.api.trace.Span
+import io.tolgee.model.branching.Branch
+import io.tolgee.model.branching.BranchMerge
+import org.springframework.stereotype.Component
+
+/**
+ * Centralized tracing for branch operations.
+ *
+ * Provides one high-level function per operation type so that services
+ * need only a single call to set all relevant span attributes.
+ */
+@Component
+class BranchTracing(
+  private val tracingContext: TolgeeTracingContext,
+) {
+  fun traceCreateBranch(
+    projectId: Long,
+    name: String,
+    originBranch: Branch,
+  ) {
+    val span = Span.current()
+    setProjectContext(span, projectId)
+    span.setAttribute("tolgee.branch.name", name)
+    span.setAttribute("tolgee.branch.origin.id", originBranch.id)
+    span.setAttribute("tolgee.branch.origin.name", originBranch.name)
+  }
+
+  fun traceCreateBranchResult(branch: Branch) {
+    Span.current().setAttribute("tolgee.branch.id", branch.id)
+  }
+
+  fun traceCopy(
+    projectId: Long,
+    sourceBranch: Branch,
+    targetBranch: Branch,
+  ) {
+    val span = Span.current()
+    setProjectContext(span, projectId)
+    setSourceAndTarget(span, sourceBranch, targetBranch)
+  }
+
+  fun traceDryRunMerge(
+    sourceBranch: Branch,
+    targetBranch: Branch,
+  ) {
+    val span = Span.current()
+    setProjectContext(span, sourceBranch.project.id)
+    setSourceAndTarget(span, sourceBranch, targetBranch)
+  }
+
+  fun traceDryRunMergeResult(merge: BranchMerge) {
+    val span = Span.current()
+    span.setAttribute("tolgee.branch.merge.id", merge.id)
+    span.setAttribute("tolgee.branch.merge.changesCount", merge.changes.size.toLong())
+  }
+
+  fun traceApplyMerge(merge: BranchMerge) {
+    val span = Span.current()
+    setProjectContext(span, merge.sourceBranch.project.id)
+    span.setAttribute("tolgee.branch.merge.id", merge.id)
+    setSourceAndTarget(span, merge.sourceBranch, merge.targetBranch)
+    span.setAttribute("tolgee.branch.merge.changesCount", merge.changes.size.toLong())
+  }
+
+  fun traceApplyMerge(
+    projectId: Long,
+    mergeId: Long,
+    deleteBranch: Boolean?,
+    merge: BranchMerge,
+  ) {
+    val span = Span.current()
+    setProjectContext(span, projectId)
+    span.setAttribute("tolgee.branch.merge.id", mergeId)
+    span.setAttribute("tolgee.branch.merge.deleteBranch", deleteBranch ?: true)
+    setSourceAndTarget(span, merge.sourceBranch, merge.targetBranch)
+  }
+
+  private fun setProjectContext(
+    span: Span,
+    projectId: Long,
+  ) {
+    span.setAttribute("tolgee.project.id", projectId)
+    tracingContext.setContext(projectId, null)
+  }
+
+  private fun setSourceAndTarget(
+    span: Span,
+    source: Branch,
+    target: Branch,
+  ) {
+    span.setAttribute("tolgee.branch.source.id", source.id)
+    span.setAttribute("tolgee.branch.source.name", source.name)
+    span.setAttribute("tolgee.branch.target.id", target.id)
+    span.setAttribute("tolgee.branch.target.name", target.name)
+  }
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCopyServiceSql.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCopyServiceSql.kt
@@ -1,11 +1,10 @@
 package io.tolgee.ee.service.branching
 
-import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.model.branching.Branch
 import io.tolgee.repository.KeyRepository
 import io.tolgee.service.branching.BranchCopyService
-import io.tolgee.tracing.TolgeeTracingContext
+import io.tolgee.tracing.BranchTracing
 import io.tolgee.util.Logging
 import jakarta.persistence.EntityManager
 import jakarta.transaction.Transactional
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Service
 class BranchCopyServiceSql(
   private val entityManager: EntityManager,
   private val keyRepository: KeyRepository,
-  private val tracingContext: TolgeeTracingContext,
+  private val branchTracing: BranchTracing,
 ) : BranchCopyService,
   Logging {
   companion object {
@@ -46,14 +45,14 @@ class BranchCopyServiceSql(
   ) {
     require(sourceBranch.id != targetBranch.id) { "Source and target branch must differ" }
 
+    branchTracing.traceCopy(projectId, sourceBranch, targetBranch)
+
     val totalKeys =
       keyRepository.countByProjectAndBranchIncludingOrphan(
         projectId,
         sourceBranch.id,
         sourceBranch.isDefault,
       )
-
-    setTracingAttributes(projectId, sourceBranch, targetBranch, totalKeys)
 
     // Create empty temporary key mapping table once (reused across batches)
     traceLogMeasureTime("branchCopyService: createKeyMappingTable") {
@@ -108,23 +107,6 @@ class BranchCopyServiceSql(
         copyTranslationComments(targetBranch)
       }
     }
-  }
-
-  private fun setTracingAttributes(
-    projectId: Long,
-    sourceBranch: Branch,
-    targetBranch: Branch,
-    totalKeys: Long,
-  ) {
-    tracingContext.setContext(projectId, null)
-
-    val span = Span.current()
-    span.setAttribute("tolgee.branch.source.id", sourceBranch.id)
-    span.setAttribute("tolgee.branch.source.name", sourceBranch.name)
-    span.setAttribute("tolgee.branch.target.id", targetBranch.id)
-    span.setAttribute("tolgee.branch.target.name", targetBranch.name)
-    span.setAttribute("tolgee.branch.copy.totalKeys", totalKeys)
-    span.setAttribute("tolgee.branch.copy.batchSize", BATCH_SIZE.toLong())
   }
 
   /**

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
@@ -1,6 +1,5 @@
 package io.tolgee.ee.service.branching
 
-import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.Metrics
 import io.tolgee.constants.Message
@@ -26,7 +25,7 @@ import io.tolgee.model.translation.Translation
 import io.tolgee.repository.KeyRepository
 import io.tolgee.service.branching.AbstractBranchMergeService
 import io.tolgee.service.language.LanguageService
-import io.tolgee.tracing.TolgeeTracingContext
+import io.tolgee.tracing.BranchTracing
 import io.tolgee.util.Logging
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.annotation.Primary
@@ -48,7 +47,7 @@ class BranchMergeService(
   @Lazy
   private val languageService: LanguageService,
   private val metrics: Metrics,
-  private val tracingContext: TolgeeTracingContext,
+  private val branchTracing: BranchTracing,
 ) : AbstractBranchMergeService(branchMergeChangeRepository),
   Logging {
   @Transactional
@@ -66,7 +65,7 @@ class BranchMergeService(
     sourceBranch: Branch,
     targetBranch: Branch,
   ): BranchMerge {
-    setDryRunTracingAttributes(sourceBranch, targetBranch)
+    branchTracing.traceDryRunMerge(sourceBranch, targetBranch)
 
     return metrics.branchMergePreviewTimer.recordCallable {
       val branchMerge =
@@ -79,9 +78,7 @@ class BranchMergeService(
       dryRun(branchMerge)
       branchMergeRepository.save(branchMerge)
 
-      val span = Span.current()
-      span.setAttribute("tolgee.branch.merge.id", branchMerge.id)
-      span.setAttribute("tolgee.branch.merge.changesCount", branchMerge.changes.size.toLong())
+      branchTracing.traceDryRunMergeResult(branchMerge)
 
       branchMerge
     }!!
@@ -111,34 +108,9 @@ class BranchMergeService(
     val targetKeyId: Long?,
   )
 
-  private fun setDryRunTracingAttributes(
-    sourceBranch: Branch,
-    targetBranch: Branch,
-  ) {
-    tracingContext.setContext(sourceBranch.project.id, null)
-
-    val span = Span.current()
-    span.setAttribute("tolgee.branch.source.id", sourceBranch.id)
-    span.setAttribute("tolgee.branch.source.name", sourceBranch.name)
-    span.setAttribute("tolgee.branch.target.id", targetBranch.id)
-    span.setAttribute("tolgee.branch.target.name", targetBranch.name)
-  }
-
-  private fun setApplyMergeTracingAttributes(merge: BranchMerge) {
-    tracingContext.setContext(merge.sourceBranch.project.id, null)
-
-    val span = Span.current()
-    span.setAttribute("tolgee.branch.merge.id", merge.id)
-    span.setAttribute("tolgee.branch.source.id", merge.sourceBranch.id)
-    span.setAttribute("tolgee.branch.source.name", merge.sourceBranch.name)
-    span.setAttribute("tolgee.branch.target.id", merge.targetBranch.id)
-    span.setAttribute("tolgee.branch.target.name", merge.targetBranch.name)
-    span.setAttribute("tolgee.branch.merge.changesCount", merge.changes.size.toLong())
-  }
-
   @WithSpan
   fun applyMerge(merge: BranchMerge) {
-    setApplyMergeTracingAttributes(merge)
+    branchTracing.traceApplyMerge(merge)
 
     metrics.branchMergeApplyTimer.record(
       Runnable {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -1,6 +1,5 @@
 package io.tolgee.ee.service.branching
 
-import io.opentelemetry.api.trace.Span
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.Metrics
 import io.tolgee.activity.ActivityHolder
@@ -26,7 +25,7 @@ import io.tolgee.model.enums.BranchKeyMergeChangeType
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.branching.AbstractBranchService
 import io.tolgee.service.branching.BranchCopyService
-import io.tolgee.tracing.TolgeeTracingContext
+import io.tolgee.tracing.BranchTracing
 import jakarta.persistence.EntityManager
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Primary
@@ -51,7 +50,7 @@ class BranchServiceImpl(
   private val branchCleanupService: BranchCleanupService,
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val metrics: Metrics,
-  private val tracingContext: TolgeeTracingContext,
+  private val branchTracing: BranchTracing,
 ) : AbstractBranchService(branchRepository, branchMergeService) {
   override fun getBranches(
     projectId: Long,
@@ -126,7 +125,7 @@ class BranchServiceImpl(
           Message.ORIGIN_BRANCH_NOT_FOUND,
         )
 
-      setCreateBranchTracingAttributes(projectId, name, originBranch)
+      branchTracing.traceCreateBranch(projectId, name, originBranch)
 
       val branch =
         createBranch(projectId, name, author).also {
@@ -134,7 +133,7 @@ class BranchServiceImpl(
         }
       branchRepository.save(branch)
 
-      Span.current().setAttribute("tolgee.branch.id", branch.id)
+      branchTracing.traceCreateBranchResult(branch)
 
       branchCopyService.copy(projectId, originBranch, branch)
       branchSnapshotService.createInitialSnapshot(projectId, originBranch, branch)
@@ -157,36 +156,6 @@ class BranchServiceImpl(
       this.name = name
       this.author = author
     }
-  }
-
-  private fun setCreateBranchTracingAttributes(
-    projectId: Long,
-    name: String,
-    originBranch: Branch,
-  ) {
-    tracingContext.setContext(projectId, null)
-
-    val span = Span.current()
-    span.setAttribute("tolgee.branch.name", name)
-    span.setAttribute("tolgee.branch.origin.id", originBranch.id)
-    span.setAttribute("tolgee.branch.origin.name", originBranch.name)
-  }
-
-  private fun setApplyMergeTracingAttributes(
-    projectId: Long,
-    mergeId: Long,
-    deleteBranch: Boolean?,
-    merge: BranchMerge,
-  ) {
-    tracingContext.setContext(projectId, null)
-
-    val span = Span.current()
-    span.setAttribute("tolgee.branch.merge.id", mergeId)
-    span.setAttribute("tolgee.branch.merge.deleteBranch", deleteBranch ?: true)
-    span.setAttribute("tolgee.branch.source.id", merge.sourceBranch.id)
-    span.setAttribute("tolgee.branch.source.name", merge.sourceBranch.name)
-    span.setAttribute("tolgee.branch.target.id", merge.targetBranch.id)
-    span.setAttribute("tolgee.branch.target.name", merge.targetBranch.name)
   }
 
   @WithSpan
@@ -242,7 +211,7 @@ class BranchServiceImpl(
       branchMergeService.findActiveMergeFull(projectId, mergeId)
         ?: throw NotFoundException(Message.BRANCH_MERGE_NOT_FOUND)
 
-    setApplyMergeTracingAttributes(projectId, mergeId, deleteBranch, merge)
+    branchTracing.traceApplyMerge(projectId, mergeId, deleteBranch, merge)
 
     if (!merge.isReadyToMerge) {
       if (!merge.isRevisionValid) {


### PR DESCRIPTION
## Summary

Alternative approach to the tracing attribute-setting in #3464 — as discussed in [this review comment](https://github.com/tolgee/tolgee-platform/pull/3464#discussion_r2782642315).

Instead of scattering `Span.current().setAttribute()` calls and `private fun set*TracingAttributes()` methods in each service, this introduces a shared `BranchTracing` component with one high-level method per operation type.

**What changes:**
- New `BranchTracing` component in `backend/data` with typed, explicit methods: `traceCopy()`, `traceDryRunMerge()`, `traceApplyMerge()`, `traceCreateBranch()`
- Services call a single method instead of multiple raw span attribute calls
- No `TolgeeTracingContext` injection needed in services (only `BranchTracing`)
- All `private fun set*TracingAttributes()` helper methods removed from services
- `@WithSpan` annotations kept as-is

**Before (current PR):**
```kotlin
private fun setDryRunTracingAttributes(sourceBranch: Branch, targetBranch: Branch) {
    tracingContext.setContext(sourceBranch.project.id, null)
    val span = Span.current()
    span.setAttribute("tolgee.branch.source.id", sourceBranch.id)
    span.setAttribute("tolgee.branch.source.name", sourceBranch.name)
    span.setAttribute("tolgee.branch.target.id", targetBranch.id)
    span.setAttribute("tolgee.branch.target.name", targetBranch.name)
}
```

**After:**
```kotlin
branchTracing.traceDryRunMerge(sourceBranch, targetBranch)
```

## Test plan

- [ ] Verify span attributes match the original PR's output in Grafana/Tempo
- [ ] Confirm `@WithSpan` creates spans as before