### PR TITLE
fix: prevent branch merge from dropping translation updates

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/branching/BranchMerge.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/branching/BranchMerge.kt
@@ -63,4 +63,9 @@ class BranchMerge :
 
   val isMerged: Boolean
     get() = mergedAt != null
+
+  fun markMerged(at: Date) {
+    changes.clear()
+    mergedAt = at
+  }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
@@ -98,16 +98,14 @@ class BranchMergeService(
     val targetKeyId: Long?,
   )
 
-  fun applyMerge(merge: BranchMerge) {
-    metrics.branchMergeApplyTimer.record(
-      Runnable {
-        try {
-          branchMergeExecutor.execute(merge)
-        } catch (_: BranchMergeConflictNotResolvedException) {
-          throw BadRequestException(Message.BRANCH_MERGE_CONFLICTS_NOT_RESOLVED)
-        }
-      },
-    )
+  fun applyMerge(merge: BranchMerge): BranchMerge {
+    return metrics.branchMergeApplyTimer.recordCallable {
+      try {
+        branchMergeExecutor.execute(merge)
+      } catch (_: BranchMergeConflictNotResolvedException) {
+        throw BadRequestException(Message.BRANCH_MERGE_CONFLICTS_NOT_RESOLVED)
+      }
+    }!!
   }
 
   fun getMerges(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -206,20 +206,20 @@ class BranchServiceImpl(
         throw BadRequestException(Message.BRANCH_MERGE_CONFLICTS_NOT_RESOLVED)
       }
     }
-    branchMergeService.applyMerge(merge)
-    if (!merge.sourceBranch.isDefault) {
+    val mergedMerge = branchMergeService.applyMerge(merge)
+    if (!mergedMerge.sourceBranch.isDefault) {
       if (deleteBranch == true) {
         val defaultBranch =
           getDefaultBranch(projectId)
             ?: throw NotFoundException(Message.BRANCH_NOT_FOUND)
-        taskService.moveTasksAfterMerge(projectId, merge.sourceBranch, defaultBranch)
-        deleteBranch(projectId, merge.sourceBranch.id)
+        taskService.moveTasksAfterMerge(projectId, mergedMerge.sourceBranch, defaultBranch)
+        deleteBranch(projectId, mergedMerge.sourceBranch.id)
       } else {
         entityManager.flush()
         branchSnapshotService.rebuildSnapshotFromSource(
           projectId = projectId,
-          sourceBranch = merge.sourceBranch,
-          targetBranch = merge.targetBranch,
+          sourceBranch = mergedMerge.sourceBranch,
+          targetBranch = mergedMerge.targetBranch,
         )
       }
     }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
@@ -16,6 +16,7 @@ import io.tolgee.repository.KeyRepository
 import io.tolgee.service.key.KeyMetaService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.translation.TranslationService
+import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.LinkedHashMap
@@ -28,6 +29,7 @@ class BranchMergeExecutor(
   private val translationService: TranslationService,
   private val currentDateProvider: CurrentDateProvider,
   private val branchSnapshotService: BranchSnapshotService,
+  private val entityManager: EntityManager,
 ) {
   @Transactional
   fun execute(merge: BranchMerge) {
@@ -35,32 +37,45 @@ class BranchMergeExecutor(
     val snapshotKeys by lazy {
       branchSnapshotService.getSnapshotKeys(merge.sourceBranch.id).associateBy { it.originalKeyId }
     }
-    merge.changes.forEach { change ->
-      when (change.change) {
-        BranchKeyMergeChangeType.ADD -> {
-          applyAddition(change, merge.targetBranch)
-        }
+    applyChanges(merge, snapshotKeys)
+    finalizeMerge(merge)
+  }
 
-        BranchKeyMergeChangeType.UPDATE -> {
-          change.withSnapshotKey(snapshotKeys) { snapshotKey ->
-            applyUpdate(change, snapshotKey)
-          }
-        }
+  /**
+   * Apply every change, deferring DELETEs to the end. [applyDeletion] eventually
+   * calls [KeyService.hardDelete], which clears the persistence context — any
+   * in-memory entity modification made *after* a delete would be silently dropped
+   * on commit. Applying deletes last ensures every other change is flushed first.
+   */
+  private fun applyChanges(
+    merge: BranchMerge,
+    snapshotKeys: Map<Long, KeySnapshot>,
+  ) {
+    merge.changes
+      .sortedBy { it.change == BranchKeyMergeChangeType.DELETE }
+      .forEach { applyChange(it, merge, snapshotKeys) }
+  }
 
-        BranchKeyMergeChangeType.DELETE -> {
-          applyDeletion(change)
-        }
-
-        BranchKeyMergeChangeType.CONFLICT -> {
-          change.withSnapshotKey(snapshotKeys) { snapshotKey ->
-            applyConflict(change, snapshotKey)
-          }
-        }
-      }
+  private fun applyChange(
+    change: BranchMergeChange,
+    merge: BranchMerge,
+    snapshotKeys: Map<Long, KeySnapshot>,
+  ) {
+    when (change.change) {
+      BranchKeyMergeChangeType.ADD -> applyAddition(change, merge.targetBranch)
+      BranchKeyMergeChangeType.UPDATE -> change.withSnapshotKey(snapshotKeys) { applyUpdate(change, it) }
+      BranchKeyMergeChangeType.DELETE -> applyDeletion(change)
+      BranchKeyMergeChangeType.CONFLICT -> change.withSnapshotKey(snapshotKeys) { applyConflict(change, it) }
     }
+  }
 
-    merge.changes.clear()
-    merge.mergedAt = currentDateProvider.date
+  /**
+   * Marks the merge complete. Re-fetches the entity first because [applyDeletion]
+   * may have cleared the persistence context, leaving [merge] detached.
+   */
+  private fun finalizeMerge(merge: BranchMerge) {
+    val managed = entityManager.find(BranchMerge::class.java, merge.id) ?: return
+    managed.markMerged(currentDateProvider.date)
   }
 
   private fun attachKeysForMerge(merge: BranchMerge) {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
@@ -32,13 +32,13 @@ class BranchMergeExecutor(
   private val entityManager: EntityManager,
 ) {
   @Transactional
-  fun execute(merge: BranchMerge) {
+  fun execute(merge: BranchMerge): BranchMerge {
     attachKeysForMerge(merge)
     val snapshotKeys by lazy {
       branchSnapshotService.getSnapshotKeys(merge.sourceBranch.id).associateBy { it.originalKeyId }
     }
     applyChanges(merge, snapshotKeys)
-    finalizeMerge(merge)
+    return finalizeMerge(merge)
   }
 
   /**
@@ -70,14 +70,17 @@ class BranchMergeExecutor(
   }
 
   /**
-   * Marks the merge complete. Re-fetches the entity first because [applyDeletion]
-   * may have cleared the persistence context, leaving [merge] detached.
+   * Marks the merge complete and returns the managed instance. Re-fetches the entity
+   * first because [applyDeletion] may have cleared the persistence context, leaving
+   * [merge] detached. Callers must use the returned instance — the passed-in [merge]
+   * is stale in the delete path.
    */
-  private fun finalizeMerge(merge: BranchMerge) {
+  private fun finalizeMerge(merge: BranchMerge): BranchMerge {
     val managed =
       entityManager.find(BranchMerge::class.java, merge.id)
         ?: throw IllegalStateException("BranchMerge ${merge.id} was not found during finalization")
     managed.markMerged(currentDateProvider.date)
+    return managed
   }
 
   private fun attachKeysForMerge(merge: BranchMerge) {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/merging/BranchMergeExecutor.kt
@@ -74,7 +74,9 @@ class BranchMergeExecutor(
    * may have cleared the persistence context, leaving [merge] detached.
    */
   private fun finalizeMerge(merge: BranchMerge) {
-    val managed = entityManager.find(BranchMerge::class.java, merge.id) ?: return
+    val managed =
+      entityManager.find(BranchMerge::class.java, merge.id)
+        ?: throw IllegalStateException("BranchMerge ${merge.id} was not found during finalization")
     managed.markMerged(currentDateProvider.date)
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchMergeServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchMergeServiceTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.dtos.request.LanguageRequest
 import io.tolgee.dtos.request.key.CreateKeyDto
 import io.tolgee.ee.repository.EeSubscriptionRepository
 import io.tolgee.ee.repository.TaskRepository
+import io.tolgee.ee.repository.branching.BranchMergeRepository
 import io.tolgee.ee.repository.branching.BranchRepository
 import io.tolgee.ee.service.LabelServiceImpl
 import io.tolgee.ee.service.eeSubscription.EeSubscriptionServiceImpl
@@ -44,6 +45,9 @@ class BranchMergeServiceTest : AbstractSpringTest() {
 
   @Autowired
   lateinit var branchRepository: BranchRepository
+
+  @Autowired
+  lateinit var branchMergeRepository: BranchMergeRepository
 
   @Autowired
   lateinit var keyRepository: KeyRepository
@@ -216,6 +220,12 @@ class BranchMergeServiceTest : AbstractSpringTest() {
       .findKey(testData.mainKeyToDelete.name)
       .assert
       .isNull()
+
+    executeInNewTransaction {
+      val finalized = branchMergeRepository.findByIdOrNull(merge.id)!!
+      finalized.mergedAt.assert.isNotNull()
+      finalized.changes.assert.hasSize(0)
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Branch merges containing both a `DELETE` and an `UPDATE`/`CONFLICT` could silently drop the source-side translation update.

`BranchMergeExecutor.execute` iterated `merge.changes` in non-deterministic order, and `KeyService.hardDelete` calls `entityManager.clear()` (workaround for a Hibernate 6.6 `CHECK_ON_FLUSH` regression). Any in-memory modification made before that `clear()` was silently dropped on commit. Re-running the merge usually masked the bug.

Symptoms:
- Translation update not propagated to the target.
- `merge.mergedAt` stays `NULL` (merge keeps showing as active).
- Stale `branch_merge_change` rows remain (orphan-removal also dropped).

### Fix

- Sort changes so `DELETE`s run last — every other change is flushed by `hardDelete`'s own `flush()` before `clear()`.
- Re-fetch the merge after the loop so `mergedAt` and orphan-removal survive the cleared persistence context.
- New `BranchMerge.markMerged(at: Date)` to finalise the state.

### Out of scope

The root cause is `entityManager.clear()` in `KeyService.hardDelete`. A proper fix needs either a more surgical workaround for the Hibernate 6.6 stale-reference check, or running hard-deletes in `Propagation.REQUIRES_NEW`.

## Test plan

- [x] `BranchMergeServiceTest` — full class passes (was: 49/50 fail under `@RepeatedTest(50)`)
- [x] `io.tolgee.ee.service.branching.*` — all branching service tests pass
- [x] `BranchRevisionsTest` — confirms the `hardDelete` workaround is still load-bearing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable branch merge completion: merges apply non-delete changes before deletions, then mark the merge as completed only after all changes are persisted to ensure accurate merged-state reporting.
* **Tests**
  * Added verification that applied merges record a completion timestamp and clear pending changes in storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->