### PR TITLE
fix: chunk key id batches in delete-keys job

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/bigMeta/BigMetaService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/bigMeta/BigMetaService.kt
@@ -218,14 +218,16 @@ class BigMetaService(
       }
 
       executeInNewTransaction(transactionManager) {
-        entityManager
-          .createQuery(
-            """
-      delete from KeysDistance kd 
+        ids.chunked(KEY_DELETE_CHUNK_SIZE).forEach { chunk ->
+          entityManager
+            .createQuery(
+              """
+      delete from KeysDistance kd
       where kd.key1Id in :ids or kd.key2Id in :ids
       """,
-          ).setParameter("ids", ids)
-          .executeUpdate()
+            ).setParameter("ids", chunk)
+            .executeUpdate()
+        }
       }
     }
   }
@@ -269,5 +271,9 @@ class BigMetaService(
 
   fun deleteAllByProjectId(id: Long) {
     keysDistanceRepository.deleteAllByProjectId(id)
+  }
+
+  companion object {
+    private const val KEY_DELETE_CHUNK_SIZE = 10_000
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
@@ -492,7 +492,10 @@ class SecurityService(
     keyIds: List<Long>,
     projectId: Long,
   ) {
-    val projectIds = keyRepository.getProjectIdsForKeyIds(keyIds)
+    val projectIds =
+      keyIds
+        .chunked(KEY_ID_LOOKUP_CHUNK_SIZE)
+        .flatMap { keyRepository.getProjectIdsForKeyIds(it) }
 
     if (projectIds.size != keyIds.size) {
       throw NotFoundException(Message.KEY_NOT_FOUND)
@@ -629,4 +632,8 @@ class SecurityService(
 
   private val activeApiKey: ApiKeyDto?
     get() = if (authenticationFacade.isProjectApiKeyAuth) authenticationFacade.projectApiKey else null
+
+  companion object {
+    private const val KEY_ID_LOOKUP_CHUNK_SIZE = 10_000
+  }
 }


### PR DESCRIPTION
Batch delete of many keys threw "PreparedStatement can take at most 65535 parameters" because SecurityService.checkKeyIdsExistAndIsFromProject and BigMetaService.onKeyDeleted passed the full key id list to a single JPA query. Chunk both into batches of 10,000 ids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized backend data processing for large-scale key operations to improve performance and system stability when handling high-volume deletions and lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->