### PR TITLE
fix: debounce QA-issue websocket events to avoid translations view freeze

### DIFF
--- a/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
+++ b/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
   Modification,
   TranslationsModifiedData,
+  QaIssuesUpdatedData,
 } from 'tg.websocket-client/WebsocketClient';
 import { useGlobalContext } from 'tg.globalContext/GlobalContext';
 import { useQaChecksEnabled } from 'tg.ee';
@@ -54,7 +55,23 @@ export const useWebsocketService = (
     }
   }
 
+  function updateQaIssues(events: QaIssuesUpdatedData[]) {
+    translationService.changeTranslations(
+      events.map((event) => ({
+        keyId: event.data.keyId,
+        language: event.data.languageTag,
+        value: {
+          id: event.data.translationId,
+          qaIssueCount: event.data.qaIssueCount,
+          qaChecksStale: event.data.qaChecksStale,
+          qaIssues: event.data.qaIssues,
+        },
+      }))
+    );
+  }
+
   const eventQueue = useRef([] as TranslationsModifiedData[]);
+  const qaEventQueue = useRef([] as QaIssuesUpdatedData[]);
 
   const handleQueue = () => {
     if (eventBlockers <= 0) {
@@ -62,6 +79,10 @@ export const useWebsocketService = (
         updateTranslations(e);
       });
       eventQueue.current = [];
+      if (qaEventQueue.current.length > 0) {
+        updateQaIssues(qaEventQueue.current);
+        qaEventQueue.current = [];
+      }
     }
   };
 
@@ -100,18 +121,8 @@ export const useWebsocketService = (
       return client.subscribe(
         `/projects/${project.id}/qa-issues-updated`,
         (event) => {
-          translationService.changeTranslations([
-            {
-              keyId: event.data.keyId,
-              language: event.data.languageTag,
-              value: {
-                id: event.data.translationId,
-                qaIssueCount: event.data.qaIssueCount,
-                qaChecksStale: event.data.qaChecksStale,
-                qaIssues: event.data.qaIssues,
-              },
-            },
-          ]);
+          qaEventQueue.current.push(event);
+          handleQueueDelayed();
         }
       );
     }


### PR DESCRIPTION
## Summary

- Fixes a UI freeze in the Translations view that could occur when QA Checks is enabled and a large batch job is running. The backend emits one `qa-issues-updated` per finished translation; the handler previously triggered a React `setState` per message with no batching, saturating the main thread (especially in Firefox) until the tab had to be closed.
- Sends events through the existing 100 ms debounced queue (`handleQueueDelayed`), so the UI updates at most ~10×/s regardless of incoming message rate.
- Reuses the existing `eventBlockers` gating so QA flushes are paused alongside translation-data flushes (e.g. during inline edits).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of QA issue updates through an event queuing system that batches real-time updates before processing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->