### PR TITLE
fix: Add Uyghur (ug) to RTL language list

### DIFF
--- a/webapp/src/fixtures/getLanguageDirection.ts
+++ b/webapp/src/fixtures/getLanguageDirection.ts
@@ -10,6 +10,7 @@ export const getLanguageDirection = (languageTag?: string): Direction => {
     'ks',
     'ku',
     'ps',
+    'ug',
     'ur',
     'yi',
   ];


### PR DESCRIPTION
Fixes #3524 — Uyghur uses Arabic script and should be rendered right-to-left in the translation editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added right-to-left text direction support for Uyghur language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->