### PR TITLE
chore: enable Sentry source context upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
 
       - name: Login to docker
         if: ${{ steps.version.outputs.VERSION != '' }}

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -19,6 +19,13 @@ plugins {
     id "org.gradle.test-retry"
 }
 
+sentry {
+    includeSourceContext = true
+    org = System.getenv("SENTRY_ORG")
+    projectName = System.getenv("SENTRY_PROJECT")
+    authToken = System.getenv("SENTRY_AUTH_TOKEN")
+}
+
 group = 'io.tolgee'
 
 if (System.getenv().containsKey("VERSION")) {


### PR DESCRIPTION
## Summary
- Configure the Sentry Gradle plugin (`sentry {}` block) in `backend/app/build.gradle` with `includeSourceContext = true`
- Add `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, and `SENTRY_PROJECT` env vars to the release workflow's bootJar step
- When these env vars are set, the plugin uploads source bundles to Sentry during release builds, enabling source code display around exceptions
- No impact on OSS/local builds — upload is silently skipped when env vars are absent

## Test plan
- [ ] Verify local build works without env vars (no errors, no upload attempt)
- [ ] Set `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN` as GitHub repository variables/secrets
- [ ] Trigger a release and verify source bundles appear in Sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated error monitoring and tracking infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->