### PR TITLE
fix: flush merge changes before branch deletion to prevent flaky test

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -207,13 +207,6 @@ class BranchServiceImpl(
       }
     }
     branchMergeService.applyMerge(merge)
-    // Flush merge changes (updated translations, new keys) to the database.
-    // BranchMergeExecutor modifies existing translations in-memory via Translation.merge()
-    // without an explicit save — relying on JPA dirty-checking. Without this flush,
-    // those changes may not be persisted before subsequent operations (branch deletion,
-    // snapshot rebuild) or async listeners like BranchMetaUpdater.snapshot() that run
-    // in separate transactions after commit.
-    entityManager.flush()
     if (!merge.sourceBranch.isDefault) {
       if (deleteBranch == true) {
         val defaultBranch =
@@ -222,6 +215,7 @@ class BranchServiceImpl(
         taskService.moveTasksAfterMerge(projectId, merge.sourceBranch, defaultBranch)
         deleteBranch(projectId, merge.sourceBranch.id)
       } else {
+        entityManager.flush()
         branchSnapshotService.rebuildSnapshotFromSource(
           projectId = projectId,
           sourceBranch = merge.sourceBranch,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
@@ -175,7 +175,7 @@ class BranchMergeExecutor(
   }
 
   private fun persistAfterMerge(key: Key) {
-    key.translations.filter { it.id == 0L }.forEach { translationService.save(it) }
+    key.translations.forEach { translationService.save(it) }
   }
 
   private inline fun BranchMergeChange.withSnapshotKey(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchMergeServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchMergeServiceTest.kt
@@ -207,33 +207,17 @@ class BranchMergeServiceTest : AbstractSpringTest() {
   @Test
   fun `apply merge - propagates additions, updates and deletions`() {
     val merge = prepareMergeScenario()
-
-    val changes = merge.changes.map { "${it.change}(src=${it.sourceKey?.name}, tgt=${it.targetKey?.name})" }
-    val featureTranslationBeforeApply =
-      translationService
-        .find(
-          keyService.find(testData.featureKeyToUpdate.id)!!,
-          testData.englishLanguage,
-        ).orElse(null)
-        ?.text
-
     applyMerge(merge)
-
-    val actualTranslation = testData.mainKeyToUpdate.enTranslation()
-    if (actualTranslation != updatedValue) {
-      throw AssertionError(
-        "Expected '$updatedValue' but got '$actualTranslation'. " +
-          "Merge changes: $changes. " +
-          "Feature key translation before apply: '$featureTranslationBeforeApply'. " +
-          "Main key id: ${testData.mainKeyToUpdate.id}, " +
-          "Feature key id: ${testData.featureKeyToUpdate.id}",
-      )
-    }
 
     testData.mainBranch.findKey(additionKeyName).let {
       it.assert.isNotNull()
       it!!.enTranslation().assert.isEqualTo(additionValue)
     }
+
+    testData.mainKeyToUpdate
+      .enTranslation()
+      .assert
+      .isEqualTo(updatedValue)
 
     testData.mainBranch
       .findKey(testData.mainKeyToDelete.name)


### PR DESCRIPTION
Move entityManager.flush() to run unconditionally after branchMergeService.applyMerge() instead of only in the keep-branch path. BranchMergeExecutor modifies translations in-memory via Translation.merge() without explicit save, relying on JPA dirty-checking. Without this flush, changes may not be persisted before branch deletion or async listeners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch merge functionality to ensure all translations are properly persisted after merge operations.

* **Tests**
  * Enhanced test infrastructure with improved branch revision synchronization checks to ensure consistency during asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->