### PR TITLE
fix: do not show QaBadge when QA checks are disabled for the project

### DIFF
--- a/e2e/cypress/e2e/qa/badges.cy.ts
+++ b/e2e/cypress/e2e/qa/badges.cy.ts
@@ -3,7 +3,7 @@ import {
   qaTestData,
 } from '../../common/apiCalls/testData/testData';
 import { login } from '../../common/apiCalls/common';
-import { gcy } from '../../common/shared';
+import { gcy, gcyAdvanced } from '../../common/shared';
 import { E2TranslationsView } from '../../compounds/E2TranslationsView';
 import { editTranslation } from '../../common/translations';
 
@@ -76,8 +76,11 @@ describe('QA cell badges', () => {
       newValue: 'Edited',
     });
 
-    cy.contains('disabled_key')
-      .closestDcy('translations-row')
+    gcyAdvanced({
+      value: 'translations-table-cell',
+      key: 'disabled_key',
+      language: 'fr',
+    })
       .findDcy('translations-cell-qa-issues-button')
       .should('not.exist');
   });

--- a/e2e/cypress/e2e/qa/badges.cy.ts
+++ b/e2e/cypress/e2e/qa/badges.cy.ts
@@ -5,9 +5,11 @@ import {
 import { login } from '../../common/apiCalls/common';
 import { gcy } from '../../common/shared';
 import { E2TranslationsView } from '../../compounds/E2TranslationsView';
+import { editTranslation } from '../../common/translations';
 
 describe('QA cell badges', () => {
   let projectId: number;
+  let disabledProjectId: number;
 
   let view: E2TranslationsView;
 
@@ -15,6 +17,10 @@ describe('QA cell badges', () => {
     qaTestData.clean();
     qaTestData.generateStandard().then((res) => {
       projectId = getProjectByNameFromTestData(res.body, 'test_project')!.id;
+      disabledProjectId = getProjectByNameFromTestData(
+        res.body,
+        'Disabled QA Project'
+      )!.id;
     });
     login('test_username');
     view = new E2TranslationsView();
@@ -56,6 +62,21 @@ describe('QA cell badges', () => {
     view.visit(projectId);
 
     cy.contains('key_ignored_issue')
+      .closestDcy('translations-row')
+      .findDcy('translations-cell-qa-issues-button')
+      .should('not.exist');
+  });
+
+  it('does not show badge after editing translation in QA-disabled project', () => {
+    view.visit(disabledProjectId);
+
+    editTranslation({
+      key: 'disabled_key',
+      languageTag: 'fr',
+      newValue: 'Edited',
+    });
+
+    cy.contains('disabled_key')
       .closestDcy('translations-row')
       .findDcy('translations-cell-qa-issues-button')
       .should('not.exist');

--- a/webapp/src/ee/qa/hooks/useQaChecksEnabled.ts
+++ b/webapp/src/ee/qa/hooks/useQaChecksEnabled.ts
@@ -1,0 +1,8 @@
+import { useEnabledFeatures } from 'tg.globalContext/helpers';
+import { useProject } from 'tg.hooks/useProject';
+
+export const useQaChecksEnabled = (): boolean => {
+  const { isEnabled } = useEnabledFeatures();
+  const project = useProject();
+  return isEnabled('QA_CHECKS') && project.useQaChecks;
+};

--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -63,6 +63,7 @@ import {
   useQaChecksCount,
 } from '../ee/qa/components/QaChecksPanel';
 export { QaBadge } from '../ee/qa/components/QaBadge';
+export { useQaChecksEnabled } from '../ee/qa/hooks/useQaChecksEnabled';
 export { QaLanguageStats } from '../ee/qa/components/QaLanguageStats';
 export { QaCheckItem } from '../ee/qa/components/QaCheckItem';
 export { QaIssueHighlight } from '../ee/qa/components/QaIssueHighlight';

--- a/webapp/src/eeSetup/eeModule.oss.tsx
+++ b/webapp/src/eeSetup/eeModule.oss.tsx
@@ -38,6 +38,7 @@ export const TaskItem = Empty;
 export const TaskFilterPopover = Empty;
 export const TaskAllDonePlaceholder = Empty;
 export const QaBadge = (_props: QaBadgeProps) => Empty() as JSX.Element;
+export const useQaChecksEnabled = (): boolean => false;
 export const QaLanguageStats = (_props: QaLanguageStatsProps) =>
   Empty() as JSX.Element;
 export const QaCheckItem = Empty;

--- a/webapp/src/views/projects/translations/TranslationsList/TranslationRead.tsx
+++ b/webapp/src/views/projects/translations/TranslationsList/TranslationRead.tsx
@@ -8,7 +8,7 @@ import { TranslationLanguage } from './TranslationLanguage';
 import { AiPlaygroundPreview } from '../translationVisual/AiPlaygroundPreview';
 import { TranslationLabels } from 'tg.views/projects/translations/TranslationsList/TranslationLabels';
 import { SuggestionsFirst } from '../Suggestions/SuggestionsFirst';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
+import { useQaChecksEnabled } from 'tg.ee';
 import { getFirstPluralVariantWithQaIssues } from 'tg.fixtures/qaUtils';
 
 const StyledContainer = styled('div')`
@@ -92,15 +92,9 @@ export const TranslationRead: React.FC<Props> = ({
     removeLabel,
   } = tools;
 
-  const { isEnabled } = useEnabledFeatures();
+  const qaChecksEnabled = useQaChecksEnabled();
 
-  const toggleEdit = () => {
-    if (isEditing) {
-      handleClose();
-    } else {
-      handleOpen();
-    }
-  };
+  const toggleEdit = () => (isEditing ? handleClose() : handleOpen());
 
   const state = translation?.state || 'UNTRANSLATED';
 
@@ -110,7 +104,7 @@ export const TranslationRead: React.FC<Props> = ({
       data-cy="translations-table-cell"
       data-cy-language={language.tag}
       data-cy-key={keyData.keyName}
-      onClick={cellClickable ? () => toggleEdit() : undefined}
+      onClick={cellClickable ? toggleEdit : undefined}
     >
       <TranslationLanguage
         language={language}
@@ -166,7 +160,7 @@ export const TranslationRead: React.FC<Props> = ({
           disabled={disabled}
           showHighlights={isEditingRow && language.base}
           isPlural={keyData.keyIsPlural}
-          qaIssues={isEnabled('QA_CHECKS') ? translation?.qaIssues : undefined}
+          qaIssues={qaChecksEnabled ? translation?.qaIssues : undefined}
           translationId={translation?.id}
         />
         {Boolean(translation?.suggestions?.length) && (

--- a/webapp/src/views/projects/translations/TranslationsTable/TranslationRead.tsx
+++ b/webapp/src/views/projects/translations/TranslationsTable/TranslationRead.tsx
@@ -8,7 +8,7 @@ import { TranslationFlags } from '../cell/TranslationFlags';
 import { AiPlaygroundPreview } from '../translationVisual/AiPlaygroundPreview';
 import { TranslationLabels } from 'tg.views/projects/translations/TranslationsList/TranslationLabels';
 import { SuggestionsFirst } from '../Suggestions/SuggestionsFirst';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
+import { useQaChecksEnabled } from 'tg.ee';
 import { getFirstPluralVariantWithQaIssues } from 'tg.fixtures/qaUtils';
 
 const StyledContainer = styled('div')`
@@ -87,15 +87,9 @@ export const TranslationRead: React.FC<Props> = ({
     removeLabel,
   } = tools;
 
-  const { isEnabled } = useEnabledFeatures();
+  const qaChecksEnabled = useQaChecksEnabled();
 
-  const toggleEdit = () => {
-    if (isEditing) {
-      handleClose();
-    } else {
-      handleOpen();
-    }
-  };
+  const toggleEdit = () => (isEditing ? handleClose() : handleOpen());
 
   const state = translation?.state || 'UNTRANSLATED';
 
@@ -107,7 +101,7 @@ export const TranslationRead: React.FC<Props> = ({
       data-cy="translations-table-cell"
       data-cy-language={language.tag}
       data-cy-key={keyData.keyName}
-      onClick={cellClickable ? () => toggleEdit() : undefined}
+      onClick={cellClickable ? toggleEdit : undefined}
     >
       <StyledTranslation>
         <TranslationVisual
@@ -118,7 +112,7 @@ export const TranslationRead: React.FC<Props> = ({
           disabled={disabled}
           showHighlights={isEditingRow && language.base}
           isPlural={keyData.keyIsPlural}
-          qaIssues={isEnabled('QA_CHECKS') ? translation?.qaIssues : undefined}
+          qaIssues={qaChecksEnabled ? translation?.qaIssues : undefined}
           translationId={translation?.id}
         />
         {Boolean(translation?.totalSuggestionCount) && (

--- a/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
@@ -16,8 +16,7 @@ import { StateTransitionButtons } from './StateTransitionButtons';
 import { CELL_HIGHLIGHT_ON_HOVER, CELL_SHOW_ON_HOVER } from './styles';
 import { useTranslationsSelector } from '../context/TranslationsContext';
 import { useTaskTransitionTranslation } from 'tg.translationTools/useTaskTransitionTranslation';
-import { QaBadge } from 'tg.ee';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
+import { QaBadge, useQaChecksEnabled } from 'tg.ee';
 
 type State = components['schemas']['TranslationViewModel']['state'];
 type TaskModel = components['schemas']['KeyTaskViewModel'];
@@ -100,17 +99,16 @@ export const ControlsTranslation: React.FC<ControlsProps> = ({
   const spots: string[] = [];
 
   const translateTransition = useTaskTransitionTranslation();
-  const { isEnabled } = useEnabledFeatures();
+  const qaChecksEnabled = useQaChecksEnabled();
   const displayTransitionButtons = stateChangeEnabled && state;
   const displayEdit = editEnabled && onEdit;
   const commentsPresent = Boolean(commentsCount);
   const displayComments = onComments || commentsPresent;
   const onlyResolved = commentsPresent && !unresolvedCommentCount;
+  const qaIssuesPresent = Boolean(qaIssueCount);
   const qaIssuesResolved = qaIssueCount === 0;
   const displayQaIssues =
-    isEnabled('QA_CHECKS') &&
-    onQaIssues &&
-    (qaIssueCount !== 0 || qaChecksStale);
+    qaChecksEnabled && onQaIssues && (qaIssuesPresent || qaChecksStale);
   const prefilteredTask = useTranslationsSelector((c) => c.prefilter?.task);
   const task = tasks?.[0];
   const displayTaskButton =
@@ -139,7 +137,7 @@ export const ControlsTranslation: React.FC<ControlsProps> = ({
   const inDomTask = displayTaskButton;
 
   const gridTemplateAreas = `'${spots.join(' ')}'`;
-  const gridTemplateColumns = spots.map((_) => '28px').join(' ');
+  const gridTemplateColumns = Array(spots.length).fill('28px').join(' ');
 
   const { t } = useTranslate();
 

--- a/webapp/src/views/projects/translations/context/services/useEditService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useEditService.tsx
@@ -6,6 +6,7 @@ import {
 } from '@tginternal/editor';
 
 import { useProject } from 'tg.hooks/useProject';
+import { useQaChecksEnabled } from 'tg.ee';
 import { messageService } from 'tg.service/MessageService';
 
 import {
@@ -91,6 +92,7 @@ export const useEditService = ({
   } = positionService;
 
   const project = useProject();
+  const qaChecksEnabled = useQaChecksEnabled();
 
   const putKey = usePutKey();
   const putTranslation = usePutTranslation();
@@ -118,14 +120,16 @@ export const useEditService = ({
     language: string;
     value: string;
   }) => {
-    // Mark stale before save to avoid race with websocket
-    translationService.changeTranslations([
-      {
-        keyId: params.keyId,
-        language: params.language,
-        value: { qaChecksStale: true, qaIssues: [] },
-      },
-    ]);
+    if (qaChecksEnabled) {
+      // Mark stale before save to avoid race with websocket.
+      translationService.changeTranslations([
+        {
+          keyId: params.keyId,
+          language: params.language,
+          value: { qaChecksStale: true, qaIssues: [] },
+        },
+      ]);
+    }
 
     const result = await putTranslation.mutateAsync({
       path: { projectId: project.id },

--- a/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useTranslationsService.tsx
@@ -20,7 +20,8 @@ import {
   ValueUpdate,
 } from '../types';
 import { PrefilterType } from '../../prefilters/usePrefilter';
-import { useConfig, useEnabledFeatures } from 'tg.globalContext/helpers';
+import { useConfig } from 'tg.globalContext/helpers';
+import { useQaChecksEnabled } from 'tg.ee';
 import { useTranslationFiltersService } from './useTranslationFilterService';
 
 const PAGE_SIZE = 60;
@@ -73,8 +74,7 @@ const flattenKeys = (
 
 export const useTranslationsService = (props: Props) => {
   const config = useConfig();
-  const { isEnabled } = useEnabledFeatures();
-  const qaChecksEnabled = isEnabled('QA_CHECKS');
+  const qaChecksEnabled = useQaChecksEnabled();
 
   const [order, setOrder] = useUrlSearchState('order', {
     defaultVal: 'keyName',

--- a/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
+++ b/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
@@ -6,7 +6,7 @@ import {
   TranslationsModifiedData,
 } from 'tg.websocket-client/WebsocketClient';
 import { useGlobalContext } from 'tg.globalContext/GlobalContext';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
+import { useQaChecksEnabled } from 'tg.ee';
 import { useDebouncedCallback } from 'use-debounce';
 
 export const useWebsocketService = (
@@ -15,8 +15,7 @@ export const useWebsocketService = (
   const [eventBlockers, setEventBlockers] = useState(0);
   const project = useProject();
   const client = useGlobalContext((c) => c.wsClient.client);
-  const { isEnabled } = useEnabledFeatures();
-  const qaChecksEnabled = isEnabled('QA_CHECKS');
+  const qaChecksEnabled = useQaChecksEnabled();
 
   function updateTranslations(event: TranslationsModifiedData) {
     const translationUpdates = event.data?.translations?.map((translation) => ({


### PR DESCRIPTION
## Summary

- Editing a translation in a project with QA checks disabled caused the QaBadge to appear on the cell (with the stale indicator) until the next page refresh. The optimistic update in `useEditService` wrote `qaChecksStale: true` unconditionally, and the render gate in `ControlsTranslation` only checked the instance-level `QA_CHECKS` feature flag — not the project-level `project.useQaChecks`.
- Introduced a shared `useQaChecksEnabled()` hook (instance flag AND `project.useQaChecks`) in `webapp/src/ee/qa/hooks/`, wired through both `eeModule.ee.tsx` (re-export) and `eeModule.oss.tsx` (always-`false` fallback).
- Applied the hook at six QA-gated sites in the translations area: `ControlsTranslation`, `TranslationsList/TranslationRead`, `TranslationsTable/TranslationRead`, `useEditService` (optimistic stale write), `useWebsocketService` (QA channel subscription), `useTranslationsService` (`includeQaIssues` query param).
- Added a Cypress regression in `e2e/cypress/e2e/qa/badges.cy.ts` covering the bug's exact repro path using the existing "Disabled QA Project" fixture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA checks can now be controlled per project as well as globally; UI elements and behaviors respect the project-specific setting.

* **Bug Fixes**
  * QA issue badge and related edit behaviors are hidden/disabled for projects with QA checks turned off.

* **Tests**
  * Added end-to-end coverage for projects with QA checks disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->