### PR TITLE
fix: always convert screenshots to PNG before sending to LLM providers

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/util/ScreenshotKeysHighlighter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/ScreenshotKeysHighlighter.kt
@@ -9,11 +9,18 @@ import java.io.InputStream
 class ScreenshotKeysHighlighter(
   imageStream: InputStream,
 ) : ImageProcessor(imageStream) {
-  fun highlightKeys(
+  fun highlightKey(
     screenshot: Screenshot,
-    keyIds: List<Long>,
+    keyId: Long,
   ): ByteArrayOutputStream {
     try {
+      val hasPositions =
+        screenshot.keyScreenshotReferences
+          .any { it.key.id == keyId && !it.positions.isNullOrEmpty() }
+
+      if (!hasPositions) {
+        return writeImage(sourceBufferedImage, 0.8f)
+      }
       // Load the image
       val newImage = sourceBufferedImage
       val g = newImage.createGraphics()
@@ -27,7 +34,7 @@ class ScreenshotKeysHighlighter(
       }
 
       screenshot.keyScreenshotReferences.forEach { reference ->
-        if (keyIds.contains(reference.key.id)) {
+        if (reference.key.id == keyId) {
           reference.positions?.forEach {
             g.drawRect(
               (it.x * scaling).toInt(),

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptParamsHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptParamsHelper.kt
@@ -75,20 +75,13 @@ class PromptParamsHelper(
 
     val filePath = screenshotService.getScreenshotPath(file)
 
-    val hasPositions =
-      screenshot.keyScreenshotReferences
-        .any { it.key.id == key.id && !it.positions.isNullOrEmpty() }
+    val highlighter =
+      ScreenshotKeysHighlighter(
+        ByteArrayInputStream(
+          fileStorage.readFile(filePath),
+        ),
+      )
 
-    if (hasPositions) {
-      val highlighter =
-        ScreenshotKeysHighlighter(
-          ByteArrayInputStream(
-            fileStorage.readFile(filePath),
-          ),
-        )
-      return highlighter.highlightKeys(screenshot, listOf(key.id)).toByteArray()
-    } else {
-      return fileStorage.readFile(filePath)
-    }
+    return highlighter.highlightKey(screenshot, key.id).toByteArray()
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/ScreenshotKeysHighlighterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/ScreenshotKeysHighlighterTest.kt
@@ -70,7 +70,7 @@ class ScreenshotKeysHighlighterTest {
     screenshot.keyScreenshotReferences.add(reference)
 
     val highlighter = ScreenshotKeysHighlighter(ByteArrayInputStream(storedBytes))
-    val outputBytes = highlighter.highlightKeys(screenshot, listOf(key.id)).toByteArray()
+    val outputBytes = highlighter.highlightKey(screenshot, key.id).toByteArray()
 
     log.info(
       "No-positions test: stored={} bytes, re-encoded={} bytes, ratio={}x",
@@ -103,7 +103,7 @@ class ScreenshotKeysHighlighterTest {
     screenshot.keyScreenshotReferences.add(reference)
 
     val highlighter = ScreenshotKeysHighlighter(ByteArrayInputStream(storedBytes))
-    val highlightedBytes = highlighter.highlightKeys(screenshot, listOf(key.id)).toByteArray()
+    val highlightedBytes = highlighter.highlightKey(screenshot, key.id).toByteArray()
 
     log.info(
       "With-positions test: stored={} bytes, highlighted={} bytes, ratio={}x",


### PR DESCRIPTION
PromptParamsHelper returned raw file bytes (possibly JPEG) when no highlight positions existed, but Anthropic/Google APIs hardcode image/png as the media type, causing a 400 error.

Moved the hasPositions check into ScreenshotKeysHighlighter.highlightKey() so images are always re-encoded as PNG. Also simplified the API from highlightKeys(screenshot, keyIds: List<Long>) to
highlightKey(screenshot, keyId: Long) since only one key is ever passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified screenshot highlighting to process individual keys rather than multiple keys per operation.
  * Enhanced screenshot processing to consistently return optimized images, even when position data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->