### PR TITLE
fix: truncate QA preview for longer translations

### DIFF
--- a/webapp/src/ee/qa/components/QaCheckItem.tsx
+++ b/webapp/src/ee/qa/components/QaCheckItem.tsx
@@ -13,6 +13,7 @@ import { useQaIssueMessage } from '../hooks/useQaIssueMessage';
 import { useQaCheckTypeLabel } from '../hooks/useQaCheckTypeLabel';
 import { QaPreviewIssue } from 'tg.ee.module/qa/models/QaPreviewWsModels';
 import { TextBlock } from 'tg.component/common/TextBlock';
+import { cropDiffContext } from 'tg.fixtures/cropDiffContext';
 
 const StyledItem = styled(Box)`
   display: flex;
@@ -87,6 +88,16 @@ const StyledAddedSpaces = styled('span')`
   background-color: ${({ theme }) => theme.palette.success.light};
 `;
 
+const StyledInsertionMarker = styled('span')`
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background-color: ${({ theme }) => theme.palette.primary.main};
+  vertical-align: text-bottom;
+  border-radius: 1px;
+  margin: 0 1px;
+`;
+
 const StyledNormalActions = styled(Box)`
   display: flex;
   align-items: center;
@@ -97,22 +108,45 @@ function renderDiff(
   text: string,
   positionStart: number,
   positionEnd: number,
-  replacement: string
+  replacement: string,
+  locale?: string
 ) {
-  const before = text.slice(0, positionStart);
-  const removed = text.slice(positionStart, positionEnd);
-  const after = text.slice(positionEnd);
-  const isReplacementSpacesOnly = /^\s+$/.test(replacement);
+  const cropped = cropDiffContext(
+    text,
+    positionStart,
+    positionEnd,
+    replacement,
+    locale
+  );
+  const isReplacementSpacesOnly = /^\s+$/.test(cropped.replacement);
   return (
     <>
-      {before && <StyledUnchanged>{before}</StyledUnchanged>}
-      {removed && <StyledRemoved>{removed}</StyledRemoved>}
-      {isReplacementSpacesOnly ? (
-        <StyledAddedSpaces>{replacement}</StyledAddedSpaces>
-      ) : (
-        <StyledAdded>{replacement}</StyledAdded>
+      {cropped.beforeEllipsis && <StyledUnchanged>…</StyledUnchanged>}
+      {cropped.before && (
+        <StyledUnchanged>
+          <bdi>{cropped.before}</bdi>
+        </StyledUnchanged>
       )}
-      {after && <StyledUnchanged>{after}</StyledUnchanged>}
+      {cropped.removed && (
+        <StyledRemoved>
+          <bdi>{cropped.removed}</bdi>
+        </StyledRemoved>
+      )}
+      {cropped.isInsertion && cropped.replacement && <StyledInsertionMarker />}
+      {cropped.replacement &&
+        (isReplacementSpacesOnly ? (
+          <StyledAddedSpaces>{cropped.replacement}</StyledAddedSpaces>
+        ) : (
+          <StyledAdded>
+            <bdi>{cropped.replacement}</bdi>
+          </StyledAdded>
+        ))}
+      {cropped.after && (
+        <StyledUnchanged>
+          <bdi>{cropped.after}</bdi>
+        </StyledUnchanged>
+      )}
+      {cropped.afterEllipsis && <StyledUnchanged>…</StyledUnchanged>}
     </>
   );
 }
@@ -121,6 +155,7 @@ type Props = {
   issue: QaPreviewIssue;
   index?: number;
   text: string;
+  locale?: string;
   slim?: boolean;
   onCorrect?: () => void;
   onIgnore?: () => void;
@@ -130,6 +165,7 @@ export const QaCheckItem = ({
   issue,
   index,
   text,
+  locale,
   slim = false,
   onCorrect,
   onIgnore,
@@ -232,7 +268,8 @@ export const QaCheckItem = ({
               text,
               issue.positionStart ?? 0,
               issue.positionEnd ?? 0,
-              issue.replacement ?? ''
+              issue.replacement ?? '',
+              locale
             )}
           </StyledDiffText>
         </TextBlock>

--- a/webapp/src/ee/qa/components/QaChecksPanel.tsx
+++ b/webapp/src/ee/qa/components/QaChecksPanel.tsx
@@ -194,6 +194,7 @@ export const QaChecksPanel: FC<PanelContentProps> = (data) => {
             issue={issue}
             index={index + 1}
             text={text}
+            locale={data.language.tag}
             slim
             onCorrect={
               isCorrectable(issue) ? () => handleCorrect(issue) : undefined

--- a/webapp/src/fixtures/__tests__/cropDiffContext.test.ts
+++ b/webapp/src/fixtures/__tests__/cropDiffContext.test.ts
@@ -1,0 +1,275 @@
+import {
+  cropDiffContext,
+  CONTEXT_AFTER,
+  CONTEXT_BEFORE,
+  MAX_FULL_LENGTH,
+  MAX_REPLACEMENT_RENDER,
+} from '../cropDiffContext';
+
+describe('cropDiffContext', () => {
+  describe('short text', () => {
+    it('does not truncate text below threshold', () => {
+      const text = 'Hello world!';
+      const result = cropDiffContext(text, 6, 11, 'earth');
+      expect(result.beforeEllipsis).toBe(false);
+      expect(result.afterEllipsis).toBe(false);
+      expect(result.before).toBe('Hello ');
+      expect(result.removed).toBe('world');
+      expect(result.replacement).toBe('earth');
+      expect(result.after).toBe('!');
+      expect(result.isInsertion).toBe(false);
+    });
+
+    it('exactly MAX_FULL_LENGTH is not cropped', () => {
+      const text = 'a'.repeat(MAX_FULL_LENGTH - 3) + 'BAD';
+      expect(text.length).toBe(MAX_FULL_LENGTH);
+      const result = cropDiffContext(
+        text,
+        MAX_FULL_LENGTH - 3,
+        MAX_FULL_LENGTH,
+        'GOOD'
+      );
+      expect(result.beforeEllipsis).toBe(false);
+      expect(result.afterEllipsis).toBe(false);
+    });
+
+    it('MAX_FULL_LENGTH + 1 is the first cropped length', () => {
+      const text = 'a'.repeat(MAX_FULL_LENGTH - 2) + 'BAD';
+      expect(text.length).toBe(MAX_FULL_LENGTH + 1);
+      const result = cropDiffContext(
+        text,
+        MAX_FULL_LENGTH - 2,
+        MAX_FULL_LENGTH + 1,
+        'GOOD'
+      );
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.afterEllipsis).toBe(false);
+    });
+  });
+
+  describe('long text', () => {
+    const longText =
+      'A'.repeat(80) + ' ' + 'foo BAD bar' + ' ' + 'B'.repeat(80);
+    // positions of "BAD" — word "BAD" starts at offset 80 + 1 + 4 = 85, ends at 88
+    const start = 85;
+    const end = 88;
+
+    it('crops on both sides when removal is in the middle of a long text', () => {
+      const result = cropDiffContext(longText, start, end, 'GOOD');
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.afterEllipsis).toBe(true);
+      expect(result.before.length).toBeLessThanOrEqual(
+        CONTEXT_BEFORE + 4 /* word-boundary slack */
+      );
+      expect(result.after.length).toBeLessThanOrEqual(CONTEXT_AFTER + 4);
+      expect(result.removed).toBe('BAD');
+      expect(result.replacement).toBe('GOOD');
+    });
+
+    it('omits leading ellipsis when change is near the start', () => {
+      const text = 'BAD ' + 'x'.repeat(MAX_FULL_LENGTH);
+      const result = cropDiffContext(text, 0, 3, 'GOOD');
+      expect(result.beforeEllipsis).toBe(false);
+      expect(result.afterEllipsis).toBe(true);
+      expect(result.before).toBe('');
+    });
+
+    it('omits trailing ellipsis when change is near the end', () => {
+      const text = 'x'.repeat(MAX_FULL_LENGTH) + ' BAD';
+      const start = MAX_FULL_LENGTH + 1;
+      const end = MAX_FULL_LENGTH + 4;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.afterEllipsis).toBe(false);
+      expect(result.after).toBe('');
+    });
+
+    it('asymmetric: text just over threshold with change near the end', () => {
+      const text = 'x'.repeat(MAX_FULL_LENGTH - 1) + ' BAD';
+      // length === MAX_FULL_LENGTH + 3
+      const start = MAX_FULL_LENGTH;
+      const end = MAX_FULL_LENGTH + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(text.length).toBe(MAX_FULL_LENGTH + 3);
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.afterEllipsis).toBe(false);
+    });
+  });
+
+  describe('insertion', () => {
+    it('marks isInsertion when positionStart === positionEnd', () => {
+      const result = cropDiffContext('hello world', 5, 5, ' there');
+      expect(result.isInsertion).toBe(true);
+      expect(result.removed).toBe('');
+    });
+
+    it('insertion at very start', () => {
+      const result = cropDiffContext('hello world', 0, 0, '> ');
+      expect(result.isInsertion).toBe(true);
+      expect(result.before).toBe('');
+    });
+
+    it('insertion at very end', () => {
+      const result = cropDiffContext('hello world', 11, 11, '!');
+      expect(result.isInsertion).toBe(true);
+      expect(result.after).toBe('');
+    });
+  });
+
+  describe('removed segment', () => {
+    it('renders a long removed segment in full (never cropped)', () => {
+      const removedSegment = 'X'.repeat(300);
+      const text =
+        'before context here ' + removedSegment + ' after context here';
+      const start = 'before context here '.length;
+      const end = start + removedSegment.length;
+      const result = cropDiffContext(text, start, end, '');
+      expect(result.removed).toBe(removedSegment);
+      expect(result.removed.length).toBe(300);
+    });
+  });
+
+  describe('word-boundary preference', () => {
+    it('prefers cutting at a whitespace within tolerance', () => {
+      // 'before' has 80 chars total ending in "...lazy dog" type words.
+      const before = 'a'.repeat(60) + ' jumped over the lazy quick brown fox ';
+      const text = before + 'BAD' + 'tail';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      // The kept slice should start right after a whitespace, so it should
+      // not start with the middle of a word.
+      expect(result.before.length).toBeGreaterThan(0);
+      expect(result.before.startsWith(' ')).toBe(false);
+      // Verify we kept content and a real word starts the slice.
+      expect(result.before).toMatch(/^[A-Za-z]/);
+    });
+
+    it('falls back to hard cut when no whitespace within tolerance', () => {
+      const before = 'a'.repeat(200); // no whitespace
+      const text = before + 'BAD' + 'b'.repeat(50);
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.before.length).toBe(CONTEXT_BEFORE);
+    });
+
+    it('trims leading whitespace from cropped before so the ellipsis abuts visible content', () => {
+      // 80 chars + "     word ..." — the cut for keep=30 lands inside 'a'-run,
+      // skips no whitespace; force whitespace at the cut by padding so the
+      // grapheme right after the cut is whitespace.
+      const before = 'a'.repeat(120) + '     foo bar baz qux';
+      const text = before + 'BAD' + 'tail';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.before.startsWith(' ')).toBe(false);
+    });
+
+    it('trims trailing whitespace from cropped after so the ellipsis abuts visible content', () => {
+      const after = 'foo bar baz qux     ' + 'b'.repeat(120);
+      const text = 'head' + 'BAD' + after;
+      const start = 'head'.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(result.afterEllipsis).toBe(true);
+      expect(result.after.endsWith(' ')).toBe(false);
+    });
+  });
+
+  describe('grapheme clusters', () => {
+    it('does not split a surrogate pair at the cut boundary', () => {
+      // 😀 = "😀", 2 UTF-16 code units, 1 grapheme.
+      // Place an emoji exactly at the would-be cut so a code-unit split would
+      // produce a lone high surrogate.
+      const padding = 'a'.repeat(100);
+      const before = padding + '😀😀😀😀😀'; // 5 emojis = 10 code units
+      const text = before + 'BAD' + 'tail';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      // Verify no lone surrogate
+      for (let i = 0; i < result.before.length; i++) {
+        const code = result.before.charCodeAt(i);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          // high surrogate — must be followed by low surrogate
+          const next = result.before.charCodeAt(i + 1);
+          expect(next).toBeGreaterThanOrEqual(0xdc00);
+          expect(next).toBeLessThanOrEqual(0xdfff);
+        }
+      }
+    });
+
+    it('does not split a ZWJ family emoji at the cut boundary', () => {
+      // 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl (1 grapheme)
+      const family = '\u{1F468}‍\u{1F469}‍\u{1F467}';
+      const before = 'a'.repeat(80) + family + family + family;
+      const text = before + 'BAD' + 'tail';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      // The kept `before` should not start or end mid-cluster (no lone ZWJ).
+      expect(result.before.startsWith('‍')).toBe(false);
+      expect(result.before.endsWith('‍')).toBe(false);
+    });
+
+    it('does not split a combining accent at the cut boundary', () => {
+      // "é" as e + COMBINING ACUTE (U+0301)
+      const accented = 'é'.repeat(40);
+      const before = 'a'.repeat(60) + accented;
+      const text = before + 'BAD' + 'tail';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      // The kept `before` must not start with a lone combining mark.
+      expect(result.before.startsWith('́')).toBe(false);
+    });
+
+    it('whitespace search runs in grapheme space and does not land inside a ZWJ cluster', () => {
+      const family = '\u{1F468}‍\u{1F469}‍\u{1F467}';
+      // Build a `before` whose hard-cut grapheme position falls inside a
+      // family cluster's region; ensure no surrogate/ZWJ leak.
+      const before = 'word ' + family.repeat(20) + ' tail';
+      const text = before + 'BAD';
+      const start = before.length;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      // Sanity: kept slice doesn't begin or end with a ZWJ.
+      expect(result.before.startsWith('‍')).toBe(false);
+      expect(result.before.endsWith('‍')).toBe(false);
+    });
+  });
+
+  describe('replacement bounds', () => {
+    it('passes through normal replacements unchanged', () => {
+      const result = cropDiffContext('abcde', 1, 4, 'XYZ');
+      expect(result.replacement).toBe('XYZ');
+      expect(result.replacementEllipsised).toBe(false);
+    });
+
+    it('inner-ellipsises replacements over MAX_REPLACEMENT_RENDER', () => {
+      const huge = 'x'.repeat(MAX_REPLACEMENT_RENDER + 100);
+      const result = cropDiffContext('abcde', 1, 4, huge);
+      expect(result.replacementEllipsised).toBe(true);
+      expect(result.replacement).toContain('…');
+      expect(result.replacement.length).toBeLessThan(huge.length);
+    });
+  });
+
+  describe('RTL', () => {
+    it('crops Arabic text correctly (string-level, not BIDI render)', () => {
+      // "السلام عليكم ورحمة الله وبركاته" repeated to exceed threshold
+      const arabic = 'السلام عليكم ورحمة الله وبركاته ';
+      const text = arabic.repeat(10) + 'BAD' + arabic.repeat(10);
+      const start = arabic.length * 10;
+      const end = start + 3;
+      const result = cropDiffContext(text, start, end, 'GOOD');
+      expect(result.beforeEllipsis).toBe(true);
+      expect(result.afterEllipsis).toBe(true);
+      expect(result.removed).toBe('BAD');
+      // No assertion on visual order — handled by <bdi> at render time.
+    });
+  });
+});

--- a/webapp/src/fixtures/cropDiffContext.ts
+++ b/webapp/src/fixtures/cropDiffContext.ts
@@ -1,0 +1,206 @@
+/**
+ * Crops a diff preview down to a context window around the affected
+ * range so long translations don't fill the whole side panel.
+ *
+ * The `removed` segment is intentionally never cropped — the user must see
+ * exactly what would be deleted. Only the surrounding context (`before` /
+ * `after`) is windowed, and the `replacement` is bounded by a generous safety
+ * cap to defend against pathological inputs.
+ *
+ * Cuts are grapheme-aligned (via `Intl.Segmenter` when available) so we don't
+ * split surrogate pairs, ZWJ sequences, flag emojis, or combining accents.
+ */
+
+export const MAX_FULL_LENGTH = 120;
+export const CONTEXT_BEFORE = 30;
+export const CONTEXT_AFTER = 30;
+export const WORD_BOUNDARY_TOLERANCE = 12;
+export const MAX_REPLACEMENT_RENDER = 240;
+const REPLACEMENT_HEAD_TAIL = 100;
+
+export type CropDiffResult = {
+  beforeEllipsis: boolean;
+  before: string;
+  removed: string;
+  replacement: string;
+  replacementEllipsised: boolean;
+  after: string;
+  afterEllipsis: boolean;
+  isInsertion: boolean;
+};
+
+type GraphemeSplitter = (input: string) => string[];
+
+/**
+ * Splits `input` into graphemes. Uses `Intl.Segmenter` when available for true
+ * grapheme-cluster awareness; otherwise falls back to a codepoint split, which
+ * is correct for surrogate pairs but not for ZWJ sequences or combining marks.
+ */
+function makeSplitter(locale?: string): GraphemeSplitter {
+  if (typeof Intl.Segmenter === 'function') {
+    const segmenter = new Intl.Segmenter(locale, { granularity: 'grapheme' });
+    return (input: string) => {
+      const out: string[] = [];
+      for (const seg of segmenter.segment(input)) {
+        out.push(seg.segment);
+      }
+      return out;
+    };
+  }
+  return (input: string) => Array.from(input);
+}
+
+/**
+ * Returns the index (in grapheme array) of the nearest whitespace grapheme
+ * within `tolerance` of `target`, searching outward from `target`.
+ *
+ * Returns -1 when no whitespace grapheme is found within tolerance.
+ */
+function findNearestWhitespace(
+  graphemes: string[],
+  target: number,
+  tolerance: number
+): number {
+  for (let delta = 0; delta <= tolerance; delta++) {
+    const left = target - delta;
+    if (left >= 0 && left < graphemes.length && /^\s$/.test(graphemes[left])) {
+      return left;
+    }
+    if (delta === 0) continue;
+    const right = target + delta;
+    if (
+      right >= 0 &&
+      right < graphemes.length &&
+      /^\s$/.test(graphemes[right])
+    ) {
+      return right;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Crops `before` from the right: keeps the trailing `keep` graphemes (snapped
+ * to a whitespace boundary if one is within tolerance), trims trailing
+ * whitespace from the kept slice, and reports whether an ellipsis is needed.
+ */
+function cropBefore(
+  before: string,
+  keep: number,
+  splitter: GraphemeSplitter
+): { text: string; ellipsis: boolean } {
+  const graphemes = splitter(before);
+  if (graphemes.length <= keep) {
+    return { text: before, ellipsis: false };
+  }
+  const hardCutFromLeft = graphemes.length - keep;
+  const ws = findNearestWhitespace(
+    graphemes,
+    hardCutFromLeft,
+    WORD_BOUNDARY_TOLERANCE
+  );
+  // Cut just AFTER the whitespace so the kept slice starts at a word.
+  let cut = ws >= 0 ? ws + 1 : hardCutFromLeft;
+  // Skip a small run of further leading whitespace graphemes after the cut so
+  // the ellipsis abuts visible content. Bounded so a long whitespace run
+  // can't devour the kept slice.
+  const maxSkip = WORD_BOUNDARY_TOLERANCE;
+  let skipped = 0;
+  while (
+    skipped < maxSkip &&
+    cut < graphemes.length &&
+    /^\s$/.test(graphemes[cut])
+  ) {
+    cut++;
+    skipped++;
+  }
+  return { text: graphemes.slice(cut).join(''), ellipsis: true };
+}
+
+/**
+ * Crops `after` from the left: keeps the leading `keep` graphemes (snapped to
+ * a whitespace boundary if one is within tolerance), trims leading whitespace
+ * from the kept slice, and reports whether an ellipsis is needed.
+ */
+function cropAfter(
+  after: string,
+  keep: number,
+  splitter: GraphemeSplitter
+): { text: string; ellipsis: boolean } {
+  const graphemes = splitter(after);
+  if (graphemes.length <= keep) {
+    return { text: after, ellipsis: false };
+  }
+  const ws = findNearestWhitespace(graphemes, keep, WORD_BOUNDARY_TOLERANCE);
+  // Cut just BEFORE the whitespace so the kept slice ends at a word.
+  let cut = ws >= 0 ? ws : keep;
+  // Strip a small trailing whitespace run inside the kept slice so the
+  // ellipsis abuts visible content. Bounded so a long whitespace run can't
+  // devour the kept slice.
+  const maxStrip = WORD_BOUNDARY_TOLERANCE;
+  let stripped = 0;
+  while (stripped < maxStrip && cut > 0 && /^\s$/.test(graphemes[cut - 1])) {
+    cut--;
+    stripped++;
+  }
+  return { text: graphemes.slice(0, cut).join(''), ellipsis: true };
+}
+
+/**
+ * Caps an oversized replacement to a head + ellipsis + tail rendering.
+ */
+function capReplacement(
+  replacement: string,
+  splitter: GraphemeSplitter
+): { text: string; ellipsised: boolean } {
+  const graphemes = splitter(replacement);
+  if (graphemes.length <= MAX_REPLACEMENT_RENDER) {
+    return { text: replacement, ellipsised: false };
+  }
+  const head = graphemes.slice(0, REPLACEMENT_HEAD_TAIL).join('');
+  const tail = graphemes.slice(-REPLACEMENT_HEAD_TAIL).join('');
+  return { text: `${head}…${tail}`, ellipsised: true };
+}
+
+export function cropDiffContext(
+  text: string,
+  positionStart: number,
+  positionEnd: number,
+  replacement: string,
+  locale?: string
+): CropDiffResult {
+  const before = text.slice(0, positionStart);
+  const removed = text.slice(positionStart, positionEnd);
+  const after = text.slice(positionEnd);
+  const isInsertion = positionStart === positionEnd;
+
+  const splitter = makeSplitter(locale);
+  const cappedReplacement = capReplacement(replacement, splitter);
+
+  if (text.length <= MAX_FULL_LENGTH) {
+    return {
+      beforeEllipsis: false,
+      before,
+      removed,
+      replacement: cappedReplacement.text,
+      replacementEllipsised: cappedReplacement.ellipsised,
+      after,
+      afterEllipsis: false,
+      isInsertion,
+    };
+  }
+
+  const beforeCrop = cropBefore(before, CONTEXT_BEFORE, splitter);
+  const afterCrop = cropAfter(after, CONTEXT_AFTER, splitter);
+
+  return {
+    beforeEllipsis: beforeCrop.ellipsis,
+    before: beforeCrop.text,
+    removed,
+    replacement: cappedReplacement.text,
+    replacementEllipsised: cappedReplacement.ellipsised,
+    after: afterCrop.text,
+    afterEllipsis: afterCrop.ellipsis,
+    isInsertion,
+  };
+}


### PR DESCRIPTION
## Summary

- The QA Checks side-panel fix preview rendered the full translation; for long translations it dominated the panel and pushed other issues off-screen. The preview is now cropped to a context window around the affected range with ellipsis prefix/suffix once the translation exceeds 120 characters.
- The `removed` segment is never cropped; only the surrounding context is windowed.
- Cuts are grapheme-aligned via `Intl.Segmenter`, so flag emojis, ZWJ sequences and combining accents are not split. Each segment is wrapped in `<bdi>` for BIDI-safe rendering.
- Zero-width fixes (insertions) now get an explicit caret marker between context and replacement so the insertion point is visible.
- Helper `cropDiffContext` (pure, 22 unit tests) lives next to the existing `qaUtils.ts` in `webapp/src/fixtures/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA checks now support locale-aware diff rendering for improved accuracy across languages.
  * Visual insertion markers added to diffs for clearer change indication.

* **Tests**
  * Comprehensive test suite added for diff context cropping and rendering, covering edge cases like grapheme clusters, word boundaries, RTL text, and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->