### PR TITLE
test: fix flaky websocket "doesn't subscribe as another user"

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
@@ -61,6 +61,7 @@ abstract class AbstractWebsocketTest : ProjectAuthControllerTest("/v2/projects/"
   @AfterEach
   fun after() {
     currentUserWebsocket.stop()
+    anotherUserWebsocket.stop()
   }
 
   @Test
@@ -245,12 +246,16 @@ abstract class AbstractWebsocketTest : ProjectAuthControllerTest("/v2/projects/"
         // anotherUser trying to spy on other user's websocket
         testData.user.id,
       )
-    spyingUserWebsocket.listenForNotificationsChanged()
-    spyingUserWebsocket.waitForForbidden()
-    saveNotificationForCurrentUser()
+    try {
+      spyingUserWebsocket.listenForNotificationsChanged()
+      spyingUserWebsocket.waitForForbidden()
+      saveNotificationForCurrentUser()
 
-    assertCurrentUserReceivedMessage()
-    spyingUserWebsocket.receivedMessages.assert.isEmpty()
+      assertCurrentUserReceivedMessage()
+      spyingUserWebsocket.receivedMessages.assert.isEmpty()
+    } finally {
+      spyingUserWebsocket.stop()
+    }
   }
 
   private fun assertCurrentUserReceivedMessage() {

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestEventListener.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestEventListener.kt
@@ -1,0 +1,32 @@
+package io.tolgee.websocket
+
+import io.tolgee.util.Logging
+import io.tolgee.util.logger
+import org.springframework.context.event.EventListener
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionSubscribeEvent
+
+/**
+ * Test-only timing probe. Logs when the server's STOMP handler receives a
+ * SUBSCRIBE so future CI runs can show how long it actually takes between
+ * the client calling `session.subscribe(...)` and the server processing it.
+ *
+ * Useful for evaluating whether `Thread.sleep(200)` in
+ * `WebsocketTestHelper.assertNotified` is well-calibrated. Pair the logged
+ * timestamp with `Client SUBSCRIBE sent` and `assertNotified: dispatching`
+ * lines from `WebsocketTestHelper`.
+ */
+@Component
+class WebsocketTestEventListener : Logging {
+  @EventListener
+  fun onSubscribe(event: SessionSubscribeEvent) {
+    val accessor = StompHeaderAccessor.wrap(event.message)
+    logger.debug(
+      "Server received SUBSCRIBE (sessionId={}, dest={}, t={}ms)",
+      accessor.sessionId,
+      accessor.destination,
+      System.currentTimeMillis(),
+    )
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestEventListener.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestEventListener.kt
@@ -22,11 +22,16 @@ class WebsocketTestEventListener : Logging {
   @EventListener
   fun onSubscribe(event: SessionSubscribeEvent) {
     val accessor = StompHeaderAccessor.wrap(event.message)
+    val correlationId = accessor.getNativeHeader(WebsocketTestSubscribeSync.CORRELATION_HEADER)?.firstOrNull()
     logger.debug(
-      "Server received SUBSCRIBE (sessionId={}, dest={}, t={}ms)",
+      "Server received SUBSCRIBE (sessionId={}, dest={}, correlationId={}, t={}ms)",
       accessor.sessionId,
       accessor.destination,
+      correlationId,
       System.currentTimeMillis(),
     )
+    if (correlationId != null) {
+      WebsocketTestSubscribeSync.notifySubscribed(correlationId)
+    }
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -16,6 +16,7 @@ import org.springframework.web.socket.messaging.WebSocketStompClient
 import org.springframework.web.socket.sockjs.client.SockJsClient
 import org.springframework.web.socket.sockjs.client.WebSocketTransport
 import java.lang.reflect.Type
+import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
@@ -53,8 +54,17 @@ class WebsocketTestHelper(
     logger.debug("Connecting websocket (userId={}, projectId={}, dest={})", userId, projectId, path)
     receivedMessages = LinkedBlockingDeque()
 
+    // Register the latch BEFORE the connect: the connect future's completion
+    // races against the test worker resuming from .get(), and ConcurrentHashMap
+    // visibility was not enough — we previously saw `awaitSubscribed` find the
+    // latch missing in the same millisecond `register` happened on the
+    // StompSession callback thread. Generating the correlationId here and
+    // registering synchronously guarantees a strict happens-before.
+    val correlationId = UUID.randomUUID().toString()
+    WebsocketTestSubscribeSync.register(correlationId)
+
     webSocketStompClient.messageConverter = SimpleMessageConverter()
-    sessionHandler = MySessionHandler(path, receivedMessages)
+    sessionHandler = MySessionHandler(path, receivedMessages, correlationId)
     connection =
       webSocketStompClient
         .connectAsync(
@@ -63,15 +73,11 @@ class WebsocketTestHelper(
           getAuthHeaders(),
           sessionHandler!!,
         ).get(10, TimeUnit.SECONDS)
-    // Anchor for timing diagnostics: pair with `Server received SUBSCRIBE` from
-    // WebsocketTestEventListener and `assertNotified: dispatching` to see how
-    // long the server-side subscription registration actually takes vs. the
-    // 200 ms wait we currently use in `assertNotified`. If subscribe→register
-    // is consistently small, the 200 ms can probably be tightened.
     logger.debug(
-      "Client SUBSCRIBE sent (sessionId={}, dest={}, t={}ms)",
+      "Client SUBSCRIBE sent (sessionId={}, dest={}, correlationId={}, t={}ms)",
       connection?.sessionId,
       path,
+      correlationId,
       System.currentTimeMillis(),
     )
   }
@@ -97,6 +103,7 @@ class WebsocketTestHelper(
     } catch (e: IllegalStateException) {
       logger.warn("Could not unsubscribe from websocket", e)
     } finally {
+      WebsocketTestSubscribeSync.cleanup(handler.subscribeCorrelationId)
       webSocketStompClient.stop()
       logger.debug("Stopped websocket listener")
     }
@@ -105,6 +112,8 @@ class WebsocketTestHelper(
   class MySessionHandler(
     val dest: String,
     val receivedMessages: LinkedBlockingDeque<String>,
+    /** Correlation ID used to match this session's SUBSCRIBE with its server-side event. */
+    val subscribeCorrelationId: String,
   ) : StompSessionHandlerAdapter(),
     Logging {
     var subscription: StompSession.Subscription? = null
@@ -144,7 +153,12 @@ class WebsocketTestHelper(
       connectedHeaders: StompHeaders,
     ) {
       logger.debug("Websocket session {} connected, subscribing to {}", session.sessionId, dest)
-      subscription = session.subscribe(dest, this)
+      val subscribeHeaders =
+        StompHeaders().apply {
+          destination = dest
+          add(WebsocketTestSubscribeSync.CORRELATION_HEADER, subscribeCorrelationId)
+        }
+      subscription = session.subscribe(subscribeHeaders, this)
     }
 
     override fun handleException(
@@ -236,15 +250,23 @@ class WebsocketTestHelper(
     dispatchCallback: () -> Unit,
     assertCallback: ((value: LinkedBlockingDeque<String>) -> Unit),
   ) {
-    Thread.sleep(200)
-    logger.debug("assertNotified: dispatching (dest={}, t={}ms)", sessionHandler?.dest, System.currentTimeMillis())
+    val handler = sessionHandler ?: error("listen() must be called before assertNotified()")
+    // Wait for the server's SessionSubscribeEvent for this specific subscription.
+    // Replaces a fragile Thread.sleep(200) with real synchronization. Note the
+    // event fires when the SUBSCRIBE hits the inbound channel; broker
+    // registration follows microseconds later on the same channel pipeline. If
+    // a broadcast goes missing despite the latch having counted down, that
+    // gap is the suspect — the timing logs in WebsocketTestSubscribeSync
+    // will make it visible.
+    WebsocketTestSubscribeSync.awaitSubscribed(handler.subscribeCorrelationId, timeoutMs = 2000)
+    logger.debug("assertNotified: dispatching (dest={}, t={}ms)", handler.dest, System.currentTimeMillis())
     dispatchCallback()
     waitFor(3000) {
       receivedMessages.isNotEmpty()
     }
     logger.debug(
       "assertNotified: broadcast received (dest={}, t={}ms)",
-      sessionHandler?.dest,
+      handler.dest,
       System.currentTimeMillis(),
     )
     assertCallback(receivedMessages)

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -16,6 +16,7 @@ import org.springframework.web.socket.messaging.WebSocketStompClient
 import org.springframework.web.socket.sockjs.client.SockJsClient
 import org.springframework.web.socket.sockjs.client.WebSocketTransport
 import java.lang.reflect.Type
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 
@@ -49,6 +50,7 @@ class WebsocketTestHelper(
   private var connection: StompSession? = null
 
   fun listen(path: String) {
+    logger.debug("Connecting websocket (userId={}, projectId={}, dest={})", userId, projectId, path)
     receivedMessages = LinkedBlockingDeque()
 
     webSocketStompClient.messageConverter = SimpleMessageConverter()
@@ -61,6 +63,7 @@ class WebsocketTestHelper(
           getAuthHeaders(),
           sessionHandler!!,
         ).get(10, TimeUnit.SECONDS)
+    logger.debug("Websocket connected (sessionId={}, dest={})", connection?.sessionId, path)
   }
 
   private fun getAuthHeaders(): StompHeaders {
@@ -73,15 +76,20 @@ class WebsocketTestHelper(
   }
 
   fun stop() {
-    logger.info("Stopping websocket listener")
+    val handler = sessionHandler ?: return
+    val activeConnection = connection
+    sessionHandler = null
+    connection = null
+    logger.debug("Stopping websocket listener (sessionId={})", activeConnection?.sessionId)
     try {
-      sessionHandler?.subscription?.unsubscribe()
-      connection?.disconnect()
+      handler.subscription?.unsubscribe()
+      activeConnection?.disconnect()
     } catch (e: IllegalStateException) {
       logger.warn("Could not unsubscribe from websocket", e)
+    } finally {
+      webSocketStompClient.stop()
+      logger.debug("Stopped websocket listener")
     }
-    webSocketStompClient.stop()
-    logger.info("Stopped websocket listener")
   }
 
   class MySessionHandler(
@@ -91,20 +99,41 @@ class WebsocketTestHelper(
     Logging {
     var subscription: StompSession.Subscription? = null
 
-    @Volatile
-    var authenticationStatus: AuthenticationStatus? = null
+    // Append-only history of every status the session observed. The sequence
+    // matters because the ERROR frame and the transport close can fire in
+    // opposite orders under CI load — checking the full list (rather than
+    // just the latest value) lets a test pass when the expected rejection
+    // frame arrived at all, even if a CONNECTION_LOST was recorded first
+    // because the close fired before the frame was processed. If the list
+    // never contains the expected status, the wait fails — with the
+    // transitions logged so the failure points at the lost rejection frame.
+    val statusTransitions: MutableList<AuthenticationStatus> =
+      CopyOnWriteArrayList()
+
+    val authenticationStatus: AuthenticationStatus?
+      get() = statusTransitions.lastOrNull()
 
     enum class AuthenticationStatus {
       UNAUTHENTICATED,
       FORBIDDEN,
+
+      // The transport closed before any ERROR frame was processed. NOT a
+      // valid substitute for UNAUTHENTICATED/FORBIDDEN — the wait helper
+      // fails if this is the only entry in the transitions list. Recorded
+      // so that the failure log shows what we did see when the expected
+      // rejection frame was lost in the server's flush-before-close window.
+      CONNECTION_LOST,
+    }
+
+    private fun recordStatus(newStatus: AuthenticationStatus) {
+      statusTransitions.add(newStatus)
     }
 
     override fun afterConnected(
       session: StompSession,
       connectedHeaders: StompHeaders,
     ) {
-      logger.info("Connected to websocket")
-      logger.info("Subscribing to $dest")
+      logger.debug("Websocket session {} connected, subscribing to {}", session.sessionId, dest)
       subscription = session.subscribe(dest, this)
     }
 
@@ -115,7 +144,14 @@ class WebsocketTestHelper(
       payload: ByteArray,
       exception: Throwable,
     ) {
-      logger.warn("Stomp Error:", exception)
+      logger.error(
+        "Websocket session {} STOMP exception (command={}, headers={}, payload={}B)",
+        session.sessionId,
+        command,
+        headers,
+        payload.size,
+        exception,
+      )
     }
 
     override fun handleTransportError(
@@ -123,20 +159,17 @@ class WebsocketTestHelper(
       exception: Throwable,
     ) {
       super.handleTransportError(session, exception)
-      logger.warn("Stomp Transport Error:", exception)
-      // When the server rejects invalid credentials, it sends an "Unauthenticated"
-      // frame and closes the connection. Under CI load, the ConnectionLostException
-      // can arrive before handleFrame processes the rejection frame, so
-      // authenticationStatus is never set and waitForUnauthenticated() times out.
-      // Treating any connection loss (when authenticationStatus is still null) as
-      // UNAUTHENTICATED may mask non-auth disconnects, but this is acceptable:
-      // tests that expect a specific status (e.g. FORBIDDEN) will have already set
-      // authenticationStatus via handleFrame before the close arrives.
-      if (authenticationStatus == null &&
+      if (statusTransitions.isEmpty() &&
         exception is org.springframework.messaging.simp.stomp.ConnectionLostException
       ) {
-        authenticationStatus = AuthenticationStatus.UNAUTHENTICATED
+        recordStatus(AuthenticationStatus.CONNECTION_LOST)
       }
+      logger.error(
+        "Websocket session {} transport error (transitions at close: {})",
+        session.sessionId,
+        statusTransitions,
+        exception,
+      )
     }
 
     override fun getPayloadType(headers: StompHeaders): Type {
@@ -147,17 +180,20 @@ class WebsocketTestHelper(
       stompHeaders: StompHeaders,
       o: Any?,
     ) {
-      handleForbidden(stompHeaders)
-      handleUnauthenticated(stompHeaders)
-
-      logger.info(
-        "Handle Frame with stompHeaders: '{}' and payload: '{}'",
+      val messageHeader = stompHeaders.get("message")?.singleOrNull()
+      logger.debug(
+        "Frame received (dest={}, messageHeader={}, payloadBytes={}, allHeaders={})",
+        dest,
+        messageHeader,
+        (o as? ByteArray)?.size,
         stompHeaders,
-        (o as? ByteArray)?.decodeToString(),
       )
 
+      handleForbidden(messageHeader)
+      handleUnauthenticated(messageHeader)
+
       if (o !is ByteArray) {
-        logger.info("Payload '{}' is not a ByteArray, not adding into received messages.", o)
+        logger.debug("Payload '{}' is not a ByteArray, not adding into received messages.", o)
         return
       }
 
@@ -168,15 +204,17 @@ class WebsocketTestHelper(
       }
     }
 
-    private fun handleForbidden(stompHeaders: StompHeaders) {
-      if (stompHeaders.get("message")?.single() == "Forbidden") {
-        authenticationStatus = AuthenticationStatus.FORBIDDEN
+    private fun handleForbidden(messageHeader: String?) {
+      if (messageHeader == "Forbidden") {
+        logger.debug("Authentication status -> FORBIDDEN (dest={})", dest)
+        recordStatus(AuthenticationStatus.FORBIDDEN)
       }
     }
 
-    private fun handleUnauthenticated(stompHeaders: StompHeaders) {
-      if (stompHeaders.get("message")?.single() == "Unauthenticated") {
-        authenticationStatus = AuthenticationStatus.UNAUTHENTICATED
+    private fun handleUnauthenticated(messageHeader: String?) {
+      if (messageHeader == "Unauthenticated") {
+        logger.debug("Authentication status -> UNAUTHENTICATED (dest={})", dest)
+        recordStatus(AuthenticationStatus.UNAUTHENTICATED)
       }
     }
   }
@@ -188,12 +226,9 @@ class WebsocketTestHelper(
     dispatchCallback: () -> Unit,
     assertCallback: ((value: LinkedBlockingDeque<String>) -> Unit),
   ) {
-    // Give the STOMP SUBSCRIBE frame enough time to be processed by the server
-    // before dispatching. Under CI load (especially with the Redis broker relay),
-    // 200ms was too tight and broadcasts could miss the not-yet-registered subscription.
-    Thread.sleep(1000)
+    Thread.sleep(200)
     dispatchCallback()
-    waitFor(10000) {
+    waitFor(3000) {
       receivedMessages.isNotEmpty()
     }
     assertCallback(receivedMessages)
@@ -210,11 +245,19 @@ class WebsocketTestHelper(
 
   fun waitForAuthenticationStatus(status: MySessionHandler.AuthenticationStatus) {
     try {
-      waitFor(10000) {
-        sessionHandler?.authenticationStatus == status
+      waitFor(5000) {
+        sessionHandler?.statusTransitions?.contains(status) == true
       }
     } catch (e: WaitNotSatisfiedException) {
-      logger.info("Authentication status was not $status, was: ${sessionHandler?.authenticationStatus}")
+      val transitions = sessionHandler?.statusTransitions ?: emptyList<MySessionHandler.AuthenticationStatus>()
+      logger.error(
+        "Expected websocket authentication status {} never observed; transitions={}. " +
+          "If transitions are only [CONNECTION_LOST], the server's STOMP ERROR frame " +
+          "was lost in the flush-before-close window — investigate the server-side " +
+          "ERROR delivery path rather than relaxing the test.",
+        status,
+        transitions,
+      )
       throw e
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -63,7 +63,17 @@ class WebsocketTestHelper(
           getAuthHeaders(),
           sessionHandler!!,
         ).get(10, TimeUnit.SECONDS)
-    logger.debug("Websocket connected (sessionId={}, dest={})", connection?.sessionId, path)
+    // Anchor for timing diagnostics: pair with `Server received SUBSCRIBE` from
+    // WebsocketTestEventListener and `assertNotified: dispatching` to see how
+    // long the server-side subscription registration actually takes vs. the
+    // 200 ms wait we currently use in `assertNotified`. If subscribe→register
+    // is consistently small, the 200 ms can probably be tightened.
+    logger.debug(
+      "Client SUBSCRIBE sent (sessionId={}, dest={}, t={}ms)",
+      connection?.sessionId,
+      path,
+      System.currentTimeMillis(),
+    )
   }
 
   private fun getAuthHeaders(): StompHeaders {
@@ -227,10 +237,16 @@ class WebsocketTestHelper(
     assertCallback: ((value: LinkedBlockingDeque<String>) -> Unit),
   ) {
     Thread.sleep(200)
+    logger.debug("assertNotified: dispatching (dest={}, t={}ms)", sessionHandler?.dest, System.currentTimeMillis())
     dispatchCallback()
     waitFor(3000) {
       receivedMessages.isNotEmpty()
     }
+    logger.debug(
+      "assertNotified: broadcast received (dest={}, t={}ms)",
+      sessionHandler?.dest,
+      System.currentTimeMillis(),
+    )
     assertCallback(receivedMessages)
     stop()
   }

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestSubscribeSync.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestSubscribeSync.kt
@@ -1,0 +1,113 @@
+package io.tolgee.websocket
+
+import io.tolgee.util.Logging
+import io.tolgee.util.logger
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * In-process synchronization between the test client and the server's
+ * `SessionSubscribeEvent` listener. Replaces the historical
+ * `Thread.sleep(200)` in `WebsocketTestHelper.assertNotified` with a real
+ * sync point: the dispatch only fires after the server has acknowledged
+ * the SUBSCRIBE.
+ *
+ * The client generates a UUID, sends it as a STOMP `x-test-correlation`
+ * header on SUBSCRIBE, registers a latch under that key, then awaits the
+ * latch. The server-side `WebsocketTestEventListener` reads the same
+ * header from the `SessionSubscribeEvent` and counts the latch down.
+ *
+ * Caveat for race detection: Spring publishes `SessionSubscribeEvent`
+ * BEFORE the broker handler registers the subscription (both subscribe to
+ * `clientInboundChannel`, may run on different threads). So waking up on
+ * the event fires very close to — but not strictly *after* — actual
+ * registration. If broadcasts go missing despite the latch having
+ * counted down, that gap is the suspect; the timing logs in
+ * [awaitSubscribed] and [notifySubscribed] make it diagnosable.
+ */
+object WebsocketTestSubscribeSync : Logging {
+  const val CORRELATION_HEADER = "x-test-correlation"
+
+  private val latches = ConcurrentHashMap<String, CountDownLatch>()
+  private val registeredAt = ConcurrentHashMap<String, Long>()
+
+  fun register(correlationId: String) {
+    latches[correlationId] = CountDownLatch(1)
+    registeredAt[correlationId] = System.currentTimeMillis()
+    logger.debug("WS subscribe latch registered (correlationId={}, t={}ms)", correlationId, System.currentTimeMillis())
+  }
+
+  fun notifySubscribed(correlationId: String) {
+    val latch = latches[correlationId]
+    if (latch == null) {
+      logger.debug(
+        "WS subscribe event for unknown correlationId={} (latch not yet registered or already cleaned up)",
+        correlationId,
+      )
+      return
+    }
+    latch.countDown()
+    val registered = registeredAt[correlationId]
+    val elapsed = if (registered != null) "${System.currentTimeMillis() - registered}ms" else "?"
+    logger.debug(
+      "WS subscribe latch counted down (correlationId={}, since-register={}, t={}ms)",
+      correlationId,
+      elapsed,
+      System.currentTimeMillis(),
+    )
+  }
+
+  /**
+   * Block until [notifySubscribed] is called for [correlationId] or [timeoutMs]
+   * elapses. Returns the actual wait duration in ms (always logged so we can
+   * compare against the prior 200 ms blanket sleep across CI runs).
+   */
+  fun awaitSubscribed(
+    correlationId: String,
+    timeoutMs: Long,
+  ): Long {
+    val latch = latches[correlationId]
+    if (latch == null) {
+      // Should not normally happen — register() runs synchronously inside
+      // afterConnected, which completes before listen() returns. If we get
+      // here, something race-y happened (e.g. cleanup ran out of order). Log
+      // loudly with the full registry state and fall back to a short blocking
+      // sleep so the test still runs.
+      logger.error(
+        "WS subscribe latch missing on awaitSubscribed (correlationId={}, current latches={}). " +
+          "Falling back to 200 ms sleep so the test still runs; investigate the missing register/cleanup order.",
+        correlationId,
+        latches.keys,
+      )
+      Thread.sleep(200)
+      return 200
+    }
+    val start = System.currentTimeMillis()
+    val ok = latch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    val waited = System.currentTimeMillis() - start
+    if (ok) {
+      logger.debug("WS subscribe latch awaited successfully (correlationId={}, waited={}ms)", correlationId, waited)
+    } else {
+      logger.error(
+        "WS subscribe latch TIMEOUT after {}ms (correlationId={}). " +
+          "SessionSubscribeEvent never fired — server-side dispatcher may be blocked or " +
+          "the event was lost. Falling back to dispatch anyway.",
+        timeoutMs,
+        correlationId,
+      )
+    }
+    return waited
+  }
+
+  fun cleanup(correlationId: String) {
+    val removed = latches.remove(correlationId)
+    registeredAt.remove(correlationId)
+    logger.debug(
+      "WS subscribe latch cleanup (correlationId={}, was-present={}, t={}ms)",
+      correlationId,
+      removed != null,
+      System.currentTimeMillis(),
+    )
+  }
+}

--- a/backend/app/src/test/resources/application.yaml
+++ b/backend/app/src/test/resources/application.yaml
@@ -102,6 +102,8 @@ tolgee:
   front-end-url: https://dummy-url.com
   ee:
     scheduled-reporting-enabled: false
-#logging:
-#  level:
-#    io.tolgee: DEBUG
+logging:
+  level:
+    io.tolgee.websocket: DEBUG
+    org.springframework.messaging.simp.stomp: DEBUG
+    org.springframework.web.socket.messaging: DEBUG


### PR DESCRIPTION
## Summary

- **Resource leak cleanup**: `anotherUserWebsocket` (class-level) and the locally-created `spyingUserWebsocket` were never stopped. Each test leaked a STOMP session. Now `anotherUserWebsocket.stop()` runs in `@AfterEach` and `spyingUserWebsocket` is wrapped in `try/finally`. `WebsocketTestHelper.stop()` is fully idempotent (clears handler/connection refs, runs `webSocketStompClient.stop()` in `finally`).
- **Track full auth status history, fail loudly on lost frame**: the previous `handleTransportError` workaround silently relabeled any `ConnectionLostException` as `UNAUTHENTICATED`, masking genuinely lost FORBIDDEN rejections. New behavior:
  - Each frame/transport handler appends to an append-only `statusTransitions` list (CopyOnWriteArrayList). `CONNECTION_LOST` is recorded only when the transport closes with no status seen yet.
  - `waitForAuthenticationStatus` now checks `transitions.contains(expected)`. So:
    - **ERROR frame arrives in any order vs close** → list contains the expected status → clean pass, no spurious WARN even when `CONNECTION_LOST` was recorded first.
    - **ERROR frame is truly lost** → `transitions == [CONNECTION_LOST]` → wait times out and the test fails, with the full transitions list logged. The failure points investigators at the server-side flush-before-close path rather than at the test.
- **Diagnostics**: STOMP/transport errors at `ERROR` level with session id and the full transitions list, structured DEBUG logs for frame arrival and status transitions, and `DEBUG` enabled for `io.tolgee.websocket` + Spring STOMP packages in test `application.yaml`. Test failures now carry the rejection path in the HTML test report.

## Context

Tracked by the "Flaky tests" project board. The original failure (`billing/actions/runs/24710980170`, `WaitNotSatisfiedException at waitFor.kt:20` from `spyingUserWebsocket.waitForForbidden()`) and a related one we reproduced on `WebsocketAuthenticationTest.unauthenticated with invalid PAT` both come from the same root cause: Spring's `StompSubProtocolHandler` writes the rejection ERROR frame and closes the WebSocket; under CI load the bytes can be lost in the close race (verified — DEBUG logs from a failing CI run show 1 ms between "subscribing" and "transport error at close: null", with no "Frame received" entry in 5 s of polling).

If the test starts failing on `main` after this lands, that is the signal — the server-side flush-before-close path needs investigation. Frontend clients see the same race; a real product fix there would also stabilize the tests. Out of scope for this PR.

## Test plan

- [x] `WebsocketWithRedisTest`, `WebsocketWithoutRedisTest`, `WebsocketAuthenticationTest` — all 27 tests green locally
- [x] `@RepeatedTest(100)` on the originally flaky test — 100/100 green locally
- [x] 10 consecutive CI reruns on prior commits — our websocket tests passed every time. Failures during those runs were unrelated board-tracked flakes (`BatchJobsGeneralWithRedisTest`, ee-test init errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved websocket test reliability and lifecycle handling: tests now always stop created websockets, ensure cleanup on failures, and more robustly exercise forbidden/authentication flows.

* **Chores**
  * Enhanced logging and diagnostics for websocket/messaging: added debug connect/stop traces, stronger error-level reporting for transport/auth issues, clearer handling/reporting of connection-loss states, and reduced verbose payload logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
