### PR TITLE
fix: correct pre-translate batch progress total items count

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
@@ -2,6 +2,7 @@ package io.tolgee.batch
 
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchJobType
+import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.processors.AutomationChunkProcessor
 import io.tolgee.batch.processors.DeleteKeysChunkProcessor
 import io.tolgee.batch.processors.PreTranslationByTmChunkProcessor
@@ -139,7 +140,7 @@ class BatchJobTestUtil(
       .whenever(preTranslationByTmChunkProcessor)
       .process(
         any(),
-        argThat { this.containsAll((1L..10).toList()) },
+        argThat { this.map { it.keyId }.containsAll((1L..10).toList()) },
         any(),
       )
   }
@@ -252,8 +253,6 @@ class BatchJobTestUtil(
   }
 
   fun makePreTranslateProcessorRepeatedlyThrowRequeueException() {
-    val throwingChunk = (1L..10).toList()
-
     doThrow(
       RequeueWithDelayException(
         message = Message.OUT_OF_CREDITS,
@@ -265,7 +264,7 @@ class BatchJobTestUtil(
       ),
     ).whenever(preTranslationByTmChunkProcessor).process(
       any(),
-      argThat { this.containsAll(throwingChunk) },
+      argThat { this.map { it.keyId }.containsAll((1L..10).toList()) },
       any(),
     )
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
@@ -5,46 +5,37 @@ import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.PreTranslationByTmRequest
 import io.tolgee.model.batch.params.PreTranslationByTmJobParams
-import io.tolgee.service.language.LanguageService
 import org.springframework.stereotype.Component
 import kotlin.coroutines.CoroutineContext
 
 @Component
 class PreTranslationByTmChunkProcessor(
-  private val languageService: LanguageService,
   private val genericAutoTranslationChunkProcessor: GenericAutoTranslationChunkProcessor,
-) : ChunkProcessor<PreTranslationByTmRequest, PreTranslationByTmJobParams, Long> {
+) : ChunkProcessor<PreTranslationByTmRequest, PreTranslationByTmJobParams, BatchTranslationTargetItem> {
   override fun process(
     job: BatchJobDto,
-    chunk: List<Long>,
+    chunk: List<BatchTranslationTargetItem>,
     coroutineContext: CoroutineContext,
   ) {
-    val parameters = getParams(job)
-    val languages = languageService.findByIdIn(parameters.targetLanguageIds)
-
-    val preparedChunk =
-      chunk
-        .map { keyId ->
-          languages.map { language ->
-            BatchTranslationTargetItem(keyId, language.id)
-          }
-        }.flatten()
-
     genericAutoTranslationChunkProcessor.process(
       job,
-      preparedChunk,
+      chunk,
       coroutineContext,
       useTranslationMemory = true,
       useMachineTranslation = false,
     )
   }
 
-  override fun getTargetItemType(): Class<Long> {
-    return Long::class.java
+  override fun getTargetItemType(): Class<BatchTranslationTargetItem> {
+    return BatchTranslationTargetItem::class.java
   }
 
-  override fun getTarget(data: PreTranslationByTmRequest): List<Long> {
-    return data.keyIds
+  override fun getTarget(data: PreTranslationByTmRequest): List<BatchTranslationTargetItem> {
+    return data.keyIds.flatMap { keyId ->
+      data.targetLanguageIds.map { languageId ->
+        BatchTranslationTargetItem(keyId, languageId)
+      }
+    }
   }
 
   override fun getParamsType(): Class<PreTranslationByTmJobParams> {


### PR DESCRIPTION
PreTranslationByTmChunkProcessor.getTarget() returned only key IDs, setting totalItems to keys.size. But process() expanded each key into key×language pairs and reported progress per pair, causing the progress to exceed the total (e.g. 2000/1000 for 1000 keys × 2 languages).

Align with MachineTranslationChunkProcessor by using BatchTranslationTargetItem as the target type so totalItems correctly reflects key×language combinations.

Closes #3573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined batch translation target processing to improve efficiency and code maintainability.
  * Simplified internal batch processing component dependencies.

* **Tests**
  * Enhanced test utilities for batch processing validation with improved mock assertion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->