### PR TITLE
chore: add MCP registry server.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ ngrok.local.yml
 
 # Worktree
 /worktree-env.sh
+
+# mcp-publisher auth tokens
+/.mcpregistry_github_token
+/.mcpregistry_registry_token

--- a/docs/mcp-server/README.md
+++ b/docs/mcp-server/README.md
@@ -1,0 +1,18 @@
+# MCP Server Publishing
+
+Tolgee is listed in the [official MCP Registry](https://registry.modelcontextprotocol.io) as a remote server pointing at `https://app.tolgee.io/mcp/developer`.
+
+## `server.json`
+
+The registry entry is defined by [`server.json`](../../server.json) at the repo root. It contains the server name (`io.github.tolgee/tolgee`), description, version, and the remote URL + `X-API-Key` header spec. Full schema: https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json.
+
+## Prerequisite: public org membership
+
+`mcp-publisher login github` only grants access to `io.github.tolgee/*` if your membership in the [`tolgee` GitHub org](https://github.com/orgs/tolgee/people) is **public**. Change visibility to Public on that page before logging in, otherwise publish will fail with "You do not have permission to publish this server".
+
+## Publishing a new version
+
+1. Install `mcp-publisher` if you don't have it: `brew install mcp-publisher`
+2. Bump `version` in [`server.json`](../../server.json).
+3. Validate: `mcp-publisher validate`
+4. Publish: `mcp-publisher login github && mcp-publisher publish`

--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tolgee/tolgee",
+  "title": "Tolgee",
+  "description": "Your app's translations in Tolgee: search keys, create translations, trigger machine translation",
+  "websiteUrl": "https://docs.tolgee.io/platform/integrations/mcp_server/setup",
+  "repository": {
+    "url": "https://github.com/tolgee/tolgee-platform",
+    "source": "github",
+    "id": "303766501"
+  },
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.tolgee.io/mcp/developer",
+      "headers": [
+        {
+          "name": "X-API-Key",
+          "description": "Tolgee Personal Access Token (tgpat_...) or Project API Key (tgpak_...)",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Publishes the Tolgee MCP server to the official MCP Registry (https://registry.modelcontextprotocol.io) as a remote server entry pointing at https://app.tolgee.io/mcp/developer, authenticated via an X-API-Key header (PAT or PAK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a server configuration to enable Tolgee MCP integration, providing authenticated streamable HTTP connectivity (requires an API key header) for remote access.

* **Documentation**
  * Added a new guide explaining the MCP registry entry, required configuration fields, publish workflow, and prerequisites for publishing new server versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->