### PR TITLE
chore: log webhook failure cause chain at info level

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
@@ -129,7 +129,7 @@ open class ChunkProcessingUtil(
 
   private fun logKnownException(exception: Throwable) {
     if (isExpectedUserError(exception)) {
-      logger.warn("Skipping Sentry capture for expected user error: ${exception.message}")
+      logger.info("Skipping Sentry capture for expected user error: ${exception.message}", exception)
       return
     }
     Sentry.captureException(exception)

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/webhookExceptions.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/webhookExceptions.kt
@@ -6,13 +6,14 @@ import org.springframework.http.HttpStatusCode
 class WebhookRespondedWithNon200Status(
   statusCode: HttpStatusCode,
   body: Any?,
-) : WebhookException()
+) : WebhookException("Webhook responded with non-2xx status $statusCode, body: $body")
 
 class WebhookExecutionFailed(
   e: Throwable,
-) : WebhookException(e)
+) : WebhookException("Webhook execution failed: ${e.javaClass.simpleName}: ${e.message}", e)
 
 open class WebhookException(
+  message: String = "Webhook execution failed",
   cause: Throwable? = null,
-) : RuntimeException("Webhook execution failed", cause),
+) : RuntimeException(message, cause),
   ExpectedUserError


### PR DESCRIPTION
## Summary

The Sentry-skip path added in #3626 logs expected user-config errors at `warn` level using only `exception.message` — for webhook failures that resolves to:

```
WARN ... Skipping Sentry capture for expected user error: unexpected_error_while_executing_webhook null
```

No HTTP status, no response body, no underlying network error. Investigating why a customer's webhook stopped working required re-enabling it in staging to reproduce.

This PR makes the log line actually useful:

- Pass the throwable to the logger so the cause chain (`RequeueWithDelayException` → `WebhookExecutionFailed` / `WebhookRespondedWithNon200Status` → underlying `IOException` / `HttpClientErrorException`) is rendered to stdout.
- Carry the HTTP status code, response body, and wrapped exception's class+message in `WebhookException`'s message so they survive being wrapped in `RequeueWithDelayException` (whose `.message` is just `"$_code $params"`).
- Drop the level from `warn` → `info`. These are expected user-misconfiguration events, not operator-actionable warnings.

Sentry capture is still skipped via the existing `ExpectedUserError` marker — no change in noise reaching Sentry.

## Test plan

- [x] `:data:test --tests "io.tolgee.unit.ExpectedUserErrorWiringTest"` passes
- [ ] Re-enable a broken webhook in staging, trigger an event, confirm stdout logs show the underlying status code / exception class
- [ ] Verify Sentry still receives no new issues for webhook failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced webhook operation error messages with more descriptive and informative details to facilitate easier troubleshooting and debugging of integration issues.
  * Optimized error logging behavior to reduce unnecessary alert noise while maintaining detailed tracking for expected user errors.
  * Improved exception handling consistency across automation processors for more reliable webhook operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->