### PR TITLE
feat: add per-call metric for MT provider latency

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -178,6 +178,30 @@ class Metrics(
       .record(Duration.ofMillis(executionTimeMs.coerceAtLeast(0)))
   }
 
+  // ==========================================================================
+  // Machine Translation Provider Metrics
+  // ==========================================================================
+
+  /**
+   * Records the duration of a single call to a machine-translation provider
+   * (one text/key). Tagged by service (GOOGLE, AWS, DEEPL, AZURE, BAIDU, PROMPT)
+   * and outcome (success / error).
+   */
+  fun recordMtProviderCall(
+    service: String,
+    outcome: String,
+    durationMs: Long,
+  ) {
+    Timer
+      .builder("tolgee.mt.provider.call")
+      .description("Time spent calling a machine-translation provider (per text/key)")
+      .publishPercentileHistogram()
+      .tag("service", service)
+      .tag("outcome", outcome)
+      .register(meterRegistry)
+      .record(Duration.ofMillis(durationMs.coerceAtLeast(0)))
+  }
+
   // Branch operations - Priority 1 (Must Have)
   val branchCreateTimer: Timer by lazy {
     Timer

--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -202,6 +202,25 @@ class Metrics(
       .record(Duration.ofMillis(durationMs.coerceAtLeast(0)))
   }
 
+  /**
+   * Records the duration of a single translation-memory lookup
+   * (TranslationMemoryService.getAutoTranslatedValue, the path hit by
+   * AUTO_TRANSLATE / PRE_TRANSLATE_BT_TM chunks before the LLM call).
+   * Tagged by outcome: hit (TM returned a value), miss (no match), error.
+   */
+  fun recordTranslationMemoryLookup(
+    outcome: String,
+    durationMs: Long,
+  ) {
+    Timer
+      .builder("tolgee.translation.memory.lookup")
+      .description("Time spent looking up a translation-memory match for a single (key, target-language) pair")
+      .publishPercentileHistogram()
+      .tag("outcome", outcome)
+      .register(meterRegistry)
+      .record(Duration.ofMillis(durationMs.coerceAtLeast(0)))
+  }
+
   // Branch operations - Priority 1 (Must Have)
   val branchCreateTimer: Timer by lazy {
     Timer

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
@@ -1,6 +1,7 @@
 package io.tolgee.component.machineTranslation
 
 import io.sentry.Sentry
+import io.tolgee.Metrics
 import io.tolgee.component.machineTranslation.providers.ProviderTranslateParams
 import io.tolgee.configuration.tolgee.InternalProperties
 import io.tolgee.constants.Caches
@@ -24,6 +25,7 @@ class MtServiceManager(
   private val applicationContext: ApplicationContext,
   private val internalProperties: InternalProperties,
   private val cacheManager: CacheManager,
+  private val metrics: Metrics,
 ) {
   private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -48,9 +50,16 @@ class MtServiceManager(
       return foundInCache
     }
 
+    val startedAt = System.currentTimeMillis()
     return try {
       val translated =
         provider.translate(translateParams)
+
+      metrics.recordMtProviderCall(
+        params.serviceInfo.serviceType.name,
+        "success",
+        System.currentTimeMillis() - startedAt,
+      )
 
       val translateResult = getTranslateResult(translated, params.serviceInfo.serviceType, params.textRaw)
 
@@ -58,6 +67,11 @@ class MtServiceManager(
 
       return translateResult
     } catch (e: Exception) {
+      metrics.recordMtProviderCall(
+        params.serviceInfo.serviceType.name,
+        "error",
+        System.currentTimeMillis() - startedAt,
+      )
       handleSilentFail(params, e)
       getEmptyResult(params.serviceInfo.serviceType, params.textRaw.isBlank(), e)
     }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationMemoryService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.translation
 
+import io.tolgee.Metrics
 import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.model.Language
 import io.tolgee.model.key.Key
@@ -16,13 +17,28 @@ import org.springframework.transaction.annotation.Transactional
 class TranslationMemoryService(
   private val translationsService: TranslationService,
   private val entityManager: EntityManager,
+  private val metrics: Metrics,
 ) {
   @Transactional
   fun getAutoTranslatedValue(
     key: Key,
     targetLanguage: Language,
   ): TranslationMemoryItemView? {
-    return translationsService.getTranslationMemoryValue(key, targetLanguage)
+    val startedAt = System.currentTimeMillis()
+    return try {
+      val result = translationsService.getTranslationMemoryValue(key, targetLanguage)
+      metrics.recordTranslationMemoryLookup(
+        outcome = if (result != null) "hit" else "miss",
+        durationMs = System.currentTimeMillis() - startedAt,
+      )
+      result
+    } catch (e: Exception) {
+      metrics.recordTranslationMemoryLookup(
+        outcome = "error",
+        durationMs = System.currentTimeMillis() - startedAt,
+      )
+      throw e
+    }
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)


### PR DESCRIPTION
Adds tolgee.mt.provider.call timer (percentile histogram) tagged by service (GOOGLE/AWS/DEEPL/AZURE/BAIDU/PROMPT) and outcome (success/error). Wraps the single provider.translate(..) chokepoint in MtServiceManager, so cache hits and fake-MT paths are intentionally excluded.

Lets us isolate LLM provider latency from total chunk-execution time and alert specifically when a provider is genuinely slow rather than on chunk-level spikes caused by one project's large LLM payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Machine Translation observability: per-call success/error tracking and execution latency metrics for MT providers, with percentile-aware histograms and aggregated reporting to surface provider performance and failures.
  * Translation memory monitoring: records hit/miss/error outcomes and lookup durations to surface translation-memory responsiveness and reliability for better operational visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->