### PR TITLE
feat: ungate AI context data for free plan users

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/aiPtomptCustomization/ProjectAiPromptCustomizationModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/aiPtomptCustomization/ProjectAiPromptCustomizationModel.kt
@@ -10,11 +10,11 @@ import java.io.Serializable
 open class ProjectAiPromptCustomizationModel(
   @Schema(
     description =
-      "The project description used in the  prompt that " +
+      "The project description used in the prompt that " +
         "helps AI translator to understand the context of your project.",
     example =
       "We are Dunder Mifflin, a paper company. We sell paper. " +
-        "This is an project of translations for out paper selling app.",
+        "This is a project of translations for our paper selling app.",
   )
   val description: String?,
 ) : RepresentationModel<ProjectAiPromptCustomizationModel>(),

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationController.kt
@@ -2,7 +2,6 @@ package io.tolgee.ee.api.v2.controllers
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import io.tolgee.constants.Feature
 import io.tolgee.ee.api.v2.hateoas.assemblers.LanguageAiPromptCustomizationModelAssembler
 import io.tolgee.ee.data.SetLanguagePromptCustomizationRequest
 import io.tolgee.ee.data.SetProjectPromptCustomizationRequest
@@ -13,7 +12,6 @@ import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.Scope
 import io.tolgee.openApiDocs.OpenApiEeExtension
 import io.tolgee.security.ProjectHolder
-import io.tolgee.security.authorization.RequiresFeatures
 import io.tolgee.security.authorization.RequiresOrganizationRole
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
@@ -52,7 +50,6 @@ class AiPromptCustomizationController(
   @Operation(summary = "Sets project level prompt customization")
   @RequiresOrganizationRole(OrganizationRoleType.OWNER)
   @RequiresProjectPermissions(scopes = [Scope.PROJECT_EDIT])
-  @RequiresFeatures(Feature.AI_PROMPT_CUSTOMIZATION)
   fun setPromptProjectCustomization(
     @Valid @RequestBody dto: SetProjectPromptCustomizationRequest,
   ): ProjectAiPromptCustomizationModel {
@@ -66,7 +63,6 @@ class AiPromptCustomizationController(
   @Operation(summary = "Sets language level prompt customization")
   @RequiresOrganizationRole(OrganizationRoleType.OWNER)
   @RequiresProjectPermissions(scopes = [Scope.PROJECT_EDIT, Scope.LANGUAGES_EDIT])
-  @RequiresFeatures(Feature.AI_PROMPT_CUSTOMIZATION)
   fun setLanguagePromptCustomization(
     @Valid @RequestBody dto: SetLanguagePromptCustomizationRequest,
     @PathVariable languageId: Long,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/SetLanguagePromptCustomizationRequest.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/SetLanguagePromptCustomizationRequest.kt
@@ -1,16 +1,18 @@
 package io.tolgee.ee.data
 
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 
 class SetLanguagePromptCustomizationRequest(
   @Schema(
     description =
-      "The language description used in the  prompt that " +
+      "The language description used in the prompt that " +
         "helps AI translator to fine tune results for specific language",
     example =
       "For arabic language, we are super formal. Always use these translations: \n" +
         "Paper -> ورقة\n" +
         "Office -> مكتب\n",
   )
+  @field:Size(max = 2000)
   var description: String? = null,
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/SetProjectPromptCustomizationRequest.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/SetProjectPromptCustomizationRequest.kt
@@ -12,6 +12,6 @@ class SetProjectPromptCustomizationRequest(
       "We are Dunder Mifflin, a paper company. We sell paper. " +
         "This is an project of translations for out paper selling app.",
   )
-  @Size(max = 2000)
+  @field:Size(max = 2000)
   var description: String? = null,
 )

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationControllerTest.kt
@@ -2,11 +2,9 @@ package io.tolgee.ee.api.v2.controllers
 
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.constants.Feature
-import io.tolgee.constants.Message
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
 import io.tolgee.ee.development.AiPromptCustomizationTestData
 import io.tolgee.fixtures.andAssertThatJson
-import io.tolgee.fixtures.andHasErrorMessage
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.node
@@ -53,14 +51,16 @@ class AiPromptCustomizationControllerTest : ProjectAuthControllerTest("/v2/proje
 
   @Test
   @ProjectJWTAuthTestMethod
-  fun `set project prompt customization fails when feature is not enabled`() {
+  fun `set project prompt customization works without feature enabled`() {
     enabledFeaturesProvider.forceEnabled = emptySet()
     performProjectAuthPut(
       "ai-prompt-customization",
       mapOf(
         "description" to "new description",
       ),
-    ).andIsBadRequest.andHasErrorMessage(Message.FEATURE_NOT_ENABLED)
+    ).andIsOk.andAssertThatJson {
+      node("description").isEqualTo("new description")
+    }
   }
 
   @Test
@@ -88,5 +88,31 @@ class AiPromptCustomizationControllerTest : ProjectAuthControllerTest("/v2/proje
     ).andIsOk.andAssertThatJson {
       node("description").isEqualTo("new description")
     }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `set language prompt customization works without feature enabled`() {
+    enabledFeaturesProvider.forceEnabled = emptySet()
+    performProjectAuthPut(
+      "languages/${testData.czech.id}/ai-prompt-customization",
+      mapOf(
+        "description" to "new description",
+      ),
+    ).andIsOk.andAssertThatJson {
+      node("description").isEqualTo("new description")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `set language prompt customization rejects description over 2000 chars`() {
+    val longDescription = "a".repeat(2001)
+    performProjectAuthPut(
+      "languages/${testData.czech.id}/ai-prompt-customization",
+      mapOf(
+        "description" to longDescription,
+      ),
+    ).andIsBadRequest
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/AiPromptCustomizationControllerTest.kt
@@ -65,6 +65,18 @@ class AiPromptCustomizationControllerTest : ProjectAuthControllerTest("/v2/proje
 
   @Test
   @ProjectJWTAuthTestMethod
+  fun `set project prompt customization rejects description over 2000 chars`() {
+    val longDescription = "a".repeat(2001)
+    performProjectAuthPut(
+      "ai-prompt-customization",
+      mapOf(
+        "description" to longDescription,
+      ),
+    ).andIsBadRequest
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
   fun `get language prompt customizations`() {
     performProjectAuthGet("language-ai-prompt-customizations")
       .andIsOk

--- a/webapp/src/ee/llm/AiContextData/AiContextData.tsx
+++ b/webapp/src/ee/llm/AiContextData/AiContextData.tsx
@@ -1,20 +1,14 @@
 import { Box, Typography } from '@mui/material';
-import { T, useTranslate } from '@tolgee/react';
+import { T } from '@tolgee/react';
 import { useProject } from 'tg.hooks/useProject';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { BoxLoading } from 'tg.component/common/BoxLoading';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
-import { DisabledFeatureBanner } from 'tg.component/common/DisabledFeatureBanner';
 
 import { AiLanguagesTable } from './AiLanguagesTable';
 import { AiProjectDescription } from './AiProjectDescription';
 
 export const AiContextData = () => {
   const project = useProject();
-  const { isEnabled } = useEnabledFeatures();
-  const { t } = useTranslate();
-
-  const featureEnabled = isEnabled('AI_PROMPT_CUSTOMIZATION');
 
   const languagesLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/languages',
@@ -23,38 +17,19 @@ export const AiContextData = () => {
     query: {
       size: 1000,
     },
-    options: {
-      enabled: featureEnabled,
-    },
   });
 
   const descriptionLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/ai-prompt-customization',
     method: 'get',
     path: { projectId: project.id },
-    options: {
-      enabled: featureEnabled,
-    },
   });
 
   const languageDescriptionsLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/language-ai-prompt-customizations',
     method: 'get',
     path: { projectId: project.id },
-    options: {
-      enabled: featureEnabled,
-    },
   });
-
-  if (!featureEnabled) {
-    return (
-      <Box mt={4} mb={3} gap={3} display="grid">
-        <DisabledFeatureBanner
-          customMessage={t('ai_customization_not_enabled_message')}
-        />
-      </Box>
-    );
-  }
 
   if (
     languagesLoadable.isLoading ||
@@ -85,7 +60,7 @@ export const AiContextData = () => {
           description={descriptionLoadable.data?.description}
         />
 
-        {Boolean(languages?.length) && (
+        {languages.length > 0 && (
           <>
             <Typography variant="h6">
               <T keyName="language_ai_prompts_title" />

--- a/webapp/src/ee/llm/AiContextData/AiLanguageDescriptionDialog.tsx
+++ b/webapp/src/ee/llm/AiContextData/AiLanguageDescriptionDialog.tsx
@@ -70,6 +70,8 @@ export const AiLanguageDescriptionDialog = ({
     );
   }
 
+  const isTooLong = Boolean(inputValue && inputValue.length > 2000);
+
   return (
     <Dialog open fullWidth maxWidth="sm" onClose={handleClose}>
       <Box sx={{ mt: 2, mx: 3, display: 'grid', gap: 0.5 }}>
@@ -87,6 +89,14 @@ export const AiLanguageDescriptionDialog = ({
             minRows={2}
             value={inputValue}
             onChange={(e) => setInputValue(e.currentTarget.value)}
+            error={isTooLong}
+            helperText={
+              isTooLong &&
+              t(
+                'language_ai_prompt_dialog_description_too_long',
+                'Description is too long (max 2000 characters)'
+              )
+            }
             data-cy="language-ai-prompt-dialog-description-input"
           />
           <AiTips
@@ -104,6 +114,7 @@ export const AiLanguageDescriptionDialog = ({
           loading={saveDescription.isLoading}
           color="primary"
           variant="contained"
+          disabled={isTooLong}
           data-cy="language-ai-prompt-dialog-save"
         >
           {t('global_form_save')}

--- a/webapp/src/ee/llm/AiPrompt/TabBasic.tsx
+++ b/webapp/src/ee/llm/AiPrompt/TabBasic.tsx
@@ -20,7 +20,6 @@ import { useProject } from 'tg.hooks/useProject';
 import { useHistory } from 'react-router-dom';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
 
 export type BasicPromptOption = NonNullable<
   components['schemas']['PromptRunDto']['basicPromptOptions']
@@ -30,7 +29,7 @@ type PromptItem = {
   id: BasicPromptOption;
   label: string;
   hint: string;
-  onEdit?: (value: boolean) => void;
+  onEdit?: () => void;
 };
 
 type Props = {
@@ -39,7 +38,6 @@ type Props = {
 };
 
 export const TabBasic = ({ value, onChange }: Props) => {
-  const { isEnabled } = useEnabledFeatures();
   const { t } = useTranslate();
   const project = useProject();
   const [projectDescription, setProjectDescription] = useState(false);
@@ -47,8 +45,7 @@ export const TabBasic = ({ value, onChange }: Props) => {
 
   const { satisfiesPermission } = useProjectPermissions();
 
-  const canCustomize =
-    satisfiesPermission('prompts.edit') && isEnabled('AI_PROMPT_CUSTOMIZATION');
+  const canCustomize = satisfiesPermission('prompts.edit');
 
   const basicPromptItems: PromptItem[] = [
     {
@@ -159,7 +156,7 @@ export const TabBasic = ({ value, onChange }: Props) => {
               <Box display="flex" alignItems="center" gap={0.5} my={-1}>
                 {onEdit && (
                   <IconButton
-                    onClick={() => onEdit(true)}
+                    onClick={() => onEdit()}
                     data-cy="prompt-basic-option-edit"
                     data-cy-id={id}
                   >

--- a/webapp/src/ee/llm/AiPrompt/TabBasic.tsx
+++ b/webapp/src/ee/llm/AiPrompt/TabBasic.tsx
@@ -47,16 +47,18 @@ export const TabBasic = ({ value, onChange }: Props) => {
 
   const canCustomize = satisfiesPermission('prompts.edit');
 
-  const basicPromptItems: PromptItem[] = [
+  const basicPromptItems = [
     {
       id: 'KEY_NAME',
       label: t('ai_prompt_item_key_name'),
       hint: t('ai_prompt_item_key_name_hint'),
+      onEdit: undefined,
     },
     {
       id: 'KEY_DESCRIPTION',
       label: t('ai_prompt_item_key_description'),
       hint: t('ai_prompt_item_key_description_hint'),
+      onEdit: undefined,
     },
     {
       id: 'PROJECT_DESCRIPTION',
@@ -81,23 +83,33 @@ export const TabBasic = ({ value, onChange }: Props) => {
       id: 'TM_SUGGESTIONS',
       label: t('ai_prompt_item_tm_suggestions'),
       hint: t('ai_prompt_item_tm_suggestions_hint'),
+      onEdit: undefined,
     },
     {
       id: 'KEY_CONTEXT',
       label: t('ai_prompt_item_key_context'),
       hint: t('ai_prompt_item_key_context_hint'),
+      onEdit: undefined,
     },
     {
       id: 'GLOSSARY',
       label: t('ai_prompt_item_glossary'),
       hint: t('ai_prompt_item_glossary_hint'),
+      onEdit: undefined,
     },
     {
       id: 'SCREENSHOT',
       label: t('ai_prompt_item_screenshot'),
       hint: t('ai_prompt_item_screenshot_hint'),
+      onEdit: undefined,
     },
-  ];
+  ] as const satisfies readonly PromptItem[];
+
+  // Type error here means a BasicPromptOption was added to the API but not to the list above
+  const _allOptionsCovered: AllOptionsCovered<
+    BasicPromptOption,
+    typeof basicPromptItems
+  > = true;
 
   const theme = useTheme();
   const [hideTip, setHideTip] = useLocalStorageState({
@@ -186,3 +198,14 @@ export const TabBasic = ({ value, onChange }: Props) => {
     </Box>
   );
 };
+
+/**
+ * Resolves to `true` if every member of `Union` appears as an `id` in `Items`.
+ * Otherwise, resolves to `{ missing: ... }`
+ */
+type AllOptionsCovered<
+  Union extends string,
+  Items extends readonly { id: string }[]
+> = [Exclude<Union, Items[number]['id']>] extends [never]
+  ? true
+  : { missing: Exclude<Union, Items[number]['id']> };

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -5100,8 +5100,8 @@ export interface components {
     };
     ProjectAiPromptCustomizationModel: {
       /**
-       * @description The project description used in the  prompt that helps AI translator to understand the context of your project.
-       * @example We are Dunder Mifflin, a paper company. We sell paper. This is an project of translations for out paper selling app.
+       * @description The project description used in the prompt that helps AI translator to understand the context of your project.
+       * @example We are Dunder Mifflin, a paper company. We sell paper. This is a project of translations for our paper selling app.
        */
       description?: string;
     };
@@ -5975,7 +5975,7 @@ export interface components {
     };
     SetLanguagePromptCustomizationRequest: {
       /**
-       * @description The language description used in the  prompt that helps AI translator to fine tune results for specific language
+       * @description The language description used in the prompt that helps AI translator to fine tune results for specific language
        * @example For arabic language, we are super formal. Always use these translations:
        * Paper -> ورقة
        * Office -> مكتب


### PR DESCRIPTION
## Summary

- Remove `@RequiresFeatures(Feature.AI_PROMPT_CUSTOMIZATION)` from the two PUT endpoints in `AiPromptCustomizationController` so free-plan users can set project description and language notes
- Remove the feature flag check from `AiContextData.tsx` (banner + query gating) and simplify `canCustomize` in `TabBasic.tsx` to permission-only
- Fix `@Size` validation on both Kotlin DTOs (`@field:Size` for Bean Validation to pick up the constraint) — pre-existing bug
- Add tests for ungated PUT endpoints and size validation
- Fix typos and minor cleanups in touched files

**Pitch:** #3583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Prompt Customization UI and endpoints are available to all users — no special feature gating.

* **Bug Fixes**
  * Corrected grammar and spacing in prompt description texts and examples.

* **Improvements**
  * Enforced a 2000-character maximum for prompt customization descriptions; UI prevents/flags overly long input.

* **Tests**
  * Updated tests to reflect availability and added validation checks for the 2000-character limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->