### PR TITLE
fix: preserve websocket subscriptions on disconnect

### DIFF
--- a/webapp/src/websocket-client/WebsocketClient.ts
+++ b/webapp/src/websocket-client/WebsocketClient.ts
@@ -57,6 +57,7 @@ export const WebsocketClient = (options: WebsocketClientOptions) => {
             const parsed = JSON.parse(message.body) as Message;
             subscription.callback(parsed as any);
           } catch (e: any) {
+            // eslint-disable-next-line no-console
             console.error(`WebSocket: error parsing message: ${e.message}`);
           }
         }


### PR DESCRIPTION
## Summary

- **Fix**: `onDisconnect` was removing all subscriptions from the array, so STOMP auto-reconnect called `resubscribe()` on an empty list — silently breaking all real-time updates (batch job progress, translation modifications) after any connection drop
- **Sync**: Aligns the platform's `WebsocketClient.ts` with the improved version from `tolgee-cli`, adding a `connecting` guard, message parse error handling, and proper null checks

Closes #3329

## Test plan

- [ ] Start a batch operation (e.g. machine translation on a few keys)
- [ ] While it's running, simulate a websocket disconnect (e.g. toggle network briefly or kill the websocket connection in devtools)
- [ ] Verify that after reconnection, progress updates resume without a page refresh
- [ ] Verify normal batch operation progress still works end-to-end without interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping WebSocket connection attempts to improve stability.
  * Ensured subscriptions only activate when a live client is present, reducing stray/duplicate subscriptions.
  * Improved message parsing error handling so malformed messages are logged without disrupting processing.
  * Streamlined disconnect behavior to rely on per-subscription cleanup, reducing unexpected teardown side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->