### PR TITLE
fix: save Translation before persisting QA issues

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -16,7 +16,10 @@ class QaTestData : BaseTestData() {
 
   lateinit var otherProjectKey: Key
 
+  /** Key that only has a base (English) translation — no French translation exists. */
   lateinit var keyWithoutFrTranslation: Key
+
+  lateinit var germanLanguage: Language
 
   init {
     project.useQaChecks = true
@@ -34,6 +37,12 @@ class QaTestData : BaseTestData() {
           name = "key-without-fr-translation"
         }.build {
           addTranslation("en", "Only English.")
+        }.self
+      germanLanguage =
+        addLanguage {
+          name = "German"
+          tag = "de"
+          originalName = "Deutsch"
         }.self
     }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -16,6 +16,8 @@ class QaTestData : BaseTestData() {
 
   lateinit var otherProjectKey: Key
 
+  lateinit var keyWithoutFrTranslation: Key
+
   init {
     project.useQaChecks = true
     projectBuilder.build {
@@ -26,6 +28,12 @@ class QaTestData : BaseTestData() {
         }.build {
           enTranslation = addTranslation("en", "Hello world.").self
           frTranslation = addTranslation("fr", "bonjour monde").self
+        }.self
+      keyWithoutFrTranslation =
+        addKey {
+          name = "key-without-fr-translation"
+        }.build {
+          addTranslation("en", "Only English.")
         }.self
     }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
@@ -115,19 +115,20 @@ class QaCheckBatchServiceImpl(
     executeInNewRepeatableTransaction(transactionManager) {
       val translation = translationService.getOrCreate(projectId, keyId, languageId)
 
-      qaIssueService.replaceIssuesForTranslation(translation, results, checkTypes)
-
-      // Only clear stale flag if the translation text hasn't changed since we collected inputs.
-      // If it changed, QaActivityListener already marked it stale again and a new batch job
+      // Only clear the stale flag if the translation text hasn't changed since we collected inputs.
+      // If it changed, QaActivityListener already marked it stale again, and a new batch job
       // will re-check with the updated text.
       if (checkTypes == null && (translation.text ?: "") == translationText) {
         translation.qaChecksStale = false
       }
-      // Disable activity logging for the translation — no content changes are happening here.
+
+      // Disable activity logging — no content changes are happening here.
       // Without this, when we create a new empty translation (so we can reference it from QA issues),
       // it gets logged.
       translation.disableActivityLogging = true
       translationService.save(translation)
+
+      qaIssueService.replaceIssuesForTranslation(translation, results, checkTypes)
 
       qaIssueService.publishQaIssuesUpdated(translation)
     }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
@@ -125,7 +125,7 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
     qa.runChecksAndPersist(testData.frTranslation)
 
     performAuthGet(translationsUrl).andIsOk.andAssertThatJson {
-      node("_embedded.keys").isArray.hasSize(2)
+      node("_embedded.keys").isArray.hasSize(3)
     }
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
@@ -56,19 +56,6 @@ class QaCheckBatchServiceTest : AuthorizedControllerTest() {
     userAccount = null
   }
 
-  private fun refetchEntities() {
-    testData.testKey = entityManager.find(Key::class.java, testData.testKey.id)
-    testData.frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
-  }
-
-  private fun runChecks(languageId: Long = testData.frTranslation.language.id) {
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      languageId,
-    )
-  }
-
   @Test
   @Transactional
   fun `creates QA issues when translation has problems`() {
@@ -127,22 +114,18 @@ class QaCheckBatchServiceTest : AuthorizedControllerTest() {
 
   @Test
   fun `creates QA issues for key with no existing translation`() {
-    // Delete the French translation so getOrCreate() will create a new one
-    executeInNewTransaction(platformTransactionManager) {
-      val translation = entityManager.find(Translation::class.java, testData.frTranslation.id)
-      qaIssueRepository.deleteAllByTranslationId(translation.id)
-      entityManager.remove(translation)
-    }
-
     // This should NOT throw TransientPropertyValueException
-    runChecks(testData.frenchLanguage.id)
+    runChecks(
+      keyId = testData.keyWithoutFrTranslation.id,
+      languageId = testData.frenchLanguage.id,
+    )
 
     // Verify that a translation was created and QA issues were persisted
     executeInNewTransaction(platformTransactionManager) {
       val translation =
         translationRepository.findOneByProjectIdAndKeyIdAndLanguageId(
           testData.project.id,
-          testData.testKey.id,
+          testData.keyWithoutFrTranslation.id,
           testData.frenchLanguage.id,
         )
       assertThat(translation).isNotNull
@@ -160,5 +143,21 @@ class QaCheckBatchServiceTest : AuthorizedControllerTest() {
     entityManager.flush()
 
     assertPostHogEventReported(postHog, "QA_CHECK_RUN")
+  }
+
+  private fun refetchEntities() {
+    testData.testKey = entityManager.find(Key::class.java, testData.testKey.id)
+    testData.frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+  }
+
+  private fun runChecks(
+    keyId: Long = testData.testKey.id,
+    languageId: Long = testData.frTranslation.language.id,
+  ) {
+    qaCheckBatchService.runChecksAndPersist(
+      testData.project.id,
+      keyId,
+      languageId,
+    )
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.fixtures.assertPostHogEventReported
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
+import io.tolgee.repository.TranslationRepository
 import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.util.executeInNewTransaction
@@ -21,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 @AutoConfigureMockMvc
-class QaBatchServiceTest : AuthorizedControllerTest() {
+class QaCheckBatchServiceTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var postHog: PostHog
@@ -31,6 +32,9 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
 
   @Autowired
   private lateinit var qaIssueRepository: TranslationQaIssueRepository
+
+  @Autowired
+  private lateinit var translationRepository: TranslationRepository
 
   @Autowired
   lateinit var qa: QaTestUtil
@@ -57,16 +61,20 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
     testData.frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
   }
 
+  private fun runChecks(languageId: Long = testData.frTranslation.language.id) {
+    qaCheckBatchService.runChecksAndPersist(
+      testData.project.id,
+      testData.testKey.id,
+      languageId,
+    )
+  }
+
   @Test
   @Transactional
   fun `creates QA issues when translation has problems`() {
     refetchEntities()
 
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      testData.frTranslation.language.id,
-    )
+    runChecks()
     entityManager.flush()
 
     val issues = qaIssueRepository.findAllByTranslationId(testData.frTranslation.id)
@@ -84,11 +92,7 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
       translation.text = "Bonjour monde."
     }
 
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      testData.frTranslation.language.id,
-    )
+    runChecks()
 
     executeInNewTransaction(platformTransactionManager) {
       val issues = qaIssueRepository.findAllByTranslationId(testData.frTranslation.id)
@@ -99,11 +103,7 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
   @Test
   fun `replaces existing issues on re-check`() {
     // First check — translation has problems
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      testData.frTranslation.language.id,
-    )
+    runChecks()
 
     executeInNewTransaction(platformTransactionManager) {
       val issuesBefore = qaIssueRepository.findAllByTranslationId(testData.frTranslation.id)
@@ -117,11 +117,7 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
     }
 
     // Re-check — should find no issues
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      testData.frTranslation.language.id,
-    )
+    runChecks()
 
     executeInNewTransaction(platformTransactionManager) {
       val issuesAfter = qaIssueRepository.findAllByTranslationId(testData.frTranslation.id)
@@ -130,15 +126,37 @@ class QaBatchServiceTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `creates QA issues for key with no existing translation`() {
+    // Delete the French translation so getOrCreate() will create a new one
+    executeInNewTransaction(platformTransactionManager) {
+      val translation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+      qaIssueRepository.deleteAllByTranslationId(translation.id)
+      entityManager.remove(translation)
+    }
+
+    // This should NOT throw TransientPropertyValueException
+    runChecks(testData.frenchLanguage.id)
+
+    // Verify that a translation was created and QA issues were persisted
+    executeInNewTransaction(platformTransactionManager) {
+      val translation =
+        translationRepository.findOneByProjectIdAndKeyIdAndLanguageId(
+          testData.project.id,
+          testData.testKey.id,
+          testData.frenchLanguage.id,
+        )
+      assertThat(translation).isNotNull
+      val issues = qaIssueRepository.findAllByTranslationId(translation!!.id)
+      assertThat(issues).isNotEmpty
+    }
+  }
+
+  @Test
   @Transactional
   fun `reports QA_CHECK_RUN event`() {
     refetchEntities()
 
-    qaCheckBatchService.runChecksAndPersist(
-      testData.project.id,
-      testData.testKey.id,
-      testData.frTranslation.language.id,
-    )
+    runChecks()
     entityManager.flush()
 
     assertPostHogEventReported(postHog, "QA_CHECK_RUN")

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -212,27 +212,13 @@ class QaEventListenerTest : AuthorizedControllerTest() {
 
   @Test
   fun `triggers recheck when base language changes`() {
-    // Add a second language to use as new base
-    val germanLanguage =
-      executeInNewTransaction(platformTransactionManager) {
-        languageService.createLanguage(
-          LanguageRequest(
-            name = "German",
-            tag = "de",
-            originalName = "Deutsch",
-            flagEmoji = "\uD83C\uDDE9\uD83C\uDDEA",
-          ),
-          testData.project,
-        )
-      }
-
     executeInNewTransaction(platformTransactionManager) {
       projectHolder.project = ProjectDto.fromEntity(testData.project)
       projectService.editProject(
         testData.project.id,
         EditProjectRequest(
           name = testData.project.name,
-          baseLanguageId = germanLanguage.id,
+          baseLanguageId = testData.germanLanguage.id,
         ),
       )
     }


### PR DESCRIPTION
## Summary

- Fix `TransientPropertyValueException` when QA checks run on a key-language pair with no existing translation
- `getOrCreate()` can return a new unsaved `Translation`; the code was saving QA issues referencing it before persisting the translation itself
- Move `translationService.save(translation)` before `replaceIssuesForTranslation()` so the entity is managed first
- Add regression test that reproduces the exact scenario
- Rename `QaBatchServiceTest` → `QaCheckBatchServiceTest` to match the service under test
- Extract `runChecks()` helper to reduce test duplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QA checks now create missing translations and persist QA issues for them.
  * QA recheck behavior adjusted to use existing language data during base-language changes.

* **Tests**
  * Improved QA tests: renamed/organized suite, centralized check invocation, added coverage for missing-translation scenario.
  * API translation list test updated to expect an additional key when no QA filter is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->