### PR TITLE
fix: allow paired void-element tags like <br></br> in HTML QA check

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
@@ -33,16 +33,12 @@ class HtmlSyntaxCheck : QaCheck {
         HtmlTagKind.SELF_CLOSING -> { /* always valid */ }
 
         HtmlTagKind.OPEN -> {
-          if (tag.name in VOID_ELEMENTS) {
-            // Void elements like <br> don't need closing tags
-          } else {
-            openTags.getOrPut(tag.name) { mutableListOf() }.add(tag)
-          }
+          openTags.getOrPut(tag.name) { mutableListOf() }.add(tag)
         }
 
         HtmlTagKind.CLOSE -> {
           val stack = openTags[tag.name]
-          if (stack != null && stack.isNotEmpty()) {
+          if (!stack.isNullOrEmpty()) {
             stack.removeAt(stack.lastIndex)
             if (stack.isEmpty()) {
               openTags.remove(tag.name)
@@ -64,8 +60,10 @@ class HtmlSyntaxCheck : QaCheck {
       }
     }
 
-    // Remaining open tags are unclosed
-    for ((_, stack) in openTags) {
+    // Remaining open tags are unclosed — except void elements, for which a leftover
+    // opener is tolerated (see VOID_ELEMENTS doc).
+    for ((name, stack) in openTags) {
+      if (name in VOID_ELEMENTS) continue
       for (openTag in stack) {
         results.add(
           QaCheckResult(
@@ -84,6 +82,14 @@ class HtmlSyntaxCheck : QaCheck {
   }
 
   companion object {
+    /**
+     * HTML void-element names. In this check they mark tag names for which a leftover
+     * opener is tolerated (ignored rather than reported as unclosed). Tolgee component
+     * interpolation could use these names as placeholders and could write them as
+     * `<br></br>`, so we cannot assume having both opener and closer is a mistake,
+     * but at the same time we cannot report bare `<br>` as unclosed.
+     * Closing tags for void elements still participate normally in stack matching.
+     */
     val VOID_ELEMENTS =
       setOf(
         "area",

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
@@ -63,7 +63,7 @@ class HtmlSyntaxCheck : QaCheck {
     // Remaining open tags are unclosed — except void elements, for which a leftover
     // opener is tolerated (see VOID_ELEMENTS doc).
     for ((name, stack) in openTags) {
-      if (name in VOID_ELEMENTS) continue
+      if (name.lowercase() in VOID_ELEMENTS) continue
       for (openTag in stack) {
         results.add(
           QaCheckResult(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
@@ -157,9 +157,14 @@ class HtmlSyntaxCheckTest {
   }
 
   @Test
-  fun `void element name is case-insensitive`() {
-    // HTML tag names are case-insensitive per spec; leftover uppercase/mixed-case
-    // void openers are tolerated just like lowercase ones.
+  fun `void element detection is case-insensitive`() {
+    // HtmlSyntaxCheck matches opener/closer names case-sensitively (so `<B></b>`
+    // would still be flagged as mismatched). This test verifies only one specific
+    // behavior: the void-element *tolerance* — i.e. whether a leftover opener is
+    // ignored rather than reported as unclosed — is case-insensitive. Examples:
+    // `<BR>` alone → tolerated (no issue), `<Br></Br>` → case-sensitive matching
+    // pops the opener, `<IMG ...>` → tolerated. See HtmlSyntaxCheck where the
+    // leftover-pass uses `name.lowercase() in VOID_ELEMENTS`.
     check.check(params("<BR>")).assertNoIssues()
     check.check(params("<Br></Br>")).assertNoIssues()
     check.check(params("<IMG src=\"x\">")).assertNoIssues()

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
@@ -118,8 +118,58 @@ class HtmlSyntaxCheckTest {
   }
 
   @Test
-  fun `void element with closing tag - closing is orphaned`() {
-    check.check(params("<br></br>")).assertSingleIssue {
+  fun `void element with matching closing tag - no issue`() {
+    check.check(params("<br></br>")).assertNoIssues()
+  }
+
+  @Test
+  fun `multiple void element pairs - no issue`() {
+    check.check(params("<br></br>More text<hr></hr>")).assertNoIssues()
+  }
+
+  @Test
+  fun `void open inside real wrapper - no issue`() {
+    check.check(params("<b><br></b>")).assertNoIssues()
+  }
+
+  @Test
+  fun `void wrapping real content - no issue`() {
+    check.check(params("<br><b>text</b></br>")).assertNoIssues()
+  }
+
+  @Test
+  fun `void open with attributes and matching close - no issue`() {
+    check.check(params("""<img src="photo.jpg"></img>""")).assertNoIssues()
+  }
+
+  @Test
+  fun `extra unmatched void open is tolerated`() {
+    // Consistent with a bare `<br>` being accepted.
+    check.check(params("<br><br></br>")).assertNoIssues()
+  }
+
+  @Test
+  fun `interleaved distinct void names - no issue`() {
+    // Regression guard: the stack must be keyed per-name so two different void names
+    // can be open and close simultaneously.
+    check.check(params("<br><hr></br></hr>")).assertNoIssues()
+    check.check(params("<br><hr></hr></br>")).assertNoIssues()
+  }
+
+  @Test
+  fun `void leftover does not mask unclosed non-void`() {
+    // Leftover void opener is tolerated, but a genuinely unclosed real tag still errors.
+    check.check(params("<br><b>text</br>")).assertSingleIssue {
+      message(QaIssueMessage.QA_HTML_UNCLOSED_TAG)
+      param("tag", "<b>")
+    }
+  }
+
+  @Test
+  fun `stray closing void tag is flagged`() {
+    // Asymmetric leniency: a close tag with no opener is meaningless
+    // even for Tolgee component interpolation, so it still errors.
+    check.check(params("</br>")).assertSingleIssue {
       message(QaIssueMessage.QA_HTML_UNOPENED_TAG)
       param("tag", "</br>")
     }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
@@ -157,6 +157,15 @@ class HtmlSyntaxCheckTest {
   }
 
   @Test
+  fun `void element name is case-insensitive`() {
+    // HTML tag names are case-insensitive per spec; leftover uppercase/mixed-case
+    // void openers are tolerated just like lowercase ones.
+    check.check(params("<BR>")).assertNoIssues()
+    check.check(params("<Br></Br>")).assertNoIssues()
+    check.check(params("<IMG src=\"x\">")).assertNoIssues()
+  }
+
+  @Test
   fun `void leftover does not mask unclosed non-void`() {
     // Leftover void opener is tolerated, but a genuinely unclosed real tag still errors.
     check.check(params("<br><b>text</br>")).assertSingleIssue {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheckTest.kt
@@ -158,13 +158,8 @@ class HtmlSyntaxCheckTest {
 
   @Test
   fun `void element detection is case-insensitive`() {
-    // HtmlSyntaxCheck matches opener/closer names case-sensitively (so `<B></b>`
-    // would still be flagged as mismatched). This test verifies only one specific
-    // behavior: the void-element *tolerance* — i.e. whether a leftover opener is
-    // ignored rather than reported as unclosed — is case-insensitive. Examples:
-    // `<BR>` alone → tolerated (no issue), `<Br></Br>` → case-sensitive matching
-    // pops the opener, `<IMG ...>` → tolerated. See HtmlSyntaxCheck where the
-    // leftover-pass uses `name.lowercase() in VOID_ELEMENTS`.
+    // In HtmlSyntaxCheck, void-element detection is case-insensitive.
+    // Leftover uppercase/mixed-case void openers are tolerated like lowercase ones.
     check.check(params("<BR>")).assertNoIssues()
     check.check(params("<Br></Br>")).assertNoIssues()
     check.check(params("<IMG src=\"x\">")).assertNoIssues()


### PR DESCRIPTION
## Summary

- `HtmlSyntaxCheck` flagged `<br></br>` as an unopened `</br>` because void-element opens were silently skipped instead of pushed to the per-name stack. Tolgee component interpolation uses names like `br`, `hr`, `img` as placeholder tag names (not real HTML) and could write them as `<br></br>`, producing false positives.
- Void-element OPEN tags are now pushed to the stack like any other tag, so a matching CLOSE can pop them. Leftover void openers are tolerated at the end rather than reported. Stray `</br>` with no opener is still flagged.
- `InconsistentHtmlCheck` is intentionally left unchanged: `<br/>` (childless) and `<br></br>` (paired, wraps children) are semantically different in Tolgee component interpolation, so mismatches between base and translation are real, not false positives.
- Added 9 tests covering the fix and regression guards (multiple void pairs, void inside/wrapping real tags, void with attributes, interleaved distinct void names, void leftover not masking a genuinely unclosed non-void tag, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * HTML syntax validation now tolerates void elements (e.g., <br>, <hr>) so they no longer produce false "unopened/unclosed" errors while still reporting real unclosed non-void tags and stray closing void tags.
* **Tests**
  * Expanded coverage for void-element cases, nesting, case-insensitivity, and edge scenarios.
* **Documentation**
  * Clarified internal docs on void-element handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->