### PR TITLE
chore: rework flaky test reporting workflow

### DIFF
--- a/.github/workflows/reportIntermittentTests.yml
+++ b/.github/workflows/reportIntermittentTests.yml
@@ -92,7 +92,10 @@ jobs:
           import xml.etree.ElementTree as ET
           import glob
           for f in glob.glob('**/build/test-results/**/TEST-*.xml', recursive=True):
-              tree = ET.parse(f)
+              try:
+                  tree = ET.parse(f)
+              except ET.ParseError:
+                  continue
               for tc in tree.findall('.//testcase'):
                   if tc.find('failure') is not None or tc.find('error') is not None:
                       print(f'{tc.get(\"classname\")}.{tc.get(\"name\")}')
@@ -293,6 +296,9 @@ jobs:
             echo "<${RUN_URL}|View failed run>"
           } > /tmp/slack-message.txt
 
-          curl -s -X POST -H 'Content-Type: application/json' \
+          curl --fail --show-error --silent \
+            --connect-timeout 5 --max-time 10 \
+            --retry 3 --retry-delay 2 --retry-connrefused \
+            -X POST -H 'Content-Type: application/json' \
             -d "$(jq -n --rawfile text /tmp/slack-message.txt '{text: $text}')" \
             "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Reworked the daily `reportIntermittentTests` workflow to run tests the same way as in PRs (single attempt) instead of running each test 3x
- Added Slack notification on failure via `SLACK_FLAKY_TESTS_WEBHOOK_URL` secret
- Added `workflow_dispatch` trigger for manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved backend failure collection: parses test reports to produce per-task failure artifacts and uploads them.
  * Simplified E2E execution and enhanced failure tracking by extracting failed screenshot identifiers into artifacts; standardized E2E artifact naming.

* **Chores**
  * Enabled manual workflow triggering and refactored test/run steps for clearer execution and cleanup conditions.
  * Upgraded artifact deletion action and added a notification step that consolidates failures and posts a summary on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->