### PR TITLE
fix: handle TYPE_CUSTOM images in screenshot upload

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/util/ImageConverter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/ImageConverter.kt
@@ -46,7 +46,7 @@ class ImageConverter(
   }
 
   private fun getScaledImage(targetDimension: Dimension): BufferedImage {
-    val resized = BufferedImage(targetDimension.width, targetDimension.height, safeImageType)
+    val resized = BufferedImage(targetDimension.width, targetDimension.height, getSafeImageType())
     val g = resized.createGraphics()
     g.setRenderingHint(
       RenderingHints.KEY_INTERPOLATION,
@@ -68,13 +68,15 @@ class ImageConverter(
     return resized
   }
 
-  private val safeImageType: Int
-    get() =
-      if (sourceBufferedImage.type == BufferedImage.TYPE_CUSTOM) {
-        if (sourceBufferedImage.colorModel.hasAlpha()) BufferedImage.TYPE_INT_ARGB else BufferedImage.TYPE_INT_RGB
-      } else {
-        sourceBufferedImage.type
-      }
+  private fun getSafeImageType(): Int {
+    if (sourceBufferedImage.type != BufferedImage.TYPE_CUSTOM) {
+      return sourceBufferedImage.type
+    }
+    if (sourceBufferedImage.colorModel.hasAlpha()) {
+      return BufferedImage.TYPE_INT_ARGB
+    }
+    return BufferedImage.TYPE_INT_RGB
+  }
 
   val targetDimension: Dimension by lazy {
     val imagePxs = sourceBufferedImage.height * sourceBufferedImage.width

--- a/backend/data/src/main/kotlin/io/tolgee/util/ImageConverter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/ImageConverter.kt
@@ -46,7 +46,7 @@ class ImageConverter(
   }
 
   private fun getScaledImage(targetDimension: Dimension): BufferedImage {
-    val resized = BufferedImage(targetDimension.width, targetDimension.height, sourceBufferedImage.type)
+    val resized = BufferedImage(targetDimension.width, targetDimension.height, safeImageType)
     val g = resized.createGraphics()
     g.setRenderingHint(
       RenderingHints.KEY_INTERPOLATION,
@@ -67,6 +67,14 @@ class ImageConverter(
     g.dispose()
     return resized
   }
+
+  private val safeImageType: Int
+    get() =
+      if (sourceBufferedImage.type == BufferedImage.TYPE_CUSTOM) {
+        if (sourceBufferedImage.colorModel.hasAlpha()) BufferedImage.TYPE_INT_ARGB else BufferedImage.TYPE_INT_RGB
+      } else {
+        sourceBufferedImage.type
+      }
 
   val targetDimension: Dimension by lazy {
     val imagePxs = sourceBufferedImage.height * sourceBufferedImage.width


### PR DESCRIPTION
## Summary
- `ImageIO.read` returns `BufferedImage.TYPE_CUSTOM` (0) for images with non-standard color models (16-bit PNG, CMYK, unusual palettes, etc.). Passing that type to `BufferedImage(w, h, type)` in `ImageConverter.getScaledImage` throws `IllegalArgumentException: Unknown image type 0`, failing the screenshot upload.
- Fix: fall back to `TYPE_INT_ARGB` / `TYPE_INT_RGB` (based on whether the source has an alpha channel) when the source is `TYPE_CUSTOM`; `Graphics2D.drawImage` handles the pixel conversion.

## Test plan
- [ ] Upload a 16-bit PNG as a key screenshot against current `main` — confirm it throws `IllegalArgumentException: Unknown image type 0`.
- [ ] Upload the same image with this branch applied — confirm the screenshot is stored and served correctly.
- [ ] Regression check: upload a regular RGB PNG and a PNG with transparency — confirm both still work and alpha is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image resizing to more reliably preserve quality and format compatibility during scaling.
  * Better handling of images with transparency so scaled outputs keep correct transparency and color fidelity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->