### PR TITLE
perf: batch-load keys in tag-complex, avoid loading full entity graphs

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ComplexTagOperationKeyProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ComplexTagOperationKeyProvider.kt
@@ -15,7 +15,6 @@ import jakarta.persistence.EntityManager
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Join
 import jakarta.persistence.criteria.JoinType
-import jakarta.persistence.criteria.Path
 import jakarta.persistence.criteria.Predicate
 import org.springframework.context.ApplicationContext
 
@@ -58,23 +57,24 @@ class ComplexTagOperationKeyProvider(
     entityManager.createQuery(query).resultList
   }
 
-  val rest: List<Key> by lazy {
-    val returnedIds = filtered.map { it.id }
+  val restKeyIds: List<Long> by lazy {
+    val allIds = allProjectKeyIds
+    val filteredIdSet = filtered.map { it.id }.toHashSet()
+    allIds.filter { it !in filteredIdSet }
+  }
+
+  private val allProjectKeyIds: List<Long> by lazy {
     val cb = entityManager.criteriaBuilder
-    val query = cb.createQuery(Key::class.java)
+    val query = cb.createQuery(Long::class.java)
     val root = query.from(Key::class.java)
-    val keyMeta = root.fetch(Key_.keyMeta, JoinType.LEFT)
     val branchJoin = root.join(Key_.branch, JoinType.LEFT)
-    @Suppress("UNCHECKED_CAST")
-    (keyMeta as Join<Key, KeyMeta>).fetch(KeyMeta_.tags, JoinType.LEFT) as Join<KeyMeta, Tag>
     entityManager
       .createQuery(
         query
-          .select(root)
+          .select(root.get(Key_.id))
           .where(
             cb.and(
               cb.equal(root.get(Key_.project).get(Project_.id), projectId),
-              cb.notIn(root.get(Key_.id), returnedIds),
               if (branch.isNullOrEmpty()) {
                 cb.or(
                   branchJoin.get(Branch_.id).isNull,
@@ -89,16 +89,6 @@ class ComplexTagOperationKeyProvider(
             ),
           ),
       ).resultList
-  }
-
-  private fun CriteriaBuilder.notIn(
-    path: Path<Long>,
-    collection: Collection<*>,
-  ): Predicate {
-    if (collection.isEmpty()) {
-      return this.and()
-    }
-    return this.not(path.`in`(collection))
   }
 
   private fun getKeyCondition(key: KeyId): Predicate? {

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -343,7 +343,10 @@ class TagService(
 
     if (req.tagOther != null || req.untagOther != null) {
       val untagOtherWithAppliedWildcards = req.untagOther?.applyWildcards(projectId)?.toList()
-      tagAndUntag(req.tagOther, untagOtherWithAppliedWildcards, provider.rest)
+      provider.restKeyIds.chunked(COMPLEX_TAG_BATCH_SIZE).forEach { chunkIds ->
+        val keys = keyService.getKeysWithTagsById(projectId, chunkIds)
+        tagAndUntag(req.tagOther, untagOtherWithAppliedWildcards, keys.toList())
+      }
     }
   }
 
@@ -414,5 +417,9 @@ class TagService(
   ) {
     val tag = getWithKeyMetasFetched(key.project.id, tagId)
     remove(key, tag)
+  }
+
+  companion object {
+    private const val COMPLEX_TAG_BATCH_SIZE = 5000
   }
 }


### PR DESCRIPTION
The tag-complex endpoint loaded ALL non-filtered keys with full entity graphs (Key + KeyMeta + Tags) in a single query. For large projects this saturated the database and caused cascading slowdowns for other users.

Replace the single massive query with:
- A lightweight ID-only query for all project keys
- In-memory set subtraction to determine rest key IDs
- Chunked entity loading (5000 keys per batch) with flush between batches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Bulk tag/untag operations are faster and use batched processing, reducing memory usage and improving responsiveness on large projects.
* **Refactor**
  * Internal query and data-fetch flow streamlined for better scalability and more reliable handling of large key sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->