### PR TITLE
fix: classify small QA-check jobs as FAST

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
@@ -101,7 +101,7 @@ class BatchJobService(
         this.target = target
         this.totalItems = target.size
         this.chunkSize = processor.getChunkSize(projectId = project?.id, request = request)
-        this.jobCharacter = processor.getJobCharacter()
+        this.jobCharacter = processor.getJobCharacter(request = request, projectId = project?.id)
         this.maxPerJobConcurrency = processor.getMaxPerJobConcurrency()
         this.type = type
         this.hidden = isHidden

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessor.kt
@@ -28,7 +28,10 @@ interface ChunkProcessor<RequestType, ParamsType, TargetItemType> {
     return -1
   }
 
-  fun getJobCharacter(): JobCharacter {
+  fun getJobCharacter(
+    request: RequestType,
+    projectId: Long?,
+  ): JobCharacter {
     return JobCharacter.FAST
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AiPlaygroundChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AiPlaygroundChunkProcessor.kt
@@ -88,7 +88,10 @@ class AiPlaygroundChunkProcessor(
     return 1
   }
 
-  override fun getJobCharacter(): JobCharacter {
+  override fun getJobCharacter(
+    request: MachineTranslationRequest,
+    projectId: Long?,
+  ): JobCharacter {
     return JobCharacter.SLOW
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
@@ -45,7 +45,10 @@ class AutoTranslateChunkProcessor(
     return batchProperties.maxPerMtJobConcurrency
   }
 
-  override fun getJobCharacter(): JobCharacter {
+  override fun getJobCharacter(
+    request: AutoTranslationRequest,
+    projectId: Long?,
+  ): JobCharacter {
     return JobCharacter.SLOW
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/MachineTranslationChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/MachineTranslationChunkProcessor.kt
@@ -48,7 +48,10 @@ class MachineTranslationChunkProcessor(
     return batchProperties.maxPerMtJobConcurrency
   }
 
-  override fun getJobCharacter(): JobCharacter {
+  override fun getJobCharacter(
+    request: MachineTranslationRequest,
+    projectId: Long?,
+  ): JobCharacter {
     return JobCharacter.SLOW
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
@@ -51,7 +51,13 @@ class QaCheckChunkProcessor(
   override fun getChunkSize(
     request: QaCheckRequest,
     projectId: Long?,
-  ): Int = 10
+  ): Int = 100
 
-  override fun getJobCharacter(): JobCharacter = JobCharacter.SLOW
+  override fun getJobCharacter(
+    request: QaCheckRequest,
+    projectId: Long?,
+  ): JobCharacter {
+    val smallJob = request.target.size <= 10
+    return if (smallJob) JobCharacter.FAST else JobCharacter.SLOW
+  }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessorTest.kt
@@ -1,0 +1,38 @@
+package io.tolgee.batch.processors
+
+import io.tolgee.batch.JobCharacter
+import io.tolgee.batch.ProgressManager
+import io.tolgee.batch.data.BatchTranslationTargetItem
+import io.tolgee.batch.request.QaCheckRequest
+import io.tolgee.service.qa.QaCheckBatchService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+class QaCheckChunkProcessorTest {
+  private val processor =
+    QaCheckChunkProcessor(
+      qaCheckBatchService = mock<QaCheckBatchService>(),
+      progressManager = mock<ProgressManager>(),
+    )
+
+  private fun request(targetSize: Int): QaCheckRequest =
+    QaCheckRequest(
+      target = (1..targetSize).map { BatchTranslationTargetItem(keyId = it.toLong(), languageId = 1L) },
+    )
+
+  @Test
+  fun `single item is FAST`() {
+    assertThat(processor.getJobCharacter(request(1), projectId = 1L)).isEqualTo(JobCharacter.FAST)
+  }
+
+  @Test
+  fun `below threshold is FAST`() {
+    assertThat(processor.getJobCharacter(request(9), projectId = 1L)).isEqualTo(JobCharacter.FAST)
+  }
+
+  @Test
+  fun `large target is SLOW`() {
+    assertThat(processor.getJobCharacter(request(50), projectId = 1L)).isEqualTo(JobCharacter.SLOW)
+  }
+}


### PR DESCRIPTION
## Summary

- Small QA-check batch jobs (target size ≤ 10) now get `JobCharacter.FAST` instead of always `SLOW`, so interactive recheck-after-edit no longer waits behind unrelated bulk `SLOW` work in the 20% concurrency lane.
- Larger QA jobs (project-wide rechecks via `QaRecheckService`) keep the `SLOW` classification — they should still yield to interactive work.
- `ChunkProcessor.getJobCharacter` now takes `(request, projectId)`, mirroring `getChunkSize`'s signature, so processors can decide character per request. Other `SLOW` processors (MT / auto-translate / AI playground) are unchanged in behavior.
- Bumped QaCheck chunk size to 100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized batch job processing to use request context for improved efficiency and resource management.
  * Enhanced QA batch processing parameters for better performance.

* **Tests**
  * Added unit tests for QA batch processor validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->