### PR TITLE
fix: allow editing content delivery config on projects with branching disabled

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/contentDelivery/ContentDeliveryConfigService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/contentDelivery/ContentDeliveryConfigService.kt
@@ -137,7 +137,6 @@ class ContentDeliveryConfigService(
     id: Long,
     dto: ContentDeliveryConfigRequest,
   ): ContentDeliveryConfig {
-    projectFeatureGuard.checkIfUsed(Feature.BRANCHING, dto.filterBranch)
     checkMultipleConfigsFeature(projectService.get(projectId), maxCurrentAllowed = 1)
     val config = get(projectId, id)
     handleUpdateSlug(config, dto)
@@ -145,7 +144,11 @@ class ContentDeliveryConfigService(
     config.name = dto.name
     config.pruneBeforePublish = dto.pruneBeforePublish
     config.zip = dto.zip
-    config.branch = branchService.getActiveOrDefault(projectId, dto.filterBranch)
+    val newBranch = branchService.getActiveOrDefault(projectId, dto.filterBranch)
+    if (newBranch?.isDefault == false || config.branch?.isDefault == false) {
+      projectFeatureGuard.checkEnabled(Feature.BRANCHING)
+    }
+    config.branch = newBranch
     config.copyPropsFrom(dto)
     handleUpdateAutoPublish(dto, config)
     return save(config)

--- a/e2e/cypress/e2e/branching/contentDeliveryBranching.cy.ts
+++ b/e2e/cypress/e2e/branching/contentDeliveryBranching.cy.ts
@@ -107,6 +107,25 @@ describe('Content delivery with branching', () => {
       .findDcy('branch-selector')
       .should('contain', 'feature');
   });
+
+  it('edits branched content delivery when branching gets disabled', () => {
+    // Seed data is created with BRANCHING enabled so the config has a branch
+    // stored on the backend. Now simulate the feature being turned off.
+    setFeature('BRANCHING', false);
+    cy.reload();
+    waitForGlobalLoading();
+
+    openEditDialog('Main CDN');
+    // Branch selector must be hidden when branching is not enabled.
+    gcy('content-delivery-form-branch').should('not.exist');
+
+    cy.gcy('content-delivery-form-name').find('input').clear().type('Renamed');
+    cy.gcy('content-delivery-form-save').click();
+    waitForGlobalLoading();
+    // Before the fix the PUT body carried the stale filterBranch which the
+    // backend rejected with FEATURE_NOT_ENABLED_FOR_PROJECT.
+    assertMessage('Content delivery successfully updated!');
+  });
 });
 
 function openEditDialog(name: string) {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigBranchingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigBranchingTest.kt
@@ -162,6 +162,36 @@ class ContentDeliveryConfigBranchingTest : ProjectAuthControllerTest("/v2/projec
 
   @Test
   @ProjectJWTAuthTestMethod
+  fun `update default-branch CDN succeeds when branching not enabled and default is echoed`() {
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.MULTIPLE_CONTENT_DELIVERY_CONFIGS)
+    performProjectAuthPut(
+      "content-delivery-configs/${testData.mainBranchCdnConfig.self.id}",
+      mapOf("name" to "Renamed", "filterBranch" to "main"),
+    ).andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `update default-branch CDN succeeds when branching not enabled and filterBranch is null`() {
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.MULTIPLE_CONTENT_DELIVERY_CONFIGS)
+    performProjectAuthPut(
+      "content-delivery-configs/${testData.mainBranchCdnConfig.self.id}",
+      mapOf("name" to "Renamed"),
+    ).andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `update non-default-branch CDN fails when branching not enabled even if branch is unchanged`() {
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.MULTIPLE_CONTENT_DELIVERY_CONFIGS)
+    performProjectAuthPut(
+      "content-delivery-configs/${testData.featureBranchCdnConfig.self.id}",
+      mapOf("name" to "Feature CDN", "filterBranch" to "feature"),
+    ).andIsBadRequest.andHasErrorMessage(Message.FEATURE_NOT_ENABLED)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
   fun `CDN config filterBranch is derived from branch entity`() {
     executeInNewTransaction {
       val config = contentDeliveryConfigService.get(testData.featureBranchCdnConfig.self.id)


### PR DESCRIPTION
## Summary

- The backend feature guard on the CDN update endpoint fired whenever `filterBranch` was non-null in the request body. Because this endpoint uses PUT replace semantics (every field in the DTO is unconditionally reassigned), the frontend always echoes the stored `branchName` back on save. As a result, editing any CDN config that referenced a branch would 400 with `FEATURE_NOT_ENABLED_FOR_PROJECT` once branching got disabled on the project (either the org's `BRANCHING` feature flag or `project.useBranching`).
- Refine the guard in `ContentDeliveryConfigService.update()` so it only fires when the config is — or would end up — pointing at a non-default branch. Echoing the default branch back on an already-default config is now a no-op.

### Guard semantics

| Current config branch | `dto.filterBranch` | Guard fires? | Rationale |
| --- | --- | --- | --- |
| default (`main`) | `null` | no | no feature usage |
| default (`main`) | `"main"` | no | echo of default, no change |
| default (`main`) | `"feature"` | yes | user is activating the feature |
| non-default (`feature`) | `"feature"` | yes | config is still using the feature |
| non-default (`feature`) | `"main"` | yes | was using the feature — guard fires |
| non-default (`feature`) | `null` | yes | currently on non-default — guard fires |

## Test plan

- [ ] Existing backend tests in `ContentDeliveryConfigBranchingTest` still pass, including `update CDN config with branch fails when branching not enabled` and `create CDN config with branch fails when branching not enabled`.
- [ ] New backend coverage:
  - `update default-branch CDN succeeds when branching not enabled and default is echoed`
  - `update default-branch CDN succeeds when branching not enabled and filterBranch is null`
  - `update non-default-branch CDN fails when branching not enabled even if branch is unchanged`
- [ ] New e2e regression `edits branched content delivery when branching gets disabled` in `contentDeliveryBranching.cy.ts` — reproduces the original 400 via the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end test for editing content delivery records when branching is disabled
  * Added controller tests for content delivery configuration updates with different branching feature states

* **Bug Fixes**
  * Improved branching validation for content delivery configurations to correctly handle default branch updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->