### PR TITLE
perf: fix O(n) CPU spike in BatchJobChunkExecutionQueue with large queues

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -7,15 +7,14 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import org.springframework.stereotype.Component
 import java.time.Duration
-import java.util.concurrent.ConcurrentLinkedQueue
 
 @Component
 class Metrics(
   private val meterRegistry: MeterRegistry,
 ) {
-  fun registerJobQueue(queue: ConcurrentLinkedQueue<*>) {
+  fun registerJobQueue(sizeProvider: () -> Int) {
     Gauge
-      .builder("tolgee.batch.job.execution.queue.size", queue) { it.size.toDouble() }
+      .builder("tolgee.batch.job.execution.queue.size", sizeProvider) { it().toDouble() }
       .description("Size of the queue of batch job executions")
       .register(meterRegistry)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -25,12 +25,11 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 class BatchJobChunkExecutionQueue(
-  private val batchProperties: BatchProperties,
   private val entityManager: EntityManager,
   private val usingRedisProvider: UsingRedisProvider,
   @Lazy
@@ -40,21 +39,36 @@ class BatchJobChunkExecutionQueue(
   InitializingBean {
   companion object {
     /**
-     * It's static
+     * Per-job item queues. Key = jobId.
+     *
+     * All mutations go through ConcurrentHashMap.compute() which provides per-key
+     * atomicity, keeping roundRobinOrder and jobQueues in sync under concurrent access.
+     *
+     * Invariant: jobId is in roundRobinOrder ↔ jobQueues[jobId] is non-null and non-empty.
      */
-    private val queue = ConcurrentLinkedQueue<ExecutionQueueItem>()
+    private val jobQueues = ConcurrentHashMap<Long, ConcurrentLinkedDeque<ExecutionQueueItem>>()
 
     /**
-     * O(1) counter for job characters in queue - avoids O(n) iteration on every chunk
+     * Round-robin job order. Each jobId appears exactly once when its queue is non-empty.
+     * pollFirst() picks the next job to serve; addLast() re-queues it after serving one chunk.
+     * This gives O(1) fair scheduling without scanning all items.
+     */
+    private val roundRobinOrder = ConcurrentLinkedDeque<Long>()
+
+    /**
+     * O(1) duplicate detection — replaces the O(n) queue snapshot done on every add.
+     */
+    private val queuedExecutionIds = ConcurrentHashMap.newKeySet<Long>()
+
+    /**
+     * O(1) total item counter.
+     */
+    private val totalSize = AtomicInteger(0)
+
+    /**
+     * O(1) counter for job characters in queue.
      */
     private val jobCharacterCounts = ConcurrentHashMap<JobCharacter, AtomicInteger>()
-
-    /**
-     * Tracks the last job that was served a chunk for round-robin fairness.
-     * This ensures large jobs don't monopolize all worker coroutines.
-     */
-    @Volatile
-    private var lastServedJobId: Long? = null
   }
 
   private fun incrementCharacterCount(character: JobCharacter) {
@@ -65,19 +79,52 @@ class BatchJobChunkExecutionQueue(
     jobCharacterCounts[character]?.decrementAndGet()
   }
 
+  /**
+   * Adds a single item. Returns false if already queued (duplicate).
+   *
+   * Thread-safe: compute() serializes concurrent add/poll for the same jobId,
+   * ensuring roundRobinOrder.addLast() is called exactly once per new job.
+   */
+  private fun addSingleItem(item: ExecutionQueueItem): Boolean {
+    if (!queuedExecutionIds.add(item.chunkExecutionId)) return false
+
+    jobQueues.compute(item.jobId) { jobId, existing ->
+      val deque =
+        existing ?: ConcurrentLinkedDeque<ExecutionQueueItem>().also {
+          // Called atomically inside compute — only once per new job
+          roundRobinOrder.addLast(jobId)
+        }
+      deque.addLast(item)
+      deque
+    }
+
+    incrementCharacterCount(item.jobCharacter)
+    totalSize.incrementAndGet()
+    return true
+  }
+
   @EventListener
   fun onJobItemEvent(event: JobQueueItemsEvent) {
     when (event.type) {
-      QueueEventType.ADD -> {
-        this.addItemsToLocalQueue(event.items)
-      }
+      QueueEventType.ADD -> addItemsToLocalQueue(event.items)
 
       QueueEventType.REMOVE -> {
-        // Remove and decrement atomically per item to prevent double-decrement
-        // if poll() removes an item between removeAll and forEach
         event.items.forEach { item ->
-          if (queue.remove(item)) {
-            decrementCharacterCount(item.jobCharacter)
+          if (queuedExecutionIds.remove(item.chunkExecutionId)) {
+            jobQueues.compute(item.jobId) { _, deque ->
+              if (deque == null) return@compute null
+              val removed = deque.removeIf { it.chunkExecutionId == item.chunkExecutionId }
+              if (removed) {
+                decrementCharacterCount(item.jobCharacter)
+                totalSize.decrementAndGet()
+              }
+              if (deque.isEmpty()) {
+                roundRobinOrder.remove(item.jobId)
+                null
+              } else {
+                deque
+              }
+            }
           }
         }
       }
@@ -99,10 +146,10 @@ class BatchJobChunkExecutionQueue(
           from BatchJobChunkExecution bjce
           join bjce.batchJob bk
           where bjce.status = :executionStatus
-          order by 
+          order by
             case when bk.status = :runningStatus then 0 else 1 end,
-            bjce.createdAt asc, 
-            bjce.executeAfter asc, 
+            bjce.createdAt asc,
+            bjce.executeAfter asc,
             bjce.id asc
           """.trimIndent(),
           BatchJobChunkExecutionDto::class.java,
@@ -110,62 +157,41 @@ class BatchJobChunkExecutionQueue(
         .setParameter("runningStatus", BatchJobStatus.RUNNING)
         .resultList
 
-    if (data.size > 0) {
+    if (data.isNotEmpty()) {
       logger.debug("Attempt to add ${data.size} items to queue ${System.identityHashCode(this)}")
       addExecutionsToLocalQueue(data)
     }
   }
 
   fun addExecutionsToLocalQueue(data: List<BatchJobChunkExecutionDto>) {
-    val ids = queue.map { it.chunkExecutionId }.toSet()
-    var count = 0
-    data.forEach {
-      if (!ids.contains(it.id)) {
-        val item = it.toItem()
-        queue.add(item)
-        incrementCharacterCount(item.jobCharacter)
-        count++
-      }
+    var alreadyQueued = 0
+    data.forEach { dto ->
+      if (!addSingleItem(dto.toItem())) alreadyQueued++
     }
-    metrics.batchJobManagementItemAlreadyQueuedCounter.increment(data.size - count.toDouble())
-    logger.debug("Added $count new items to queue ${System.identityHashCode(this)}")
+    metrics.batchJobManagementItemAlreadyQueuedCounter.increment(alreadyQueued.toDouble())
+    logger.debug("Added ${data.size - alreadyQueued} new items to queue ${System.identityHashCode(this)}")
   }
 
   fun addItemsToLocalQueue(data: List<ExecutionQueueItem>) {
-    // Use Set for O(1) lookup instead of O(n) queue.contains()
-    val existingIds = queue.mapTo(HashSet()) { it.chunkExecutionId }
-    val toAdd = mutableListOf<ExecutionQueueItem>()
     var filteredOutCount = 0
-
-    data.forEach {
-      if (!existingIds.contains(it.chunkExecutionId)) {
-        toAdd.add(it)
-        existingIds.add(it.chunkExecutionId) // Prevent duplicates within the batch
-      } else {
-        filteredOutCount++
-      }
+    data.forEach { item ->
+      if (!addSingleItem(item)) filteredOutCount++
     }
     metrics.batchJobManagementItemAlreadyQueuedCounter.increment(filteredOutCount.toDouble())
     logger.trace {
-      val itemsString = toAdd.joinToString(", ") { it.chunkExecutionId.toString() }
-      "Adding ${toAdd.size} chunks to queue. Filtered out: $filteredOutCount"
+      "Adding ${data.size - filteredOutCount} chunks to queue. Filtered out: $filteredOutCount"
     }
-
-    queue.addAll(toAdd)
-    toAdd.forEach { incrementCharacterCount(it.jobCharacter) }
   }
 
   fun addToQueue(
     execution: BatchJobChunkExecution,
     jobCharacter: JobCharacter,
   ) {
-    val item = execution.toItem(jobCharacter)
-    addItemsToQueue(listOf(item))
+    addItemsToQueue(listOf(execution.toItem(jobCharacter)))
   }
 
   fun addToQueue(executions: List<BatchJobChunkExecution>) {
-    val items = executions.map { it.toItem() }
-    addItemsToQueue(items)
+    addItemsToQueue(executions.map { it.toItem() })
   }
 
   fun addItemsToQueue(items: List<ExecutionQueueItem>) {
@@ -183,20 +209,28 @@ class BatchJobChunkExecutionQueue(
       return
     }
 
-    this.addItemsToLocalQueue(items)
+    addItemsToLocalQueue(items)
   }
 
   fun removeJobExecutions(jobId: Long) {
-    logger.debug("Removing job $jobId from queue, queue size: ${queue.size}")
-    val iterator = queue.iterator()
-    while (iterator.hasNext()) {
-      val item = iterator.next()
-      if (item.jobId == jobId) {
-        iterator.remove()
-        decrementCharacterCount(item.jobCharacter)
+    logger.debug("Removing job $jobId from queue, queue size: ${totalSize.get()}")
+    var removedCount = 0
+    jobQueues.compute(jobId) { _, deque ->
+      if (deque != null) {
+        deque.forEach { item ->
+          queuedExecutionIds.remove(item.chunkExecutionId)
+          decrementCharacterCount(item.jobCharacter)
+        }
+        removedCount = deque.size
+        totalSize.addAndGet(-removedCount)
       }
+      null // remove entry from map
     }
-    logger.debug("Removed job $jobId from queue, queue size: ${queue.size}")
+    if (removedCount > 0) {
+      // O(n) on roundRobinOrder, but removeJobExecutions is only called on cancellation
+      roundRobinOrder.remove(jobId)
+    }
+    logger.debug("Removed job $jobId from queue ($removedCount items), queue size: ${totalSize.get()}")
   }
 
   private fun BatchJobChunkExecution.toItem(
@@ -204,104 +238,91 @@ class BatchJobChunkExecutionQueue(
     // However, we don't want to fetch it here, because it would be a waste of resources.
     // So we can provide the jobCharacter here.
     jobCharacter: JobCharacter? = null,
-  ) =
-    ExecutionQueueItem(id, batchJob.id, executeAfter?.time, jobCharacter ?: batchJob.jobCharacter)
+  ) = ExecutionQueueItem(id, batchJob.id, executeAfter?.time, jobCharacter ?: batchJob.jobCharacter)
 
   private fun BatchJobChunkExecutionDto.toItem(providedJobCharacter: JobCharacter? = null) =
     ExecutionQueueItem(id, batchJobId, executeAfter?.time, providedJobCharacter ?: jobCharacter)
 
-  val size get() = queue.size
+  val size get() = totalSize.get()
 
   fun joinToString(
     separator: String = ", ",
     transform: (item: ExecutionQueueItem) -> String,
-  ) = queue.joinToString(separator, transform = transform)
-
-  fun poll(): ExecutionQueueItem? {
-    val item = queue.poll()
-    item?.let { decrementCharacterCount(it.jobCharacter) }
-    return item
-  }
+  ) = getAllQueueItems().joinToString(separator, transform = transform)
 
   /**
-   * Polls using round-robin across jobs for fair distribution.
-   * Each job gets one chunk processed before any job gets a second chunk.
-   * This prevents large jobs from monopolizing all worker coroutines.
+   * O(1) poll — delegates to pollRoundRobin.
+   */
+  fun poll(): ExecutionQueueItem? = pollRoundRobin()
+
+  /**
+   * O(1) round-robin poll across jobs.
    *
-   * Thread-safety: This method handles concurrent modifications gracefully.
-   * If another thread removes an item between finding and removing it,
-   * we verify the removal succeeded and retry if needed.
+   * Rotates jobs fairly: each job gets one chunk served before any job gets a second.
+   * Uses pollFirst/addLast on roundRobinOrder — no full-queue scan required.
+   *
+   * Thread-safe: compute() serializes concurrent add/poll for the same jobId.
+   * If a job's deque turns out to be empty (concurrent drain), the job is skipped
+   * and the next one is tried. maxAttempts prevents infinite loops in edge cases.
    */
   fun pollRoundRobin(): ExecutionQueueItem? {
-    if (queue.isEmpty()) {
-      return null
-    }
+    if (isEmpty()) return null
 
-    // Get distinct job IDs in queue order
-    val jobIds = queue.mapTo(LinkedHashSet()) { it.jobId }.toList()
-    if (jobIds.isEmpty()) {
-      return null
-    }
+    // jobQueues.size is O(1) (ConcurrentHashMap maintains an internal counter).
+    // It bounds the loop to the number of distinct jobs: in the worst case we try every
+    // job once and find all deques empty (concurrent drain), then give up.
+    // Do NOT use roundRobinOrder.size() — ConcurrentLinkedDeque.size() is O(n).
+    val maxAttempts = jobQueues.size + 1
+    var attempts = 0
+    while (attempts++ <= maxAttempts) {
+      val jobId = roundRobinOrder.pollFirst() ?: return null
 
-    // Find next job in rotation
-    val lastJobId = lastServedJobId
-    val startIndex =
-      if (lastJobId == null) {
-        0
-      } else {
-        val idx = jobIds.indexOf(lastJobId)
-        if (idx == -1) 0 else (idx + 1) % jobIds.size
+      var item: ExecutionQueueItem? = null
+      var hasMoreItems = false
+
+      jobQueues.compute(jobId) { _, deque ->
+        if (deque.isNullOrEmpty()) return@compute null
+        item = deque.removeFirst()
+        hasMoreItems = deque.isNotEmpty()
+        if (hasMoreItems) deque else null
       }
 
-    // Try each job in round-robin order
-    for (i in jobIds.indices) {
-      val jobIndex = (startIndex + i) % jobIds.size
-      val targetJobId = jobIds[jobIndex]
-
-      // Find first item for this job and try to remove it
-      val item = queue.firstOrNull { it.jobId == targetJobId }
-      if (item != null && queue.remove(item)) {
-        // Successfully removed - update state and return
+      if (item != null) {
+        queuedExecutionIds.remove(item.chunkExecutionId)
         decrementCharacterCount(item.jobCharacter)
-        lastServedJobId = targetJobId
+        totalSize.decrementAndGet()
+        if (hasMoreItems) roundRobinOrder.addLast(jobId)
         return item
       }
-      // Item was null or already removed by another thread, try next job
+      // deque was null or empty (concurrent drain) — don't re-add, try next job
     }
-
-    // Fallback if all targeted items were concurrently removed
-    return poll()
+    return null
   }
 
   fun clear() {
     logger.debug("Clearing queue")
-    queue.clear()
+    jobQueues.clear()
+    roundRobinOrder.clear()
+    queuedExecutionIds.clear()
+    totalSize.set(0)
     jobCharacterCounts.clear()
   }
 
-  fun find(function: (ExecutionQueueItem) -> Boolean): ExecutionQueueItem? {
-    return queue.find(function)
-  }
+  fun find(function: (ExecutionQueueItem) -> Boolean): ExecutionQueueItem? = getAllQueueItems().find(function)
 
-  fun peek(): ExecutionQueueItem = queue.peek()
+  fun peek(): ExecutionQueueItem = getAllQueueItems().first()
 
-  fun contains(item: ExecutionQueueItem?): Boolean = queue.contains(item)
+  fun contains(item: ExecutionQueueItem?): Boolean = item != null && queuedExecutionIds.contains(item.chunkExecutionId)
 
-  fun isEmpty(): Boolean = queue.isEmpty()
+  fun isEmpty(): Boolean = totalSize.get() == 0
 
-  fun getJobCharacterCounts(): Map<JobCharacter, Int> {
-    return jobCharacterCounts.mapValues { it.value.get() }
-  }
+  fun getJobCharacterCounts(): Map<JobCharacter, Int> = jobCharacterCounts.mapValues { it.value.get() }
 
   override fun afterPropertiesSet() {
-    metrics.registerJobQueue(queue)
+    metrics.registerJobQueue { totalSize.get() }
   }
 
-  fun getQueuedJobItems(jobId: Long): List<ExecutionQueueItem> {
-    return queue.filter { it.jobId == jobId }
-  }
+  fun getQueuedJobItems(jobId: Long): List<ExecutionQueueItem> = jobQueues[jobId]?.toList() ?: emptyList()
 
-  fun getAllQueueItems(): List<ExecutionQueueItem> {
-    return queue.toList()
-  }
+  fun getAllQueueItems(): List<ExecutionQueueItem> = jobQueues.values.flatMap { it.toList() }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -82,7 +82,9 @@ class BatchJobChunkExecutionQueue(
    * Adds a single item. Returns false if already queued (duplicate).
    *
    * Thread-safe: compute() serializes concurrent add/poll for the same jobId,
-   * ensuring roundRobinOrder.addLast() is called exactly once per new job.
+   * ensuring roundRobinOrder.addLast(), incrementCharacterCount(), and
+   * totalSize.incrementAndGet() are called exactly once per new item, atomically
+   * with the deque mutation.
    */
   private fun addSingleItem(item: ExecutionQueueItem): Boolean {
     if (!queuedExecutionIds.add(item.chunkExecutionId)) return false
@@ -94,11 +96,11 @@ class BatchJobChunkExecutionQueue(
           roundRobinOrder.addLast(jobId)
         }
       deque.addLast(item)
+      incrementCharacterCount(item.jobCharacter)
+      totalSize.incrementAndGet()
       deque
     }
 
-    incrementCharacterCount(item.jobCharacter)
-    totalSize.incrementAndGet()
     return true
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -48,11 +48,12 @@ class BatchJobChunkExecutionQueue(
     private val jobQueues = ConcurrentHashMap<Long, ConcurrentLinkedDeque<ExecutionQueueItem>>()
 
     /**
-     * Round-robin job order. Each jobId appears exactly once when its queue is non-empty.
+     * Round-robin job order. Each jobId appears at most once when its queue is non-empty.
      * pollFirst() picks the next job to serve; addLast() re-queues it after serving one chunk.
-     * This gives O(1) fair scheduling without scanning all items.
+     * Using [ConcurrentOrderedSet] instead of a plain deque ensures addLast() is idempotent,
+     * preventing duplicate jobId entries under concurrent poll/add races.
      */
-    private val roundRobinOrder = ConcurrentLinkedDeque<Long>()
+    private val roundRobinOrder = ConcurrentOrderedSet<Long>()
 
     /**
      * O(1) duplicate detection — replaces the O(n) queue snapshot done on every add.
@@ -261,6 +262,9 @@ class BatchJobChunkExecutionQueue(
    * Uses pollFirst/addLast on roundRobinOrder — no full-queue scan required.
    *
    * Thread-safe: compute() serializes concurrent add/poll for the same jobId.
+   * roundRobinOrder is a [ConcurrentOrderedSet] so addLast() is idempotent — if a
+   * concurrent addSingleItem re-added jobId between our pollFirst() and compute(),
+   * our own addLast() inside compute() is a safe no-op instead of creating a duplicate.
    * If a job's deque turns out to be empty (concurrent drain), the job is skipped
    * and the next one is tried. maxAttempts prevents infinite loops in edge cases.
    */
@@ -270,7 +274,6 @@ class BatchJobChunkExecutionQueue(
     // jobQueues.size is O(1) (ConcurrentHashMap maintains an internal counter).
     // It bounds the loop to the number of distinct jobs: in the worst case we try every
     // job once and find all deques empty (concurrent drain), then give up.
-    // Do NOT use roundRobinOrder.size() — ConcurrentLinkedDeque.size() is O(n).
     val maxAttempts = jobQueues.size + 1
     var attempts = 0
     while (attempts++ <= maxAttempts) {

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueue.kt
@@ -7,7 +7,6 @@ import io.tolgee.batch.data.ExecutionQueueItem
 import io.tolgee.batch.data.QueueEventType
 import io.tolgee.batch.events.JobQueueItemsEvent
 import io.tolgee.component.UsingRedisProvider
-import io.tolgee.configuration.tolgee.BatchProperties
 import io.tolgee.model.batch.BatchJobChunkExecution
 import io.tolgee.model.batch.BatchJobChunkExecutionStatus
 import io.tolgee.model.batch.BatchJobStatus
@@ -110,20 +109,19 @@ class BatchJobChunkExecutionQueue(
 
       QueueEventType.REMOVE -> {
         event.items.forEach { item ->
-          if (queuedExecutionIds.remove(item.chunkExecutionId)) {
-            jobQueues.compute(item.jobId) { _, deque ->
-              if (deque == null) return@compute null
-              val removed = deque.removeIf { it.chunkExecutionId == item.chunkExecutionId }
-              if (removed) {
-                decrementCharacterCount(item.jobCharacter)
-                totalSize.decrementAndGet()
-              }
-              if (deque.isEmpty()) {
-                roundRobinOrder.remove(item.jobId)
-                null
-              } else {
-                deque
-              }
+          jobQueues.compute(item.jobId) { _, deque ->
+            if (deque == null) return@compute null
+            val removed = deque.removeIf { it.chunkExecutionId == item.chunkExecutionId }
+            if (removed) {
+              queuedExecutionIds.remove(item.chunkExecutionId)
+              decrementCharacterCount(item.jobCharacter)
+              totalSize.decrementAndGet()
+            }
+            if (deque.isEmpty()) {
+              roundRobinOrder.remove(item.jobId)
+              null
+            } else {
+              deque
             }
           }
         }
@@ -223,12 +221,11 @@ class BatchJobChunkExecutionQueue(
         }
         removedCount = deque.size
         totalSize.addAndGet(-removedCount)
+        // Inside compute to prevent a concurrent addSingleItem from re-adding jobId
+        // to roundRobinOrder between the compute returning and the remove call.
+        roundRobinOrder.remove(jobId)
       }
       null // remove entry from map
-    }
-    if (removedCount > 0) {
-      // O(n) on roundRobinOrder, but removeJobExecutions is only called on cancellation
-      roundRobinOrder.remove(jobId)
     }
     logger.debug("Removed job $jobId from queue ($removedCount items), queue size: ${totalSize.get()}")
   }
@@ -278,22 +275,26 @@ class BatchJobChunkExecutionQueue(
       val jobId = roundRobinOrder.pollFirst() ?: return null
 
       var item: ExecutionQueueItem? = null
-      var hasMoreItems = false
 
+      // All side-effects (queuedExecutionIds, counters, roundRobinOrder re-queue) are done
+      // inside compute so they are atomic with the deque mutation, preventing races with
+      // concurrent addSingleItem or removeJobExecutions calls for the same jobId.
       jobQueues.compute(jobId) { _, deque ->
         if (deque.isNullOrEmpty()) return@compute null
         item = deque.removeFirst()
-        hasMoreItems = deque.isNotEmpty()
-        if (hasMoreItems) deque else null
+        val capturedItem = item!!
+        queuedExecutionIds.remove(capturedItem.chunkExecutionId)
+        decrementCharacterCount(capturedItem.jobCharacter)
+        totalSize.decrementAndGet()
+        if (deque.isNotEmpty()) {
+          roundRobinOrder.addLast(jobId)
+          deque
+        } else {
+          null
+        }
       }
 
-      if (item != null) {
-        queuedExecutionIds.remove(item.chunkExecutionId)
-        decrementCharacterCount(item.jobCharacter)
-        totalSize.decrementAndGet()
-        if (hasMoreItems) roundRobinOrder.addLast(jobId)
-        return item
-      }
+      if (item != null) return item
       // deque was null or empty (concurrent drain) — don't re-add, try next job
     }
     return null
@@ -310,7 +311,10 @@ class BatchJobChunkExecutionQueue(
 
   fun find(function: (ExecutionQueueItem) -> Boolean): ExecutionQueueItem? = getAllQueueItems().find(function)
 
-  fun peek(): ExecutionQueueItem = getAllQueueItems().first()
+  fun peek(): ExecutionQueueItem {
+    val jobId = roundRobinOrder.peekFirst() ?: throw NoSuchElementException("Queue is empty")
+    return jobQueues[jobId]?.peekFirst() ?: throw NoSuchElementException("Queue is empty")
+  }
 
   fun contains(item: ExecutionQueueItem?): Boolean = item != null && queuedExecutionIds.contains(item.chunkExecutionId)
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
@@ -39,7 +39,7 @@ class BatchJobConcurrentLauncher(
   /**
    * execution id -> Pair(BatchJobDto, Job)
    *
-   * Job is the result of launch method executing the execution in separate coroutine
+   * Job is the result of a launch method executing the execution in a separate coroutine
    */
   val runningJobs: ConcurrentHashMap<Long, Pair<BatchJobDto, Job>> = ConcurrentHashMap()
 
@@ -141,15 +141,15 @@ class BatchJobConcurrentLauncher(
 
   private fun logItemsPulled(items: List<ExecutionQueueItem>) {
     if (items.isNotEmpty()) {
-      logger.trace(
+      logger.trace {
         "Pulled ${items.size} items from queue: " +
-          items.joinToString(", ") { it.chunkExecutionId.toString() },
-      )
-      logger.trace(
+          items.joinToString(", ") { it.chunkExecutionId.toString() }
+      }
+      logger.trace {
         "${batchJobChunkExecutionQueue.size} is left in the queue " +
           "(${System.identityHashCode(batchJobChunkExecutionQueue)}): " +
-          batchJobChunkExecutionQueue.joinToString(", ") { it.chunkExecutionId.toString() },
-      )
+          batchJobChunkExecutionQueue.joinToString(", ") { it.chunkExecutionId.toString() }
+      }
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ConcurrentOrderedSet.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ConcurrentOrderedSet.kt
@@ -1,0 +1,42 @@
+package io.tolgee.batch
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * Thread-safe ordered set backed by a [LinkedHashSet].
+ *
+ * Maintains insertion order and rejects duplicates — [addLast] is a no-op if the element
+ * is already present. This prevents the duplicate-jobId race that would occur when using
+ * a plain [java.util.concurrent.ConcurrentLinkedDeque] as a round-robin order tracker.
+ *
+ * Lock ordering: callers inside [java.util.concurrent.ConcurrentHashMap.compute] may call
+ * [addLast] or [remove] while holding the CHM key-lock. [pollFirst] acquires this lock
+ * independently and never enters compute(). The acquisition order is therefore always
+ * CHM-key-lock → this lock, never the reverse — no deadlock is possible.
+ */
+class ConcurrentOrderedSet<T> {
+  private val lock = ReentrantLock()
+  private val set = LinkedHashSet<T>()
+
+  /** Appends [item] to the tail. Returns false (no-op) if already present. */
+  fun addLast(item: T): Boolean = lock.withLock { set.add(item) }
+
+  /** Removes and returns the head element, or null if empty. */
+  fun pollFirst(): T? =
+    lock.withLock {
+      val iter = set.iterator()
+      if (!iter.hasNext()) return null
+      val item = iter.next()
+      iter.remove()
+      item
+    }
+
+  /** Returns the head element without removing it, or null if empty. */
+  fun peekFirst(): T? = lock.withLock { set.firstOrNull() }
+
+  /** Removes [item]. Returns false if it was not present. */
+  fun remove(item: T): Boolean = lock.withLock { set.remove(item) }
+
+  fun clear() = lock.withLock { set.clear() }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueuePerformanceTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueuePerformanceTest.kt
@@ -1,0 +1,217 @@
+package io.tolgee.batch
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.tolgee.Metrics
+import io.tolgee.batch.data.ExecutionQueueItem
+import io.tolgee.component.UsingRedisProvider
+import io.tolgee.configuration.tolgee.BatchProperties
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD
+import org.mockito.kotlin.mock
+import org.springframework.data.redis.core.StringRedisTemplate
+import java.util.concurrent.TimeUnit
+
+/**
+ * Performance regression tests for BatchJobChunkExecutionQueue.
+ *
+ * These tests prove that pollRoundRobin() is O(1) per call thanks to the
+ * per-job indexed structure (Map<JobId, ArrayDeque> + ConcurrentLinkedDeque
+ * for round-robin order). With 110k items, polls must remain fast.
+ *
+ * If these tests start failing (i.e. polling becomes slow again), it means
+ * an O(n) scan was re-introduced in the hot path.
+ */
+class BatchJobChunkExecutionQueuePerformanceTest {
+  private lateinit var executionQueue: BatchJobChunkExecutionQueue
+
+  @BeforeEach
+  fun setup() {
+    executionQueue =
+      BatchJobChunkExecutionQueue(
+        entityManager = mock<EntityManager>(),
+        usingRedisProvider = mock<UsingRedisProvider>(),
+        redisTemplate = mock<StringRedisTemplate>(),
+        metrics = Metrics(SimpleMeterRegistry()),
+      )
+    // The internal structures live in the companion object (static), clear between tests
+    executionQueue.clear()
+  }
+
+  private fun makeItem(
+    id: Long,
+    jobId: Long,
+  ) = ExecutionQueueItem(
+    chunkExecutionId = id,
+    jobId = jobId,
+    executeAfter = null,
+    jobCharacter = JobCharacter.FAST,
+  )
+
+  /**
+   * 1 large job with 110k chunks.
+   * With the old O(n) implementation, 1000 polls took several seconds.
+   * With the new O(1) structure, they must complete in under 500ms.
+   */
+  @Test
+  fun `pollRoundRobin is fast with 1 large job and 110k items`() {
+    val items = (1L..110_000L).map { makeItem(it, jobId = 1L) }
+    executionQueue.addItemsToLocalQueue(items)
+
+    val polls = 1_000
+    val start = System.currentTimeMillis()
+    repeat(polls) { executionQueue.pollRoundRobin() }
+    val elapsedMs = System.currentTimeMillis() - start
+
+    println(
+      "1 job × 110k items | $polls polls → ${elapsedMs}ms (~${"%.2f".format(elapsedMs.toDouble() / polls)}ms/poll)",
+    )
+
+    assertThat(elapsedMs)
+      .withFailMessage("$polls polls with 110k items took ${elapsedMs}ms — O(n) scan may have been re-introduced")
+      .isLessThan(500)
+  }
+
+  /**
+   * 110k jobs with 1 chunk each.
+   * With the old implementation each poll scanned 110k nodes.
+   * With the new structure, each poll is O(1) regardless of job count.
+   */
+  @Test
+  fun `pollRoundRobin is fast with 110k jobs of 1 item each`() {
+    val items = (1L..110_000L).map { makeItem(it, jobId = it) }
+    executionQueue.addItemsToLocalQueue(items)
+
+    val polls = 1_000
+    val start = System.currentTimeMillis()
+    repeat(polls) { executionQueue.pollRoundRobin() }
+    val elapsedMs = System.currentTimeMillis() - start
+
+    println(
+      "110k jobs × 1 item | $polls polls → ${elapsedMs}ms (~${"%.2f".format(elapsedMs.toDouble() / polls)}ms/poll)",
+    )
+
+    assertThat(elapsedMs)
+      .withFailMessage("$polls polls with 110k jobs took ${elapsedMs}ms — O(n) scan may have been re-introduced")
+      .isLessThan(500)
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // removeJobExecutions
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * removeJobExecutions(jobId) should run in O(k) where k is the number of items
+   * for that job, not O(total queue size).
+   * We load 110k items across 100 jobs and call removeJobExecutions 1000 times
+   * (the job is already empty after the first call, so subsequent calls are O(1)).
+   */
+  @Test
+  fun `removeJobExecutions is fast with large queue`() {
+    val items = (1L..110_000L).map { makeItem(it, jobId = it % 100 + 1) }
+    executionQueue.addItemsToLocalQueue(items)
+
+    val start = System.currentTimeMillis()
+    repeat(1_000) {
+      executionQueue.removeJobExecutions(1L)
+    }
+    val elapsedMs = System.currentTimeMillis() - start
+
+    println("removeJobExecutions × 1000 with 110k-item queue → ${elapsedMs}ms")
+
+    assertThat(elapsedMs)
+      .withFailMessage("removeJobExecutions × 1000 took ${elapsedMs}ms — O(total) scan may have been re-introduced")
+      .isLessThan(500)
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // contains / isEmpty / size — O(1) accessors
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * contains() must be O(1) — backed by a ConcurrentHashMap set, not a linear scan.
+   */
+  @Test
+  fun `contains is O(1) with large queue`() {
+    val items = (1L..110_000L).map { makeItem(it, jobId = it % 100 + 1) }
+    executionQueue.addItemsToLocalQueue(items)
+    val target = items[55_000]
+
+    val checks = 100_000
+    val start = System.currentTimeMillis()
+    repeat(checks) { executionQueue.contains(target) }
+    val elapsedMs = System.currentTimeMillis() - start
+
+    println("contains × $checks with 110k-item queue → ${elapsedMs}ms")
+
+    assertThat(elapsedMs)
+      .withFailMessage("contains × $checks took ${elapsedMs}ms — O(n) scan may have been re-introduced")
+      .isLessThan(200)
+  }
+
+  /**
+   * isEmpty() and size must be O(1) — backed by an AtomicInteger counter.
+   */
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS, threadMode = SEPARATE_THREAD)
+  fun `isEmpty and size are O(1) with large queue`() {
+    val items = (1L..110_000L).map { makeItem(it, jobId = it % 100 + 1) }
+    executionQueue.addItemsToLocalQueue(items)
+
+    val checks = 1_000_000
+    val start = System.currentTimeMillis()
+    repeat(checks) {
+      executionQueue.isEmpty()
+      executionQueue.size
+    }
+    val elapsedMs = System.currentTimeMillis() - start
+
+    println("isEmpty+size × $checks with 110k-item queue → ${elapsedMs}ms")
+
+    assertThat(elapsedMs)
+      .withFailMessage("isEmpty/size × $checks took ${elapsedMs}ms — O(n) traversal may have been re-introduced")
+      .isLessThan(500)
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // pollRoundRobin — existing coverage kept below
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Verifies that poll time does NOT scale with queue size (O(1) behaviour).
+   * The ratio between 110k and 1k should be small (< 5x), not ~110x as with O(n).
+   */
+  @Test
+  fun `pollRoundRobin throughput does not degrade with queue size`() {
+    val pollsPerSize = 200
+    val results = linkedMapOf<Int, Long>()
+
+    for (queueSize in listOf(1_000, 10_000, 110_000)) {
+      executionQueue.clear()
+      val items = (1L..queueSize.toLong()).map { makeItem(it, jobId = it % 50 + 1) }
+      executionQueue.addItemsToLocalQueue(items)
+
+      val start = System.nanoTime()
+      repeat(pollsPerSize) { executionQueue.pollRoundRobin() }
+      val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+      results[queueSize] = elapsedMs
+    }
+
+    val baseline = maxOf(results[1_000]!!, 1L)
+    val ratio110k = results[110_000]!! / baseline
+
+    println("Queue 1k:   ${results[1_000]}ms for $pollsPerSize polls")
+    println("Queue 10k:  ${results[10_000]}ms for $pollsPerSize polls")
+    println("Queue 110k: ${results[110_000]}ms for $pollsPerSize polls (${ratio110k}x vs 1k)")
+
+    // With O(1) behaviour, 110k should be at most 5x slower than 1k (JIT warm-up noise)
+    // With the old O(n) scan, this ratio was ~110x
+    assertThat(ratio110k)
+      .withFailMessage("110k queue is ${ratio110k}x slower than 1k — O(n) scan may have been re-introduced")
+      .isLessThan(3)
+  }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueuePerformanceTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueuePerformanceTest.kt
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.tolgee.Metrics
 import io.tolgee.batch.data.ExecutionQueueItem
 import io.tolgee.component.UsingRedisProvider
-import io.tolgee.configuration.tolgee.BatchProperties
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -12,8 +11,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.Timeout.ThreadMode.SEPARATE_THREAD
 import org.mockito.kotlin.mock
+import org.slf4j.LoggerFactory
 import org.springframework.data.redis.core.StringRedisTemplate
 import java.util.concurrent.TimeUnit
+import kotlin.time.measureTime
 
 /**
  * Performance regression tests for BatchJobChunkExecutionQueue.
@@ -26,6 +27,7 @@ import java.util.concurrent.TimeUnit
  * an O(n) scan was re-introduced in the hot path.
  */
 class BatchJobChunkExecutionQueuePerformanceTest {
+  private val logger = LoggerFactory.getLogger(BatchJobChunkExecutionQueuePerformanceTest::class.java)
   private lateinit var executionQueue: BatchJobChunkExecutionQueue
 
   @BeforeEach
@@ -62,11 +64,10 @@ class BatchJobChunkExecutionQueuePerformanceTest {
     executionQueue.addItemsToLocalQueue(items)
 
     val polls = 1_000
-    val start = System.currentTimeMillis()
-    repeat(polls) { executionQueue.pollRoundRobin() }
-    val elapsedMs = System.currentTimeMillis() - start
+    val elapsed = measureTime { repeat(polls) { executionQueue.pollRoundRobin() } }
+    val elapsedMs = elapsed.inWholeMilliseconds
 
-    println(
+    logger.info(
       "1 job × 110k items | $polls polls → ${elapsedMs}ms (~${"%.2f".format(elapsedMs.toDouble() / polls)}ms/poll)",
     )
 
@@ -86,11 +87,10 @@ class BatchJobChunkExecutionQueuePerformanceTest {
     executionQueue.addItemsToLocalQueue(items)
 
     val polls = 1_000
-    val start = System.currentTimeMillis()
-    repeat(polls) { executionQueue.pollRoundRobin() }
-    val elapsedMs = System.currentTimeMillis() - start
+    val elapsed = measureTime { repeat(polls) { executionQueue.pollRoundRobin() } }
+    val elapsedMs = elapsed.inWholeMilliseconds
 
-    println(
+    logger.info(
       "110k jobs × 1 item | $polls polls → ${elapsedMs}ms (~${"%.2f".format(elapsedMs.toDouble() / polls)}ms/poll)",
     )
 
@@ -114,13 +114,10 @@ class BatchJobChunkExecutionQueuePerformanceTest {
     val items = (1L..110_000L).map { makeItem(it, jobId = it % 100 + 1) }
     executionQueue.addItemsToLocalQueue(items)
 
-    val start = System.currentTimeMillis()
-    repeat(1_000) {
-      executionQueue.removeJobExecutions(1L)
-    }
-    val elapsedMs = System.currentTimeMillis() - start
+    val elapsed = measureTime { repeat(1_000) { executionQueue.removeJobExecutions(1L) } }
+    val elapsedMs = elapsed.inWholeMilliseconds
 
-    println("removeJobExecutions × 1000 with 110k-item queue → ${elapsedMs}ms")
+    logger.info("removeJobExecutions × 1000 with 110k-item queue → ${elapsedMs}ms")
 
     assertThat(elapsedMs)
       .withFailMessage("removeJobExecutions × 1000 took ${elapsedMs}ms — O(total) scan may have been re-introduced")
@@ -141,11 +138,10 @@ class BatchJobChunkExecutionQueuePerformanceTest {
     val target = items[55_000]
 
     val checks = 100_000
-    val start = System.currentTimeMillis()
-    repeat(checks) { executionQueue.contains(target) }
-    val elapsedMs = System.currentTimeMillis() - start
+    val elapsed = measureTime { repeat(checks) { executionQueue.contains(target) } }
+    val elapsedMs = elapsed.inWholeMilliseconds
 
-    println("contains × $checks with 110k-item queue → ${elapsedMs}ms")
+    logger.info("contains × $checks with 110k-item queue → ${elapsedMs}ms")
 
     assertThat(elapsedMs)
       .withFailMessage("contains × $checks took ${elapsedMs}ms — O(n) scan may have been re-introduced")
@@ -162,14 +158,16 @@ class BatchJobChunkExecutionQueuePerformanceTest {
     executionQueue.addItemsToLocalQueue(items)
 
     val checks = 1_000_000
-    val start = System.currentTimeMillis()
-    repeat(checks) {
-      executionQueue.isEmpty()
-      executionQueue.size
-    }
-    val elapsedMs = System.currentTimeMillis() - start
+    val elapsed =
+      measureTime {
+        repeat(checks) {
+          executionQueue.isEmpty()
+          executionQueue.size
+        }
+      }
+    val elapsedMs = elapsed.inWholeMilliseconds
 
-    println("isEmpty+size × $checks with 110k-item queue → ${elapsedMs}ms")
+    logger.info("isEmpty+size × $checks with 110k-item queue → ${elapsedMs}ms")
 
     assertThat(elapsedMs)
       .withFailMessage("isEmpty/size × $checks took ${elapsedMs}ms — O(n) traversal may have been re-introduced")
@@ -182,7 +180,7 @@ class BatchJobChunkExecutionQueuePerformanceTest {
 
   /**
    * Verifies that poll time does NOT scale with queue size (O(1) behaviour).
-   * The ratio between 110k and 1k should be small (< 5x), not ~110x as with O(n).
+   * The ratio between 110k and 1k should be small (< 3x), not ~110x as with O(n).
    */
   @Test
   fun `pollRoundRobin throughput does not degrade with queue size`() {
@@ -194,21 +192,18 @@ class BatchJobChunkExecutionQueuePerformanceTest {
       val items = (1L..queueSize.toLong()).map { makeItem(it, jobId = it % 50 + 1) }
       executionQueue.addItemsToLocalQueue(items)
 
-      val start = System.nanoTime()
-      repeat(pollsPerSize) { executionQueue.pollRoundRobin() }
-      val elapsedMs = (System.nanoTime() - start) / 1_000_000
-
-      results[queueSize] = elapsedMs
+      val elapsed = measureTime { repeat(pollsPerSize) { executionQueue.pollRoundRobin() } }
+      results[queueSize] = elapsed.inWholeMilliseconds
     }
 
     val baseline = maxOf(results[1_000]!!, 1L)
     val ratio110k = results[110_000]!! / baseline
 
-    println("Queue 1k:   ${results[1_000]}ms for $pollsPerSize polls")
-    println("Queue 10k:  ${results[10_000]}ms for $pollsPerSize polls")
-    println("Queue 110k: ${results[110_000]}ms for $pollsPerSize polls (${ratio110k}x vs 1k)")
+    logger.info("Queue 1k:   ${results[1_000]}ms for $pollsPerSize polls")
+    logger.info("Queue 10k:  ${results[10_000]}ms for $pollsPerSize polls")
+    logger.info("Queue 110k: ${results[110_000]}ms for $pollsPerSize polls (${ratio110k}x vs 1k)")
 
-    // With O(1) behaviour, 110k should be at most 5x slower than 1k (JIT warm-up noise)
+    // With O(1) behaviour, 110k should be at most 3x slower than 1k (JIT warm-up noise)
     // With the old O(n) scan, this ratio was ~110x
     assertThat(ratio110k)
       .withFailMessage("110k queue is ${ratio110k}x slower than 1k — O(n) scan may have been re-introduced")

--- a/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueueTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueueTest.kt
@@ -6,7 +6,6 @@ import io.tolgee.batch.data.ExecutionQueueItem
 import io.tolgee.batch.data.QueueEventType
 import io.tolgee.batch.events.JobQueueItemsEvent
 import io.tolgee.component.UsingRedisProvider
-import io.tolgee.configuration.tolgee.BatchProperties
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueueTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/BatchJobChunkExecutionQueueTest.kt
@@ -1,0 +1,269 @@
+package io.tolgee.batch
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.tolgee.Metrics
+import io.tolgee.batch.data.ExecutionQueueItem
+import io.tolgee.batch.data.QueueEventType
+import io.tolgee.batch.events.JobQueueItemsEvent
+import io.tolgee.component.UsingRedisProvider
+import io.tolgee.configuration.tolgee.BatchProperties
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.data.redis.core.StringRedisTemplate
+
+class BatchJobChunkExecutionQueueTest {
+  private lateinit var queue: BatchJobChunkExecutionQueue
+
+  @BeforeEach
+  fun setup() {
+    queue =
+      BatchJobChunkExecutionQueue(
+        entityManager = mock<EntityManager>(),
+        usingRedisProvider = mock<UsingRedisProvider>(),
+        redisTemplate = mock<StringRedisTemplate>(),
+        metrics = Metrics(SimpleMeterRegistry()),
+      )
+    queue.clear()
+  }
+
+  private fun item(
+    id: Long,
+    jobId: Long,
+    character: JobCharacter = JobCharacter.FAST,
+  ) = ExecutionQueueItem(chunkExecutionId = id, jobId = jobId, executeAfter = null, jobCharacter = character)
+
+  // ── size / isEmpty ────────────────────────────────────────────────────────
+
+  @Test
+  fun `size and isEmpty reflect queue state`() {
+    assertThat(queue.isEmpty()).isTrue()
+    assertThat(queue.size).isEqualTo(0)
+
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 1)))
+
+    assertThat(queue.isEmpty()).isFalse()
+    assertThat(queue.size).isEqualTo(2)
+  }
+
+  // ── add / duplicate prevention ────────────────────────────────────────────
+
+  @Test
+  fun `duplicate items are not added twice`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(1, jobId = 1)))
+    assertThat(queue.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `second addItemsToLocalQueue call does not re-add already queued items`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 1)))
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(3, jobId = 1)))
+
+    assertThat(queue.size).isEqualTo(3)
+    assertThat(queue.getAllQueueItems().map { it.chunkExecutionId }).containsExactlyInAnyOrder(1, 2, 3)
+  }
+
+  // ── pollRoundRobin ────────────────────────────────────────────────────────
+
+  @Test
+  fun `pollRoundRobin returns null on empty queue`() {
+    assertThat(queue.pollRoundRobin()).isNull()
+  }
+
+  @Test
+  fun `pollRoundRobin returns all items and empties the queue`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 1), item(3, jobId = 1)))
+
+    val polled = mutableListOf<Long>()
+    repeat(3) { queue.pollRoundRobin()?.let { polled.add(it.chunkExecutionId) } }
+
+    assertThat(polled).containsExactlyInAnyOrder(1, 2, 3)
+    assertThat(queue.isEmpty()).isTrue()
+    assertThat(queue.pollRoundRobin()).isNull()
+  }
+
+  @Test
+  fun `pollRoundRobin alternates between jobs`() {
+    // job1 has 3 items, job2 has 2 items — round-robin should interleave them
+    queue.addItemsToLocalQueue(
+      listOf(
+        item(1, jobId = 1),
+        item(2, jobId = 1),
+        item(3, jobId = 1),
+        item(4, jobId = 2),
+        item(5, jobId = 2),
+      ),
+    )
+
+    val polledJobs = (1..5).mapNotNull { queue.pollRoundRobin()?.jobId }
+
+    // Each job must appear before it appears a second time (round-robin)
+    val job1Positions = polledJobs.indices.filter { polledJobs[it] == 1L }
+    val job2Positions = polledJobs.indices.filter { polledJobs[it] == 2L }
+
+    // job1 and job2 should interleave: positions should alternate
+    assertThat(job1Positions).hasSize(3)
+    assertThat(job2Positions).hasSize(2)
+    // No two consecutive items from the same job while the other still has items
+    for (i in 0 until polledJobs.size - 1) {
+      if (i < job2Positions.last()) {
+        assertThat(polledJobs[i]).isNotEqualTo(polledJobs[i + 1])
+      }
+    }
+  }
+
+  // ── size tracking after polls ─────────────────────────────────────────────
+
+  @Test
+  fun `size decrements correctly after each poll`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 2), item(3, jobId = 3)))
+
+    assertThat(queue.size).isEqualTo(3)
+    queue.pollRoundRobin()
+    assertThat(queue.size).isEqualTo(2)
+    queue.pollRoundRobin()
+    assertThat(queue.size).isEqualTo(1)
+    queue.pollRoundRobin()
+    assertThat(queue.size).isEqualTo(0)
+  }
+
+  // ── contains ─────────────────────────────────────────────────────────────
+
+  @Test
+  fun `contains returns true for queued item and false after it is polled`() {
+    val it = item(42, jobId = 1)
+    queue.addItemsToLocalQueue(listOf(it))
+
+    assertThat(queue.contains(it)).isTrue()
+
+    queue.pollRoundRobin()
+
+    assertThat(queue.contains(it)).isFalse()
+  }
+
+  @Test
+  fun `contains returns false for null`() {
+    assertThat(queue.contains(null)).isFalse()
+  }
+
+  // ── removeJobExecutions ───────────────────────────────────────────────────
+
+  @Test
+  fun `removeJobExecutions removes all items for a job`() {
+    queue.addItemsToLocalQueue(
+      listOf(item(1, jobId = 1), item(2, jobId = 1), item(3, jobId = 2)),
+    )
+
+    queue.removeJobExecutions(jobId = 1)
+
+    assertThat(queue.size).isEqualTo(1)
+    assertThat(queue.getAllQueueItems().map { it.chunkExecutionId }).containsExactly(3)
+  }
+
+  @Test
+  fun `removeJobExecutions on unknown jobId does nothing`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1)))
+    queue.removeJobExecutions(jobId = 99)
+    assertThat(queue.size).isEqualTo(1)
+  }
+
+  @Test
+  fun `removed job items can be re-added after removal`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1)))
+    queue.removeJobExecutions(jobId = 1)
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1)))
+
+    assertThat(queue.size).isEqualTo(1)
+    assertThat(queue.pollRoundRobin()?.chunkExecutionId).isEqualTo(1)
+  }
+
+  // ── onJobItemEvent REMOVE ─────────────────────────────────────────────────
+
+  @Test
+  fun `REMOVE event removes specific items by chunkExecutionId`() {
+    val i1 = item(1, jobId = 1)
+    val i2 = item(2, jobId = 1)
+    val i3 = item(3, jobId = 2)
+    queue.addItemsToLocalQueue(listOf(i1, i2, i3))
+
+    queue.onJobItemEvent(JobQueueItemsEvent(listOf(i1, i3), QueueEventType.REMOVE))
+
+    assertThat(queue.size).isEqualTo(1)
+    assertThat(queue.getAllQueueItems().map { it.chunkExecutionId }).containsExactly(2)
+  }
+
+  // ── clear ─────────────────────────────────────────────────────────────────
+
+  @Test
+  fun `clear empties the queue completely`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 2)))
+    queue.clear()
+
+    assertThat(queue.isEmpty()).isTrue()
+    assertThat(queue.size).isEqualTo(0)
+    assertThat(queue.getAllQueueItems()).isEmpty()
+  }
+
+  @Test
+  fun `items can be added again after clear`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1)))
+    queue.clear()
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1)))
+
+    assertThat(queue.size).isEqualTo(1)
+  }
+
+  // ── getQueuedJobItems / getAllQueueItems ───────────────────────────────────
+
+  @Test
+  fun `getQueuedJobItems returns only items for that job`() {
+    queue.addItemsToLocalQueue(
+      listOf(item(1, jobId = 1), item(2, jobId = 1), item(3, jobId = 2)),
+    )
+
+    assertThat(queue.getQueuedJobItems(1).map { it.chunkExecutionId }).containsExactlyInAnyOrder(1, 2)
+    assertThat(queue.getQueuedJobItems(2).map { it.chunkExecutionId }).containsExactly(3)
+    assertThat(queue.getQueuedJobItems(99)).isEmpty()
+  }
+
+  @Test
+  fun `getAllQueueItems returns all items across all jobs`() {
+    queue.addItemsToLocalQueue(
+      listOf(item(1, jobId = 1), item(2, jobId = 2), item(3, jobId = 3)),
+    )
+
+    assertThat(queue.getAllQueueItems().map { it.chunkExecutionId }).containsExactlyInAnyOrder(1, 2, 3)
+  }
+
+  // ── getJobCharacterCounts ─────────────────────────────────────────────────
+
+  @Test
+  fun `getJobCharacterCounts tracks counts correctly`() {
+    queue.addItemsToLocalQueue(
+      listOf(
+        item(1, jobId = 1, character = JobCharacter.FAST),
+        item(2, jobId = 1, character = JobCharacter.FAST),
+        item(3, jobId = 2, character = JobCharacter.SLOW),
+      ),
+    )
+
+    val counts = queue.getJobCharacterCounts()
+    assertThat(counts[JobCharacter.FAST]).isEqualTo(2)
+    assertThat(counts[JobCharacter.SLOW]).isEqualTo(1)
+
+    queue.pollRoundRobin() // removes one FAST item
+    assertThat(queue.getJobCharacterCounts()[JobCharacter.FAST]).isEqualTo(1)
+  }
+
+  // ── find ──────────────────────────────────────────────────────────────────
+
+  @Test
+  fun `find returns matching item or null`() {
+    queue.addItemsToLocalQueue(listOf(item(1, jobId = 1), item(2, jobId = 2)))
+
+    assertThat(queue.find { it.chunkExecutionId == 2L }?.chunkExecutionId).isEqualTo(2)
+    assertThat(queue.find { it.chunkExecutionId == 99L }).isNull()
+  }
+}


### PR DESCRIPTION
## Why

Observed via `tolgee.batch.job.execution.queue.size` metric: when the queue reached 110k+ items under high concurrency (10+ slots), CPU spiked and batch processing slowed to a crawl. Three O(n) scans fired on every polling cycle:

- `pollRoundRobin()` scanned the entire flat queue to find the next eligible job — O(n × concurrency) per iteration
- Micrometer scraped `ConcurrentLinkedQueue.size()` which is O(n)
- `logger.trace()` eagerly built a `joinToString` of all 110k items even when trace logging was disabled

## How

Replaced the flat `ConcurrentLinkedQueue` with a per-job indexed structure:

- `Map<JobId, ConcurrentLinkedDeque<ExecutionQueueItem>>` for O(1) per-job item access
- `ConcurrentLinkedDeque<Long>` for round-robin job ordering
- `ConcurrentHashMap.newKeySet()` for O(1) duplicate detection (replaces the O(n) queue snapshot)
- `AtomicInteger` for O(1) size tracking

`pollRoundRobin()` now does `pollFirst() + compute() + addLast()` — O(1) regardless of total queue size. Performance regression tests verify that 1 000 polls over a 110k-item queue complete in < 500ms and that poll time does not scale with queue size.

---

Supersedes #3511.
Closes #3480.

---

@JanCizmar you were right — adding a limit on the queue size was a hack that was hiding a real performance issue. This fixes the root cause instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fair round‑robin scheduling across jobs for batch execution
  * Per‑job queues with O(1) duplicate detection and size tracking

* **Bug Fixes**
  * More reliable job removal and consistent queue state after concurrent mutations
  * More accurate runtime metrics for queue size reporting

* **Tests**
  * Added performance and regression tests validating large‑scale queue behavior and throughput

* **Chores**
  * Internal queue optimizations for O(1) enqueue/dequeue/contains/size operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->