### PR TITLE
fix: avoid loading full keyMetas collection when deleting tagged keys

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
@@ -115,6 +115,16 @@ interface TagRepository : JpaRepository<Tag, Long> {
 
   @Query(
     """
+    from Tag t where t.project.id = :projectId and t.id = :tagId
+  """,
+  )
+  fun findByIdAndProjectId(
+    tagId: Long,
+    projectId: Long,
+  ): Tag?
+
+  @Query(
+    """
     from Tag t left join fetch t.keyMetas km where t.project.id = :projectId and t.id = :tagId
   """,
   )

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
@@ -63,31 +63,34 @@ interface TagRepository : JpaRepository<Tag, Long> {
   )
   fun getImportKeysWithTags(keyIds: Iterable<Long>): List<ImportKey>
 
+@Transactional
+  @Modifying(flushAutomatically = true)
+  @Query("delete from Tag t where t.id in :tagIds")
+  fun deleteByIdIn(tagIds: Collection<Long>)
+
   /**
-   * Returns IDs of tags that would have no remaining keyMetas after removing [keyMetaIds].
-   * Uses a pure-ID projection to avoid loading any entity graph.
+   * Deletes tags atomically: only removes a tag if it has no remaining keyMeta links at delete time.
+   *
+   * This avoids the race condition where two concurrent transactions each check emptiness before
+   * either has flushed their join-table removal — both see the other's link, both skip the delete,
+   * and the tag survives with zero keyMetas.
+   *
+   * flushAutomatically = true is required so that pending key_meta_tags removals are written
+   * before this DELETE FROM tag runs (same reason as deleteByIdIn).
    */
+  @Transactional
+  @Modifying(flushAutomatically = true)
   @Query(
     """
-    select t.id from Tag t
-    where t.id in :tagIds
+    delete from Tag t where t.id in :tagIds
     and not exists (
         select km from KeyMeta km
         join km.tags tg
         where tg.id = t.id
-        and km.id not in :keyMetaIds
     )
     """,
   )
-  fun findTagIdsThatWouldBecomeEmpty(
-    tagIds: Collection<Long>,
-    keyMetaIds: Collection<Long>,
-  ): List<Long>
-
-  @Transactional
-  @Modifying(flushAutomatically = true)
-  @Query("delete from Tag t where t.id in :tagIds")
-  fun deleteByIdIn(tagIds: Collection<Long>)
+  fun deleteUnusedByIdIn(tagIds: Collection<Long>)
 
   fun findAllByProjectId(projectId: Long): List<Tag>
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 @Lazy
@@ -62,14 +63,31 @@ interface TagRepository : JpaRepository<Tag, Long> {
   )
   fun getImportKeysWithTags(keyIds: Iterable<Long>): List<ImportKey>
 
+  /**
+   * Returns IDs of tags that would have no remaining keyMetas after removing [keyMetaIds].
+   * Uses a pure-ID projection to avoid loading any entity graph.
+   */
   @Query(
     """
-    from Tag t
-    join fetch t.keyMetas
+    select t.id from Tag t
     where t.id in :tagIds
+    and not exists (
+        select km from KeyMeta km
+        join km.tags tg
+        where tg.id = t.id
+        and km.id not in :keyMetaIds
+    )
     """,
   )
-  fun getTagsWithKeyMetas(tagIds: Iterable<Long>): List<Tag>
+  fun findTagIdsThatWouldBecomeEmpty(
+    tagIds: Collection<Long>,
+    keyMetaIds: Collection<Long>,
+  ): List<Long>
+
+  @Transactional
+  @Modifying(flushAutomatically = true)
+  @Query("delete from Tag t where t.id in :tagIds")
+  fun deleteByIdIn(tagIds: Collection<Long>)
 
   fun findAllByProjectId(projectId: Long): List<Tag>
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TagRepository.kt
@@ -63,11 +63,6 @@ interface TagRepository : JpaRepository<Tag, Long> {
   )
   fun getImportKeysWithTags(keyIds: Iterable<Long>): List<ImportKey>
 
-@Transactional
-  @Modifying(flushAutomatically = true)
-  @Query("delete from Tag t where t.id in :tagIds")
-  fun deleteByIdIn(tagIds: Collection<Long>)
-
   /**
    * Deletes tags atomically: only removes a tag if it has no remaining keyMeta links at delete time.
    *

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -425,7 +425,8 @@ class TagService(
     key: Key,
     tagId: Long,
   ) {
-    val tag = getWithKeyMetasFetched(key.project.id, tagId)
+    val tag = find(tagId)?.takeIf { it.project.id == key.project.id }
+      ?: throw NotFoundException(Message.TAG_NOT_FOUND)
     remove(key, tag)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -406,7 +406,7 @@ class TagService(
     tagId: Long,
   ) {
     val tag =
-      find(tagId)?.takeIf { it.project.id == key.project.id }
+      tagRepository.findByIdAndProjectId(tagId, key.project.id)
         ?: throw NotFoundException(Message.TAG_NOT_FOUND)
     remove(key, tag)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -192,12 +192,15 @@ class TagService(
     tag: Tag,
   ) {
     key.keyMeta?.let { keyMeta ->
-      tag.keyMetas.remove(keyMeta)
+      // Check emptiness via query before modifying anything.
+      // Do NOT access tag.keyMetas — it lazy-loads the entire KeyMeta
+      // collection for the tag, which can be 10k+ objects for large projects.
+      val tagWouldBecomeEmpty =
+        tagRepository.findTagIdsThatWouldBecomeEmpty(listOf(tag.id), listOf(keyMeta.id)).isNotEmpty()
       keyMeta.tags.remove(tag)
-      tagRepository.save(tag)
       keyMetaService.save(keyMeta)
-      if (tag.keyMetas.size < 1) {
-        tagRepository.delete(tag)
+      if (tagWouldBecomeEmpty) {
+        tagRepository.deleteByIdIn(listOf(tag.id))
       }
     }
   }
@@ -281,27 +284,37 @@ class TagService(
   }
 
   private fun deleteAllTagsForKeys(keys: Iterable<WithKeyMeta>) {
-    val tagIds = keys.flatMap { it.keyMeta?.tags?.map { it.id } ?: listOf() }.toSet()
-    // get tags with fetched keyMetas
-    val tagKeyMetasMap =
-      traceLogMeasureTime("tagService: deleteAllTagsForKeys: getTagsWithKeyMetas") {
-        tagRepository.getTagsWithKeyMetas(tagIds).associate {
-          it.id to it.keyMetas
-        }
+    val keyMetas = keys.mapNotNull { it.keyMeta }
+    if (keyMetas.isEmpty()) return
+
+    val keyMetaIds = keyMetas.map { it.id }.toSet()
+    val tagIds = keyMetas.flatMap { km -> km.tags.map { it.id } }.toSet()
+    if (tagIds.isEmpty()) return
+
+    // Find which tags would become empty after removing these keyMetas,
+    // using a pure-ID existence query — no entity graph loaded.
+    val tagIdsToDelete =
+      traceLogMeasureTime("tagService: deleteAllTagsForKeys: findTagIdsThatWouldBecomeEmpty") {
+        tagRepository.findTagIdsThatWouldBecomeEmpty(tagIds, keyMetaIds)
       }
-    keys.forEach { key ->
-      key.keyMeta?.let { keyMeta ->
-        keyMeta.tags.forEach { tag ->
-          // remove from tagsKeyMetas to find out whether to delete the tag
-          val tagKeyMetas = tagKeyMetasMap[tag.id]
-          tagKeyMetas?.removeIf { it.id == keyMeta.id }
-          if (tagKeyMetas?.isEmpty() != false) {
-            tagRepository.delete(tag)
-          }
-        }
-        keyMeta.tags.clear()
-        keyMetaService.save(keyMeta)
-      }
+
+    // Clear tags from each keyMeta (owning side): removes join-table entries
+    // and triggers activity logging via @ActivityLoggedProp on KeyMeta.tags.
+    keyMetas.forEach { keyMeta ->
+      keyMeta.tags.clear()
+      keyMetaService.save(keyMeta)
+    }
+
+    // Delete tags that have no remaining keyMetas.
+    // flushAutomatically = true on deleteByIdIn is required here, not defensive:
+    // Hibernate AUTO flush mode only flushes before queries that might read
+    // data in tables already dirtied in the session. A DELETE FROM tag touches
+    // a different table than key_meta_tags (where the tags.clear() writes are
+    // pending), so Hibernate would NOT auto-flush — leaving the join-table FK
+    // entries intact and causing a constraint violation. The explicit flush
+    // ensures key_meta_tags is written before the tag rows are removed.
+    if (tagIdsToDelete.isNotEmpty()) {
+      tagRepository.deleteByIdIn(tagIdsToDelete)
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -192,16 +192,9 @@ class TagService(
     tag: Tag,
   ) {
     key.keyMeta?.let { keyMeta ->
-      // Check emptiness via query before modifying anything.
-      // Do NOT access tag.keyMetas — it lazy-loads the entire KeyMeta
-      // collection for the tag, which can be 10k+ objects for large projects.
-      val tagWouldBecomeEmpty =
-        tagRepository.findTagIdsThatWouldBecomeEmpty(listOf(tag.id), listOf(keyMeta.id)).isNotEmpty()
       keyMeta.tags.remove(tag)
       keyMetaService.save(keyMeta)
-      if (tagWouldBecomeEmpty) {
-        tagRepository.deleteByIdIn(listOf(tag.id))
-      }
+      tagRepository.deleteUnusedByIdIn(listOf(tag.id))
     }
   }
 
@@ -287,16 +280,8 @@ class TagService(
     val keyMetas = keys.mapNotNull { it.keyMeta }
     if (keyMetas.isEmpty()) return
 
-    val keyMetaIds = keyMetas.map { it.id }.toSet()
     val tagIds = keyMetas.flatMap { km -> km.tags.map { it.id } }.toSet()
     if (tagIds.isEmpty()) return
-
-    // Find which tags would become empty after removing these keyMetas,
-    // using a pure-ID existence query — no entity graph loaded.
-    val tagIdsToDelete =
-      traceLogMeasureTime("tagService: deleteAllTagsForKeys: findTagIdsThatWouldBecomeEmpty") {
-        tagRepository.findTagIdsThatWouldBecomeEmpty(tagIds, keyMetaIds)
-      }
 
     // Clear tags from each keyMeta (owning side): removes join-table entries
     // and triggers activity logging via @ActivityLoggedProp on KeyMeta.tags.
@@ -305,17 +290,12 @@ class TagService(
       keyMetaService.save(keyMeta)
     }
 
-    // Delete tags that have no remaining keyMetas.
-    // flushAutomatically = true on deleteByIdIn is required here, not defensive:
-    // Hibernate AUTO flush mode only flushes before queries that might read
-    // data in tables already dirtied in the session. A DELETE FROM tag touches
-    // a different table than key_meta_tags (where the tags.clear() writes are
-    // pending), so Hibernate would NOT auto-flush — leaving the join-table FK
-    // entries intact and causing a constraint violation. The explicit flush
-    // ensures key_meta_tags is written before the tag rows are removed.
-    if (tagIdsToDelete.isNotEmpty()) {
-      tagRepository.deleteByIdIn(tagIdsToDelete)
-    }
+    // Delete tags that have no remaining keyMetas, atomically.
+    // deleteUnusedByIdIn re-checks NOT EXISTS at delete time, so two concurrent
+    // transactions cannot both skip the delete and leave orphaned tags.
+    // flushAutomatically = true ensures key_meta_tags removals are written
+    // before the DELETE FROM tag runs (Hibernate would not auto-flush across tables).
+    tagRepository.deleteUnusedByIdIn(tagIds)
   }
 
   /**

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -405,8 +405,9 @@ class TagService(
     key: Key,
     tagId: Long,
   ) {
-    val tag = find(tagId)?.takeIf { it.project.id == key.project.id }
-      ?: throw NotFoundException(Message.TAG_NOT_FOUND)
+    val tag =
+      find(tagId)?.takeIf { it.project.id == key.project.id }
+        ?: throw NotFoundException(Message.TAG_NOT_FOUND)
     remove(key, tag)
   }
 }


### PR DESCRIPTION
Closes #3567

## Summary

- `deleteAllTagsForKeys` used `join fetch t.keyMetas` to load the entire `KeyMeta` collection for every affected tag into the JPA session — 10k+ entities for large projects
- Under concurrent `DELETE_KEYS` batch jobs this caused G1 Old Gen to fill up, excessive GC, and liveness probe failures
- Same issue existed in the single-key `remove(key, tag)` path

## Changes

- Replace `getTagsWithKeyMetas` (full entity-graph fetch) with `findTagIdsThatWouldBecomeEmpty`, a pure-ID `EXISTS` subquery that returns only tag IDs that would become empty
- Remove empty tags via a bulk JPQL `DELETE` — no entity graph loaded
- `flushAutomatically = true` on `deleteByIdIn` is required (not defensive): Hibernate AUTO flush mode does not flush `key_meta_tags` before a `DELETE FROM tag`, which would cause a FK constraint violation
- `getTagsWithKeyMetas` removed as dead code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined tag dissociation to avoid loading full tag associations and perform a single conditional bulk delete of unreferenced tags, reducing DB work and improving performance.
* **Bug Fix**
  * Improved tag lookup and project ownership validation to ensure tags are verified before removal, preventing incorrect deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->