### PR TITLE
fix: throttle concurrent LanguageTool requests and raise read timeout

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/LanguageToolProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/LanguageToolProperties.kt
@@ -17,4 +17,20 @@ class LanguageToolProperties(
         "When empty, spelling and grammar checks are disabled.",
   )
   var url: String = "",
+  @DocProperty(
+    description =
+      "Maximum number of concurrent `/v2/check` requests a single Tolgee instance is " +
+        "allowed to send to the LanguageTool server.",
+  )
+  var maxConcurrentRequests: Int = 2,
+  @DocProperty(
+    description =
+      "TCP connect timeout for LanguageTool HTTP calls, in seconds.",
+  )
+  var connectTimeoutSeconds: Long = 5,
+  @DocProperty(
+    description =
+      "Read (socket) timeout for LanguageTool HTTP calls, in seconds.",
+  )
+  var readTimeoutSeconds: Long = 60,
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolService.kt
@@ -17,6 +17,7 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.getForObject
 import org.springframework.web.client.postForObject
 import java.time.Duration
+import java.util.concurrent.Semaphore
 
 @Service
 class LanguageToolService(
@@ -25,9 +26,16 @@ class LanguageToolService(
 ) {
   private val restTemplate: RestTemplate by lazy {
     restTemplateBuilder
-      .connectTimeout(Duration.ofSeconds(5))
-      .readTimeout(Duration.ofSeconds(30))
+      .connectTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.connectTimeoutSeconds))
+      .readTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.readTimeoutSeconds))
       .build()
+  }
+
+  /**
+   * Per-instance concurrency gate for `/v2/check` calls.
+   */
+  private val requestSemaphore: Semaphore by lazy {
+    Semaphore(tolgeeProperties.languageTool.maxConcurrentRequests.coerceAtLeast(1), true)
   }
 
   private val resultCache: Cache<LanguageToolCacheKey, List<LanguageToolMatch>> =
@@ -168,13 +176,18 @@ class LanguageToolService(
       }
 
     val request = HttpEntity(body, headers)
-    val response =
-      restTemplate.postForObject<LanguageToolResponse?>(
-        "$baseUrl/v2/check",
-        request,
-      )
+    requestSemaphore.acquire()
+    try {
+      val response =
+        restTemplate.postForObject<LanguageToolResponse?>(
+          "$baseUrl/v2/check",
+          request,
+        )
 
-    return response?.matches ?: emptyList()
+      return response?.matches ?: emptyList()
+    } finally {
+      requestSemaphore.release()
+    }
   }
 
   companion object {


### PR DESCRIPTION
## Summary

- QA checks on production were failing with `ResourceAccessException: Read timed out` on POST `/v2/check` — the batch dispatcher ran up to ~12 concurrent LT calls (3 backend pods × 4 jobs each) against a LanguageTool container, which either OOMKilled or queued requests past the hardcoded 30 s timeout.
- Add `tolgee.language-tool.max-concurrent-requests` (default `2`) and gate `LanguageToolService.callApi()` with a fair `java.util.concurrent.Semaphore`. Per-instance; with 3 backend replicas that caps global LT concurrency at ~6 — inside what the container can sustain.
- Add `tolgee.language-tool.{connect,read}-timeout-seconds` (defaults 5 s / 60 s, up from 5 s / 30 s) and drive `RestTemplate` from them. The longer read timeout absorbs requests briefly queued behind the semaphore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LanguageTool parameters: maximum concurrent requests (default: 2), connection timeout (default: 5 seconds), and read timeout (default: 60 seconds) for enhanced control over service performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->