### PR TITLE
perf: use readOnly transactions for pure-read service methods

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/activity/ActivityService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/ActivityService.kt
@@ -112,7 +112,7 @@ class ActivityService(
     }
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun findProjectActivity(
     projectId: Long,
     pageable: Pageable,
@@ -129,7 +129,7 @@ class ActivityService(
     ).get()
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun findProjectActivity(revisionId: Long): ProjectActivityView? {
     return ProjectActivityViewByRevisionProvider(
       applicationContext = applicationContext,
@@ -137,7 +137,7 @@ class ActivityService(
     ).get()
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun findProjectActivity(
     projectId: Long,
     revisionId: Long,
@@ -152,7 +152,7 @@ class ActivityService(
     ).get()
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun getTranslationHistory(
     translationId: Long,
     pageable: Pageable,

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
@@ -131,6 +131,7 @@ class OrganizationService(
   /**
    * Returns any organizations accessible by user.
    */
+  @Transactional(readOnly = true)
   fun findPreferred(
     userAccountId: Long,
     exceptOrganizationId: Long = 0,
@@ -163,6 +164,7 @@ class OrganizationService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun findPermittedPaged(
     pageable: Pageable,
     requestParamsDto: OrganizationRequestParamsDto,
@@ -176,6 +178,7 @@ class OrganizationService(
     )
   }
 
+  @Transactional(readOnly = true)
   fun findPermittedPaged(
     pageable: Pageable,
     filterCurrentUserOwner: Boolean = false,
@@ -191,27 +194,33 @@ class OrganizationService(
     )
   }
 
+  @Transactional(readOnly = true)
   fun get(id: Long): Organization {
     return organizationRepository.find(id) ?: throw NotFoundException(Message.ORGANIZATION_NOT_FOUND)
   }
 
+  @Transactional(readOnly = true)
   fun find(id: Long): Organization? {
     return organizationRepository.find(id)
   }
 
+  @Transactional(readOnly = true)
   fun get(slug: String): Organization {
     return find(slug) ?: throw NotFoundException(Message.ORGANIZATION_NOT_FOUND)
   }
 
+  @Transactional(readOnly = true)
   fun find(slug: String): Organization? {
     return organizationRepository.findBySlug(slug)
   }
 
+  @Transactional(readOnly = true)
   @Cacheable(cacheNames = [Caches.ORGANIZATIONS], key = "{'id', #id}")
   fun findDto(id: Long): CachedOrganizationDto? {
     return find(id)?.let { CachedOrganizationDto.fromEntity(it) }
   }
 
+  @Transactional(readOnly = true)
   @Cacheable(cacheNames = [Caches.ORGANIZATIONS], key = "{'slug', #slug}")
   fun findDto(slug: String): CachedOrganizationDto? {
     return find(slug)?.let { CachedOrganizationDto.fromEntity(it) }
@@ -324,14 +333,17 @@ class OrganizationService(
    * Checks slug uniqueness
    * @return Returns true if valid
    */
+  @Transactional(readOnly = true)
   fun validateSlugUniqueness(slug: String): Boolean {
     return !organizationRepository.organizationWithSlugExists(slug)
   }
 
+  @Transactional(readOnly = true)
   fun isThereAnotherOwner(id: Long): Boolean {
     return organizationRoleService.isAnotherOwnerInOrganization(id)
   }
 
+  @Transactional(readOnly = true)
   fun generateSlug(
     name: String,
     oldSlug: String? = null,
@@ -347,6 +359,7 @@ class OrganizationService(
   /**
    * Returns all organizations which are owned only by the specified user
    */
+  @Transactional(readOnly = true)
   fun getAllSingleOwnedByUser(userAccount: UserAccount) = organizationRepository.getAllSingleOwnedByUser(userAccount)
 
   @Caching(
@@ -359,6 +372,7 @@ class OrganizationService(
     organizationRepository.save(organization)
   }
 
+  @Transactional(readOnly = true)
   fun findAllPaged(
     pageable: Pageable,
     search: String?,
@@ -367,10 +381,12 @@ class OrganizationService(
     return organizationRepository.findAllViews(pageable, search, userId)
   }
 
+  @Transactional(readOnly = true)
   fun findAllByName(name: String): List<Organization> {
     return organizationRepository.findAllByName(name)
   }
 
+  @Transactional(readOnly = true)
   fun getProjectOwner(projectId: Long): Organization {
     return organizationRepository.getProjectOwner(projectId)
   }
@@ -387,6 +403,7 @@ class OrganizationService(
     permissionService.save(basePermission)
   }
 
+  @Transactional(readOnly = true)
   fun findPrivateView(
     id: Long,
     currentUserId: Long,
@@ -397,6 +414,7 @@ class OrganizationService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun findView(
     id: Long,
     currentUserId: Long,

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
@@ -154,6 +154,7 @@ class LanguageStatsService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun getLanguageStats(
     projectId: Long,
     branchId: Long? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -112,7 +112,7 @@ class ProjectService(
   @set:Lazy
   lateinit var aiPlaygroundResultService: AiPlaygroundResultService
 
-  @Transactional
+  @Transactional(readOnly = true)
   @Cacheable(cacheNames = [Caches.PROJECTS], key = "#id")
   fun findDto(id: Long): ProjectDto? {
     return projectRepository.find(id)?.let {
@@ -120,29 +120,33 @@ class ProjectService(
     }
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   @Cacheable(cacheNames = [Caches.PROJECTS], key = "#id")
   fun getDto(id: Long): ProjectDto {
     return findDto(id) ?: throw ProjectNotFoundException(id)
   }
 
+  @Transactional(readOnly = true)
   fun get(id: Long): Project {
     return find(id) ?: throw ProjectNotFoundException(id)
   }
 
+  @Transactional(readOnly = true)
   fun find(id: Long): Project? {
     return projectRepository.find(id)
   }
 
+  @Transactional(readOnly = true)
   fun findAll(ids: Iterable<Long>): List<Project> {
     return projectRepository.findAllById(ids)
   }
 
+  @Transactional(readOnly = true)
   fun findDeleted(id: Long): Project? {
     return projectRepository.findDeleted(id)
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun getView(id: Long): ProjectWithLanguagesView {
     val perms = permissionService.getProjectPermissionData(id, authenticationFacade.authenticatedUser.id)
     val withoutPermittedLanguages =
@@ -218,6 +222,7 @@ class ProjectService(
     return project
   }
 
+  @Transactional(readOnly = true)
   fun findAllPermitted(userAccount: UserAccount): List<ProjectDTO> {
     return projectRepository
       .findAllPermitted(userAccount.id)
@@ -239,14 +244,17 @@ class ProjectService(
       }.toList()
   }
 
+  @Transactional(readOnly = true)
   fun findAllInOrganization(organizationId: Long): List<Project> {
     return this.projectRepository.findAllByOrganizationOwnerId(organizationId)
   }
 
+  @Transactional(readOnly = true)
   fun findAllWithQaEnabledInOrganization(organizationId: Long): List<Project> {
     return projectRepository.findAllByOrganizationOwnerIdAndUseQaChecksTrueAndDeletedAtIsNull(organizationId)
   }
 
+  @Transactional(readOnly = true)
   fun findAllWithQaEnabled(): List<Project> {
     return projectRepository.findAllByUseQaChecksTrueAndDeletedAtIsNull()
   }
@@ -314,10 +322,12 @@ class ProjectService(
     avatarService.setAvatar(project, avatar)
   }
 
+  @Transactional(readOnly = true)
   fun validateSlugUniqueness(slug: String): Boolean {
     return projectRepository.countAllBySlug(slug) < 1
   }
 
+  @Transactional(readOnly = true)
   fun generateSlug(
     name: String,
     oldSlug: String? = null,
@@ -330,6 +340,7 @@ class ProjectService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun findPermittedInOrganizationPaged(
     pageable: Pageable,
     search: String?,
@@ -345,6 +356,7 @@ class ProjectService(
     )
   }
 
+  @Transactional(readOnly = true)
   fun findPermittedInOrganizationPaged(
     pageable: Pageable,
     search: String?,
@@ -377,6 +389,7 @@ class ProjectService(
     return project
   }
 
+  @Transactional(readOnly = true)
   fun refresh(project: Project): Project {
     if (project.id == 0L) {
       return project
@@ -395,6 +408,7 @@ class ProjectService(
     save(project)
   }
 
+  @Transactional(readOnly = true)
   fun findAllByNameAndOrganizationOwner(
     name: String,
     organization: Organization,
@@ -402,6 +416,7 @@ class ProjectService(
     return projectRepository.findAllByNameAndOrganizationOwner(name, organization)
   }
 
+  @Transactional(readOnly = true)
   fun getProjectsWithDirectPermissions(
     id: Long,
     userIds: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
-@Transactional
+@Transactional(readOnly = true)
 @Service
 class ProjectStatsService(
   private val entityManager: EntityManager,

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
@@ -62,7 +62,7 @@ class PermissionService(
   @set:Autowired
   lateinit var projectService: ProjectService
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun findPermissionNonCached(
     projectId: Long? = null,
     userId: Long? = null,
@@ -75,19 +75,23 @@ class PermissionService(
     )
   }
 
+  @Transactional(readOnly = true)
   fun getAllOfProject(project: Project?): Set<Permission> {
     return permissionRepository.getAllByProjectAndUserNotNull(project)
   }
 
+  @Transactional(readOnly = true)
   fun findById(id: Long): Permission? {
     return cachedPermissionService.find(id)
   }
 
+  @Transactional(readOnly = true)
   fun getProjectPermissionScopesNoApiKey(
     projectId: Long,
     userAccount: UserAccount,
   ) = getProjectPermissionScopesNoApiKey(projectId, userAccount.id)
 
+  @Transactional(readOnly = true)
   fun getProjectPermissionScopesNoApiKey(
     projectId: Long,
     userAccountId: Long,
@@ -95,6 +99,7 @@ class PermissionService(
     return getProjectPermissionData(projectId, userAccountId).computedPermissions.expandedScopes
   }
 
+  @Transactional(readOnly = true)
   fun getProjectPermissionData(
     project: ProjectDto,
     userAccountId: Long,
@@ -126,6 +131,7 @@ class PermissionService(
     )
   }
 
+  @Transactional(readOnly = true)
   fun getUserProjectPermission(
     projectId: Long,
     userId: Long,
@@ -133,6 +139,7 @@ class PermissionService(
     return find(projectId, userId)
   }
 
+  @Transactional(readOnly = true)
   fun getPermittedTranslateLanguagesForUserIds(
     userIds: List<Long>,
     projectId: Long,
@@ -149,6 +156,7 @@ class PermissionService(
     return result
   }
 
+  @Transactional(readOnly = true)
   fun getPermittedTranslateLanguagesForProjectIds(
     projectIds: List<Long>,
     userId: Long,
@@ -165,6 +173,7 @@ class PermissionService(
     return result
   }
 
+  @Transactional(readOnly = true)
   fun getProjectPermissionData(
     projectId: Long,
     userAccountId: Long,
@@ -189,6 +198,7 @@ class PermissionService(
     delete(permission)
   }
 
+  @Transactional(readOnly = true)
   fun get(permissionId: Long): Permission {
     return this.cachedPermissionService.find(permissionId) ?: throw NotFoundException()
   }
@@ -216,6 +226,7 @@ class PermissionService(
     create(permission)
   }
 
+  @Transactional(readOnly = true)
   fun computeProjectPermission(
     organizationRole: OrganizationRoleType?,
     organizationBasePermission: IPermission,
@@ -262,7 +273,7 @@ class PermissionService(
     return this.save(permission)
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun find(
     projectId: Long? = null,
     userId: Long? = null,
@@ -447,6 +458,7 @@ class PermissionService(
     this.delete(permissionEntity)
   }
 
+  @Transactional(readOnly = true)
   fun getPermittedViewLanguages(
     projectId: Long,
     userId: Long,
@@ -492,6 +504,7 @@ class PermissionService(
     permissionRepository.deleteAll(permissions)
   }
 
+  @Transactional(readOnly = true)
   fun getAgencyPermissions(agencyId: Long): List<Permission> {
     return permissionRepository.findAllByAgencyId(agencyId)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -80,7 +80,7 @@ class TranslationService(
   @set:Lazy
   lateinit var projectService: ProjectService
 
-  @Transactional
+  @Transactional(readOnly = true)
   @Suppress("UNCHECKED_CAST")
   fun getTranslations(
     languageTags: Set<String>,
@@ -105,6 +105,7 @@ class TranslationService(
     return langTranslations
   }
 
+  @Transactional(readOnly = true)
   fun getAllByLanguageId(
     languageId: Long,
     branch: String? = null,
@@ -112,6 +113,7 @@ class TranslationService(
     return translationRepository.getAllByLanguageId(languageId, branch)
   }
 
+  @Transactional(readOnly = true)
   fun getKeyTranslations(
     languages: Set<ILanguage>,
     project: Project,
@@ -161,6 +163,7 @@ class TranslationService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun find(
     key: Key,
     language: ILanguage,
@@ -168,14 +171,17 @@ class TranslationService(
     return translationRepository.findOneByKeyAndLanguageId(key, language.id)
   }
 
+  @Transactional(readOnly = true)
   fun get(id: Long): Translation {
     return this.find(id) ?: throw NotFoundException(Message.TRANSLATION_NOT_FOUND)
   }
 
+  @Transactional(readOnly = true)
   fun find(id: Long): Translation? {
     return this.translationRepository.findById(id).orElse(null)
   }
 
+  @Transactional(readOnly = true)
   fun find(
     projectId: Long,
     translationId: Long,
@@ -183,6 +189,7 @@ class TranslationService(
     return this.translationRepository.find(projectId, translationId)
   }
 
+  @Transactional(readOnly = true)
   fun get(
     projectId: Long,
     translationId: Long,
@@ -268,6 +275,7 @@ class TranslationService(
     return translationRepository.save(translation)
   }
 
+  @Transactional(readOnly = true)
   fun findForKeyByLanguages(
     key: Key,
     languageTags: Collection<String>,
@@ -401,6 +409,7 @@ class TranslationService(
     translationRepository.setOutdated(keyIds)
   }
 
+  @Transactional(readOnly = true)
   fun get(keyLanguagesMap: Map<Key, List<LanguageDto>>): List<Translation> {
     val cb = entityManager.criteriaBuilder
     val query = cb.createQuery(Translation::class.java)
@@ -420,6 +429,7 @@ class TranslationService(
     return entityManager.createQuery(query).resultList
   }
 
+  @Transactional(readOnly = true)
   fun getForKeys(
     keyIds: List<Long>,
     languageTags: List<String>,
@@ -462,11 +472,13 @@ class TranslationService(
     saveAll(translations)
   }
 
+  @Transactional(readOnly = true)
   fun getTranslations(
     keyIds: List<Long>,
     languageIds: List<Long>,
   ) = translationRepository.getAllByKeyIdInAndLanguageIdIn(keyIds, languageIds)
 
+  @Transactional(readOnly = true)
   fun getAllByKeyId(keyId: Long): List<Translation> = translationRepository.getAllByKeyIdIn(listOf(keyId)).toList()
 
   fun clearBatch(
@@ -588,7 +600,7 @@ class TranslationService(
     }
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   fun getTranslationsWithLabels(
     keyIds: List<Long>,
     languageIds: List<Long>,
@@ -597,6 +609,7 @@ class TranslationService(
       .getTranslationsWithLabels(keyIds, languageIds)
   }
 
+  @Transactional(readOnly = true)
   fun getTranslationIdsByKeyIds(
     keyIds: List<Long>,
     languageIds: List<Long>? = null,
@@ -623,6 +636,7 @@ class TranslationService(
     }
   }
 
+  @Transactional(readOnly = true)
   fun getNotStaleTranslationIds(
     projectId: Long,
     languageIds: List<Long>? = null,
@@ -685,6 +699,7 @@ class TranslationService(
     translationRepository.setQaChecksStaleByProjectIdAndLanguageIds(projectId, languageIds)
   }
 
+  @Transactional(readOnly = true)
   fun getKeyLanguagePairsForQaRecheck(
     projectId: Long,
     languageIds: List<Long>? = null,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
@@ -304,7 +304,7 @@ class PromptVariablesHelper(
     return relatedKeys
   }
 
-  @Transactional(readOnly = true)
+  @Transactional
   fun getVariables(
     projectId: Long,
     keyId: Long?,


### PR DESCRIPTION
Mark getter/find methods in Activity, Organization, Project, ProjectStats, Permission, LanguageStats, and Translation services as @Transactional(readOnly = true) to enable Hibernate read-only optimizations (no dirty-checking, read-replica routing).

Also drops readOnly=true from PromptVariablesHelper.getVariables, which transitively runs `SET local pg_trgm.similarity_threshold` via TranslationMemoryService.getSuggestionsList — PostgreSQL disallows SET in a read-only transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend performance through targeted optimizations to transaction handling and database operations across core services including activity tracking, organization management, project operations, and security permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->