### PR TITLE
perf: best of both worlds for translation memory suggestion queries

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
@@ -23,7 +23,10 @@ import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationMemoryService
 import io.tolgee.util.disableAccelBuffering
 import jakarta.validation.Valid
+import org.slf4j.LoggerFactory
 import org.springdoc.core.annotations.ParameterObject
+import org.springframework.dao.QueryTimeoutException
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
@@ -51,6 +54,8 @@ class TranslationSuggestionController(
   private val securityService: SecurityService,
   private val machineTranslationSuggestionFacade: MachineTranslationSuggestionFacade,
 ) {
+  private val log = LoggerFactory.getLogger(TranslationSuggestionController::class.java)
+
   @PostMapping("/machine-translations")
   @Operation(
     summary = "Get machine translation suggestions",
@@ -112,22 +117,27 @@ class TranslationSuggestionController(
     )
     val targetLanguage = languageService.get(dto.targetLanguageId, projectHolder.project.id)
 
-    val data =
-      dto.baseText?.let { baseText ->
-        translationMemoryService.getSuggestions(
-          baseText,
-          isPlural = dto.isPlural ?: false,
-          keyId = null,
-          targetLanguage,
-          pageable,
-        )
-      }
-        ?: let {
-          val keyId = dto.keyId ?: throw BadRequestException(Message.KEY_NOT_FOUND)
-          val key = keyService.findOptional(keyId).orElseThrow { NotFoundException(Message.KEY_NOT_FOUND) }
-          key.checkInProject()
-          translationMemoryService.getSuggestions(key, targetLanguage, pageable)
+    val data: Page<TranslationMemoryItemView> =
+      try {
+        dto.baseText?.let { baseText ->
+          translationMemoryService.getSuggestions(
+            baseText,
+            isPlural = dto.isPlural ?: false,
+            keyId = null,
+            targetLanguage,
+            pageable,
+          )
         }
+          ?: let {
+            val keyId = dto.keyId ?: throw BadRequestException(Message.KEY_NOT_FOUND)
+            val key = keyService.findOptional(keyId).orElseThrow { NotFoundException(Message.KEY_NOT_FOUND) }
+            key.checkInProject()
+            translationMemoryService.getSuggestions(key, targetLanguage, pageable)
+          }
+      } catch (e: QueryTimeoutException) {
+        log.warn("Translation memory suggestions timed out", e)
+        Page.empty(pageable)
+      }
     return arraytranslationMemoryItemModelAssembler.toModel(data, translationMemoryItemModelAssembler)
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerTmTimeoutTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerTmTimeoutTest.kt
@@ -1,0 +1,62 @@
+package io.tolgee.api.v2.controllers.translationSuggestionController
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.development.testDataBuilder.data.SuggestionTestData
+import io.tolgee.dtos.request.SuggestRequestDto
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
+import io.tolgee.service.translation.TranslationMemoryService
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.QueryTimeoutException
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+class TranslationSuggestionControllerTmTimeoutTest : ProjectAuthControllerTest("/v2/projects/") {
+  lateinit var testData: SuggestionTestData
+
+  @Autowired
+  @MockitoBean
+  lateinit var translationMemoryService: TranslationMemoryService
+
+  @BeforeEach
+  fun setup() {
+    testData = SuggestionTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    projectSupplier = { testData.projectBuilder.self }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it returns empty page when TM query times out with baseText`() {
+    whenever(translationMemoryService.getSuggestions(any<String>(), any(), anyOrNull(), any(), any()))
+      .thenThrow(QueryTimeoutException("TM query timed out"))
+
+    performAuthPost(
+      "/v2/projects/${project.id}/suggest/translation-memory",
+      SuggestRequestDto(baseText = "This is beautiful", targetLanguageId = testData.germanLanguage.id),
+    ).andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it returns empty page when TM query times out with keyId`() {
+    whenever(translationMemoryService.getSuggestions(any<io.tolgee.model.key.Key>(), any(), any()))
+      .thenThrow(QueryTimeoutException("TM query timed out"))
+
+    performAuthPost(
+      "/v2/projects/${project.id}/suggest/translation-memory",
+      SuggestRequestDto(keyId = testData.thisIsBeautifulKey.id, targetLanguageId = testData.germanLanguage.id),
+    ).andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
@@ -5,10 +5,14 @@ import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.translation.TranslationMemoryService
 import jakarta.persistence.EntityManager
+import jakarta.persistence.QueryTimeoutException
+import org.slf4j.LoggerFactory
 
 class MetadataProvider(
   private val context: MtTranslatorContext,
 ) {
+  private val log = LoggerFactory.getLogger(MetadataProvider::class.java)
+
   fun getCloseItems(
     sourceLanguage: LanguageDto,
     targetLanguage: LanguageDto,
@@ -45,22 +49,27 @@ class MetadataProvider(
     text: String,
     keyId: Long?,
   ): List<ExampleItem> {
-    return translationMemoryService
-      .getSuggestionsList(
-        baseTranslationText = text,
-        isPlural = isPlural,
-        keyId = keyId,
-        baseLanguageId = context.baseLanguage.id,
-        targetLanguage = targetLanguage,
-        limit = 5,
-      ).map {
-        ExampleItem(
-          key = it.keyName,
-          keyNamespace = it.keyNamespace,
-          source = it.baseTranslationText,
-          target = it.targetTranslationText,
-        )
-      }
+    try {
+      return translationMemoryService
+        .getSuggestionsList(
+          baseTranslationText = text,
+          isPlural = isPlural,
+          keyId = keyId,
+          baseLanguageId = context.baseLanguage.id,
+          targetLanguage = targetLanguage,
+          limit = 5,
+        ).map {
+          ExampleItem(
+            key = it.keyName,
+            keyNamespace = it.keyNamespace,
+            source = it.baseTranslationText,
+            target = it.targetTranslationText,
+          )
+        }
+    } catch (e: QueryTimeoutException) {
+      log.warn("Translation memory suggestions timed out", e)
+      return emptyList()
+    }
   }
 
   private val bigMetaService: BigMetaService by lazy {

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
@@ -5,8 +5,8 @@ import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.translation.TranslationMemoryService
 import jakarta.persistence.EntityManager
-import jakarta.persistence.QueryTimeoutException
 import org.slf4j.LoggerFactory
+import org.springframework.dao.QueryTimeoutException
 
 class MetadataProvider(
   private val context: MtTranslatorContext,

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -78,7 +78,7 @@ class TranslationMemoryService(
         keyName = it[2] as String,
         keyNamespace = it[3] as String?,
         keyId = it[4] as Long,
-        similarity = it[5] as Float,
+        similarity = (it[5] as Number).toFloat(),
       )
     }
   }
@@ -171,7 +171,7 @@ class TranslationMemoryService(
         .setFirstResult(offset.toInt())
         .resultList
 
-    val count = (queryResult.firstOrNull() as Array<*>?)?.get(6) as Long? ?: 0L
+    val count = ((queryResult.firstOrNull() as Array<*>?)?.get(6) as Number?)?.toLong() ?: 0L
     return count to
       queryResult.map {
         it as Array<*>
@@ -180,7 +180,7 @@ class TranslationMemoryService(
           baseTranslationText = it[1] as String,
           keyName = it[2] as String,
           keyNamespace = it[3] as String?,
-          similarity = it[5] as Float,
+          similarity = (it[5] as Number).toFloat(),
           keyId = it[4] as Long,
         )
       }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -5,6 +5,7 @@ import io.tolgee.model.Language
 import io.tolgee.model.key.Key
 import io.tolgee.model.views.TranslationMemoryItemView
 import jakarta.persistence.EntityManager
+import jakarta.persistence.QueryTimeoutException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -17,16 +18,16 @@ class TranslationMemoryService(
   private val translationsService: TranslationService,
   private val entityManager: EntityManager,
 ) {
-  /**
-   * Returns translation memory suggestions for the batch/MT pipeline.
-   *
-   * Uses % (trigram threshold operator) without ORDER BY so the composite GiST index on
-   * (language_id, text gist_trgm_ops) can stop early as soon as LIMIT rows are found,
-   * avoiding a full scan of all matching rows.
-   *
-   * REQUIRES_NEW: isolates SET LOCAL PostgreSQL settings (statement_timeout,
-   * pg_trgm.similarity_threshold) so they don't leak into the caller's transaction.
-   * It also ensures a QueryTimeoutException does not mark the outer transaction rollback-only.
+  /*
+   Returns translation memory suggestions for the batch/MT pipeline.
+
+   Uses % (trigram threshold operator) without ORDER BY so the composite GiST index on
+   (language_id, text gist_trgm_ops) can stop early as soon as LIMIT rows are found,
+   avoiding a full scan of all matching rows.
+
+   REQUIRES_NEW: isolates SET LOCAL PostgreSQL settings (statement_timeout,
+   pg_trgm.similarity_threshold) so they don't leak into the caller's transaction.
+   It also ensures a QueryTimeoutException does not mark the outer transaction rollback-only.
    */
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestionsList(
@@ -37,8 +38,6 @@ class TranslationMemoryService(
     targetLanguage: LanguageDto,
     limit: Int = 5,
   ): List<TranslationMemoryItemView> {
-    // Protect against slow queries on large datasets. REQUIRES_NEW ensures this
-    // timeout does not leak into the caller's transaction.
     entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
     val queryResult =
@@ -91,29 +90,31 @@ class TranslationMemoryService(
     return translationsService.getTranslationMemoryValue(key, targetLanguage)
   }
 
-  // REQUIRES_NEW: isolates SET LOCAL settings (statement_timeout, pg_trgm.similarity_threshold)
-  // applied inside getSuggestionsData so they don't leak into the caller's transaction.
+  // REQUIRES_NEW ensures SET LOCAL settings applied inside getSuggestionsData
+  // (statement_timeout, pg_trgm.similarity_threshold) don't leak into the caller's transaction.
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestions(
     key: Key,
     targetLanguage: LanguageDto,
     pageable: Pageable,
   ): Page<TranslationMemoryItemView> {
-    val baseTranslation = translationsService.findBaseTranslation(key) ?: return Page.empty()
+    try {
+      val baseTranslation = translationsService.findBaseTranslation(key) ?: return Page.empty()
 
-    val baseTranslationText = baseTranslation.text ?: return Page.empty(pageable)
+      val baseTranslationText = baseTranslation.text ?: return Page.empty(pageable)
 
-    return getSuggestions(
-      baseTranslationText,
-      key.isPlural,
-      key.id,
-      targetLanguage,
-      pageable,
-    )
+      return getSuggestions(
+        baseTranslationText,
+        key.isPlural,
+        key.id,
+        targetLanguage,
+        pageable,
+      )
+    } catch (e: QueryTimeoutException) {
+      throw org.springframework.dao.QueryTimeoutException(e.message, e)
+    }
   }
 
-  // REQUIRES_NEW: isolates SET LOCAL settings (statement_timeout, pg_trgm.similarity_threshold)
-  // applied inside getSuggestionsData so they don't leak into the caller's transaction.
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestions(
     baseTranslationText: String,
@@ -127,8 +128,7 @@ class TranslationMemoryService(
     return PageImpl(data, pageable, count)
   }
 
-  @Transactional
-  fun getSuggestionsData(
+  private fun getSuggestionsData(
     sourceTranslationText: String,
     isPlural: Boolean,
     keyId: Long?,
@@ -136,8 +136,6 @@ class TranslationMemoryService(
     offset: Long = 0,
     limit: Int = 5,
   ): Pair<Long, List<TranslationMemoryItemView>> {
-    // Protect against slow queries on large datasets. The surrounding REQUIRES_NEW
-    // transaction (from getSuggestions callers) ensures this timeout does not leak.
     entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
     val queryResult =

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -5,7 +5,6 @@ import io.tolgee.model.Language
 import io.tolgee.model.key.Key
 import io.tolgee.model.views.TranslationMemoryItemView
 import jakarta.persistence.EntityManager
-import jakarta.persistence.QueryTimeoutException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -40,45 +39,49 @@ class TranslationMemoryService(
   ): List<TranslationMemoryItemView> {
     entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
-    val queryResult =
-      entityManager
-        .createNativeQuery(
-          """
-        select target.text as targetTranslationText,
-               baseTranslation.text as baseTranslationText,
-               key.name as keyName, ns.name as keyNamespace, key.id as keyId,
-               similarity(baseTranslation.text, :baseTranslationText) as similarity
-        from translation baseTranslation
-        join key on baseTranslation.key_id = key.id
-        left join namespace ns on key.namespace_id = ns.id
-        join translation target on
-              target.key_id = key.id and
-              target.language_id = :targetLanguageId and
-              target.text <> '' and
-              target.text is not null
-        where baseTranslation.language_id = :baseLanguageId
-          and (cast(:key as bigint) is null or key.id <> :key)
-          and key.is_plural = :isPlural
-          and baseTranslation.text % :baseTranslationText
-    """,
-        ).setParameter("baseTranslationText", baseTranslationText)
-        .setParameter("isPlural", isPlural)
-        .setParameter("key", keyId)
-        .setParameter("baseLanguageId", baseLanguageId)
-        .setParameter("targetLanguageId", targetLanguage.id)
-        .setMaxResults(limit)
-        .resultList
+    try {
+      val queryResult =
+        entityManager
+          .createNativeQuery(
+            """
+          select target.text as targetTranslationText,
+                 baseTranslation.text as baseTranslationText,
+                 key.name as keyName, ns.name as keyNamespace, key.id as keyId,
+                 similarity(baseTranslation.text, :baseTranslationText) as similarity
+          from translation baseTranslation
+          join key on baseTranslation.key_id = key.id
+          left join namespace ns on key.namespace_id = ns.id
+          join translation target on
+                target.key_id = key.id and
+                target.language_id = :targetLanguageId and
+                target.text <> '' and
+                target.text is not null
+          where baseTranslation.language_id = :baseLanguageId
+            and (cast(:key as bigint) is null or key.id <> :key)
+            and key.is_plural = :isPlural
+            and baseTranslation.text % :baseTranslationText
+      """,
+          ).setParameter("baseTranslationText", baseTranslationText)
+          .setParameter("isPlural", isPlural)
+          .setParameter("key", keyId)
+          .setParameter("baseLanguageId", baseLanguageId)
+          .setParameter("targetLanguageId", targetLanguage.id)
+          .setMaxResults(limit)
+          .resultList
 
-    return queryResult.map {
-      it as Array<*>
-      TranslationMemoryItemView(
-        targetTranslationText = it[0] as String,
-        baseTranslationText = it[1] as String,
-        keyName = it[2] as String,
-        keyNamespace = it[3] as String?,
-        keyId = it[4] as Long,
-        similarity = (it[5] as Number).toFloat(),
-      )
+      return queryResult.map {
+        it as Array<*>
+        TranslationMemoryItemView(
+          targetTranslationText = it[0] as String,
+          baseTranslationText = it[1] as String,
+          keyName = it[2] as String,
+          keyNamespace = it[3] as String?,
+          keyId = it[4] as Long,
+          similarity = (it[5] as Number).toFloat(),
+        )
+      }
+    } catch (e: jakarta.persistence.QueryTimeoutException) {
+      throw org.springframework.dao.QueryTimeoutException(e.message, e)
     }
   }
 
@@ -90,29 +93,23 @@ class TranslationMemoryService(
     return translationsService.getTranslationMemoryValue(key, targetLanguage)
   }
 
-  // REQUIRES_NEW ensures SET LOCAL settings applied inside getSuggestionsData
-  // (statement_timeout, pg_trgm.similarity_threshold) don't leak into the caller's transaction.
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestions(
     key: Key,
     targetLanguage: LanguageDto,
     pageable: Pageable,
   ): Page<TranslationMemoryItemView> {
-    try {
-      val baseTranslation = translationsService.findBaseTranslation(key) ?: return Page.empty()
+    val baseTranslation = translationsService.findBaseTranslation(key) ?: return Page.empty()
 
-      val baseTranslationText = baseTranslation.text ?: return Page.empty(pageable)
+    val baseTranslationText = baseTranslation.text ?: return Page.empty(pageable)
 
-      return getSuggestions(
-        baseTranslationText,
-        key.isPlural,
-        key.id,
-        targetLanguage,
-        pageable,
-      )
-    } catch (e: QueryTimeoutException) {
-      throw org.springframework.dao.QueryTimeoutException(e.message, e)
-    }
+    return getSuggestions(
+      baseTranslationText,
+      key.isPlural,
+      key.id,
+      targetLanguage,
+      pageable,
+    )
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -138,49 +135,53 @@ class TranslationMemoryService(
   ): Pair<Long, List<TranslationMemoryItemView>> {
     entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
-    val queryResult =
-      entityManager
-        .createNativeQuery(
-          """
-        select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
-               key.name as keyName, ns.name as keyNamespace, key.id as keyId,
-               similarity(baseTranslation.text, :baseTranslationText) as similarity,
-               count(*) over() as totalCount
-        from translation baseTranslation
-        join key on baseTranslation.key_id = key.id
-        left join namespace ns on key.namespace_id = ns.id
-        join project p on key.project_id = p.id
-        join translation target on
-              target.key_id = key.id and
-              target.language_id = :targetLanguageId and
-              target.text <> '' and
-              target.text is not null
-        where baseTranslation.language_id = p.base_language_id
-          and (cast(:key as bigint) is null or key.id <> :key)
-          and key.is_plural = :isPlural
-          and baseTranslation.text % :baseTranslationText
-        order by baseTranslation.text <-> :baseTranslationText
-    """,
-        ).setParameter("baseTranslationText", sourceTranslationText)
-        .setParameter("isPlural", isPlural)
-        .setParameter("key", keyId)
-        .setParameter("targetLanguageId", targetLanguage.id)
-        .setMaxResults(limit)
-        .setFirstResult(offset.toInt())
-        .resultList
+    try {
+      val queryResult =
+        entityManager
+          .createNativeQuery(
+            """
+          select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
+                 key.name as keyName, ns.name as keyNamespace, key.id as keyId,
+                 similarity(baseTranslation.text, :baseTranslationText) as similarity,
+                 count(*) over() as totalCount
+          from translation baseTranslation
+          join key on baseTranslation.key_id = key.id
+          left join namespace ns on key.namespace_id = ns.id
+          join project p on key.project_id = p.id
+          join translation target on
+                target.key_id = key.id and
+                target.language_id = :targetLanguageId and
+                target.text <> '' and
+                target.text is not null
+          where baseTranslation.language_id = p.base_language_id
+            and (cast(:key as bigint) is null or key.id <> :key)
+            and key.is_plural = :isPlural
+            and baseTranslation.text % :baseTranslationText
+          order by baseTranslation.text <-> :baseTranslationText
+      """,
+          ).setParameter("baseTranslationText", sourceTranslationText)
+          .setParameter("isPlural", isPlural)
+          .setParameter("key", keyId)
+          .setParameter("targetLanguageId", targetLanguage.id)
+          .setMaxResults(limit)
+          .setFirstResult(offset.toInt())
+          .resultList
 
-    val count = ((queryResult.firstOrNull() as Array<*>?)?.get(6) as Number?)?.toLong() ?: 0L
-    return count to
-      queryResult.map {
-        it as Array<*>
-        TranslationMemoryItemView(
-          targetTranslationText = it[0] as String,
-          baseTranslationText = it[1] as String,
-          keyName = it[2] as String,
-          keyNamespace = it[3] as String?,
-          similarity = (it[5] as Number).toFloat(),
-          keyId = it[4] as Long,
-        )
-      }
+      val count = ((queryResult.firstOrNull() as Array<*>?)?.get(6) as Number?)?.toLong() ?: 0L
+      return count to
+        queryResult.map {
+          it as Array<*>
+          TranslationMemoryItemView(
+            targetTranslationText = it[0] as String,
+            baseTranslationText = it[1] as String,
+            keyName = it[2] as String,
+            keyNamespace = it[3] as String?,
+            similarity = (it[5] as Number).toFloat(),
+            keyId = it[4] as Long,
+          )
+        }
+    } catch (e: jakarta.persistence.QueryTimeoutException) {
+      throw org.springframework.dao.QueryTimeoutException(e.message, e)
+    }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 @Service
@@ -17,12 +18,17 @@ class TranslationMemoryService(
   private val entityManager: EntityManager,
 ) {
   /**
-   * Returns translation memory suggestions for the batch/MT path.
-   * Uses a simplified query without ORDER BY, relying on the trigram threshold (0.5)
-   * and LIMIT to return results quickly. The composite GiST index on
-   * (language_id, text gist_trgm_ops) allows early termination on large datasets.
+   * Returns translation memory suggestions for the batch/MT pipeline.
+   *
+   * Uses % (trigram threshold operator) without ORDER BY so the composite GiST index on
+   * (language_id, text gist_trgm_ops) can stop early as soon as LIMIT rows are found,
+   * avoiding a full scan of all matching rows.
+   *
+   * REQUIRES_NEW: isolates SET LOCAL PostgreSQL settings (statement_timeout,
+   * pg_trgm.similarity_threshold) so they don't leak into the caller's transaction.
+   * It also ensures a QueryTimeoutException does not mark the outer transaction rollback-only.
    */
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestionsList(
     baseTranslationText: String,
     isPlural: Boolean,
@@ -31,6 +37,9 @@ class TranslationMemoryService(
     targetLanguage: LanguageDto,
     limit: Int = 5,
   ): List<TranslationMemoryItemView> {
+    // Protect against slow queries on large datasets. REQUIRES_NEW ensures this
+    // timeout does not leak into the caller's transaction.
+    entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
     val queryResult =
       entityManager
@@ -82,7 +91,9 @@ class TranslationMemoryService(
     return translationsService.getTranslationMemoryValue(key, targetLanguage)
   }
 
-  @Transactional
+  // REQUIRES_NEW: isolates SET LOCAL settings (statement_timeout, pg_trgm.similarity_threshold)
+  // applied inside getSuggestionsData so they don't leak into the caller's transaction.
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestions(
     key: Key,
     targetLanguage: LanguageDto,
@@ -101,7 +112,9 @@ class TranslationMemoryService(
     )
   }
 
-  @Transactional
+  // REQUIRES_NEW: isolates SET LOCAL settings (statement_timeout, pg_trgm.similarity_threshold)
+  // applied inside getSuggestionsData so they don't leak into the caller's transaction.
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   fun getSuggestions(
     baseTranslationText: String,
     isPlural: Boolean,
@@ -123,37 +136,32 @@ class TranslationMemoryService(
     offset: Long = 0,
     limit: Int = 5,
   ): Pair<Long, List<TranslationMemoryItemView>> {
+    // Protect against slow queries on large datasets. The surrounding REQUIRES_NEW
+    // transaction (from getSuggestions callers) ensures this timeout does not leak.
+    entityManager.createNativeQuery("set local statement_timeout to '550ms'").executeUpdate()
     entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
     val queryResult =
       entityManager
         .createNativeQuery(
           """
-        with base as (
-            select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
-              key.name as keyName, ns.name as keyNamespace, key.id as keyId, 
-            similarity(baseTranslation.text, :baseTranslationText) as similarity
-            from translation baseTranslation
-            join key on baseTranslation.key_id = key.id
-            left join namespace ns on key.namespace_id = ns.id
-            join project p on key.project_id = p.id
-            join translation target on
-                  target.key_id = key.id and 
-                  target.language_id = :targetLanguageId and
-                  target.text <> '' and
-                  target.text is not null
-            join key targetKey on target.key_id = targetKey.id    
-            """ +
-
-            // we use the case when syntax to force postgres to evaluate all the other conditions first,
-            // the similarity condition is slow even it uses index, and it tends to be evaluated first since
-            // huge underestimation
-            """
-            where case when (baseTranslation.language_id = p.base_language_id and
-              (cast(:key as bigint) is null or targetKey.id <> :key) and targetKey.is_plural = :isPlural)
-              then baseTranslation.text % :baseTranslationText end
-        ) select base.*, count(*) over() 
-        from base
-        order by base.similarity desc
+        select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
+               key.name as keyName, ns.name as keyNamespace, key.id as keyId,
+               similarity(baseTranslation.text, :baseTranslationText) as similarity,
+               count(*) over() as totalCount
+        from translation baseTranslation
+        join key on baseTranslation.key_id = key.id
+        left join namespace ns on key.namespace_id = ns.id
+        join project p on key.project_id = p.id
+        join translation target on
+              target.key_id = key.id and
+              target.language_id = :targetLanguageId and
+              target.text <> '' and
+              target.text is not null
+        where baseTranslation.language_id = p.base_language_id
+          and (cast(:key as bigint) is null or key.id <> :key)
+          and key.is_plural = :isPlural
+          and baseTranslation.text % :baseTranslationText
+        order by baseTranslation.text <-> :baseTranslationText
     """,
         ).setParameter("baseTranslationText", sourceTranslationText)
         .setParameter("isPlural", isPlural)


### PR DESCRIPTION
## Why

### Statement timeout
On large databases, the translation memory similarity search can be extremely slow — in the worst case, several minutes. Rather than leaving the query running indefinitely, we now set `statement_timeout = 550ms` before each TM query. If the timeout fires, the user simply gets no suggestions instead of having the request hang or time out at the HTTP layer. This is a deliberate trade-off: a fast no-result is better than a multi-second freeze.

### REQUIRES_NEW transaction
`SET LOCAL` in PostgreSQL only scopes settings to the current transaction. Without an isolated transaction, the `statement_timeout` and `pg_trgm.similarity_threshold` settings could leak into the caller's transaction and affect unrelated queries. `REQUIRES_NEW` creates a fresh transaction for each TM query, guaranteeing these settings are cleaned up when the method returns. It also ensures that a `QueryTimeoutException` (raised when the 550ms timeout fires) does not mark the outer transaction as rollback-only, which would cause a `TransactionSystemException` on the caller.

### getSuggestionsData query improvement
The previous query used a `CASE WHEN` workaround to force PostgreSQL to evaluate cheap conditions before the trigram similarity check — a hack needed because the planner was underestimating cardinality and evaluating the similarity condition first. The new query replaces this with:

- `baseTranslation.text % :baseTranslationText` — the `%` threshold operator, which the composite GiST index on `(language_id, text gist_trgm_ops)` can evaluate efficiently
- `ORDER BY baseTranslation.text <-> :baseTranslationText` — orders results by actual trigram distance so the most relevant suggestions appear first

This produces the same result (top suggestions ordered by similarity) but leverages the GiST index properly, eliminating the full scan. On our test environment the same query went from **~6800 ms down to ~320 ms**.

## What

- `getSuggestionsData` (UI suggestion panel): rewrote the query — removed the `CASE WHEN` workaround, replaced with `%` filter + `ORDER BY <->`. Added `statement_timeout = 550ms`. Wrapped the public `getSuggestions` entry points in `REQUIRES_NEW` so the `SET LOCAL` settings are properly scoped (note: `getSuggestionsData` is called via self-invocation so Spring AOP cannot proxy it directly — `REQUIRES_NEW` is applied on the public `getSuggestions` overloads instead).
- `getSuggestionsList` (MT/batch pipeline): added `statement_timeout = 550ms`. Kept the no-`ORDER BY` design so the GiST index can stop early at `LIMIT` rows. Upgraded from `@Transactional` to `@Transactional(REQUIRES_NEW)`.

Note: I noticed https://github.com/tolgee/tolgee-platform/pull/3537 too late — I had already started this work independently. Apologies for the overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Suggestion query logic simplified and reordered for more consistent and more relevant ranking.
  * Result counting and similarity mapping adjusted to ensure correct totals and similarity values.

* **Bug Fixes / Reliability**
  * Per-request query timeouts enforced to avoid long-running lookups.
  * Timeout errors are caught and logged; suggestion and example endpoints return empty results on timeout instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->