### PR TITLE
perf: add composite index on translation(key_id, language_id)

### DIFF
--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5210,4 +5210,18 @@
             <sql>DROP INDEX CONCURRENTLY IF EXISTS translation_lang_text_gist_trgm;</sql>
         </rollback>
     </changeSet>
+    <changeSet author="dkrizan" id="1742900000000-1" runInTransaction="false">
+        <comment>Add composite btree index on translation(key_id, language_id) to speed up
+            translation view queries that LEFT JOIN translation by key and language.
+            Critical for projects with 50K+ keys where select-all and count queries
+            were taking minutes without this index.
+            A single-column btree index on translation(key_id) already exists (IDXkrh888rhj0c4mm455al08el84).</comment>
+        <sql dbms="postgresql">
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS translation_key_id_language_id
+            ON translation (key_id, language_id);
+        </sql>
+        <rollback>
+            <sql>DROP INDEX CONCURRENTLY IF EXISTS translation_key_id_language_id;</sql>
+        </rollback>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Problem

The translation view's "select all" endpoint (`/v2/projects/{id}/translations/select-all`) runs a query that LEFT JOINs the `translation` table on `(key_id, language_id)` to find keys matching a filter (e.g. "untranslated"):

```sql
SELECT DISTINCT k.id
FROM key k
LEFT JOIN translation t ON k.id = t.key_id AND t.language_id = ?
WHERE ...
  AND (t.state = 0 OR t.state IS NULL)
```

The `OR t.state IS NULL` part is what catches keys with **no translation row at all** for a given language — i.e. untranslated keys. This requires Postgres to prove the *absence* of a matching row for each key via the LEFT JOIN.

Currently, the `translation` table only has **single-column indexes** on `key_id` and `language_id` separately. For this LEFT JOIN, Postgres has to combine two index scans or fall back to less efficient plans.

On a project with 50K+ keys, this query takes **45+ minutes**. When a user clicks "select all" and it doesn't respond, they click again — piling up multiple copies of the same expensive query, which drove our production DB to 100% CPU.

## Fix

Add a **composite B-tree index** on `translation(key_id, language_id)`. This lets Postgres resolve the LEFT JOIN with a single index lookup per key instead of combining two separate indexes.

The index was already tested on production — the query went from **45+ minutes to sub-second**.

## Notes

- Uses `CREATE INDEX CONCURRENTLY` — no table locks, no downtime
- `IF NOT EXISTS` — safe to run if the index was already created manually (as we did on prod)
- `runInTransaction="false"` — required by Liquibase for concurrent index creation
- Index size on prod: ~389 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied database infrastructure optimization to improve system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->