### PR TITLE
fix: allow agency invitations to be accepted by any user

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/invitation/PublicInvitationModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/invitation/PublicInvitationModelAssembler.kt
@@ -14,13 +14,14 @@ class PublicInvitationModelAssembler(
     PublicInvitationModel::class.java,
   ) {
   override fun toModel(entity: Invitation): PublicInvitationModel {
+    val isAgencyInvitation = entity.permission?.agency != null
     return PublicInvitationModel(
       id = entity.id!!,
       code = entity.code,
       projectName = entity.permission?.project?.name,
       organizationName = entity.organizationRole?.organization?.name,
       createdBy = entity.createdBy?.let { simpleUserAccountModelAssembler.toModel(it) },
-      inviteeEmail = entity.email,
+      inviteeEmail = if (isAgencyInvitation) null else entity.email,
     )
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
@@ -167,6 +167,9 @@ class InvitationService(
     invitation: Invitation,
     userAccount: UserAccount,
   ) {
+    if (invitation.permission?.agency != null) {
+      return
+    }
     val invitationEmail = invitation.email
     if (!invitationEmail.isNullOrBlank() &&
       !invitationEmail.equals(userAccount.username, ignoreCase = true)


### PR DESCRIPTION
Agency invitations are stored with email = agency.email purely as a delivery hint; the agency forwards the link to one of its translators, who has a different personal email. The email-binding check introduced in #3605 unintentionally caught these and hid the accept button.

Skip the email-match check when the invitation is bound to a translation agency, and omit inviteeEmail from the public invitation payload so the frontend doesn't render the mismatch UI for agency invitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced email handling and validation for agency invitations to improve security and streamline the invitation acceptance process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->