### PR TITLE
fix: wrap StyledHelpIcon in Box to enable Tooltip on hover

### DIFF
--- a/webapp/src/component/common/form/LoadingCheckboxWithSkeleton.tsx
+++ b/webapp/src/component/common/form/LoadingCheckboxWithSkeleton.tsx
@@ -29,7 +29,9 @@ const StyledLabel = styled('div')`
 
 const StyledHelpIcon = styled(HelpCircle)`
   color: ${({ theme }) => theme.palette.tokens.icon.primary};
-  width: 16px;
+  width: 15px;
+  height: 15px;
+  display: block;
 `;
 
 export const LoadingCheckboxWithSkeleton: FC<
@@ -52,7 +54,11 @@ export const LoadingCheckboxWithSkeleton: FC<
           <div>{label}</div>
           {hint && (
             <Tooltip title={hint}>
-              {customHelpIcon || <StyledHelpIcon />}
+              {customHelpIcon || (
+                <Box display="flex" alignItems="center">
+                  <StyledHelpIcon />
+                </Box>
+              )}
             </Tooltip>
           )}
         </StyledLabel>

--- a/webapp/src/views/projects/import/component/ImportSettingsPanel.tsx
+++ b/webapp/src/views/projects/import/component/ImportSettingsPanel.tsx
@@ -156,9 +156,12 @@ const additionalCheckboxProps = {
 
 const StyledLink = styled('a')`
   color: ${({ theme }) => theme.palette.tokens.icon.primary};
+  display: inline-flex;
+  align-items: center;
 
   .icon {
-    width: 18px;
-    height: 18px;
+    width: 15px;
+    height: 15px;
+    display: block;
   }
 `;


### PR DESCRIPTION
fixes #3646
Unified help icon size to 15×15px across all occurrences, and ensured vertical alignment with adjacent text using [display: block](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the SVG and [alignItems: center](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the flex wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined help icon appearance with slightly smaller, more consistent sizing for a balanced look.
  * Improved alignment and spacing for help icons and tooltips across forms and import settings, yielding cleaner, more consistent layout and improved visual alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->