### PR TITLE
fix: roll back TM suggestion query optimizations

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/suggestion/TranslationSuggestionController.kt
@@ -24,7 +24,6 @@ import io.tolgee.service.translation.TranslationMemoryService
 import io.tolgee.util.disableAccelBuffering
 import jakarta.validation.Valid
 import org.springdoc.core.annotations.ParameterObject
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PagedResourcesAssembler
 import org.springframework.hateoas.PagedModel
@@ -113,7 +112,7 @@ class TranslationSuggestionController(
     )
     val targetLanguage = languageService.get(dto.targetLanguageId, projectHolder.project.id)
 
-    val data: Page<TranslationMemoryItemView> =
+    val data =
       dto.baseText?.let { baseText ->
         translationMemoryService.getSuggestions(
           baseText,

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
@@ -5,6 +5,7 @@ import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.translation.TranslationMemoryService
 import jakarta.persistence.EntityManager
+import org.springframework.data.domain.Pageable
 
 class MetadataProvider(
   private val context: MtTranslatorContext,
@@ -46,14 +47,14 @@ class MetadataProvider(
     keyId: Long?,
   ): List<ExampleItem> {
     return translationMemoryService
-      .getSuggestionsList(
+      .getSuggestions(
         baseTranslationText = text,
         isPlural = isPlural,
         keyId = keyId,
-        baseLanguageId = context.baseLanguage.id,
         targetLanguage = targetLanguage,
-        limit = 5,
-      ).map {
+        pageable = Pageable.ofSize(5),
+      ).content
+      .map {
         ExampleItem(
           key = it.keyName,
           keyNamespace = it.keyNamespace,

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -17,65 +17,6 @@ class TranslationMemoryService(
   private val translationsService: TranslationService,
   private val entityManager: EntityManager,
 ) {
-  /*
-   Returns translation memory suggestions for the batch/MT pipeline.
-
-   Uses % (trigram threshold operator) without ORDER BY so the composite GiST index on
-   (language_id, text gist_trgm_ops) can stop early as soon as LIMIT rows are found,
-   avoiding a full scan of all matching rows.
-   */
-  @Transactional
-  fun getSuggestionsList(
-    baseTranslationText: String,
-    isPlural: Boolean,
-    keyId: Long? = null,
-    baseLanguageId: Long,
-    targetLanguage: LanguageDto,
-    limit: Int = 5,
-  ): List<TranslationMemoryItemView> {
-    entityManager.createNativeQuery("set local pg_trgm.similarity_threshold to 0.5").executeUpdate()
-    val queryResult =
-      entityManager
-        .createNativeQuery(
-          """
-        select target.text as targetTranslationText,
-               baseTranslation.text as baseTranslationText,
-               key.name as keyName, ns.name as keyNamespace, key.id as keyId,
-               similarity(baseTranslation.text, :baseTranslationText) as similarity
-        from translation baseTranslation
-        join key on baseTranslation.key_id = key.id
-        left join namespace ns on key.namespace_id = ns.id
-        join translation target on
-              target.key_id = key.id and
-              target.language_id = :targetLanguageId and
-              target.text <> '' and
-              target.text is not null
-        where baseTranslation.language_id = :baseLanguageId
-          and (cast(:key as bigint) is null or key.id <> :key)
-          and key.is_plural = :isPlural
-          and baseTranslation.text % :baseTranslationText
-    """,
-        ).setParameter("baseTranslationText", baseTranslationText)
-        .setParameter("isPlural", isPlural)
-        .setParameter("key", keyId)
-        .setParameter("baseLanguageId", baseLanguageId)
-        .setParameter("targetLanguageId", targetLanguage.id)
-        .setMaxResults(limit)
-        .resultList
-
-    return queryResult.map {
-      it as Array<*>
-      TranslationMemoryItemView(
-        targetTranslationText = it[0] as String,
-        baseTranslationText = it[1] as String,
-        keyName = it[2] as String,
-        keyNamespace = it[3] as String?,
-        keyId = it[4] as Long,
-        similarity = (it[5] as Number).toFloat(),
-      )
-    }
-  }
-
   @Transactional
   fun getAutoTranslatedValue(
     key: Key,
@@ -116,7 +57,8 @@ class TranslationMemoryService(
     return PageImpl(data, pageable, count)
   }
 
-  private fun getSuggestionsData(
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun getSuggestionsData(
     sourceTranslationText: String,
     isPlural: Boolean,
     keyId: Long?,
@@ -129,24 +71,32 @@ class TranslationMemoryService(
       entityManager
         .createNativeQuery(
           """
-        select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
-               key.name as keyName, ns.name as keyNamespace, key.id as keyId,
-               similarity(baseTranslation.text, :baseTranslationText) as similarity,
-               count(*) over() as totalCount
-        from translation baseTranslation
-        join key on baseTranslation.key_id = key.id
-        left join namespace ns on key.namespace_id = ns.id
-        join project p on key.project_id = p.id
-        join translation target on
-              target.key_id = key.id and
-              target.language_id = :targetLanguageId and
-              target.text <> '' and
-              target.text is not null
-        where baseTranslation.language_id = p.base_language_id
-          and (cast(:key as bigint) is null or key.id <> :key)
-          and key.is_plural = :isPlural
-          and baseTranslation.text % :baseTranslationText
-        order by baseTranslation.text <-> :baseTranslationText
+        with base as (
+            select target.text as targetTranslationText, baseTranslation.text as baseTranslationText,
+              key.name as keyName, ns.name as keyNamespace, key.id as keyId, 
+            similarity(baseTranslation.text, :baseTranslationText) as similarity
+            from translation baseTranslation
+            join key on baseTranslation.key_id = key.id
+            left join namespace ns on key.namespace_id = ns.id
+            join project p on key.project_id = p.id
+            join translation target on
+                  target.key_id = key.id and 
+                  target.language_id = :targetLanguageId and
+                  target.text <> '' and
+                  target.text is not null
+            join key targetKey on target.key_id = targetKey.id    
+            """ +
+
+            // we use the case when syntax to force postgres to evaluate all the other conditions first,
+            // the similarity condition is slow even it uses index, and it tends to be evaluated first since
+            // huge underestimation
+            """
+            where case when (baseTranslation.language_id = p.base_language_id and
+              (cast(:key as bigint) is null or targetKey.id <> :key) and targetKey.is_plural = :isPlural)
+              then baseTranslation.text % :baseTranslationText end
+        ) select base.*, count(*) over() 
+        from base
+        order by base.similarity desc
     """,
         ).setParameter("baseTranslationText", sourceTranslationText)
         .setParameter("isPlural", isPlural)
@@ -156,7 +106,7 @@ class TranslationMemoryService(
         .setFirstResult(offset.toInt())
         .resultList
 
-    val count = ((queryResult.firstOrNull() as Array<*>?)?.get(6) as Number?)?.toLong() ?: 0L
+    val count = (queryResult.firstOrNull() as Array<*>?)?.get(6) as Long? ?: 0L
     return count to
       queryResult.map {
         it as Array<*>
@@ -165,7 +115,7 @@ class TranslationMemoryService(
           baseTranslationText = it[1] as String,
           keyName = it[2] as String,
           keyNamespace = it[3] as String?,
-          similarity = (it[5] as Number).toFloat(),
+          similarity = it[5] as Float,
           keyId = it[4] as Long,
         )
       }

--- a/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
@@ -25,6 +25,8 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.notNull
 import org.mockito.kotlin.whenever
 import org.springframework.context.ApplicationContext
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import kotlin.reflect.KClass
 
 class MtBatchTranslatorTest {
@@ -179,16 +181,15 @@ class MtBatchTranslatorTest {
     val translationMemoryServiceMock = TranslationMemoryService::class.mockIntoAppContext(appContextMock)
 
     doAnswer {
-      emptyList<TranslationMemoryItemView>()
+      Page.empty<TranslationMemoryItemView>()
     }.whenever(
       translationMemoryServiceMock,
-    ).getSuggestionsList(
+    ).getSuggestions(
       any<String>(),
       any<Boolean>(),
       notNull(),
-      any<Long>(),
       any<LanguageDto>(),
-      any<Int>(),
+      any<Pageable>(),
     )
 
     val bigMetaServiceMock = BigMetaService::class.mockIntoAppContext(appContextMock)


### PR DESCRIPTION
(#3537, #3540, #3615)

Restores getSuggestionsList / getSuggestionsData and the call site in MetadataProvider.getExamples to the state before commit 0d08a40db (#3537), which closed #3517 by switching the trigram predicate from `similarity(text, :input) > 0.5 ORDER BY similarity DESC` to `text % :input` (no ORDER BY) and added composite trigram indexes designed for early-LIMIT termination on very large language partitions.

The optimization helped projects with 1M+ translations per language, as described in #3517. For everything below that scale the new shape gave the planner a tempting GIN+language BitmapAnd path that — on long source inputs (notably ICU plural strings) — builds a multi-thousand-row bitmap before any filtering. EXPLAIN ANALYZE on production data confirmed getSuggestionsList wall-clock at multiple seconds per call. Multiplied by the per-translation invocation rate of AUTO_TRANSLATE / MACHINE_TRANSLATE batches (via PromptVariablesHelper for prompt-based MT providers), entire batch jobs were degrading to multi-minute or multi-hour run times. The follow-up timeout cap added by #3540 and removed by #3615 only masked or unmasked the symptom; neither addressed the planner trap.

The pre-#3537 query (`similarity > 0.5 ORDER BY DESC`) cannot use the trigram bitmap index for the predicate, so the planner falls back to an Index Scan on the language_id btree with a row-level similarity filter. That plan is bounded by language partition size and well-shaped for the typical project. EXPLAIN ANALYZE on the same production data and inputs that previously took 2.8 s now run in 67–131 ms. For very large projects this plan can scan an entire language partition (originally the motivation for #3537), so reverting brings back the regression described in #3517 — that needs a proper, planner-stable solution which is being investigated separately.

Schema is left untouched. The btree index on language_id introduced by #3537 has 21M production scans (a top-N hot index used well beyond TM suggestions) and must be kept. The composite GiST index from #3537 has zero production scans since it was created — harmless to leave in place, can be cleaned up in a separate, lower-stakes follow-up.

Refs: #3517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized translation memory suggestion retrieval by consolidating internal APIs and streamlining pagination handling.

* **Tests**
  * Updated translation service tests to align with refactored suggestion retrieval mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->