### PR TITLE
feat: add tooltips to S3 storage form fields

### DIFF
--- a/webapp/src/ee/developer/storage/StorageFormS3.tsx
+++ b/webapp/src/ee/developer/storage/StorageFormS3.tsx
@@ -5,6 +5,7 @@ import { Form, Formik, setNestedObjectValues } from 'formik';
 import { TextField } from 'tg.component/common/form/fields/TextField';
 import { components } from 'tg.service/apiSchema.generated';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
+import { LabelHint } from 'tg.component/common/LabelHint';
 import { StorageFormActions } from './StorageFormActions';
 
 type ContentStorageRequest = components['schemas']['ContentStorageRequest'];
@@ -87,13 +88,31 @@ export const StorageFormS3 = ({
               <TextField
                 size="small"
                 name="s3ContentStorageConfig.path"
-                label="Path prefix"
+                label={
+                  <LabelHint
+                    title={t(
+                      'storage_form_s3_path_hint',
+                      'Optional subdirectory inside the bucket, e.g. "i18n". Leave empty to use the bucket root.'
+                    )}
+                  >
+                    Path prefix
+                  </LabelHint>
+                }
                 data-cy="storage-form-s3-path"
               />
               <TextField
                 size="small"
                 name="s3ContentStorageConfig.accessKey"
-                label="Access key"
+                label={
+                  <LabelHint
+                    title={t(
+                      'storage_form_s3_access_key_hint',
+                      'Requires "s3:PutObject", "s3:GetObject", "s3:DeleteObject" (and "s3:ListBucket" if "Prune before publish" is enabled) on the bucket. For Cloudflare R2: use an API token with "Object Read & Write" permission.'
+                    )}
+                  >
+                    Access key
+                  </LabelHint>
+                }
                 placeholder={keepAsIsPlaceholder}
                 InputLabelProps={keepAsIsInputLabelProps}
                 data-cy="storage-form-s3-access-key"
@@ -109,19 +128,57 @@ export const StorageFormS3 = ({
               <TextField
                 size="small"
                 name="s3ContentStorageConfig.endpoint"
-                label="Endpoint"
+                label={
+                  <LabelHint
+                    title={t(
+                      'storage_form_s3_endpoint_hint',
+                      'e.g. "{awsExample}", "{r2Example}"',
+                      {
+                        awsExample: 'https://s3.eu-central-1.amazonaws.com',
+                        r2Example:
+                          'https://<account-id>.r2.cloudflarestorage.com',
+                      }
+                    )}
+                  >
+                    Endpoint
+                  </LabelHint>
+                }
                 data-cy="storage-form-s3-endpoint"
               />
               <TextField
                 size="small"
                 name="s3ContentStorageConfig.signingRegion"
-                label="Signing region"
+                label={
+                  <LabelHint
+                    title={t(
+                      'storage_form_s3_signing_region_hint',
+                      'e.g. "eu-central-1", "auto" for Cloudflare'
+                    )}
+                  >
+                    Signing region
+                  </LabelHint>
+                }
                 data-cy="storage-form-s3-signing-region"
               />
               <TextField
                 size="small"
                 name="publicUrlPrefix"
-                label={t('storage_form_public_url_prefix')}
+                label={
+                  <LabelHint
+                    title={t(
+                      'storage_form_s3_public_url_prefix_hint',
+                      'e.g. "{awsExample}", "{r2Example}"',
+                      {
+                        awsExample:
+                          'https://<bucket-name>.s3.eu-central-1.amazonaws.com',
+                        r2Example:
+                          'https://<account-id>.r2.cloudflarestorage.com/<bucket-name>',
+                      }
+                    )}
+                  >
+                    {t('storage_form_public_url_prefix')}
+                  </LabelHint>
+                }
                 data-cy="storage-form-public-url-prefix"
               />
             </DialogContent>


### PR DESCRIPTION
Adds question-mark hint icons next to Access key, Endpoint, Signing region, Path prefix, and Public URL prefix in the S3 content storage form, with examples for AWS S3 and Cloudflare R2 and the IAM permissions required by the Test button and content delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual guidance hints to S3 storage configuration fields (Path prefix, Access key, Endpoint, Signing region, and Public URL prefix) to help users better understand each setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->