### PR TITLE
fix: TOTP clock-drift tolerance with replay prevention

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -69,7 +69,6 @@ allOpen {
     annotation("jakarta.persistence.Embeddable")
     annotation("org.springframework.stereotype.Service")
     annotation("org.springframework.stereotype.Component")
-    annotation("org.springframework.stereotype.Service")
     annotation("org.springframework.transaction.annotation.Transactional")
     annotation("org.springframework.beans.factory.annotation.Configurable")
     annotation("org.springframework.boot.test.context.SpringBootTest")

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
@@ -46,6 +46,9 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
         mfaService.generateStringCode(encodedKey),
       )
     }
+    // `enableMfaTotp` bumps `tokens_valid_not_before` - invalidating all tokens.
+    // Refresh the token, so we have a new valid one.
+    refreshJwtToken()
   }
 
   private fun enableMfaAtFixedTime() {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
@@ -15,12 +15,12 @@ import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.NotificationTestUtil
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.apache.commons.codec.binary.Base32
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.time.Instant
 
 @Import(TestEmailConfiguration::class)
 class UserMfaControllerTest : AuthorizedControllerTest() {
@@ -58,7 +58,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
     }
 
     val fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.totpKey).isEqualTo(encodedKey)
+    assertThat(fromDb!!.totpKey).isEqualTo(encodedKey)
 
     notificationUtil.newestInAppNotification().also {
       assertThat(it.type).isEqualTo(MFA_ENABLED)
@@ -81,7 +81,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       )
     performAuthDelete("/v2/user/mfa/totp", requestDto).andIsOk
     val fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.totpKey).isNull()
+    assertThat(fromDb!!.totpKey).isNull()
 
     notificationUtil.newestInAppNotification().also {
       assertThat(it.type).isEqualTo(MFA_DISABLED)
@@ -104,11 +104,11 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       )
 
     var fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
+    assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
 
     performAuthPut("/v2/user/mfa/recovery", requestDto).andIsOk
     fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.mfaRecoveryCodes).isNotEmpty
+    assertThat(fromDb!!.mfaRecoveryCodes).isNotEmpty
   }
 
   @Test
@@ -128,7 +128,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
 
       assertThat(res).error().isCustomValidation.hasMessage("invalid_otp_code")
       val fromDb = userAccountService.findActive(initialUsername)
-      Assertions.assertThat(fromDb!!.totpKey).isNull()
+      assertThat(fromDb!!.totpKey).isNull()
     }
   }
 
@@ -142,7 +142,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       )
 
     val disableRequestDto =
-      UserTotpEnableRequestDto(
+      UserTotpDisableRequestDto(
         password = "pwease let me innn!!!! >:(",
       )
 
@@ -153,7 +153,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
 
     performAuthPut("/v2/user/mfa/totp", enableRequestDto).andIsForbidden
     var fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.totpKey).isNull()
+    assertThat(fromDb!!.totpKey).isNull()
 
     enableMfa()
 
@@ -161,11 +161,11 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
 
     performAuthDelete("/v2/user/mfa/totp", disableRequestDto).andIsForbidden
     fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.totpKey).isNotNull
+    assertThat(fromDb!!.totpKey).isNotNull
 
     performAuthPut("/v2/user/mfa/recovery", recoveryRequestDto).andIsForbidden
     fromDb = userAccountService.findActive(initialUsername)
-    Assertions.assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
+    assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
   }
 
   @Test
@@ -197,5 +197,24 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       refreshUser()
       performAuthGet("/v2/user").andExpect(MockMvcResultMatchers.status().isUnauthorized)
     }
+  }
+
+  @Test
+  fun `it accepts TOTP codes from adjacent time steps`() {
+    // Code from previous time step should be accepted
+    val previousCode = mfaService.generateStringCode(encodedKey, -1)
+    assertThat(mfaService.validateTotpCode(encodedKey, previousCode)).isTrue()
+
+    // Code from next time step should be accepted
+    val nextCode = mfaService.generateStringCode(encodedKey, 1)
+    assertThat(mfaService.validateTotpCode(encodedKey, nextCode)).isTrue()
+
+    // Code from 2 steps away (past) should be rejected
+    val tooOldCode = mfaService.generateStringCode(encodedKey, -2)
+    assertThat(mfaService.validateTotpCode(encodedKey, tooOldCode)).isFalse()
+
+    // Code from 2 steps away (future) should be rejected
+    val tooNewCode = mfaService.generateStringCode(encodedKey, 2)
+    assertThat(mfaService.validateTotpCode(encodedKey, tooNewCode)).isFalse()
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserMfaControllerTest.kt
@@ -4,23 +4,28 @@ import io.tolgee.config.TestEmailConfiguration
 import io.tolgee.dtos.request.UserMfaRecoveryRequestDto
 import io.tolgee.dtos.request.UserTotpDisableRequestDto
 import io.tolgee.dtos.request.UserTotpEnableRequestDto
+import io.tolgee.exceptions.AuthenticationException
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.retry
 import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.model.UserAccount
 import io.tolgee.model.notifications.NotificationType.MFA_DISABLED
 import io.tolgee.model.notifications.NotificationType.MFA_ENABLED
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.NotificationTestUtil
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.apache.commons.codec.binary.Base32
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import java.time.Instant
+import java.time.Duration
+import java.util.Date
 
 @Import(TestEmailConfiguration::class)
 class UserMfaControllerTest : AuthorizedControllerTest() {
@@ -34,14 +39,30 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
   private lateinit var notificationUtil: NotificationTestUtil
 
   private fun enableMfa() {
-    userAccount?.let {
-      userAccountService.enableMfaTotp(userAccountService.get(it.id), encodedKey)
+    userAccount!!.let {
+      userAccountService.enableMfaTotp(
+        userAccountService.get(it.id),
+        encodedKey,
+        mfaService.generateStringCode(encodedKey),
+      )
     }
   }
+
+  private fun enableMfaAtFixedTime() {
+    setForcedDate(Date())
+    enableMfa()
+  }
+
+  private fun persistedUser(): UserAccount = userAccountService.findActive(initialUsername)!!
 
   @BeforeEach
   fun setUp() {
     notificationUtil.init()
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clearForcedDate()
   }
 
   @Test
@@ -57,8 +78,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       performAuthPut("/v2/user/mfa/totp", requestDto).andIsOk
     }
 
-    val fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.totpKey).isEqualTo(encodedKey)
+    assertThat(persistedUser().totpKey).isEqualTo(encodedKey)
 
     notificationUtil.newestInAppNotification().also {
       assertThat(it.type).isEqualTo(MFA_ENABLED)
@@ -80,8 +100,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
         password = initialPassword,
       )
     performAuthDelete("/v2/user/mfa/totp", requestDto).andIsOk
-    val fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.totpKey).isNull()
+    assertThat(persistedUser().totpKey).isNull()
 
     notificationUtil.newestInAppNotification().also {
       assertThat(it.type).isEqualTo(MFA_DISABLED)
@@ -103,12 +122,10 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
         password = initialPassword,
       )
 
-    var fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
+    assertThat(persistedUser().mfaRecoveryCodes).isEmpty()
 
     performAuthPut("/v2/user/mfa/recovery", requestDto).andIsOk
-    fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.mfaRecoveryCodes).isNotEmpty
+    assertThat(persistedUser().mfaRecoveryCodes).isNotEmpty
   }
 
   @Test
@@ -127,8 +144,7 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
           .andReturn()
 
       assertThat(res).error().isCustomValidation.hasMessage("invalid_otp_code")
-      val fromDb = userAccountService.findActive(initialUsername)
-      assertThat(fromDb!!.totpKey).isNull()
+      assertThat(persistedUser().totpKey).isNull()
     }
   }
 
@@ -152,20 +168,17 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
       )
 
     performAuthPut("/v2/user/mfa/totp", enableRequestDto).andIsForbidden
-    var fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.totpKey).isNull()
+    assertThat(persistedUser().totpKey).isNull()
 
     enableMfa()
 
     loginAsUser(userAccount!!) // get new token
 
     performAuthDelete("/v2/user/mfa/totp", disableRequestDto).andIsForbidden
-    fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.totpKey).isNotNull
+    assertThat(persistedUser().totpKey).isNotNull
 
     performAuthPut("/v2/user/mfa/recovery", recoveryRequestDto).andIsForbidden
-    fromDb = userAccountService.findActive(initialUsername)
-    assertThat(fromDb!!.mfaRecoveryCodes).isEmpty()
+    assertThat(persistedUser().mfaRecoveryCodes).isEmpty()
   }
 
   @Test
@@ -216,5 +229,177 @@ class UserMfaControllerTest : AuthorizedControllerTest() {
     // Code from 2 steps away (future) should be rejected
     val tooNewCode = mfaService.generateStringCode(encodedKey, 2)
     assertThat(mfaService.validateTotpCode(encodedKey, tooNewCode)).isFalse()
+  }
+
+  @Test
+  fun `it rejects replay of the enable-time TOTP code`() {
+    enableMfaAtFixedTime()
+    val user = persistedUser()
+    // Verify the seed value, not just that it was written — a regression that seeds the
+    // wrong step (e.g. always the past-drift candidate) would otherwise slip through.
+    assertThat(user.totpLastUsedTimeStep).isEqualTo(mfaService.currentTimeStep())
+
+    val enableTimeCode = mfaService.generateStringCode(encodedKey)
+    assertThatThrownBy { userAccountService.consumeTotpCode(user, enableTimeCode) }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it rejects replay of a successful TOTP code within the same window`() {
+    enableMfaAtFixedTime()
+    // Move one full step forward so the code we generate below is strictly newer than the
+    // counter seeded during enable.
+    moveCurrentDate(Duration.ofSeconds(30))
+
+    val code = mfaService.generateStringCode(encodedKey)
+    userAccountService.consumeTotpCode(persistedUser(), code) // first use — succeeds
+
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), code) }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it rejects replay of a past-drift TOTP code`() {
+    enableMfaAtFixedTime()
+    // Advance past the step used to seed the counter during enable so the -1 candidate
+    // becomes a valid future-relative-to-stored step.
+    moveCurrentDate(Duration.ofSeconds(60))
+
+    val pastDriftCode = mfaService.generateStringCode(encodedKey, -1)
+    userAccountService.consumeTotpCode(persistedUser(), pastDriftCode) // accepted
+
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), pastDriftCode) }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it burns the current and past windows when future-drift code is accepted`() {
+    enableMfaAtFixedTime()
+    moveCurrentDate(Duration.ofSeconds(60))
+
+    val futureDriftCode = mfaService.generateStringCode(encodedKey, 1)
+    userAccountService.consumeTotpCode(persistedUser(), futureDriftCode) // accepted
+
+    val currentCode = mfaService.generateStringCode(encodedKey, 0)
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), currentCode) }
+      .isInstanceOf(AuthenticationException::class.java)
+
+    val pastCode = mfaService.generateStringCode(encodedKey, -1)
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), pastCode) }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it accepts a new code from the next time step`() {
+    enableMfaAtFixedTime()
+    moveCurrentDate(Duration.ofSeconds(30))
+
+    val firstCode = mfaService.generateStringCode(encodedKey)
+    userAccountService.consumeTotpCode(persistedUser(), firstCode)
+    val firstStep = persistedUser().totpLastUsedTimeStep!!
+
+    moveCurrentDate(Duration.ofSeconds(30))
+    val nextCode = mfaService.generateStringCode(encodedKey)
+    userAccountService.consumeTotpCode(persistedUser(), nextCode)
+
+    // The stored counter must have strictly advanced to the new window's step.
+    val nextStep = persistedUser().totpLastUsedTimeStep!!
+    assertThat(nextStep).isGreaterThan(firstStep)
+    assertThat(nextStep).isEqualTo(mfaService.currentTimeStep())
+  }
+
+  @Test
+  fun `it resets the counter on disable and re-enable`() {
+    enableMfaAtFixedTime()
+    // Advance the counter far into the future via a normal authentication.
+    moveCurrentDate(Duration.ofSeconds(300))
+    userAccountService.consumeTotpCode(persistedUser(), mfaService.generateStringCode(encodedKey))
+    val advancedStep = persistedUser().totpLastUsedTimeStep!!
+
+    userAccountService.disableMfaTotp(persistedUser())
+    assertThat(persistedUser().totpLastUsedTimeStep).isNull()
+
+    // Re-enable at the SAME wall-clock time. The enable flow must reset + reseed the
+    // counter; a subsequent authentication at a later window must succeed.
+    enableMfa()
+    val seededStep = persistedUser().totpLastUsedTimeStep!!
+    assertThat(seededStep).isEqualTo(mfaService.currentTimeStep())
+
+    moveCurrentDate(Duration.ofSeconds(30))
+    userAccountService.consumeTotpCode(persistedUser(), mfaService.generateStringCode(encodedKey))
+    val postReEnableStep = persistedUser().totpLastUsedTimeStep!!
+    assertThat(postReEnableStep).isGreaterThan(seededStep)
+    // The post-re-enable flow works regardless of how high the previous counter was.
+    assertThat(advancedStep).isLessThan(postReEnableStep + 1L) // sanity: values are comparable
+  }
+
+  @Test
+  fun `it burns the TOTP window when a recovery code is consumed`() {
+    enableMfaAtFixedTime()
+    // Provision a known recovery code directly on the user (bypasses the password-protected
+    // regeneration endpoint — the unit under test is the replay guard, not the generator).
+    val recoveryCode = "aaaa-bbbb-cccc-dddd"
+    userAccountService.setMfaRecoveryCodes(persistedUser(), listOf(recoveryCode))
+
+    moveCurrentDate(Duration.ofSeconds(30))
+    val burnTimeStep = mfaService.currentTimeStep()
+    userAccountService.consumeMfaRecoveryCode(persistedUser(), recoveryCode)
+
+    // The counter must be bumped to exactly `currentTimeStep + 1`, burning the entire ±1
+    // window from the recovery-consumption moment.
+    assertThat(persistedUser().totpLastUsedTimeStep).isEqualTo(burnTimeStep + 1L)
+
+    // A TOTP code generated at the recovery-consumption time must now be rejected.
+    val totpAtRecoveryTime = mfaService.generateStringCode(encodedKey)
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), totpAtRecoveryTime) }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it rejects TOTP consumption for a user without a TOTP key`() {
+    loginAsAdminIfNotLogged()
+    // Deliberately do NOT call enableMfa — the persisted user has a null `totpKey`.
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), "123456") }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it rejects malformed TOTP codes on the authenticated path`() {
+    enableMfaAtFixedTime()
+
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), "abcdef") }
+      .isInstanceOf(AuthenticationException::class.java)
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), "12345") }
+      .isInstanceOf(AuthenticationException::class.java)
+    assertThatThrownBy { userAccountService.consumeTotpCode(persistedUser(), "1234567") }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+
+  @Test
+  fun `it rejects TOTP replay on the login endpoint`() {
+    enableMfaAtFixedTime()
+    moveCurrentDate(Duration.ofSeconds(30))
+
+    val code = mfaService.generateStringCode(encodedKey)
+    val body = mapOf("username" to initialUsername, "password" to initialPassword, "otp" to code)
+
+    performPost("/api/public/generatetoken", body).andIsOk
+    performPost("/api/public/generatetoken", body)
+      .andExpect(MockMvcResultMatchers.status().isUnauthorized)
+  }
+
+  @Test
+  fun `it rejects TOTP replay on the super-token endpoint`() {
+    enableMfaAtFixedTime()
+    moveCurrentDate(Duration.ofSeconds(30))
+    // `enableMfa` cleared the JWT-valid-from marker, so refresh the test's auth token.
+    loginAsUser(persistedUser())
+
+    val code = mfaService.generateStringCode(encodedKey)
+    val body = mapOf("otp" to code)
+
+    performAuthPost("/v2/user/generate-super-token", body).andIsOk
+    performAuthPost("/v2/user/generate-super-token", body)
+      .andExpect(MockMvcResultMatchers.status().isUnauthorized)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SensitiveOperationProtectionTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SensitiveOperationProtectionTestData.kt
@@ -6,6 +6,7 @@ import io.tolgee.model.UserAccount
 
 class SensitiveOperationProtectionTestData {
   companion object {
+    val TOTP_USERNAME = "pepa"
     val TOTP_KEY = "meowmeowmeowmeow".toByteArray()
   }
 
@@ -28,7 +29,7 @@ class SensitiveOperationProtectionTestData {
         }
       }
       addUserAccount {
-        username = "pepa"
+        username = TOTP_USERNAME
         name = "Pepa"
         totpKey = TOTP_KEY
         pepa = this

--- a/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
@@ -59,6 +59,9 @@ data class UserAccount(
   @Column(name = "totp_key", columnDefinition = "bytea")
   override var totpKey: ByteArray? = null
 
+  @Column(name = "totp_last_used_time_step")
+  var totpLastUsedTimeStep: Long? = null
+
   @Type(ListArrayType::class)
   @Column(name = "mfa_recovery_codes", columnDefinition = "text[]")
   var mfaRecoveryCodes: List<String> = emptyList()

--- a/backend/data/src/main/kotlin/io/tolgee/repository/UserAccountRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/UserAccountRepository.kt
@@ -135,6 +135,30 @@ interface UserAccountRepository : JpaRepository<UserAccount, Long> {
     now: Date,
   )
 
+  /**
+   * Atomically bumps [UserAccount.totpLastUsedTimeStep] to [newTimeStep] only if the stored
+   * value is currently `null` or strictly less than [newTimeStep]. This is the CAS primitive
+   * behind TOTP replay prevention (RFC 6238 §5.2).
+   *
+   * @return `1` if the row was updated, `0` if another concurrent request already bumped at
+   *         or past [newTimeStep]. Callers **must** inspect this value: a return of `0`
+   *         indicates a replayed or racing OTP and must be surfaced as an authentication
+   *         failure.
+   */
+  @Modifying
+  @Query(
+    """
+    update UserAccount ua
+       set ua.totpLastUsedTimeStep = :newTimeStep
+     where ua.id = :id
+       and (ua.totpLastUsedTimeStep is null or ua.totpLastUsedTimeStep < :newTimeStep)
+    """,
+  )
+  fun updateTotpLastUsedTimeStepIfGreater(
+    id: Long,
+    newTimeStep: Long,
+  ): Int
+
   @Query(
     """
   select new io.tolgee.dtos.queryResults.UserAccountView(

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/MfaService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/MfaService.kt
@@ -61,7 +61,7 @@ class MfaService(
       throw PermissionException(Message.BAD_CREDENTIALS)
     }
 
-    if (user.totpKey?.isNotEmpty() != true) {
+    if (!hasMfaEnabled(user)) {
       throw BadRequestException(Message.MFA_NOT_ENABLED)
     }
 
@@ -109,7 +109,7 @@ class MfaService(
       throw AuthenticationException(Message.MFA_ENABLED)
     }
 
-    if (otp.length == 6) {
+    if (otp.length == totpGenerator.passwordLength) {
       if (!validateTotpCode(user, otp)) {
         throw AuthenticationException(Message.INVALID_OTP_CODE)
       }
@@ -130,23 +130,33 @@ class MfaService(
     key: ByteArray,
     code: String,
   ): Boolean {
-    if (code.length != 6) return false
+    if (code.length != totpGenerator.passwordLength) return false
 
     return try {
       val parsedCode = code.toInt()
-      val expectedCode = generateCode(key)
-      parsedCode == expectedCode
+      listOf(-1L, 0L, 1L).any { timeSlotOffset ->
+        parsedCode == generateCode(key, timeSlotOffset)
+      }
     } catch (e: NumberFormatException) {
       false
     }
   }
 
-  fun generateCode(key: ByteArray): Int {
-    return totpGenerator.generateOneTimePassword(SecretKeySpec(key, SecurityConfiguration.OTP_ALGORITHM), Instant.now())
+  fun generateCode(
+    key: ByteArray,
+    timeSlotOffset: Long = 0,
+  ): Int {
+    val timestamp = Instant.now().plus(totpGenerator.timeStep.multipliedBy(timeSlotOffset))
+    return totpGenerator.generateOneTimePassword(SecretKeySpec(key, SecurityConfiguration.OTP_ALGORITHM), timestamp)
   }
 
-  fun generateStringCode(key: ByteArray): String {
-    return generateCode(key).toString().padStart(6, '0')
+  fun generateStringCode(
+    key: ByteArray,
+    timeSlotOffset: Long = 0,
+  ): String {
+    return generateCode(key, timeSlotOffset)
+      .toString()
+      .padStart(totpGenerator.passwordLength, '0')
   }
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/MfaService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/MfaService.kt
@@ -2,13 +2,13 @@ package io.tolgee.service.security
 
 import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator
 import io.tolgee.api.isMfaEnabled
+import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.KeyGenerator
 import io.tolgee.configuration.SecurityConfiguration
 import io.tolgee.constants.Message
 import io.tolgee.dtos.request.UserMfaRecoveryRequestDto
 import io.tolgee.dtos.request.UserTotpDisableRequestDto
 import io.tolgee.dtos.request.UserTotpEnableRequestDto
-import io.tolgee.dtos.request.validators.exceptions.ValidationException
 import io.tolgee.exceptions.AuthenticationException
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.PermissionException
@@ -24,6 +24,7 @@ class MfaService(
   private val userAccountService: UserAccountService,
   private val userCredentialsService: UserCredentialsService,
   private val keyGenerator: KeyGenerator,
+  private val currentDateProvider: CurrentDateProvider,
 ) {
   private val base32 = Base32()
 
@@ -31,35 +32,21 @@ class MfaService(
     user: UserAccount,
     dto: UserTotpEnableRequestDto,
   ) {
-    try {
-      userCredentialsService.checkUserCredentials(user, dto.password)
-    } catch (e: AuthenticationException) {
-      // Re-throw as a permission exception to set status to 403 instead of 401
-      throw PermissionException(Message.BAD_CREDENTIALS)
-    }
+    requireCredentials(user, dto.password)
 
     if (user.isMfaEnabled) {
       throw BadRequestException(Message.MFA_ENABLED)
     }
 
     val key = base32.decode(dto.totpKey)
-    if (!validateTotpCode(key, dto.otp)) {
-      throw ValidationException(Message.INVALID_OTP_CODE)
-    }
-
-    userAccountService.enableMfaTotp(user, key)
+    userAccountService.enableMfaTotp(user, key, dto.otp)
   }
 
   fun disableTotpFor(
     user: UserAccount,
     dto: UserTotpDisableRequestDto,
   ) {
-    try {
-      userCredentialsService.checkUserCredentials(user, dto.password)
-    } catch (e: AuthenticationException) {
-      // Re-throw as a permission exception to set status to 403 instead of 401
-      throw PermissionException(Message.BAD_CREDENTIALS)
-    }
+    requireCredentials(user, dto.password)
 
     if (!hasMfaEnabled(user)) {
       throw BadRequestException(Message.MFA_NOT_ENABLED)
@@ -72,12 +59,7 @@ class MfaService(
     user: UserAccount,
     dto: UserMfaRecoveryRequestDto,
   ): List<String> {
-    try {
-      userCredentialsService.checkUserCredentials(user, dto.password)
-    } catch (e: AuthenticationException) {
-      // Re-throw as a permission exception to set status to 403 instead of 401
-      throw PermissionException(Message.BAD_CREDENTIALS)
-    }
+    requireCredentials(user, dto.password)
 
     if (!hasMfaEnabled(user)) {
       throw BadRequestException(Message.MFA_NOT_ENABLED)
@@ -93,6 +75,18 @@ class MfaService(
     return codes
   }
 
+  private fun requireCredentials(
+    user: UserAccount,
+    password: String,
+  ) {
+    try {
+      userCredentialsService.checkUserCredentials(user, password)
+    } catch (e: AuthenticationException) {
+      // Re-throw as a permission exception to set status to 403 instead of 401
+      throw PermissionException(Message.BAD_CREDENTIALS)
+    }
+  }
+
   fun hasMfaEnabled(user: UserAccount): Boolean {
     return mfaEnabled(user.totpKey)
   }
@@ -105,49 +99,77 @@ class MfaService(
       return
     }
 
-    if (otp?.isEmpty() != false) {
+    if (otp.isNullOrEmpty()) {
       throw AuthenticationException(Message.MFA_ENABLED)
     }
 
     if (otp.length == totpGenerator.passwordLength) {
-      if (!validateTotpCode(user, otp)) {
-        throw AuthenticationException(Message.INVALID_OTP_CODE)
-      }
+      userAccountService.consumeTotpCode(user, otp)
     } else {
       userAccountService.consumeMfaRecoveryCode(user, otp)
     }
   }
 
-  fun validateTotpCode(
-    user: UserAccount,
-    code: String,
-  ): Boolean {
-    if (user.totpKey?.isNotEmpty() != true) return true
-    return validateTotpCode(user.totpKey!!, code)
-  }
-
+  /**
+   * Stateless TOTP validator — returns `true` if [code] matches any of the codes in the
+   * ±1 time-step window centred on the current time.
+   *
+   * **Do not use this for authentication.** Authentication flows must go through
+   * [UserAccountService.consumeTotpCode], which additionally enforces replay prevention
+   * against the user's stored [UserAccount.totpLastUsedTimeStep] (RFC 6238 §5.2).
+   */
   fun validateTotpCode(
     key: ByteArray,
     code: String,
-  ): Boolean {
-    if (code.length != totpGenerator.passwordLength) return false
+  ): Boolean = findMatchingTimeStep(key, code, minExclusiveTimeStep = null) != null
 
-    return try {
-      val parsedCode = code.toInt()
-      listOf(-1L, 0L, 1L).any { timeSlotOffset ->
-        parsedCode == generateCode(key, timeSlotOffset)
-      }
-    } catch (e: NumberFormatException) {
-      false
-    }
+  /**
+   * Returns the absolute TOTP time step counter whose generated OTP equals [code], or `null`
+   * if no candidate in the ±1 window matches.
+   *
+   * @param minExclusiveTimeStep if non-null, candidates with counter `<=` this value are
+   *        filtered out. Used by [UserAccountService.consumeTotpCode] to enforce replay
+   *        prevention: a code whose counter is not strictly greater than the user's stored
+   *        last-used counter cannot match.
+   */
+  internal fun findMatchingTimeStep(
+    key: ByteArray,
+    code: String,
+    minExclusiveTimeStep: Long?,
+  ): Long? {
+    if (code.length != totpGenerator.passwordLength) return null
+    val parsed = code.toIntOrNull() ?: return null
+    val now = currentTimeStep()
+    return listOf(-1L, 0L, 1L)
+      .map { now + it }
+      .filter { minExclusiveTimeStep == null || it > minExclusiveTimeStep }
+      .firstOrNull { step -> parsed == generateCodeForTimeStep(key, step) }
+  }
+
+  /**
+   * Current absolute TOTP time step counter, derived from the mockable [currentDateProvider]
+   * using the same millis-based quantization that the underlying [totpGenerator] uses
+   * internally (`floor(epochMillis / timeStepMillis)`). Exposed as public so tests in other
+   * Gradle modules can assert the exact seeded / burned counter value.
+   */
+  fun currentTimeStep(): Long = currentDateProvider.date.time / totpGenerator.timeStep.toMillis()
+
+  private fun generateCodeForTimeStep(
+    key: ByteArray,
+    timeStep: Long,
+  ): Int {
+    val instant = Instant.ofEpochMilli(timeStep * totpGenerator.timeStep.toMillis())
+    return totpGenerator.generateOneTimePassword(
+      SecretKeySpec(key, SecurityConfiguration.OTP_ALGORITHM),
+      instant,
+    )
   }
 
   fun generateCode(
     key: ByteArray,
     timeSlotOffset: Long = 0,
   ): Int {
-    val timestamp = Instant.now().plus(totpGenerator.timeStep.multipliedBy(timeSlotOffset))
-    return totpGenerator.generateOneTimePassword(SecretKeySpec(key, SecurityConfiguration.OTP_ALGORITHM), timestamp)
+    return generateCodeForTimeStep(key, currentTimeStep() + timeSlotOffset)
   }
 
   fun generateStringCode(

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/UserAccountService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/UserAccountService.kt
@@ -35,6 +35,7 @@ import io.tolgee.service.notification.NotificationService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.util.Logging
 import io.tolgee.util.addMinutes
+import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import jakarta.servlet.http.HttpServletRequest
 import org.apache.commons.lang3.time.DateUtils
@@ -56,6 +57,7 @@ import java.util.Calendar
 import java.util.Date
 
 @Service
+@Suppress("SelfReferenceConstructorParameter")
 class UserAccountService(
   @Lazy
   private val userAccountRepository: UserAccountRepository,
@@ -68,9 +70,10 @@ class UserAccountService(
   private val entityManager: EntityManager,
   private val currentDateProvider: CurrentDateProvider,
   private val cacheManager: CacheManager,
-  @Suppress("SelfReferenceConstructorParameter")
   @Lazy
   private val self: UserAccountService,
+  @Lazy
+  private val mfaService: MfaService,
 ) : Logging {
   @Autowired
   @Lazy
@@ -318,17 +321,18 @@ class UserAccountService(
   fun enableMfaTotp(
     userAccount: UserAccount,
     key: ByteArray,
+    initialOtp: String,
   ): UserAccount {
+    // Validate the OTP and seed `totpLastUsedTimeStep` from the matched step so
+    // the same code can't be replayed against the login endpoint immediately after enable.
+    val matchedStep =
+      mfaService.findMatchingTimeStep(key, initialOtp, minExclusiveTimeStep = null)
+        ?: throw ValidationException(Message.INVALID_OTP_CODE)
     userAccount.totpKey = key
+    userAccount.totpLastUsedTimeStep = matchedStep
     resetTokensValidNotBefore(userAccount)
     val savedUser = userAccountRepository.save(userAccount)
-    notificationService.notify(
-      Notification().apply {
-        this.user = userAccount
-        this.type = NotificationType.MFA_ENABLED
-        this.originatingUser = userAccount
-      },
-    )
+    notifySelf(userAccount, NotificationType.MFA_ENABLED)
     return savedUser
   }
 
@@ -336,31 +340,80 @@ class UserAccountService(
   @CacheEvict(cacheNames = [Caches.USER_ACCOUNTS], key = "#result.id")
   fun disableMfaTotp(userAccount: UserAccount): UserAccount {
     userAccount.totpKey = null
+    userAccount.totpLastUsedTimeStep = null
     // note: if support for more MFA methods is added, this should be only done if no other MFA method is enabled
     userAccount.mfaRecoveryCodes = emptyList()
     resetTokensValidNotBefore(userAccount)
     val savedUser = userAccountRepository.save(userAccount)
+    notifySelf(userAccount, NotificationType.MFA_DISABLED)
+    return savedUser
+  }
+
+  private fun notifySelf(
+    userAccount: UserAccount,
+    notificationType: NotificationType,
+  ) {
     notificationService.notify(
       Notification().apply {
         this.user = userAccount
-        this.type = NotificationType.MFA_DISABLED
+        this.type = notificationType
         this.originatingUser = userAccount
       },
     )
-    return savedUser
+  }
+
+  /**
+   * Verifies a TOTP code against [userAccount] and atomically advances the stored
+   * [UserAccount.totpLastUsedTimeStep] so the same (or earlier) time step cannot be accepted
+   * again. This enforces RFC 6238 §5.2 replay prevention on top of the ±1 drift tolerance
+   * in [MfaService.findMatchingTimeStep].
+   *
+   * Throws [AuthenticationException] with [Message.INVALID_OTP_CODE] on every failure mode:
+   * missing/empty TOTP key, no matching code in the allowed window, or a concurrent request
+   * that already bumped the counter at or past the matched step.
+   */
+  @Transactional
+  @CacheEvict(cacheNames = [Caches.USER_ACCOUNTS], key = "#result.id")
+  fun consumeTotpCode(
+    userAccount: UserAccount,
+    code: String,
+  ): UserAccount {
+    if (!MfaService.mfaEnabled(userAccount.totpKey)) {
+      throw AuthenticationException(Message.INVALID_OTP_CODE)
+    }
+    val key = userAccount.totpKey!!
+    val matchedStep =
+      mfaService.findMatchingTimeStep(key, code, userAccount.totpLastUsedTimeStep)
+        ?: throw AuthenticationException(Message.INVALID_OTP_CODE)
+    val rowsAffected =
+      userAccountRepository.updateTotpLastUsedTimeStepIfGreater(userAccount.id, matchedStep)
+    if (rowsAffected == 0) {
+      logger.warn(
+        "TOTP replay rejected for user {}: concurrent bump lost the race",
+        userAccount.id,
+      )
+      throw AuthenticationException(Message.INVALID_OTP_CODE)
+    }
+    // Keep the in-memory entity consistent for the remainder of this request.
+    userAccount.totpLastUsedTimeStep = matchedStep
+    return userAccount
   }
 
   @Transactional
   @CacheEvict(cacheNames = [Caches.USER_ACCOUNTS], key = "#result.id")
   fun consumeMfaRecoveryCode(
     userAccount: UserAccount,
-    token: String,
+    recoveryCode: String,
   ): UserAccount {
-    if (!userAccount.mfaRecoveryCodes.contains(token)) {
+    if (!userAccount.mfaRecoveryCodes.contains(recoveryCode)) {
       throw AuthenticationException(Message.INVALID_OTP_CODE)
     }
 
-    userAccount.mfaRecoveryCodes = userAccount.mfaRecoveryCodes.minus(token)
+    userAccount.mfaRecoveryCodes = userAccount.mfaRecoveryCodes.minus(recoveryCode)
+
+    // Burn the current and next TOTP windows
+    val burnThrough = mfaService.currentTimeStep() + 1L
+    userAccount.totpLastUsedTimeStep = maxOf(burnThrough, userAccount.totpLastUsedTimeStep ?: burnThrough)
     return userAccountRepository.save(userAccount)
   }
 
@@ -506,13 +559,7 @@ class UserAccountService(
     userAccount.password = passwordEncoder.encode(dto.password)
     userAccount.passwordChanged = true
     val savedUser = userAccountRepository.save(userAccount)
-    notificationService.notify(
-      Notification().apply {
-        this.user = userAccount
-        this.type = NotificationType.PASSWORD_CHANGED
-        this.originatingUser = userAccount
-      },
-    )
+    notifySelf(userAccount, NotificationType.PASSWORD_CHANGED)
     return savedUser
   }
 

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5322,7 +5322,7 @@
     <changeSet author="anty (generated)" id="1775613609391-13">
         <addForeignKeyConstraint baseColumnNames="language_id" baseTableName="language_qa_config" constraintName="FKoqiiuc35c8wo16bm34pcv3ckw" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="language" validate="true"/>
     </changeSet>
-    <changeSet author="jirikuchynka" id="1775819597000-1">
+    <changeSet author="anty (generated)" id="1775827823285-1">
         <addColumn tableName="user_account">
             <column name="totp_last_used_time_step" type="BIGINT"/>
         </addColumn>

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5322,4 +5322,9 @@
     <changeSet author="anty (generated)" id="1775613609391-13">
         <addForeignKeyConstraint baseColumnNames="language_id" baseTableName="language_qa_config" constraintName="FKoqiiuc35c8wo16bm34pcv3ckw" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="language" validate="true"/>
     </changeSet>
+    <changeSet author="jirikuchynka" id="1775819597000-1">
+        <addColumn tableName="user_account">
+            <column name="totp_last_used_time_step" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
@@ -43,7 +43,9 @@ class SensitiveOperationProtectionE2eDataController(
   @Transactional
   fun getTotp(): Map<String, String> {
     // Reset OTP replay protection, so E2E tests can use MFA tokens with higher cadence than once every 30s
-    userAccountRepository.findActive("pepa")?.also { it.totpLastUsedTimeStep = null }
+    userAccountRepository.findActive(SensitiveOperationProtectionTestData.TOTP_USERNAME)!!.also {
+      it.totpLastUsedTimeStep = null
+    }
     return mapOf("otp" to mfaService.generateStringCode(SensitiveOperationProtectionTestData.TOTP_KEY))
   }
 

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
@@ -42,7 +42,7 @@ class SensitiveOperationProtectionE2eDataController(
   @GetMapping(value = ["/get-totp"])
   @Transactional
   fun getTotp(): Map<String, String> {
-    // Reset OTP replay protection, so E2E tests can use MFA tokens with higher cadency then once every 30s
+    // Reset OTP replay protection, so E2E tests can use MFA tokens with higher cadence than once every 30s
     userAccountRepository.findActive("pepa")?.also { it.totpLastUsedTimeStep = null }
     return mapOf("otp" to mfaService.generateStringCode(SensitiveOperationProtectionTestData.TOTP_KEY))
   }

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/SensitiveOperationProtectionE2eDataController.kt
@@ -5,6 +5,7 @@ import io.tolgee.configuration.tolgee.AuthenticationProperties
 import io.tolgee.controllers.internal.InternalController
 import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
 import io.tolgee.development.testDataBuilder.data.SensitiveOperationProtectionTestData
+import io.tolgee.repository.UserAccountRepository
 import io.tolgee.security.authentication.JwtService
 import io.tolgee.service.security.MfaService
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +18,7 @@ class SensitiveOperationProtectionE2eDataController(
   private val currentDateProvider: CurrentDateProvider,
   private val mfaService: MfaService,
   private val jwtService: JwtService,
+  private val userAccountRepository: UserAccountRepository,
 ) : AbstractE2eDataController() {
   @GetMapping(value = ["/generate"])
   @Transactional
@@ -40,6 +42,8 @@ class SensitiveOperationProtectionE2eDataController(
   @GetMapping(value = ["/get-totp"])
   @Transactional
   fun getTotp(): Map<String, String> {
+    // Reset OTP replay protection, so E2E tests can use MFA tokens with higher cadency then once every 30s
+    userAccountRepository.findActive("pepa")?.also { it.totpLastUsedTimeStep = null }
     return mapOf("otp" to mfaService.generateStringCode(SensitiveOperationProtectionTestData.TOTP_KEY))
   }
 


### PR DESCRIPTION
This PR was made in preparation for implementing support for WebAuthn (HW MFA tokens).

## Summary

- Accept TOTP codes from the previous and next 30-second time steps in addition to the current one so a few seconds of clock drift between the user's device and the server no longer cause confusing login failures (±1 time-step tolerance is the RFC 6238 recommendation and matches Google / GitHub / Microsoft).
- Prevent replay of the now-widened window per RFC 6238 §5.2 by tracking the last accepted absolute time step counter on `UserAccount` and rejecting any authentication whose matched counter is not strictly greater.
- Use a conditional atomic UPDATE (`updateTotpLastUsedTimeStepIfGreater`) so concurrent requests with the same code are handled without row locks: the first commit wins and the loser is rejected as a replay.
- Seed the counter from the matched step inside `enableMfaTotp` so the same code used to enable MFA cannot be replayed against the login endpoint immediately afterwards.
- Burn the current + next TOTP windows inside `consumeMfaRecoveryCode` so a previously captured TOTP cannot be replayed after a recovery-code authentication.
- Reset the counter inside `disableMfaTotp` so re-enabling starts from a clean slate.
- Covered by 11 new integration tests exercising enable-time replay, same-window replay, past/future-drift behaviour, forward progress, disable-and-re-enable, recovery-code burn, null-key defence, malformed codes, and end-to-end replay on both `/api/public/generatetoken` and `/v2/user/generate-super-token`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MFA/TOTP behavior: accepts adjacent time windows, prevents replayed codes, advances/locks time windows on consumption, rejects malformed or out-of-window TOTPs, and ensures recovery-code use invalidates related TOTP windows. Added race-resistant last-used-step checks to prevent replay under concurrency.
* **Chores**
  * Removed a duplicate build configuration entry and added a database migration to store the last-used TOTP time step.
* **Tests**
  * Added comprehensive MFA/TOTP tests covering replay, windowing, burn behavior, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->