### PR TITLE
fix: clean docker build dir before copying to prevent duplicate JARs

### DIFF
--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -4,6 +4,7 @@ ext {
 
 tasks.register('dockerPrepare') {
     doLast {
+        delete(dockerPath)
         copy {
             from(tasks.unpack.outputs, 'docker/app')
             into(dockerPath)


### PR DESCRIPTION
## Summary

- The `dockerPrepare` task copies JARs into the Docker build directory without cleaning it first
- When the release workflow runs `dockerPublish` twice (versioned tag, then `latest`), the second build inherits JARs from the first run, resulting in duplicate module JARs (e.g. `data-latest.jar` + `data-v3.172.2.jar`)
- This causes `tolgee/tolgee:latest` to crash on startup with a Liquibase `ChangeLogParseException` due to conflicting `db/changelog/schema.xml` files
- Fix: add `delete(dockerPath)` at the start of `dockerPrepare` so it always starts with a clean directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build reliability by ensuring the build destination is cleared before new artifacts are deployed, preventing conflicts from previous builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->