### PR TITLE
perf: chunk bulk batch-job processors at 5000 items

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AbstractTranslationLabelChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AbstractTranslationLabelChunkProcessor.kt
@@ -50,6 +50,11 @@ abstract class AbstractTranslationLabelChunkProcessor(
     )
   }
 
+  override fun getChunkSize(
+    request: LabelTranslationsRequest,
+    projectId: Long?,
+  ): Int = 5000
+
   abstract fun process(
     subChunk: List<Long>,
     languageIds: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/ClearTranslationsChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/ClearTranslationsChunkProcessor.kt
@@ -50,4 +50,9 @@ class ClearTranslationsChunkProcessor(
       languageIds = data.languageIds
     }
   }
+
+  override fun getChunkSize(
+    request: ClearTranslationsRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/CopyTranslationsChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/CopyTranslationsChunkProcessor.kt
@@ -50,4 +50,9 @@ class CopyTranslationsChunkProcessor(
       targetLanguageIds = data.targetLanguageIds
     }
   }
+
+  override fun getChunkSize(
+    request: CopyTranslationRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/DeleteKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/DeleteKeysChunkProcessor.kt
@@ -50,4 +50,9 @@ class DeleteKeysChunkProcessor(
   override fun getTarget(data: DeleteKeysRequest): List<Long> {
     return data.keyIds
   }
+
+  override fun getChunkSize(
+    request: DeleteKeysRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/HardDeleteKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/HardDeleteKeysChunkProcessor.kt
@@ -47,4 +47,9 @@ class HardDeleteKeysChunkProcessor(
   override fun getTarget(data: HardDeleteKeysRequest): List<Long> {
     return data.keyIds
   }
+
+  override fun getChunkSize(
+    request: HardDeleteKeysRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/RestoreKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/RestoreKeysChunkProcessor.kt
@@ -53,4 +53,9 @@ class RestoreKeysChunkProcessor(
   override fun getTarget(data: RestoreKeysRequest): List<Long> {
     return data.keyIds
   }
+
+  override fun getChunkSize(
+    request: RestoreKeysRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetKeysNamespaceChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetKeysNamespaceChunkProcessor.kt
@@ -72,4 +72,9 @@ class SetKeysNamespaceChunkProcessor(
       this.namespace = data.namespace
     }
   }
+
+  override fun getChunkSize(
+    request: SetKeysNamespaceRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetTranslationsStateChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetTranslationsStateChunkProcessor.kt
@@ -50,4 +50,9 @@ class SetTranslationsStateChunkProcessor(
       state = data.state
     }
   }
+
+  override fun getChunkSize(
+    request: SetTranslationsStateStateRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
@@ -52,4 +52,9 @@ class TagKeysChunkProcessor(
       this.tags = data.tags
     }
   }
+
+  override fun getChunkSize(
+    request: TagKeysRequest,
+    projectId: Long?,
+  ): Int = 5000
 }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
@@ -51,4 +51,9 @@ class UntagKeysChunkProcessor(
       this.tags = data.tags
     }
   }
+
+  override fun getChunkSize(
+    request: UntagKeysRequest,
+    projectId: Long?,
+  ): Int = 5000
 }


### PR DESCRIPTION
Bulk data-modification processors (delete, hard-delete, copy, clear, set-state, tag, untag, set-namespace, restore, label/unlabel) inherited the default chunkSize=0 from ChunkProcessor, meaning the entire job target was processed as a single transaction. This caused production issues — a delete of ~40k keys triggered OOM-class problems.

**Why chunking is the right fix (not just clearing the persistence context)**

The Hibernate ActivityDatabaseInterceptor does NOT persist activity records as it fires; onSave/onFlushDirty/onDelete only append to activityHolder.modifiedEntities, an in-memory mutable Map on the ActivityHolder bean. The actual write happens once at BeforeTransactionCompletionProcess in InterceptedEventsManager, right before commit (flush + clear + storeActivityData).

This means calling entityManager.clear() between sub-batches inside the processor — which would help with the Hibernate first-level cache — does not bound the activity-side memory. activityHolder.modifiedEntities still grows for the entire transaction, just like the issue we hit when optimizing import (where we ended up writing activity records manually).

Per-chunk transactions, on the other hand, drain modifiedEntities at each commit boundary automatically, with no manual plumbing.

**Why 5000**

Activity entities created per item depend on the operation:
- soft-delete:  ~1 modified-entity row + ~1 describing-entity row per key
- hard-delete:  cascades to translations (1/lang), KeyMeta, comments, tags, screenshots — roughly (2 + numLanguages) modified entities per key, so ~7 per key for a 5-language project, more for projects with 10–20+ languages

Heap budget at 5000 items per chunk:
- soft-delete:  ~5k entries  → a few MB
- hard-delete:  ~35k entries (5 langs) / ~100k+ (15+ langs) → tens to ~100 MB heap per chunk, well within tolerance For a 50k-key project: 10 chunks. For the 40k incident: 8 chunks.

10000 was considered but is too close to the cliff for projects with many languages — at 20 langs, a 10k chunk produces 200k+ activity entries per transaction, which is the same shape that caused the original problem. 5000 gives ~3-4× headroom on language count without fragmenting too much.

**Activity merge cost at job completion**

Per-chunk transactions create one ActivityRevision each, so BatchJobActivityFinalizer must merge them at job completion. The merge runs five SQL statements: a duplicates-cleanup on
activity_describing_entity (the only nonlinear one — three GROUP BYs over the involved revisions), an UPDATE rewiring describing_entity to the master revision, an UPDATE rewiring modified_entity, a DELETE of the source revisions, and an UPDATE stamping the master with the job metadata. All are bounded by the revision-id list, so cost scales with chunk count (~10), not project history. The duplicates-cleanup is the one that was already designed for this — the existing chunked processors (machine-translate, auto-translate, etc.) have always used small chunkSizes and exercised this path. Bearable.

Stability

- No surprises with OOM: per-chunk activity & Hibernate state is bounded regardless of project size, language count, or input size.
- Better retry behavior: a failing chunk retries 5k items instead of the entire job. The existing chunk-level retry in BatchJobActionService now actually does what it advertises.
- Shorter project-lock holds per chunk, so other queued jobs aren't blocked for the full duration of a 50k operation.

The internal chunked(100)/chunked(1000) loops inside each processor remain — they bound SQL parameter list size and are independent of the framework chunking.

(as part of https://github.com/tolgee/tolgee-platform/issues/3576)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized batch processing for multiple operations by standardizing chunk sizes. This improves performance and consistency across translation clearing, copying, key management, and state-setting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->