### PR TITLE
feat: deprecate embedded postgres ahead of v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
           docker buildx create --use
           ./gradlew dockerPublish
           VERSION=latest ./gradlew dockerPublish
+          DOCKER_CACHE_FROM=type=registry,ref=tolgee/tolgee:slim ./gradlew dockerPublishSlim
+          VERSION=latest DOCKER_CACHE_FROM=type=registry,ref=tolgee/tolgee:slim ./gradlew dockerPublishSlim
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,6 @@ jobs:
           docker buildx create --use
           ./gradlew dockerPublish
           VERSION=latest ./gradlew dockerPublish
-          ./gradlew dockerPublishSlim
-          VERSION=latest ./gradlew dockerPublishSlim
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
           docker buildx create --use
           ./gradlew dockerPublish
           VERSION=latest ./gradlew dockerPublish
-          DOCKER_CACHE_FROM=type=registry,ref=tolgee/tolgee:slim ./gradlew dockerPublishSlim
-          VERSION=latest DOCKER_CACHE_FROM=type=registry,ref=tolgee/tolgee:slim ./gradlew dockerPublishSlim
+          ./gradlew dockerPublishSlim
+          VERSION=latest ./gradlew dockerPublishSlim
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -504,7 +504,7 @@ jobs:
       contents: read
     services:
       postgres:
-        image: postgres:13
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
@@ -531,9 +531,6 @@ jobs:
         env:
           SKIP_SERVER_BUILD: true
 
-      # The slim image bundles no postgres server — must connect to the service
-      # container above. `--network host` puts the app on the runner's network
-      # so localhost:5432 resolves to the mapped postgres port.
       - name: Start slim image
         run: |
           docker run -d --name tolgee-slim --network host \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -500,6 +500,8 @@ jobs:
     name: Slim Docker smoke 🐳
     needs: [backend-build]
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     services:
       postgres:
         image: postgres:13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -496,6 +496,69 @@ jobs:
         run: npm run eslint
         working-directory: ./email
 
+  docker-slim-smoke:
+    name: Slim Docker smoke 🐳
+    needs: [backend-build]
+    runs-on: ubuntu-24.04
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          node: "false"
+
+      - name: Download backend build result
+        uses: ./.github/actions/download-backend-build
+
+      - name: Build slim Docker image
+        run: ./gradlew dockerSlim
+        env:
+          SKIP_SERVER_BUILD: true
+
+      # The slim image bundles no postgres server — must connect to the service
+      # container above. `--network host` puts the app on the runner's network
+      # so localhost:5432 resolves to the mapped postgres port.
+      - name: Start slim image
+        run: |
+          docker run -d --name tolgee-slim --network host \
+            -e SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/postgres \
+            -e SPRING_DATASOURCE_USERNAME=postgres \
+            -e SPRING_DATASOURCE_PASSWORD=postgres \
+            tolgee/tolgee:slim
+
+      - name: Wait for app to report healthy
+        run: |
+          for i in $(seq 1 90); do
+            status=$(curl -fsS http://localhost:8080/actuator/health 2>/dev/null \
+              | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+            if [ "$status" = "UP" ]; then
+              echo "Slim image healthy after $((i * 2))s"
+              exit 0
+            fi
+            echo "[$i] status=${status:-<unreachable>}; retrying in 2s"
+            sleep 2
+          done
+          echo "❌ Slim image did not report UP within 180s"
+          exit 1
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs tolgee-slim || true
+
   everything-passed:
     name: Everything passed 🎉
     needs:
@@ -508,6 +571,7 @@ jobs:
       - schema-check
       - migration-check
       - data-cy-check
+      - docker-slim-smoke
       - e2e
       - e2e-code-checks
       - e2e-install-deps
@@ -548,6 +612,10 @@ jobs:
 
           if [[ "${{ needs.data-cy-check.result }}" != "success" ]]; then
             failed_jobs+=("data-cy-check")
+          fi
+
+          if [[ "${{ needs.docker-slim-smoke.result }}" != "success" ]]; then
+            failed_jobs+=("docker-slim-smoke")
           fi
 
           if [[ "${{ needs.e2e.result }}" != "success" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -544,7 +544,7 @@ jobs:
         run: |
           for i in $(seq 1 90); do
             status=$(curl -fsS http://localhost:8080/actuator/health 2>/dev/null \
-              | sed -n 's/.*"status":"\([^"]*\)".*/\1/p')
+              | jq -r '.status // empty')
             if [ "$status" = "UP" ]; then
               echo "Slim image healthy after $((i * 2))s"
               exit 0

--- a/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
@@ -21,7 +21,7 @@ class EmbeddedPostgresDeprecationCommandLineRunner(
       "The embedded PostgreSQL bundled in the tolgee/tolgee image is deprecated and will be removed in Tolgee v4. " +
         "Migrate to an external database before upgrading. " +
         "See https://docs.tolgee.io/platform/self_hosting/running_with_docker" +
-        "#running-with-docker-compose-with-external-postgresql-database",
+        "#migrate-from-the-bundled-database",
     )
   }
 }

--- a/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
@@ -18,8 +18,8 @@ class EmbeddedPostgresDeprecationCommandLineRunner(
     }
 
     logger.warn(
-      "The embedded PostgreSQL bundled in the tolgee/tolgee image is deprecated and will be removed in a future " +
-        "major version. Migrate to an external database and use the slim tolgee/tolgee image. " +
+      "The embedded PostgreSQL bundled in the tolgee/tolgee image is deprecated and will be removed in Tolgee v4. " +
+        "Migrate to an external database before upgrading. " +
         "See https://docs.tolgee.io/platform/self_hosting/running_with_docker" +
         "#running-with-docker-compose-with-external-postgresql-database",
     )

--- a/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/EmbeddedPostgresDeprecationCommandLineRunner.kt
@@ -1,0 +1,27 @@
+package io.tolgee.commandLineRunners
+
+import io.tolgee.configuration.tolgee.PostgresAutostartProperties
+import io.tolgee.configuration.tolgee.PostgresAutostartProperties.PostgresAutostartMode
+import org.slf4j.LoggerFactory
+import org.springframework.boot.CommandLineRunner
+import org.springframework.stereotype.Component
+
+@Component
+class EmbeddedPostgresDeprecationCommandLineRunner(
+  private val postgresAutostartProperties: PostgresAutostartProperties,
+) : CommandLineRunner {
+  private val logger = LoggerFactory.getLogger(this::class.java)
+
+  override fun run(vararg args: String) {
+    if (!postgresAutostartProperties.enabled || postgresAutostartProperties.mode != PostgresAutostartMode.EMBEDDED) {
+      return
+    }
+
+    logger.warn(
+      "The embedded PostgreSQL bundled in the tolgee/tolgee image is deprecated and will be removed in a future " +
+        "major version. Migrate to an external database and use the slim tolgee/tolgee image. " +
+        "See https://docs.tolgee.io/platform/self_hosting/running_with_docker" +
+        "#running-with-docker-compose-with-external-postgresql-database",
+    )
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/PostgresAutostartProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/PostgresAutostartProperties.kt
@@ -26,8 +26,8 @@ class PostgresAutostartProperties {
         "`EMBEDDED` is deprecated. Tolgee v4 removes the bundled PostgreSQL from the " +
         "`tolgee/tolgee` image, so setups using it have to move to an external database " +
         "before upgrading. See " +
-        "[Running with Docker](/self_hosting/running_with_docker" +
-        "#running-with-docker-compose-with-external-postgresql-database).",
+        "[Migrate from the bundled database](/self_hosting/running_with_docker" +
+        "#migrate-from-the-bundled-database).",
   )
   var mode: PostgresAutostartMode = PostgresAutostartMode.DOCKER
 

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/PostgresAutostartProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/PostgresAutostartProperties.kt
@@ -21,7 +21,13 @@ class PostgresAutostartProperties {
         "This is default option when running Tolgee using Java. " +
         "See [Running with Java](/self_hosting/running_with_java.mdx).\n" +
         "- `EMBEDDED` - Tolgee tries to run it's embedded PostgreSQL " +
-        "which is bundled in the `tolgee/tolgee` Docker image.",
+        "which is bundled in the `tolgee/tolgee` Docker image.\n" +
+        "\n" +
+        "`EMBEDDED` is deprecated. Tolgee v4 removes the bundled PostgreSQL from the " +
+        "`tolgee/tolgee` image, so setups using it have to move to an external database " +
+        "before upgrading. See " +
+        "[Running with Docker](/self_hosting/running_with_docker" +
+        "#running-with-docker-compose-with-external-postgresql-database).",
   )
   var mode: PostgresAutostartMode = PostgresAutostartMode.DOCKER
 

--- a/docker/app/Dockerfile.slim
+++ b/docker/app/Dockerfile.slim
@@ -1,0 +1,47 @@
+FROM eclipse-temurin:21-jre-alpine
+
+RUN apk --no-cache add bash
+
+#############
+### Tolgee  #
+#############
+
+# Expose application port
+EXPOSE 8080
+
+# Define persistent volume for data storage
+VOLUME /data
+
+# Environment variables for configuration
+# Postgres autostart is disabled — the slim image doesn't bundle the postgres
+# server, so it must be run against an external database.
+ENV HEALTHCHECK_PORT=8080 \
+    spring_profiles_active=docker \
+    TOLGEE_POSTGRES_AUTOSTART_ENABLED=false
+
+# Copy necessary application files
+COPY BOOT-INF/lib /app/lib
+COPY META-INF /app/META-INF
+COPY BOOT-INF/classes /app
+COPY --chmod=755 cmd.sh /app
+
+# Download OpenTelemetry Java agent for distributed tracing
+# When OTEL_JAVAAGENT_ENABLED=true, cmd.sh will use this agent
+# See: docs/observability/
+# Version is passed from gradle.properties via --build-arg (see gradle/docker.gradle)
+ARG OTEL_AGENT_VERSION
+RUN test -n "$OTEL_AGENT_VERSION" || (echo "OTEL_AGENT_VERSION build arg is required" && exit 1)
+RUN wget -O /app/opentelemetry-javaagent.jar \
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_AGENT_VERSION}/opentelemetry-javaagent.jar"
+
+#################
+### Let's go   ##
+#################
+
+# Define the startup command
+ENTRYPOINT ["/app/cmd.sh"]
+
+
+# Health check to ensure the app is up and running
+HEALTHCHECK --interval=10s --timeout=3s --retries=20 \
+    CMD wget --spider -q "http://127.0.0.1:$HEALTHCHECK_PORT/actuator/health" || exit 1

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -33,6 +33,23 @@ tasks.register('docker') {
     dependsOn("dockerPrepare")
 }
 
+// Builds the slim Docker image for local development.
+// Single platform, no push, tagged as tolgee/tolgee:slim.
+// Uses Dockerfile.slim — JRE-only base, no embedded postgres.
+tasks.register('dockerSlim') {
+    doLast {
+        exec {
+            workingDir dockerPath
+            commandLine "docker", "build", ".",
+                "-f", "Dockerfile.slim",
+                "-t", "tolgee/tolgee:slim",
+                "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
+                "--cache-from", "type=registry,ref=tolgee/tolgee:slim"
+        }
+    }
+    dependsOn("dockerPrepare")
+}
+
 // Builds and pushes multi-platform Docker image for CI.
 // Reads configuration from environment variables:
 //   - VERSION: image tag version (default: 'latest')
@@ -49,6 +66,42 @@ task dockerPublish {
         def cacheTo = System.getenv('DOCKER_CACHE_TO')
 
         def commandParams = ["docker", "buildx", "build", ".",
+            "-t", tag,
+            "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
+            "--platform", "linux/arm64,linux/amd64",
+            "--push"]
+
+        if (cacheFrom) {
+            commandParams += ["--cache-from", cacheFrom]
+        }
+        if (cacheTo) {
+            commandParams += ["--cache-to", cacheTo]
+        }
+
+        exec {
+            workingDir dockerPath
+            commandLine commandParams
+        }
+    }
+    dependsOn("dockerPrepare")
+}
+
+// Builds and pushes the multi-platform slim Docker image for CI.
+// Uses Dockerfile.slim — JRE-only base, no embedded postgres.
+// Tag mapping:
+//   - VERSION=latest   -> tolgee/tolgee:slim         (floating slim tag)
+//   - VERSION=vX.Y.Z   -> tolgee/tolgee:vX.Y.Z-slim  (versioned slim tag)
+// Other env vars match dockerPublish (DOCKER_IMAGE, DOCKER_CACHE_FROM, DOCKER_CACHE_TO).
+task dockerPublishSlim {
+    doLast {
+        def version = System.getenv('VERSION') ?: 'latest'
+        def imageName = System.getenv('DOCKER_IMAGE') ?: 'tolgee/tolgee'
+        def tag = version == 'latest' ? "${imageName}:slim" : "${imageName}:${version}-slim"
+        def cacheFrom = System.getenv('DOCKER_CACHE_FROM')
+        def cacheTo = System.getenv('DOCKER_CACHE_TO')
+
+        def commandParams = ["docker", "buildx", "build", ".",
+            "-f", "Dockerfile.slim",
             "-t", tag,
             "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
             "--platform", "linux/arm64,linux/amd64",

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -33,9 +33,10 @@ tasks.register('docker') {
     dependsOn("dockerPrepare")
 }
 
-// Builds the slim Docker image for local development.
-// Single platform, no push, tagged as tolgee/tolgee:slim.
-// Uses Dockerfile.slim — JRE-only base, no embedded postgres.
+// Builds the slim Docker image, tagged as tolgee/tolgee:slim.
+// Uses Dockerfile.slim - JRE-only base, no embedded postgres.
+// The slim image is not published; it is built on demand by the EE image
+// build in the billing repo and by the slim smoke test.
 tasks.register('dockerSlim') {
     doLast {
         exec {
@@ -43,8 +44,7 @@ tasks.register('dockerSlim') {
             commandLine "docker", "build", ".",
                 "-f", "Dockerfile.slim",
                 "-t", "tolgee/tolgee:slim",
-                "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
-                "--cache-from", "type=registry,ref=tolgee/tolgee:slim"
+                "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}"
         }
     }
     dependsOn("dockerPrepare")
@@ -66,42 +66,6 @@ task dockerPublish {
         def cacheTo = System.getenv('DOCKER_CACHE_TO')
 
         def commandParams = ["docker", "buildx", "build", ".",
-            "-t", tag,
-            "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
-            "--platform", "linux/arm64,linux/amd64",
-            "--push"]
-
-        if (cacheFrom) {
-            commandParams += ["--cache-from", cacheFrom]
-        }
-        if (cacheTo) {
-            commandParams += ["--cache-to", cacheTo]
-        }
-
-        exec {
-            workingDir dockerPath
-            commandLine commandParams
-        }
-    }
-    dependsOn("dockerPrepare")
-}
-
-// Builds and pushes the multi-platform slim Docker image for CI.
-// Uses Dockerfile.slim — JRE-only base, no embedded postgres.
-// Tag mapping:
-//   - VERSION=latest   -> tolgee/tolgee:slim         (floating slim tag)
-//   - VERSION=vX.Y.Z   -> tolgee/tolgee:vX.Y.Z-slim  (versioned slim tag)
-// Other env vars match dockerPublish (DOCKER_IMAGE, DOCKER_CACHE_FROM, DOCKER_CACHE_TO).
-task dockerPublishSlim {
-    doLast {
-        def version = System.getenv('VERSION') ?: 'latest'
-        def imageName = System.getenv('DOCKER_IMAGE') ?: 'tolgee/tolgee'
-        def tag = version == 'latest' ? "${imageName}:slim" : "${imageName}:${version}-slim"
-        def cacheFrom = System.getenv('DOCKER_CACHE_FROM')
-        def cacheTo = System.getenv('DOCKER_CACHE_TO')
-
-        def commandParams = ["docker", "buildx", "build", ".",
-            "-f", "Dockerfile.slim",
             "-t", tag,
             "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
             "--platform", "linux/arm64,linux/amd64",


### PR DESCRIPTION
## What

Two changes, both preparing for v4 dropping the bundled postgres from `tolgee/tolgee`:

1. **Deprecation warning** — the app logs a `WARN` on startup when it's actually running the bundled postgres, pointing at the external-database docs.
2. **Internal slim image** — `Dockerfile.slim` + the `dockerSlim` Gradle task. Not published. Built on demand by the EE image build and by the smoke test.

## Why

In v4, `tolgee/tolgee` loses the embedded postgres. Self-hosters running the bundled database have to move to an external one before upgrading.

They can already do that today on the current image by setting `postgres-autostart.enabled=false` (this is what the external-database docs section has always described). So the warning gives them a full release cycle of notice, on every boot, for a migration that needs nothing new from us.

The slim image is deliberately **not** published: a public `:slim` tag would only advertise a name that goes obsolete the moment v4 makes it the default, and it buys users nothing they can't already do. It exists so the internal EE image can drop the postgres layers now.

## Notes for review

- No behavior change for existing users beyond the log line. The default `Dockerfile` and the `tolgee/tolgee` tag are untouched.
- The warning is guarded on `enabled=true` **and** `mode=EMBEDDED`, so it stays silent for external-database setups and for Java + `DOCKER` autostart (that mode isn't going away).
- `docker-slim-smoke` boots the slim image against a postgres service and waits for `/actuator/health`.
- Docs: tolgee/documentation#1121 · EE image switch: tolgee/billing#274
- Revives #3193 (stale). Thanks @transparentChange for the original work.
