### PR TITLE
fix: skip Sentry reports for expected user-config errors

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
@@ -8,6 +8,7 @@ import io.tolgee.Metrics
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.component.CurrentDateProvider
+import io.tolgee.constants.Message
 import io.tolgee.exceptions.ExceptionWithMessage
 import io.tolgee.exceptions.LlmRateLimitedException
 import io.tolgee.exceptions.OutOfCreditsException
@@ -127,11 +128,18 @@ open class ChunkProcessingUtil(
   }
 
   private fun logKnownException(exception: Throwable) {
-    val isKnownCause = knownCauses.any { ExceptionUtils.indexOfType(exception, it) > -1 }
-    if (!isKnownCause) {
-      Sentry.captureException(exception)
-      logger.error(exception.message, exception)
+    if (isExpectedUserError(exception)) {
+      logger.warn("Skipping Sentry capture for expected user error: ${exception.message}")
+      return
     }
+    Sentry.captureException(exception)
+    logger.error(exception.message, exception)
+  }
+
+  private fun isExpectedUserError(exception: Throwable): Boolean {
+    if (knownCauses.any { ExceptionUtils.indexOfType(exception, it) > -1 }) return true
+    val tolgeeMessage = (exception as? ExceptionWithMessage)?.tolgeeMessage
+    return tolgeeMessage in expectedUserErrorMessages
   }
 
   private fun retryFailedExecution(exception: Throwable) {
@@ -154,7 +162,9 @@ open class ChunkProcessingUtil(
     )
     if (errorKeyRetries >= maxRetries && maxRetries != -1) {
       logger.debug("Max retries reached for job execution ${execution.id}")
-      Sentry.captureException(exception)
+      if (!isExpectedUserError(exception)) {
+        Sentry.captureException(exception)
+      }
       return
     }
 
@@ -167,6 +177,15 @@ open class ChunkProcessingUtil(
     listOf(
       OutOfCreditsException::class.java,
       LlmRateLimitedException::class.java,
+    )
+  }
+
+  private val expectedUserErrorMessages: Set<Message> by lazy {
+    setOf(
+      // User's webhook URL is broken/unreachable — not our bug
+      Message.UNEXPECTED_ERROR_WHILE_EXECUTING_WEBHOOK,
+      // User's webhook returned a non-2xx response — not our bug
+      Message.WEBHOOK_RESPONDED_WITH_NON_200_STATUS,
     )
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
@@ -8,8 +8,8 @@ import io.tolgee.Metrics
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.component.CurrentDateProvider
-import io.tolgee.constants.Message
 import io.tolgee.exceptions.ExceptionWithMessage
+import io.tolgee.exceptions.ExpectedUserError
 import io.tolgee.exceptions.LlmRateLimitedException
 import io.tolgee.exceptions.OutOfCreditsException
 import io.tolgee.model.batch.BatchJob
@@ -138,8 +138,10 @@ open class ChunkProcessingUtil(
 
   private fun isExpectedUserError(exception: Throwable): Boolean {
     if (knownCauses.any { ExceptionUtils.indexOfType(exception, it) > -1 }) return true
-    val tolgeeMessage = (exception as? ExceptionWithMessage)?.tolgeeMessage
-    return tolgeeMessage in expectedUserErrorMessages
+    if (exception is MultipleItemsFailedException) {
+      return exception.exceptions.isNotEmpty() && exception.exceptions.all { isExpectedUserError(it) }
+    }
+    return ExceptionUtils.getThrowableList(exception).any { it is ExpectedUserError }
   }
 
   private fun retryFailedExecution(exception: Throwable) {
@@ -177,15 +179,6 @@ open class ChunkProcessingUtil(
     listOf(
       OutOfCreditsException::class.java,
       LlmRateLimitedException::class.java,
-    )
-  }
-
-  private val expectedUserErrorMessages: Set<Message> by lazy {
-    setOf(
-      // User's webhook URL is broken/unreachable — not our bug
-      Message.UNEXPECTED_ERROR_WHILE_EXECUTING_WEBHOOK,
-      // User's webhook returned a non-2xx response — not our bug
-      Message.WEBHOOK_RESPONDED_WITH_NON_200_STATUS,
     )
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/SentryBeforeSendCallback.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/SentryBeforeSendCallback.kt
@@ -19,6 +19,10 @@ class SentryBeforeSendCallback : SentryOptions.BeforeSendCallback {
         "FailedDontRequeueException",
         "ClientAbortException",
         "AsyncRequestNotUsableException",
+        // Spring Security firewall rejecting malformed requests (suspicious user agents, headers, etc.)
+        "RequestRejectedException",
+        // Client hit a URL whose handler expects a path variable that wasn't provided
+        "MissingPathVariableException",
       )
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/webhookExceptions.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/webhookExceptions.kt
@@ -1,5 +1,6 @@
 package io.tolgee.component.automations.processors
 
+import io.tolgee.exceptions.ExpectedUserError
 import org.springframework.http.HttpStatusCode
 
 class WebhookRespondedWithNon200Status(
@@ -13,4 +14,5 @@ class WebhookExecutionFailed(
 
 open class WebhookException(
   cause: Throwable? = null,
-) : RuntimeException("Webhook execution failed", cause)
+) : RuntimeException("Webhook execution failed", cause),
+  ExpectedUserError

--- a/backend/data/src/main/kotlin/io/tolgee/exceptions/ExpectedUserError.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/exceptions/ExpectedUserError.kt
@@ -1,0 +1,12 @@
+package io.tolgee.exceptions
+
+/**
+ * Marker interface for exceptions caused by expected user or external misconfiguration —
+ * e.g. a user's webhook is unreachable, the user's Slack bot was removed from the channel.
+ *
+ * Such failures are normal operational conditions the user has to fix on their side, not
+ * bugs in our code, so they must not be reported to Sentry. Code that decides whether to
+ * send an event to Sentry should treat any throwable in the cause chain that implements
+ * this interface as expected.
+ */
+interface ExpectedUserError

--- a/backend/data/src/test/kotlin/io/tolgee/unit/ExpectedUserErrorWiringTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/ExpectedUserErrorWiringTest.kt
@@ -1,0 +1,37 @@
+package io.tolgee.unit
+
+import io.tolgee.batch.RequeueWithDelayException
+import io.tolgee.component.automations.processors.WebhookExecutionFailed
+import io.tolgee.constants.Message
+import io.tolgee.exceptions.ExpectedUserError
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+/**
+ * Locks in the assumption that webhook failures carry an [ExpectedUserError] somewhere
+ * in the cause chain — that is the structural contract `ChunkProcessingUtil` relies on
+ * to skip Sentry capture for user-misconfigured webhooks.
+ */
+class ExpectedUserErrorWiringTest {
+  @Test
+  fun `WebhookExecutionFailed implements ExpectedUserError`() {
+    val ex = WebhookExecutionFailed(IOException("connection refused"))
+    assertThat(ex).isInstanceOf(ExpectedUserError::class.java)
+  }
+
+  @Test
+  fun `RequeueWithDelayException wrapping WebhookExecutionFailed exposes the marker via cause chain`() {
+    val webhookFailure = WebhookExecutionFailed(IOException("connection refused"))
+    val wrapped =
+      RequeueWithDelayException(
+        message = Message.UNEXPECTED_ERROR_WHILE_EXECUTING_WEBHOOK,
+        cause = webhookFailure,
+        delayInMs = 5000,
+      )
+
+    val hasMarker = ExceptionUtils.getThrowableList(wrapped).any { it is ExpectedUserError }
+    assertThat(hasMarker).isTrue()
+  }
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackChannelMessagesOperations.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackChannelMessagesOperations.kt
@@ -101,13 +101,13 @@ class SlackChannelMessagesOperations(
 
       return ChatSuccess(response)
     } catch (e: SlackApiException) {
-      return ChatFailureException<R>(e).also {
-        if (isUserConfigSlackError(it.error)) {
-          logger.warn("Cannot send message in slack: ${it.error}")
-        } else {
-          logger.error("Cannot send message in slack: ${it.error}", it)
-        }
+      val failure = ChatFailureException<R>(e)
+      if (isUserConfigSlackError(failure.error)) {
+        logger.warn("Cannot send message in slack: ${failure.error}")
+      } else {
+        logger.error("Cannot send message in slack: ${failure.error}", e)
       }
+      return failure
     }
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackChannelMessagesOperations.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/slackIntegration/SlackChannelMessagesOperations.kt
@@ -96,19 +96,32 @@ class SlackChannelMessagesOperations(
 
       if (!response.isOk) {
         return ChatFailureResponseNotOk(response)
-          .also { failure ->
-            RuntimeException("Cannot send message in slack: ${failure.error}")
-              .let { logger.error(it.message, it) }
-          }
+          .also { failure -> logSlackFailure(failure.error) }
       }
 
       return ChatSuccess(response)
     } catch (e: SlackApiException) {
       return ChatFailureException<R>(e).also {
-        logger.error("Cannot send message in slack: ${it.error}", it)
+        if (isUserConfigSlackError(it.error)) {
+          logger.warn("Cannot send message in slack: ${it.error}")
+        } else {
+          logger.error("Cannot send message in slack: ${it.error}", it)
+        }
       }
     }
   }
+
+  private fun logSlackFailure(error: String) {
+    val message = "Cannot send message in slack: $error"
+    if (isUserConfigSlackError(error)) {
+      // User-side workspace/channel state — not a server bug, no need to alert
+      logger.warn(message)
+      return
+    }
+    logger.error(message, RuntimeException(message))
+  }
+
+  private fun isUserConfigSlackError(error: String): Boolean = error in USER_CONFIG_SLACK_ERRORS
 
   private fun OrganizationSlackWorkspace?.getSlackToken(): String {
     return this?.accessToken ?: tolgeeProperties.slack.token ?: throw SlackNotConfiguredException()
@@ -147,4 +160,18 @@ class SlackChannelMessagesOperations(
   data class SlackWorkspaceToken(
     val token: String,
   ) : SlackToken
+
+  companion object {
+    // Slack API errors caused by user/workspace state, not bugs in our code
+    private val USER_CONFIG_SLACK_ERRORS =
+      setOf(
+        "not_in_channel",
+        "channel_not_found",
+        "is_archived",
+        "account_inactive",
+        "token_revoked",
+        "missing_scope",
+        "invalid_auth",
+      )
+  }
 }


### PR DESCRIPTION
## Summary

Filters out Sentry events caused by user/external misconfiguration that were generating high volumes of noise:

- **Webhook failures** (`UNEXPECTED_ERROR_WHILE_EXECUTING_WEBHOOK`, `WEBHOOK_RESPONDED_WITH_NON_200_STATUS`) — user's webhook URL is broken or returns non-2xx. Currently produces ~50,000 events across multiple Sentry issues. Filtered at the batch-job layer so each retry stops counting.
- **Slack workspace state** (`not_in_channel`, `channel_not_found`, `is_archived`, `account_inactive`, `token_revoked`, `missing_scope`, `invalid_auth`) — bot was removed from a channel etc. Currently ~18,500 events. Demoted to `warn` so the Sentry log appender doesn't capture them.
- **`RequestRejectedException`** — Spring Security firewall blocking malformed requests (suspicious user agents/headers). Added to `SentryBeforeSendCallback.IGNORED_EXCEPTIONS`.
- **`MissingPathVariableException`** — client hit a URL whose handler expects a path variable that wasn't provided. Added to `SentryBeforeSendCallback.IGNORED_EXCEPTIONS`.

Visibility on stdout is preserved (warn-level log lines, plus the existing per-execution `BatchJobChunkExecution.errorMessage` / `stackTrace` persisted to DB).

`WebhookProcessor.kt` itself was deliberately left untouched to avoid conflicts with the in-flight webhook auto-disable branch — filtering happens one layer up in `ChunkProcessingUtil`.

## Test plan

- [ ] Trigger a webhook with a 500-returning URL and confirm the resulting batch-job error does not appear in Sentry, but a `warn` line appears in stdout
- [ ] Trigger a webhook with an unreachable URL — same expectation
- [ ] Send a Slack notification while the bot is not in the target channel — confirm `warn` line on stdout, no Sentry event
- [ ] Send a request with a forbidden user-agent header — confirm 403 response and no Sentry event
- [ ] Confirm normal MT failures, DB errors, and other unexpected exceptions still reach Sentry as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Suppress reporting for expected user-level errors so non-actionable issues are no longer sent to error tracking.
  * Classify and de-escalate integration failures (e.g., Slack, webhooks) to reduce noisy error alerts and log them at appropriate severity.
* **Tests**
  * Added tests verifying expected-user-error tagging and propagation through exception chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->