### PR TITLE
fix: hide QA checks filter when QA checks are disabled for the project

### DIFF
--- a/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
@@ -16,7 +16,7 @@ import { SubfilterComments } from './SubfilterComments';
 import { SubfilterLabels } from 'tg.views/projects/translations/TranslationFilters/SubfilterLabels';
 import { SubfilterSuggestions } from './SubfilterSuggestions';
 import { SubfilterDeletedBy } from './SubfilterDeletedBy';
-import { SubfilterQaChecks } from 'tg.ee';
+import { getQaChecksFiltersLength, SubfilterQaChecks } from 'tg.ee';
 
 type Props = {
   value: FiltersType;
@@ -86,11 +86,14 @@ export const TranslationFiltersPopup = ({
               actions={actions}
               projectId={projectId}
             />
-            <SubfilterQaChecks
-              value={value}
-              actions={actions}
-              projectId={projectId}
-            />
+            {(project.useQaChecks ||
+              Boolean(getQaChecksFiltersLength(value))) && (
+              <SubfilterQaChecks
+                value={value}
+                actions={actions}
+                projectId={projectId}
+              />
+            )}
           </>
         )}
         {project.suggestionsMode !== 'DISABLED' && (


### PR DESCRIPTION
## Summary

- In the translations view filter popup, the QA checks subfilter was rendered unconditionally, so users saw QA filter options even when QA checks were disabled on the project.
- Wrap `<SubfilterQaChecks>` in a `project.useQaChecks` conditional (with a fallback for stale filter values, matching the existing `SubfilterNamespaces` pattern in the same file) so it's hidden when QA is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QA Checks filter now displays only when relevant to your project or when existing filters are active, providing a cleaner and more intuitive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->