### PR TITLE
feat: filter for translations with stale QA checks + QA checks testing framework improvements

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebConfiguration.kt
@@ -30,7 +30,10 @@ import java.util.concurrent.TimeUnit
 
 @Configuration
 @EnableScheduling
-@EnableAsync
+// proxyTargetClass reason: Prefer CGLIB-proxies. Otherwise, we would need to include
+// all necessary methods in interfaces every time we implement an interface in a component
+// class when we need to use it with `@Autowired`.
+@EnableAsync(proxyTargetClass = true)
 class WebConfiguration(
   private val tolgeeProperties: TolgeeProperties,
   private val activityInterceptor: ActivityHandlerInterceptor,

--- a/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
@@ -15,12 +15,8 @@ import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.Language
 import io.tolgee.model.UserAccount
-import io.tolgee.model.enums.qa.QaCheckType
-import io.tolgee.model.enums.qa.QaIssueMessage
 import io.tolgee.model.qa.LanguageQaConfig
-import io.tolgee.model.qa.TranslationQaIssue
 import io.tolgee.repository.qa.LanguageQaConfigRepository
-import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authentication.TolgeeAuthentication
 import io.tolgee.testing.assert
@@ -50,9 +46,6 @@ class LanguageServiceTest : AbstractSpringTest() {
 
   @Autowired
   private lateinit var languageQaConfigRepository: LanguageQaConfigRepository
-
-  @Autowired
-  private lateinit var translationQaIssueRepository: TranslationQaIssueRepository
 
   @Test
   @Transactional
@@ -192,19 +185,12 @@ class LanguageServiceTest : AbstractSpringTest() {
   @Transactional
   fun `deletes language with QA config and issues`() {
     val testData = TranslationsTestData()
+    testData.addQaIssueOnAKeyGerman()
     testDataService.saveTestData(testData.root)
 
     val language = testData.germanLanguage
-    val translation = testData.aKeyGermanTranslation
 
     languageQaConfigRepository.save(LanguageQaConfig(language = language))
-    translationQaIssueRepository.save(
-      TranslationQaIssue(
-        type = QaCheckType.EMPTY_TRANSLATION,
-        message = QaIssueMessage.QA_EMPTY_TRANSLATION,
-        translation = translation,
-      ),
-    )
     entityManager.flush()
 
     languageService.hardDeleteLanguage(language.id)

--- a/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/LanguageServiceTest.kt
@@ -15,8 +15,6 @@ import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.Language
 import io.tolgee.model.UserAccount
-import io.tolgee.model.qa.LanguageQaConfig
-import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authentication.TolgeeAuthentication
 import io.tolgee.testing.assert
@@ -43,9 +41,6 @@ class LanguageServiceTest : AbstractSpringTest() {
 
   @Autowired
   private lateinit var sessionFactory: SessionFactory
-
-  @Autowired
-  private lateinit var languageQaConfigRepository: LanguageQaConfigRepository
 
   @Test
   @Transactional
@@ -186,12 +181,10 @@ class LanguageServiceTest : AbstractSpringTest() {
   fun `deletes language with QA config and issues`() {
     val testData = TranslationsTestData()
     testData.addQaIssueOnAKeyGerman()
+    testData.addLanguageQaConfigOnGermanLanguage()
     testDataService.saveTestData(testData.root)
 
     val language = testData.germanLanguage
-
-    languageQaConfigRepository.save(LanguageQaConfig(language = language))
-    entityManager.flush()
 
     languageService.hardDeleteLanguage(language.id)
     languageService.findEntity(language.id).assert.isNull()

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -16,19 +16,16 @@ import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
 import io.tolgee.development.testDataBuilder.data.WebhooksTestData
 import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
+import io.tolgee.ee.development.QaTestData
 import io.tolgee.fixtures.waitFor
 import io.tolgee.model.Project
-import io.tolgee.model.enums.qa.QaCheckType
-import io.tolgee.model.enums.qa.QaIssueMessage
 import io.tolgee.model.qa.LanguageQaConfig
-import io.tolgee.model.qa.ProjectQaConfig
-import io.tolgee.model.qa.TranslationQaIssue
 import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.repository.qa.ProjectQaConfigRepository
-import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewRepeatableTransaction
+import io.tolgee.util.executeInNewTransaction
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -49,9 +46,6 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
 
   @Autowired
   private lateinit var languageQaConfigRepository: LanguageQaConfigRepository
-
-  @Autowired
-  private lateinit var translationQaIssueRepository: TranslationQaIssueRepository
 
   @Test
   fun `deletes project with MT Settings`() {
@@ -136,7 +130,7 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
   fun `deletes project with webhooks`() {
     val testData = WebhooksTestData()
     testDataService.saveTestData(testData.root)
-    io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
+    executeInNewTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
     }
   }
@@ -145,34 +139,21 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
   fun `deletes project with suggestions`() {
     val testData = SuggestionsTestData()
     testDataService.saveTestData(testData.root)
-    io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
+    executeInNewTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
     }
   }
 
   @Test
   fun `deletes project with QA entities`() {
-    val testData = BaseTestData()
-    testData.projectBuilder.addKey(keyName = "test-key") {
-      addTranslation("en", "Hello world.")
-    }
+    val testData = QaTestData()
     testDataService.saveTestData(testData.root)
 
-    io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
-      val project = projectService.get(testData.projectBuilder.self.id)
+    executeInNewTransaction(platformTransactionManager) {
+      val project = projectService.get(testData.project.id)
       val language = languageService.getEntity(testData.englishLanguage.id)
-      val key = keyService.get(project.id, "test-key", null)
-      val translation = translationService.find(key, language).get()
-
-      projectQaConfigRepository.save(ProjectQaConfig(project = project))
+      projectQaConfigRepository.save(testData.createDefaultQaConfig().also { it.project = project })
       languageQaConfigRepository.save(LanguageQaConfig(language = language))
-      translationQaIssueRepository.save(
-        TranslationQaIssue(
-          type = QaCheckType.EMPTY_TRANSLATION,
-          message = QaIssueMessage.QA_EMPTY_TRANSLATION,
-          translation = translation,
-        ),
-      )
       entityManager.flush()
     }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -16,10 +16,12 @@ import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
 import io.tolgee.development.testDataBuilder.data.WebhooksTestData
 import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
-import io.tolgee.ee.development.QaTestData
 import io.tolgee.fixtures.waitFor
 import io.tolgee.model.Project
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
 import io.tolgee.model.qa.LanguageQaConfig
+import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.repository.qa.ProjectQaConfigRepository
 import io.tolgee.service.bigMeta.BigMetaService
@@ -146,13 +148,25 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
 
   @Test
   fun `deletes project with QA entities`() {
-    val testData = QaTestData()
+    // QA-issue persistence is exercised via the builder's `addQaIssue`. Project- and
+    // language-level QA configs are added in a follow-up transaction since BaseTestData
+    // doesn't model them and the EE-module `QaTestData` is not on this test suite's
+    // classpath (`runWithoutEeTests`).
+    val testData = BaseTestData()
+    testData.projectBuilder.addKey(keyName = "test-key") {
+      addTranslation("en", "Hello world.").build {
+        addQaIssue {
+          type = QaCheckType.EMPTY_TRANSLATION
+          message = QaIssueMessage.QA_EMPTY_TRANSLATION
+        }
+      }
+    }
     testDataService.saveTestData(testData.root)
 
     executeInNewTransaction(platformTransactionManager) {
-      val project = projectService.get(testData.project.id)
+      val project = projectService.get(testData.projectBuilder.self.id)
       val language = languageService.getEntity(testData.englishLanguage.id)
-      projectQaConfigRepository.save(testData.createDefaultQaConfig().also { it.project = project })
+      projectQaConfigRepository.save(ProjectQaConfig(project = project))
       languageQaConfigRepository.save(LanguageQaConfig(language = language))
       entityManager.flush()
     }

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -12,16 +12,13 @@ import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.development.testDataBuilder.data.BatchJobsTestData
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
 import io.tolgee.development.testDataBuilder.data.MtSettingsTestData
+import io.tolgee.development.testDataBuilder.data.ProjectWithQaEntitiesTestData
 import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
 import io.tolgee.development.testDataBuilder.data.WebhooksTestData
 import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
 import io.tolgee.fixtures.waitFor
 import io.tolgee.model.Project
-import io.tolgee.model.enums.qa.QaCheckType
-import io.tolgee.model.enums.qa.QaIssueMessage
-import io.tolgee.model.qa.LanguageQaConfig
-import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.repository.qa.ProjectQaConfigRepository
 import io.tolgee.service.bigMeta.BigMetaService
@@ -148,26 +145,12 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
 
   @Test
   fun `deletes project with QA entities`() {
-    // QA-issue persistence is exercised via the builder's `addQaIssue`. Project- and
-    // language-level QA configs are added in a follow-up transaction since BaseTestData
-    // doesn't model them and the EE-module `QaTestData` is not on this test suite's
-    // classpath (`runWithoutEeTests`).
-    val testData = BaseTestData()
-    testData.projectBuilder.addKey(keyName = "test-key") {
-      addTranslation("en", "Hello world.").build {
-        addQaIssue {
-          type = QaCheckType.EMPTY_TRANSLATION
-          message = QaIssueMessage.QA_EMPTY_TRANSLATION
-        }
-      }
-    }
+    val testData = ProjectWithQaEntitiesTestData()
     testDataService.saveTestData(testData.root)
 
     executeInNewTransaction(platformTransactionManager) {
-      val project = projectService.get(testData.projectBuilder.self.id)
-      val language = languageService.getEntity(testData.englishLanguage.id)
-      projectQaConfigRepository.save(ProjectQaConfig(project = project))
-      languageQaConfigRepository.save(LanguageQaConfig(language = language))
+      projectQaConfigRepository.save(testData.createProjectQaConfig())
+      languageQaConfigRepository.save(testData.createLanguageQaConfig())
       entityManager.flush()
     }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -19,8 +19,6 @@ import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
 import io.tolgee.fixtures.waitFor
 import io.tolgee.model.Project
-import io.tolgee.repository.qa.LanguageQaConfigRepository
-import io.tolgee.repository.qa.ProjectQaConfigRepository
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewRepeatableTransaction
@@ -39,12 +37,6 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
 
   @Autowired
   private lateinit var projectHardDeletingService: ProjectHardDeletingService
-
-  @Autowired
-  private lateinit var projectQaConfigRepository: ProjectQaConfigRepository
-
-  @Autowired
-  private lateinit var languageQaConfigRepository: LanguageQaConfigRepository
 
   @Test
   fun `deletes project with MT Settings`() {
@@ -147,12 +139,6 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
   fun `deletes project with QA entities`() {
     val testData = ProjectWithQaEntitiesTestData()
     testDataService.saveTestData(testData.root)
-
-    executeInNewTransaction(platformTransactionManager) {
-      projectQaConfigRepository.save(testData.createProjectQaConfig())
-      languageQaConfigRepository.save(testData.createLanguageQaConfig())
-      entityManager.flush()
-    }
 
     io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())

--- a/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/BypassableActivityListener.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/BypassableActivityListener.kt
@@ -1,0 +1,12 @@
+package io.tolgee.component.eventListeners
+
+/**
+ * Interface for activity / event listeners whose side-effects can be globally
+ * suppressed via a [bypass] flag.
+ *
+ * Used by `TestDataService` to disable downstream side-effects while seeding
+ * test data — so test fixtures stay synthetic.
+ */
+interface BypassableActivityListener {
+  var bypass: Boolean
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
@@ -26,8 +26,8 @@ class LanguageStatsListener(
   private val keyRepository: KeyRepository,
   private val translationRepository: TranslationRepository,
   private val activityService: ActivityService,
-) {
-  var bypass = false
+) : BypassableActivityListener {
+  override var bypass = false
 
   @TransactionalEventListener
   @Async

--- a/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
@@ -13,6 +13,8 @@ import io.tolgee.repository.TranslationRepository
 import io.tolgee.service.project.LanguageStatsService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.util.runSentryCatching
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
@@ -29,10 +31,25 @@ class LanguageStatsListener(
 ) : BypassableActivityListener {
   override var bypass = false
 
+  @Lazy
+  @Autowired
+  private lateinit var self: LanguageStatsListener
+
   @TransactionalEventListener
-  @Async
   fun onActivity(event: OnProjectActivityEvent) {
     if (bypass) return
+    self.refreshForActivity(event)
+  }
+
+  @EventListener(OnBatchJobFinalized::class)
+  fun onQaBatchJobFinalized(event: OnBatchJobFinalized) {
+    if (bypass) return
+    if (event.job.type != BatchJobType.QA_CHECK) return
+    self.refreshForQaBatchJob(event)
+  }
+
+  @Async
+  fun refreshForActivity(event: OnProjectActivityEvent) {
     runSentryCatching {
       val projectId = event.activityRevision.projectId ?: return
 
@@ -60,11 +77,8 @@ class LanguageStatsListener(
     }
   }
 
-  @EventListener(OnBatchJobFinalized::class)
   @Async
-  fun onQaBatchJobFinalized(event: OnBatchJobFinalized) {
-    if (bypass) return
-    if (event.job.type != BatchJobType.QA_CHECK) return
+  fun refreshForQaBatchJob(event: OnBatchJobFinalized) {
     val projectId = event.job.projectId ?: return
     runSentryCatching {
       projectService.findDto(projectId) ?: return@runSentryCatching

--- a/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/eventListeners/LanguageStatsListener.kt
@@ -29,6 +29,7 @@ class LanguageStatsListener(
   private val translationRepository: TranslationRepository,
   private val activityService: ActivityService,
 ) : BypassableActivityListener {
+  @Volatile
   override var bypass = false
 
   @Lazy

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
@@ -346,7 +346,9 @@ class TestDataService(
 
   private fun saveQaConfigs(builder: ProjectBuilder) {
     builder.data.qaConfig?.let { entityManager.persist(it.self) }
-    builder.data.languageQaConfigs.forEach { entityManager.persist(it.self) }
+    builder.data.languages
+      .mapNotNull { it.data.qaConfig }
+      .forEach { entityManager.persist(it.self) }
   }
 
   private fun saveWebhookConfigs(builder: ProjectBuilder) {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
@@ -1,7 +1,7 @@
 package io.tolgee.development.testDataBuilder
 
 import io.tolgee.activity.ActivityHolder
-import io.tolgee.component.eventListeners.LanguageStatsListener
+import io.tolgee.component.eventListeners.BypassableActivityListener
 import io.tolgee.development.testDataBuilder.builders.AuthProviderChangeRequestBuilder
 import io.tolgee.development.testDataBuilder.builders.BatchJobBuilder
 import io.tolgee.development.testDataBuilder.builders.GlossaryBuilder
@@ -91,7 +91,7 @@ class TestDataService(
   private val activityHolder: ActivityHolder,
   private val automationService: AutomationService,
   private val contentDeliveryConfigService: ContentDeliveryConfigService,
-  private val languageStatsListener: LanguageStatsListener,
+  private val bypassableActivityListeners: List<BypassableActivityListener>,
   private val invitationService: InvitationService,
   private val keyCodeReferenceRepository: KeyCodeReferenceRepository,
 ) : Logging {
@@ -106,37 +106,40 @@ class TestDataService(
   @Transactional
   fun saveTestData(builder: TestDataBuilder) {
     activityHolder.enableAutoCompletion = false
-    languageStatsListener.bypass = true
-    runBeforeSaveMethodsOfAdditionalSavers(builder)
-    prepare()
+    bypassableActivityListeners.forEach { it.bypass = true }
+    try {
+      runBeforeSaveMethodsOfAdditionalSavers(builder)
+      prepare()
 
-    // Projects have to be stored in separate transaction since projectHolder's
-    // project has to be stored for transaction scope.
-    //
-    // To be able to save project in its separate transaction,
-    // user/organization has to be stored first.
-    executeInNewTransaction(transactionManager) {
-      generateSlugsForOrganizations(builder)
-      saveAllUsers(builder)
-      saveOrganizationData(builder)
+      // Projects have to be stored in separate transaction since projectHolder's
+      // project has to be stored for transaction scope.
+      //
+      // To be able to save project in its separate transaction,
+      // user/organization has to be stored first.
+      executeInNewTransaction(transactionManager) {
+        generateSlugsForOrganizations(builder)
+        saveAllUsers(builder)
+        saveOrganizationData(builder)
+      }
+
+      executeInNewTransaction(transactionManager) {
+        additionalTestDataSavers.forEach { it.save(builder) }
+      }
+      entityManager.flush()
+      entityManager.clear()
+
+      executeInNewTransaction(transactionManager) {
+        saveProjectData(builder)
+        saveGlossaryData(builder)
+        saveNotifications(builder)
+        finalize()
+      }
+
+      updateLanguageStats(builder)
+    } finally {
+      activityHolder.enableAutoCompletion = true
+      bypassableActivityListeners.forEach { it.bypass = false }
     }
-
-    executeInNewTransaction(transactionManager) {
-      additionalTestDataSavers.forEach { it.save(builder) }
-    }
-    entityManager.flush()
-    entityManager.clear()
-
-    executeInNewTransaction(transactionManager) {
-      saveProjectData(builder)
-      saveGlossaryData(builder)
-      saveNotifications(builder)
-      finalize()
-    }
-
-    updateLanguageStats(builder)
-    activityHolder.enableAutoCompletion = true
-    languageStatsListener.bypass = false
 
     runAfterSaveMethodsOfAdditionalSavers(builder)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
@@ -345,8 +345,8 @@ class TestDataService(
   }
 
   private fun saveQaConfigs(builder: ProjectBuilder) {
-    builder.data.qaConfig?.let { entityManager.persist(it) }
-    builder.data.languageQaConfigs.forEach { entityManager.persist(it) }
+    builder.data.qaConfig?.let { entityManager.persist(it.self) }
+    builder.data.languageQaConfigs.forEach { entityManager.persist(it.self) }
   }
 
   private fun saveWebhookConfigs(builder: ProjectBuilder) {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/TestDataService.kt
@@ -326,6 +326,7 @@ class TestDataService(
     saveSlackConfigs(builder)
     saveAutomations(builder)
     saveImportSettings(builder)
+    saveQaConfigs(builder)
     saveBatchJobs(builder)
     saveTasks(builder)
     saveTaskKeys(builder)
@@ -341,6 +342,11 @@ class TestDataService(
       entityManager.merge(it.userAccount)
       entityManager.persist(it)
     }
+  }
+
+  private fun saveQaConfigs(builder: ProjectBuilder) {
+    builder.data.qaConfig?.let { entityManager.persist(it) }
+    builder.data.languageQaConfigs.forEach { entityManager.persist(it) }
   }
 
   private fun saveWebhookConfigs(builder: ProjectBuilder) {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageBuilder.kt
@@ -19,7 +19,6 @@ class LanguageBuilder(
       project = projectBuilder.self
     }
 
-  /** Seeds the language's [LanguageQaConfig]. There is at most one config per language. */
   fun setQaConfig(ft: FT<LanguageQaConfig> = {}): LanguageQaConfigBuilder {
     val builder = LanguageQaConfigBuilder(this).apply { ft(self) }
     data.qaConfig = builder

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageBuilder.kt
@@ -1,13 +1,28 @@
 package io.tolgee.development.testDataBuilder.builders
 
 import io.tolgee.development.testDataBuilder.EntityDataBuilder
+import io.tolgee.development.testDataBuilder.FT
 import io.tolgee.model.Language
+import io.tolgee.model.qa.LanguageQaConfig
 
 class LanguageBuilder(
   val projectBuilder: ProjectBuilder,
 ) : EntityDataBuilder<Language, LanguageBuilder> {
+  class DATA {
+    var qaConfig: LanguageQaConfigBuilder? = null
+  }
+
+  val data = DATA()
+
   override var self: Language =
     Language().apply {
       project = projectBuilder.self
     }
+
+  /** Seeds the language's [LanguageQaConfig]. There is at most one config per language. */
+  fun setQaConfig(ft: FT<LanguageQaConfig> = {}): LanguageQaConfigBuilder {
+    val builder = LanguageQaConfigBuilder(this).apply { ft(self) }
+    data.qaConfig = builder
+    return builder
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageQaConfigBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageQaConfigBuilder.kt
@@ -1,0 +1,12 @@
+package io.tolgee.development.testDataBuilder.builders
+
+import io.tolgee.development.testDataBuilder.EntityDataBuilder
+import io.tolgee.model.Language
+import io.tolgee.model.qa.LanguageQaConfig
+
+class LanguageQaConfigBuilder(
+  val projectBuilder: ProjectBuilder,
+  language: Language,
+) : EntityDataBuilder<LanguageQaConfig, LanguageQaConfigBuilder> {
+  override var self: LanguageQaConfig = LanguageQaConfig(language = language)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageQaConfigBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/LanguageQaConfigBuilder.kt
@@ -1,12 +1,10 @@
 package io.tolgee.development.testDataBuilder.builders
 
 import io.tolgee.development.testDataBuilder.EntityDataBuilder
-import io.tolgee.model.Language
 import io.tolgee.model.qa.LanguageQaConfig
 
 class LanguageQaConfigBuilder(
-  val projectBuilder: ProjectBuilder,
-  language: Language,
+  val languageBuilder: LanguageBuilder,
 ) : EntityDataBuilder<LanguageQaConfig, LanguageQaConfigBuilder> {
-  override var self: LanguageQaConfig = LanguageQaConfig(language = language)
+  override var self: LanguageQaConfig = LanguageQaConfig(language = languageBuilder.self)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
@@ -246,7 +246,6 @@ class ProjectBuilder(
     data.importSettings = ImportSettings(this.self).apply(ft)
   }
 
-  /** Seeds the project's [ProjectQaConfig]. There is at most one config per project. */
   fun setQaConfig(ft: FT<ProjectQaConfig> = {}): ProjectQaConfigBuilder {
     val builder = ProjectQaConfigBuilder(this).apply { ft(self) }
     data.qaConfig = builder

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
@@ -74,8 +74,8 @@ class ProjectBuilder(
     var contentDeliveryConfigs = mutableListOf<ContentDeliveryContentBuilder>()
     var webhookConfigs = mutableListOf<WebhookConfigBuilder>()
     var importSettings: ImportSettings? = null
-    var qaConfig: ProjectQaConfig? = null
-    val languageQaConfigs = mutableListOf<LanguageQaConfig>()
+    var qaConfig: ProjectQaConfigBuilder? = null
+    val languageQaConfigs = mutableListOf<LanguageQaConfigBuilder>()
     var slackConfigs = mutableListOf<SlackConfigBuilder>()
     val batchJobs: MutableList<BatchJobBuilder> = mutableListOf()
     val tasks = mutableListOf<TaskBuilder>()
@@ -249,16 +249,19 @@ class ProjectBuilder(
   }
 
   /** Seeds the project's [ProjectQaConfig]. There is at most one config per project. */
-  fun setQaConfig(ft: FT<ProjectQaConfig> = {}) {
-    data.qaConfig = ProjectQaConfig(project = this.self).apply(ft)
+  fun setQaConfig(ft: FT<ProjectQaConfig> = {}): ProjectQaConfigBuilder {
+    val builder = ProjectQaConfigBuilder(this).apply { ft(self) }
+    data.qaConfig = builder
+    return builder
   }
 
   /** Seeds a per-language [LanguageQaConfig]. There is at most one config per language. */
   fun addLanguageQaConfig(
     language: Language,
     ft: FT<LanguageQaConfig> = {},
-  ) {
-    data.languageQaConfigs.add(LanguageQaConfig(language = language).apply(ft))
+  ): LanguageQaConfigBuilder {
+    val builder = LanguageQaConfigBuilder(this, language)
+    return addOperation(data.languageQaConfigs, builder, ft)
   }
 
   fun addPrompt(ft: FT<Prompt>) = addOperation(data.prompts, ft)

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
@@ -27,6 +27,8 @@ import io.tolgee.model.key.Tag
 import io.tolgee.model.key.screenshotReference.KeyScreenshotReference
 import io.tolgee.model.keyBigMeta.KeysDistance
 import io.tolgee.model.mtServiceConfig.MtServiceConfig
+import io.tolgee.model.qa.LanguageQaConfig
+import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.model.slackIntegration.SlackConfig
 import io.tolgee.model.task.Task
 import io.tolgee.model.task.TaskKey
@@ -72,6 +74,8 @@ class ProjectBuilder(
     var contentDeliveryConfigs = mutableListOf<ContentDeliveryContentBuilder>()
     var webhookConfigs = mutableListOf<WebhookConfigBuilder>()
     var importSettings: ImportSettings? = null
+    var qaConfig: ProjectQaConfig? = null
+    val languageQaConfigs = mutableListOf<LanguageQaConfig>()
     var slackConfigs = mutableListOf<SlackConfigBuilder>()
     val batchJobs: MutableList<BatchJobBuilder> = mutableListOf()
     val tasks = mutableListOf<TaskBuilder>()
@@ -242,6 +246,19 @@ class ProjectBuilder(
 
   fun setImportSettings(ft: FT<ImportSettings>) {
     data.importSettings = ImportSettings(this.self).apply(ft)
+  }
+
+  /** Seeds the project's [ProjectQaConfig]. There is at most one config per project. */
+  fun setQaConfig(ft: FT<ProjectQaConfig> = {}) {
+    data.qaConfig = ProjectQaConfig(project = this.self).apply(ft)
+  }
+
+  /** Seeds a per-language [LanguageQaConfig]. There is at most one config per language. */
+  fun addLanguageQaConfig(
+    language: Language,
+    ft: FT<LanguageQaConfig> = {},
+  ) {
+    data.languageQaConfigs.add(LanguageQaConfig(language = language).apply(ft))
   }
 
   fun addPrompt(ft: FT<Prompt>) = addOperation(data.prompts, ft)

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
@@ -27,7 +27,6 @@ import io.tolgee.model.key.Tag
 import io.tolgee.model.key.screenshotReference.KeyScreenshotReference
 import io.tolgee.model.keyBigMeta.KeysDistance
 import io.tolgee.model.mtServiceConfig.MtServiceConfig
-import io.tolgee.model.qa.LanguageQaConfig
 import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.model.slackIntegration.SlackConfig
 import io.tolgee.model.task.Task
@@ -75,7 +74,6 @@ class ProjectBuilder(
     var webhookConfigs = mutableListOf<WebhookConfigBuilder>()
     var importSettings: ImportSettings? = null
     var qaConfig: ProjectQaConfigBuilder? = null
-    val languageQaConfigs = mutableListOf<LanguageQaConfigBuilder>()
     var slackConfigs = mutableListOf<SlackConfigBuilder>()
     val batchJobs: MutableList<BatchJobBuilder> = mutableListOf()
     val tasks = mutableListOf<TaskBuilder>()
@@ -253,15 +251,6 @@ class ProjectBuilder(
     val builder = ProjectQaConfigBuilder(this).apply { ft(self) }
     data.qaConfig = builder
     return builder
-  }
-
-  /** Seeds a per-language [LanguageQaConfig]. There is at most one config per language. */
-  fun addLanguageQaConfig(
-    language: Language,
-    ft: FT<LanguageQaConfig> = {},
-  ): LanguageQaConfigBuilder {
-    val builder = LanguageQaConfigBuilder(this, language)
-    return addOperation(data.languageQaConfigs, builder, ft)
   }
 
   fun addPrompt(ft: FT<Prompt>) = addOperation(data.prompts, ft)

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectQaConfigBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectQaConfigBuilder.kt
@@ -1,0 +1,10 @@
+package io.tolgee.development.testDataBuilder.builders
+
+import io.tolgee.development.testDataBuilder.EntityDataBuilder
+import io.tolgee.model.qa.ProjectQaConfig
+
+class ProjectQaConfigBuilder(
+  val projectBuilder: ProjectBuilder,
+) : EntityDataBuilder<ProjectQaConfig, ProjectQaConfigBuilder> {
+  override var self: ProjectQaConfig = ProjectQaConfig(project = projectBuilder.self)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BaseTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BaseTestData.kt
@@ -1,5 +1,6 @@
 package io.tolgee.development.testDataBuilder.data
 
+import io.tolgee.development.testDataBuilder.builders.LanguageBuilder
 import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
 import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
 import io.tolgee.development.testDataBuilder.builders.UserAccountBuilder
@@ -14,7 +15,8 @@ open class BaseTestData(
   var projectBuilder: ProjectBuilder
   val project get() = projectBuilder.self
 
-  lateinit var englishLanguage: Language
+  lateinit var englishLanguageBuilder: LanguageBuilder
+  val englishLanguage: Language get() = englishLanguageBuilder.self
   var user: UserAccount
   var userAccountBuilder: UserAccountBuilder
 
@@ -39,13 +41,13 @@ open class BaseTestData(
             type = ProjectPermissionType.MANAGE
           }
 
-          addLanguage {
-            name = "English"
-            tag = "en"
-            originalName = "English"
-            englishLanguage = this
-            this@buildProject.self.baseLanguage = this
-          }
+          englishLanguageBuilder =
+            addLanguage {
+              name = "English"
+              tag = "en"
+              originalName = "English"
+              this@buildProject.self.baseLanguage = this
+            }
 
           this.self {
             baseLanguage = englishLanguage

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
@@ -13,15 +13,13 @@ import io.tolgee.model.enums.qa.QaIssueMessage
  */
 class ProjectWithQaEntitiesTestData : BaseTestData() {
   init {
-    projectBuilder.apply {
-      setQaConfig()
-      addLanguageQaConfig(englishLanguage)
-      addKey(keyName = "test-key") {
-        addTranslation("en", "Hello world.").build {
-          addQaIssue {
-            type = QaCheckType.EMPTY_TRANSLATION
-            message = QaIssueMessage.QA_EMPTY_TRANSLATION
-          }
+    projectBuilder.setQaConfig()
+    englishLanguageBuilder.setQaConfig()
+    projectBuilder.addKey(keyName = "test-key") {
+      addTranslation("en", "Hello world.").build {
+        addQaIssue {
+          type = QaCheckType.EMPTY_TRANSLATION
+          message = QaIssueMessage.QA_EMPTY_TRANSLATION
         }
       }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
@@ -2,43 +2,28 @@ package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.model.enums.qa.QaIssueMessage
-import io.tolgee.model.qa.LanguageQaConfig
-import io.tolgee.model.qa.ProjectQaConfig
 
 /**
  * Test data covering every QA-related persistent entity on a project so the
- * hard-delete flow can be exercised against all of them at once: a translation
- * with a [io.tolgee.model.qa.TranslationQaIssue] (added through the builder)
- * plus a [ProjectQaConfig] and a [LanguageQaConfig] which are exposed via
- * factory methods because the builder framework does not yet model QA configs.
- *
- * Lives in the data module — and not in the EE-only `QaTestData` — so tests in
- * `:server-app` (which is built without `:ee-app` for the `runWithoutEeTests`
- * task) can still use it.
+ * hard-delete flow can be exercised against all of them at once: a
+ * [ProjectQaConfig][io.tolgee.model.qa.ProjectQaConfig], a
+ * [LanguageQaConfig][io.tolgee.model.qa.LanguageQaConfig] for the base
+ * language, and a translation with a
+ * [TranslationQaIssue][io.tolgee.model.qa.TranslationQaIssue].
  */
 class ProjectWithQaEntitiesTestData : BaseTestData() {
   init {
-    projectBuilder.addKey(keyName = "test-key") {
-      addTranslation("en", "Hello world.").build {
-        addQaIssue {
-          type = QaCheckType.EMPTY_TRANSLATION
-          message = QaIssueMessage.QA_EMPTY_TRANSLATION
+    projectBuilder.apply {
+      setQaConfig()
+      addLanguageQaConfig(englishLanguage)
+      addKey(keyName = "test-key") {
+        addTranslation("en", "Hello world.").build {
+          addQaIssue {
+            type = QaCheckType.EMPTY_TRANSLATION
+            message = QaIssueMessage.QA_EMPTY_TRANSLATION
+          }
         }
       }
     }
   }
-
-  /**
-   * Builds (but does NOT persist) a [ProjectQaConfig] for [project]. The caller
-   * persists it through the repository so we don't have to model QA configs in
-   * the builder framework.
-   */
-  fun createProjectQaConfig(): ProjectQaConfig = ProjectQaConfig(project = project)
-
-  /**
-   * Builds (but does NOT persist) a [LanguageQaConfig] for [englishLanguage].
-   * See [createProjectQaConfig] for why this is a factory rather than seeded
-   * by the builder.
-   */
-  fun createLanguageQaConfig(): LanguageQaConfig = LanguageQaConfig(language = englishLanguage)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
@@ -1,0 +1,44 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
+import io.tolgee.model.qa.LanguageQaConfig
+import io.tolgee.model.qa.ProjectQaConfig
+
+/**
+ * Test data covering every QA-related persistent entity on a project so the
+ * hard-delete flow can be exercised against all of them at once: a translation
+ * with a [io.tolgee.model.qa.TranslationQaIssue] (added through the builder)
+ * plus a [ProjectQaConfig] and a [LanguageQaConfig] which are exposed via
+ * factory methods because the builder framework does not yet model QA configs.
+ *
+ * Lives in the data module — and not in the EE-only `QaTestData` — so tests in
+ * `:server-app` (which is built without `:ee-app` for the `runWithoutEeTests`
+ * task) can still use it.
+ */
+class ProjectWithQaEntitiesTestData : BaseTestData() {
+  init {
+    projectBuilder.addKey(keyName = "test-key") {
+      addTranslation("en", "Hello world.").build {
+        addQaIssue {
+          type = QaCheckType.EMPTY_TRANSLATION
+          message = QaIssueMessage.QA_EMPTY_TRANSLATION
+        }
+      }
+    }
+  }
+
+  /**
+   * Builds (but does NOT persist) a [ProjectQaConfig] for [project]. The caller
+   * persists it through the repository so we don't have to model QA configs in
+   * the builder framework.
+   */
+  fun createProjectQaConfig(): ProjectQaConfig = ProjectQaConfig(project = project)
+
+  /**
+   * Builds (but does NOT persist) a [LanguageQaConfig] for [englishLanguage].
+   * See [createProjectQaConfig] for why this is a factory rather than seeded
+   * by the builder.
+   */
+  fun createLanguageQaConfig(): LanguageQaConfig = LanguageQaConfig(language = englishLanguage)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectWithQaEntitiesTestData.kt
@@ -3,14 +3,6 @@ package io.tolgee.development.testDataBuilder.data
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.model.enums.qa.QaIssueMessage
 
-/**
- * Test data covering every QA-related persistent entity on a project so the
- * hard-delete flow can be exercised against all of them at once: a
- * [ProjectQaConfig][io.tolgee.model.qa.ProjectQaConfig], a
- * [LanguageQaConfig][io.tolgee.model.qa.LanguageQaConfig] for the base
- * language, and a translation with a
- * [TranslationQaIssue][io.tolgee.model.qa.TranslationQaIssue].
- */
 class ProjectWithQaEntitiesTestData : BaseTestData() {
   init {
     projectBuilder.setQaConfig()

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
@@ -601,4 +601,10 @@ class TranslationsTestData {
         state = QaIssueState.OPEN
       }
   }
+
+  fun addLanguageQaConfigOnGermanLanguage() {
+    projectBuilder.data.languages
+      .first { it.self === germanLanguage }
+      .setQaConfig()
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
@@ -15,6 +15,9 @@ import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.model.enums.TranslationCommentState
 import io.tolgee.model.enums.TranslationState
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
+import io.tolgee.model.enums.qa.QaIssueState
 import io.tolgee.model.key.Key
 import io.tolgee.model.key.screenshotReference.KeyInScreenshotPosition
 import io.tolgee.model.translation.Translation
@@ -587,5 +590,15 @@ class TranslationsTestData {
         name = "plural_key"
         isPlural = true
       }.self
+  }
+
+  fun addQaIssueOnAKeyGerman() {
+    projectBuilder.data.translations
+      .first { it.self === aKeyGermanTranslation }
+      .addQaIssue {
+        type = QaCheckType.EMPTY_TRANSLATION
+        message = QaIssueMessage.QA_EMPTY_TRANSLATION
+        state = QaIssueState.OPEN
+      }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
@@ -160,6 +160,14 @@ To filter default namespace, set to empty string.
   var filterQaCheckType: List<QaCheckType>? = null
 
   @field:Parameter(
+    description =
+      "Filter keys whose QA checks are stale (pending recomputation) in lang. " +
+        "When set, only keys with at least one stale translation in any of the provided " +
+        "languages are returned.",
+  )
+  var filterQaChecksStaleInLang: List<String>? = null
+
+  @field:Parameter(
     description = "Filter keys with any suggestions in lang",
   )
   var filterHasSuggestionsInLang: List<String>? = null

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
@@ -153,8 +153,7 @@ class QueryTranslationFiltering(
   }
 
   /**
-   * QA filters — `filterHasQaIssuesInLang` (collapsed across requested langs) and
-   * `filterQaCheckType` (collapsed across all selected return langs).
+   * QA filters — `filterHasQaIssuesInLang`, `filterQaCheckType` and `filterQaChecksStaleInLang`.
    */
   fun applyQaFilters() {
     val hasIssuesLangIds = languageIdsForTags(params.filterHasQaIssuesInLang)
@@ -167,6 +166,12 @@ class QueryTranslationFiltering(
       if (allLangIds.isNotEmpty()) {
         queryBase.translationConditions.add(buildQaIssueExists(allLangIds, checkTypes = checkTypes))
       }
+    }
+    val staleLangIds = languageIdsForTags(params.filterQaChecksStaleInLang)
+    if (staleLangIds != null) {
+      queryBase.translationConditions.add(
+        buildTranslationExists(staleLangIds) { t -> cb.isTrue(t.get(Translation_.qaChecksStale)) },
+      )
     }
   }
 

--- a/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
@@ -17,4 +17,16 @@ class ActivityTestUtil(
         ActivityRevision::class.java,
       ).singleResult
   }
+
+  fun findRevisionsAfter(afterId: Long): List<ActivityRevision> {
+    return entityManager
+      .createQuery(
+        """
+        from ActivityRevision ar left join fetch ar.modifiedEntities
+          where ar.id > :afterId order by ar.id asc
+        """.trimMargin(),
+        ActivityRevision::class.java,
+      ).setParameter("afterId", afterId)
+      .resultList
+  }
 }

--- a/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
@@ -15,7 +15,8 @@ class ActivityTestUtil(
         from ActivityRevision ar left join fetch ar.modifiedEntities order by ar.id desc limit 1
         """.trimMargin(),
         ActivityRevision::class.java,
-      ).singleResult
+      ).resultList
+      .firstOrNull()
   }
 
   fun findRevisionsAfter(afterId: Long): List<ActivityRevision> {

--- a/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/ActivityTestUtil.kt
@@ -23,7 +23,7 @@ class ActivityTestUtil(
     return entityManager
       .createQuery(
         """
-        from ActivityRevision ar left join fetch ar.modifiedEntities
+        select distinct ar from ActivityRevision ar left join fetch ar.modifiedEntities
           where ar.id > :afterId order by ar.id asc
         """.trimMargin(),
         ActivityRevision::class.java,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -8,6 +8,7 @@ import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.events.OnBatchJobFinalized
 import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
+import io.tolgee.component.eventListeners.BypassableActivityListener
 import io.tolgee.constants.Feature
 import io.tolgee.ee.service.qa.QaRecheckService
 import io.tolgee.events.OnProjectActivityEvent
@@ -46,11 +47,14 @@ class QaActivityListener(
   private val translationService: TranslationService,
   private val qaRecheckService: QaRecheckService,
   private val enabledFeaturesProvider: EnabledFeaturesProvider,
-) {
+) : BypassableActivityListener {
+  override var bypass = false
+
   // region Event listeners
 
   @EventListener
   fun onActivity(event: OnProjectActivityEvent) {
+    if (bypass) return
     runSentryCatching {
       val projectId = event.activityRevision.projectId ?: return
       val isBatchChunk = event.activityRevision.batchJobChunkExecution != null
@@ -80,6 +84,7 @@ class QaActivityListener(
 
   @EventListener
   fun onBatchJobFinalized(event: OnBatchJobFinalized) {
+    if (bypass) return
     runSentryCatching {
       val projectId = event.job.projectId ?: return
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -48,6 +48,7 @@ class QaActivityListener(
   private val qaRecheckService: QaRecheckService,
   private val enabledFeaturesProvider: EnabledFeaturesProvider,
 ) : BypassableActivityListener {
+  @Volatile
   override var bypass = false
 
   // region Event listeners

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
@@ -6,16 +6,8 @@ import io.tolgee.model.branching.Branch
 import io.tolgee.model.enums.qa.QaCheckSeverity
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.model.key.Key
-import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.model.translation.Translation
 
-/**
- * Test data for QA language-stats refresh scenarios that involve branches.
- *
- * Contains a project with branching enabled, two branches (`main` + `feature`), and
- * one `fr` translation on each branch so stats can be asserted independently per
- * branch.
- */
 class QaLanguageStatsBranchTestData : BaseTestData() {
   lateinit var frenchLanguage: Language
 
@@ -62,24 +54,17 @@ class QaLanguageStatsBranchTestData : BaseTestData() {
         addTranslation("en", "Feature hello.")
         featureFrTranslation = addTranslation("fr", "bonjour feature").self
       }.also { featureKey = it.self }
-    }
-  }
 
-  /**
-   * Creates QA config with all check types enabled at WARNING, except SPELLING and GRAMMAR
-   * which are OFF (they depend on an external LanguageTool container).
-   */
-  fun createDefaultQaConfig(): ProjectQaConfig {
-    return ProjectQaConfig(
-      project = project,
-      settings =
-        QaCheckType.entries
-          .associateWith { type ->
-            when (type) {
-              QaCheckType.SPELLING, QaCheckType.GRAMMAR -> QaCheckSeverity.OFF
-              else -> QaCheckSeverity.WARNING
-            }
-          }.toMutableMap(),
-    )
+      setQaConfig {
+        settings =
+          QaCheckType.entries
+            .associateWith { type ->
+              when (type) {
+                QaCheckType.SPELLING, QaCheckType.GRAMMAR -> QaCheckSeverity.OFF
+                else -> QaCheckSeverity.WARNING
+              }
+            }.toMutableMap()
+      }
+    }
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
@@ -52,10 +52,7 @@ class QaLanguageStatsBranchTestData : BaseTestData() {
         branch = mainBranch
       }.build {
         addTranslation("en", "Hello world.")
-        mainFrTranslation =
-          addTranslation("fr", "bonjour monde")
-            .also { it.self.qaChecksStale = true }
-            .self
+        mainFrTranslation = addTranslation("fr", "bonjour monde").self
       }.also { mainKey = it.self }
 
       addKey {
@@ -63,10 +60,7 @@ class QaLanguageStatsBranchTestData : BaseTestData() {
         branch = featureBranch
       }.build {
         addTranslation("en", "Feature hello.")
-        featureFrTranslation =
-          addTranslation("fr", "bonjour feature")
-            .also { it.self.qaChecksStale = true }
-            .self
+        featureFrTranslation = addTranslation("fr", "bonjour feature").self
       }.also { featureKey = it.self }
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -10,7 +10,9 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.model.translation.Translation
 
-class QaTestData : BaseTestData() {
+class QaTestData(
+  includeDefaultQaConfig: Boolean = true,
+) : BaseTestData() {
   lateinit var frenchLanguage: Language
   lateinit var testKey: Key
   lateinit var enTranslation: Translation
@@ -127,6 +129,18 @@ class QaTestData : BaseTestData() {
           tag = "de"
           originalName = "Deutsch"
         }.self
+      if (includeDefaultQaConfig) {
+        setQaConfig {
+          settings =
+            QaCheckType.entries
+              .associateWith { type ->
+                when (type) {
+                  QaCheckType.SPELLING, QaCheckType.GRAMMAR -> QaCheckSeverity.OFF
+                  else -> QaCheckSeverity.WARNING
+                }
+              }.toMutableMap()
+        }
+      }
     }
 
     root.apply {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -4,6 +4,8 @@ import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.model.Language
 import io.tolgee.model.enums.qa.QaCheckSeverity
 import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
+import io.tolgee.model.enums.qa.QaIssueState
 import io.tolgee.model.key.Key
 import io.tolgee.model.qa.ProjectQaConfig
 import io.tolgee.model.translation.Translation
@@ -19,12 +21,35 @@ class QaTestData : BaseTestData() {
   /** Key that only has a base (English) translation — no French translation exists. */
   lateinit var keyWithoutFrTranslation: Key
 
+  /** Key whose FR translation has fresh (non-stale) QA checks and no QA issues. */
+  lateinit var freshFrKey: Key
+  lateinit var freshFrTranslation: Translation
+  lateinit var freshEnTranslation: Translation
+
+  /** Key whose FR translation has stale QA checks and no QA issues. */
+  lateinit var staleFrKey: Key
+  lateinit var staleFrTranslation: Translation
+
+  /**
+   * Key whose FR translation has OPEN PUNCTUATION_MISMATCH + CHARACTER_CASE_MISMATCH
+   * issues seeded. Used by filter tests that need at least one key with active issues.
+   */
+  lateinit var keyWithIssues: Key
+
+  /**
+   * Key whose FR translation has only IGNORED QA issues. Used to verify that filters
+   * which target OPEN issues correctly exclude translations whose issues have all been
+   * ignored.
+   */
+  lateinit var ignoredOnlyKey: Key
+
   lateinit var germanLanguage: Language
 
   init {
     project.useQaChecks = true
     projectBuilder.build {
       frenchLanguage = addFrench().self
+      // testKey: clean. No QA issues — tests that a pristine translation.
       testKey =
         addKey {
           name = "test-key"
@@ -32,11 +57,69 @@ class QaTestData : BaseTestData() {
           enTranslation = addTranslation("en", "Hello world.").self
           frTranslation = addTranslation("fr", "bonjour monde").self
         }.self
+      keyWithIssues =
+        addKey {
+          name = "key-with-issues"
+        }.build {
+          addTranslation("en", "Hello world.")
+          addTranslation("fr", "bonjour monde")
+            .also { it.self.qaChecksStale = false }
+            .build {
+              addQaIssue {
+                type = QaCheckType.PUNCTUATION_MISMATCH
+                message = QaIssueMessage.QA_PUNCTUATION_ADD
+                state = QaIssueState.OPEN
+                positionStart = 13
+                positionEnd = 13
+                replacement = "."
+              }
+              addQaIssue {
+                type = QaCheckType.CHARACTER_CASE_MISMATCH
+                message = QaIssueMessage.QA_CASE_CAPITALIZE
+                state = QaIssueState.OPEN
+                positionStart = 0
+                positionEnd = 1
+                replacement = "B"
+              }
+            }
+        }.self
       keyWithoutFrTranslation =
         addKey {
           name = "key-without-fr-translation"
         }.build {
           addTranslation("en", "Only English.")
+        }.self
+      freshFrKey =
+        addKey {
+          name = "fresh-fr-key"
+        }.build {
+          freshEnTranslation = addTranslation("en", "Fresh.").also { it.self.qaChecksStale = false }.self
+          freshFrTranslation = addTranslation("fr", "Frais.").also { it.self.qaChecksStale = false }.self
+        }.self
+      staleFrKey =
+        addKey {
+          name = "stale-fr-key"
+        }.build {
+          addTranslation("en", "Stale.").also { it.self.qaChecksStale = false }
+          staleFrTranslation = addTranslation("fr", "Périmé.").also { it.self.qaChecksStale = true }.self
+        }.self
+      ignoredOnlyKey =
+        addKey {
+          name = "ignored-only-key"
+        }.build {
+          addTranslation("en", "Click here.").also { it.self.qaChecksStale = false }
+          addTranslation("fr", "Cliquez ici")
+            .also { it.self.qaChecksStale = false }
+            .build {
+              addQaIssue {
+                type = QaCheckType.PUNCTUATION_MISMATCH
+                message = QaIssueMessage.QA_PUNCTUATION_ADD
+                state = QaIssueState.IGNORED
+                positionStart = 11
+                positionEnd = 11
+                replacement = "."
+              }
+            }
         }.self
       germanLanguage =
         addLanguage {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketTest.kt
@@ -43,7 +43,6 @@ class QaCheckPreviewWebSocketTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
     jwtToken = jwtService.emitToken(testData.user.id)
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
@@ -39,7 +39,6 @@ class QaDashboardStatsTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
@@ -7,7 +7,6 @@ import io.tolgee.ee.development.QaTestData
 import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.model.translation.Translation
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.util.executeInNewTransaction
 import net.javacrumbs.jsonunit.assertj.assertThatJson
@@ -69,11 +68,6 @@ class QaDashboardStatsTest : AuthorizedControllerTest() {
 
   @Test
   fun `language stats include qaChecksStaleCount`() {
-    executeInNewTransaction(platformTransactionManager) {
-      val translation = entityManager.find(Translation::class.java, testData.frTranslation.id)
-      translation.qaChecksStale = true
-      entityManager.persist(translation)
-    }
     languageStatsService.refreshLanguageStats(testData.project.id)
 
     performAuthGet(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
@@ -21,7 +21,6 @@ import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
@@ -535,30 +535,24 @@ class QaIssueControllerTest : AuthorizedControllerTest() {
   }
 
   @Test
-  @Disabled(
-    "Was previously passing only because TestDataService activity events were leaking " +
-      "through to subsequent transactions, so `getLastRevision()` returned an unrelated " +
-      "BeforeEach-driven revision instead of the one created by `runChecksAndPersist`. " +
-      "Now that `BypassableActivityListener` properly suppresses activities during test-data " +
-      "save, the only revision is the QA-issue persistence one, which DOES contain a " +
-      "`TranslationQaIssue` modification despite `disableActivityLogging = true` being set on " +
-      "the entities — the assertion needs to be reworked. Tracking in a separate PR.",
-  )
   fun `batch QA recalculation does not create visible activity`() {
+    val baselineRevisionId = activityUtil.getLastRevision()?.id ?: 0L
+
     qa.runChecksAndPersist(testData.frTranslation)
 
-    val revision = activityUtil.getLastRevision()
-    // The batch QA check has activityType = null, so either no revision exists
-    // or the latest revision is not a QA-related activity type
-    if (revision != null) {
-      assertThat(revision.type).isNotIn(
-        ActivityType.QA_ISSUE_IGNORE,
-        ActivityType.QA_ISSUE_UNIGNORE,
-      )
-      val modifiedEntity =
-        revision.modifiedEntities.find { it.entityClass == TranslationQaIssue::class.simpleName }
-      assertThat(modifiedEntity).isNull()
-    }
+    val newRevisions = activityUtil.findRevisionsAfter(baselineRevisionId)
+    assertThat(newRevisions)
+      .withFailMessage(
+        "runChecksAndPersist must not create user-visible activity revisions, but produced: %s",
+        newRevisions.map { it.id to it.type },
+      ).allSatisfy { revision ->
+        assertThat(revision.type).isNotIn(
+          ActivityType.QA_ISSUE_IGNORE,
+          ActivityType.QA_ISSUE_UNIGNORE,
+        )
+        assertThat(revision.modifiedEntities.map { it.entityClass })
+          .doesNotContain(TranslationQaIssue::class.simpleName)
+      }
   }
 
   private fun virtualCaseMismatchRequest() =

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
@@ -21,6 +21,7 @@ import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -535,6 +536,15 @@ class QaIssueControllerTest : AuthorizedControllerTest() {
   }
 
   @Test
+  @Disabled(
+    "Was previously passing only because TestDataService activity events were leaking " +
+      "through to subsequent transactions, so `getLastRevision()` returned an unrelated " +
+      "BeforeEach-driven revision instead of the one created by `runChecksAndPersist`. " +
+      "Now that `BypassableActivityListener` properly suppresses activities during test-data " +
+      "save, the only revision is the QA-issue persistence one, which DOES contain a " +
+      "`TranslationQaIssue` modification despite `disableActivityLogging = true` being set on " +
+      "the entities — the assertion needs to be reworked. Tracking in a separate PR.",
+  )
   fun `batch QA recalculation does not create visible activity`() {
     qa.runChecksAndPersist(testData.frTranslation)
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
@@ -58,7 +58,6 @@ class QaIssueControllerTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaKeysImportTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaKeysImportTest.kt
@@ -49,7 +49,6 @@ class QaKeysImportTest : ProjectAuthControllerTest("/v2/projects/") {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
     projectSupplier = { testData.project }
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
@@ -46,7 +46,7 @@ class QaSettingsControllerTest : AuthorizedControllerTest() {
   @BeforeEach
   fun setup() {
     enabledFeaturesProvider.forceEnabled = setOf(Feature.QA_CHECKS)
-    testData = QaTestData()
+    testData = QaTestData(includeDefaultQaConfig = false)
     testDataService.saveTestData(testData.root)
     qa.testData = testData
     userAccount = testData.user

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
@@ -4,13 +4,10 @@ import com.posthog.server.PostHog
 import io.tolgee.constants.Feature
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
 import io.tolgee.ee.development.QaTestData
-import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.model.enums.qa.QaIssueState
-import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.testing.AuthorizedControllerTest
-import io.tolgee.util.executeInNewTransaction
+import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,12 +26,6 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
   @Autowired
   private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
 
-  @Autowired
-  lateinit var qa: QaTestUtil
-
-  @Autowired
-  private lateinit var qaIssueRepository: TranslationQaIssueRepository
-
   lateinit var testData: QaTestData
 
   private val translationsUrl
@@ -44,17 +35,7 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
   fun setup() {
     enabledFeaturesProvider.forceEnabled = setOf(Feature.QA_CHECKS)
     testData = QaTestData()
-    // Add a second key with clean translation
-    testData.projectBuilder
-      .addKey {
-        name = "clean-key"
-      }.build {
-        addTranslation("en", "Clean text.")
-        addTranslation("fr", "Texte propre.")
-      }
     testDataService.saveTestData(testData.root)
-    qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 
@@ -66,77 +47,92 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
   }
 
   @Test
-  fun `filters translations with QA issues in language`() {
-    // Create QA issues on the FR translation of test-key
-    qa.runChecksAndPersist(testData.frTranslation)
-
+  fun `filterHasQaIssuesInLang matches keys with OPEN issues, excludes keys with only IGNORED issues`() {
     performAuthGet(
       "$translationsUrl?filterHasQaIssuesInLang=fr",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys").isArray.hasSize(1)
-      node("_embedded.keys[0].keyName").isEqualTo("test-key")
+      node("_embedded.keys[0].keyName").isEqualTo("key-with-issues")
     }
   }
 
   @Test
-  fun `excludes translations with only ignored issues`() {
-    qa.runChecksAndPersist(testData.frTranslation)
-
-    // Ignore all issues
-    executeInNewTransaction(platformTransactionManager) {
-      val issues = qaIssueRepository.findAll().filter { it.translation.id == testData.frTranslation.id }
-      issues.forEach { it.state = QaIssueState.IGNORED }
-      qaIssueRepository.saveAll(issues)
-    }
-
-    performAuthGet(
-      "$translationsUrl?filterHasQaIssuesInLang=fr",
-    ).andIsOk.andAssertThatJson {
-      node("_embedded.keys").isAbsent()
-    }
-  }
-
-  @Test
-  fun `filters by specific check type`() {
-    qa.runChecksAndPersist(testData.frTranslation)
-
+  fun `filterQaCheckType matches keys with that check type in OPEN state`() {
     performAuthGet(
       "$translationsUrl?filterQaCheckType=PUNCTUATION_MISMATCH",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys").isArray.hasSize(1)
-      node("_embedded.keys[0].keyName").isEqualTo("test-key")
+      node("_embedded.keys[0].keyName").isEqualTo("key-with-issues")
     }
   }
 
   @Test
-  fun `filters by multiple check types`() {
-    qa.runChecksAndPersist(testData.frTranslation)
-
+  fun `filterQaCheckType supports multiple check types (OR semantics)`() {
     performAuthGet(
       "$translationsUrl?filterQaCheckType=PUNCTUATION_MISMATCH&filterQaCheckType=CHARACTER_CASE_MISMATCH",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys").isArray.hasSize(1)
-      node("_embedded.keys[0].keyName").isEqualTo("test-key")
+      node("_embedded.keys[0].keyName").isEqualTo("key-with-issues")
     }
   }
 
   @Test
   fun `returns all translations when no QA filter`() {
-    qa.runChecksAndPersist(testData.frTranslation)
-
     performAuthGet(translationsUrl).andIsOk.andAssertThatJson {
-      node("_embedded.keys").isArray.hasSize(3)
+      // test-key, key-without-fr-translation, fresh-fr-key, stale-fr-key, key-with-issues, ignored-only-key
+      node("_embedded.keys").isArray.hasSize(6)
     }
   }
 
   @Test
   fun `combines QA filter with language filter`() {
-    qa.runChecksAndPersist(testData.frTranslation)
-
     performAuthGet(
       "$translationsUrl?filterHasQaIssuesInLang=fr&languages=fr",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys").isArray.hasSize(1)
+      node("_embedded.keys[0].keyName").isEqualTo("key-with-issues")
+    }
+  }
+
+  @Test
+  fun `filterQaChecksStaleInLang matches only translations with qaChecksStale=true in lang`() {
+    // FR matches: test-key + stale-fr-key. Fresh, key-with-issues (fr fresh) and
+    // ignored-only must be absent.
+    performAuthGet("$translationsUrl?filterQaChecksStaleInLang=fr").andIsOk.andAssertThatJson {
+      node("_embedded.keys").isArray.hasSize(2)
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("test-key")
+      }
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("stale-fr-key")
+      }
+    }
+
+    // EN matches: test-key + key-without-fr-translation + key-with-issues (en is default
+    // stale because the seeded issues are on fr). fresh / stale (en is fresh) /
+    // ignored-only (en is fresh) are excluded.
+    performAuthGet("$translationsUrl?filterQaChecksStaleInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys").isArray.hasSize(3)
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("test-key")
+      }
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("key-without-fr-translation")
+      }
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("key-with-issues")
+      }
+    }
+  }
+
+  @Test
+  fun `stale filter is silently ignored when QA feature is disabled`() {
+    enabledFeaturesProvider.forceEnabled = emptySet()
+
+    performAuthGet("$translationsUrl?filterQaChecksStaleInLang=fr").andIsOk.andAssertThatJson {
+      // Filter is gated by qaEnabled — when QA is off, the param is ignored and all
+      // keys are returned.
+      node("page.totalElements").isEqualTo(6)
     }
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBaseChangeRecheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBaseChangeRecheckTest.kt
@@ -35,7 +35,6 @@ class QaBaseChangeRecheckTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBaseChangeRecheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBaseChangeRecheckTest.kt
@@ -49,6 +49,8 @@ class QaBaseChangeRecheckTest : AuthorizedControllerTest() {
     testData.testKey = entityManager.find(Key::class.java, testData.testKey.id)
     testData.enTranslation = entityManager.find(Translation::class.java, testData.enTranslation.id)
     testData.frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+    testData.freshEnTranslation = entityManager.find(Translation::class.java, testData.freshEnTranslation.id)
+    testData.freshFrTranslation = entityManager.find(Translation::class.java, testData.freshFrTranslation.id)
   }
 
   @Test
@@ -86,18 +88,14 @@ class QaBaseChangeRecheckTest : AuthorizedControllerTest() {
   fun `setQaChecksStaleForBaseTranslationKeys marks siblings stale`() {
     refetchEntities()
 
-    // Clear stale flag first so we can verify it gets set
-    testData.frTranslation.qaChecksStale = false
-    entityManager.flush()
-
     val baseLanguage = languageService.getProjectBaseLanguage(testData.project.id)
     translationService.setQaChecksStaleForBaseTranslationKeys(
-      translationIds = listOf(testData.enTranslation.id),
+      translationIds = listOf(testData.freshEnTranslation.id),
       baseLanguageId = baseLanguage.id,
     )
     entityManager.flushAndClear()
 
-    val frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+    val frTranslation = entityManager.find(Translation::class.java, testData.freshFrTranslation.id)
     assertThat(frTranslation.qaChecksStale).isTrue()
   }
 
@@ -106,19 +104,15 @@ class QaBaseChangeRecheckTest : AuthorizedControllerTest() {
   fun `setQaChecksStaleForBaseTranslationKeys does nothing when no base translations in input`() {
     refetchEntities()
 
-    // Clear stale flag first
-    testData.frTranslation.qaChecksStale = false
-    entityManager.flush()
-
     val baseLanguage = languageService.getProjectBaseLanguage(testData.project.id)
     // Only FR (non-base) in input — no siblings should be marked
     translationService.setQaChecksStaleForBaseTranslationKeys(
-      translationIds = listOf(testData.frTranslation.id),
+      translationIds = listOf(testData.freshFrTranslation.id),
       baseLanguageId = baseLanguage.id,
     )
     entityManager.flushAndClear()
 
-    val frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+    val frTranslation = entityManager.find(Translation::class.java, testData.freshFrTranslation.id)
     assertThat(frTranslation.qaChecksStale).isFalse()
   }
 
@@ -127,20 +121,18 @@ class QaBaseChangeRecheckTest : AuthorizedControllerTest() {
   fun `setQaChecksStaleForBaseTranslationKeys includes empty translations`() {
     refetchEntities()
 
-    // Set FR translation to null (empty) and clear stale flag
-    testData.frTranslation.text = null
-    testData.frTranslation.qaChecksStale = false
+    testData.freshFrTranslation.text = null
     entityManager.flush()
 
     val baseLanguage = languageService.getProjectBaseLanguage(testData.project.id)
     translationService.setQaChecksStaleForBaseTranslationKeys(
-      translationIds = listOf(testData.enTranslation.id),
+      translationIds = listOf(testData.freshEnTranslation.id),
       baseLanguageId = baseLanguage.id,
     )
     entityManager.flushAndClear()
 
     // Empty translations should still be marked stale
-    val frTranslation = entityManager.find(Translation::class.java, testData.frTranslation.id)
+    val frTranslation = entityManager.find(Translation::class.java, testData.freshFrTranslation.id)
     assertThat(frTranslation.qaChecksStale).isTrue()
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBatchOperationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaBatchOperationTest.kt
@@ -46,7 +46,6 @@ class QaBatchOperationTest : ProjectAuthControllerTest("/v2/projects/") {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
     projectSupplier = { testData.project }
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceTest.kt
@@ -46,7 +46,6 @@ class QaCheckBatchServiceTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -74,7 +74,6 @@ class QaEventListenerTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaLanguageStatsRefreshTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaLanguageStatsRefreshTest.kt
@@ -13,7 +13,6 @@ import io.tolgee.model.activity.ActivityModifiedEntity
 import io.tolgee.model.activity.ActivityRevision
 import io.tolgee.model.batch.BatchJobStatus
 import io.tolgee.model.translation.Translation
-import io.tolgee.repository.qa.ProjectQaConfigRepository
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assertions.Assertions.assertThat
 import io.tolgee.util.executeInNewTransaction
@@ -34,9 +33,6 @@ class QaLanguageStatsRefreshTest : AuthorizedControllerTest() {
   @Autowired
   lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
 
-  @Autowired
-  lateinit var projectQaConfigRepository: ProjectQaConfigRepository
-
   lateinit var testData: QaLanguageStatsBranchTestData
 
   @BeforeEach
@@ -44,7 +40,6 @@ class QaLanguageStatsRefreshTest : AuthorizedControllerTest() {
     enabledFeaturesProvider.forceEnabled = setOf(Feature.QA_CHECKS, Feature.BRANCHING)
     testData = QaLanguageStatsBranchTestData()
     testDataService.saveTestData(testData.root)
-    projectQaConfigRepository.save(testData.createDefaultQaConfig())
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaMaxCharLimitTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaMaxCharLimitTest.kt
@@ -61,28 +61,18 @@ class QaMaxCharLimitTest : ProjectAuthControllerTest("/v2/projects/") {
   @ProjectJWTAuthTestMethod
   @Test
   fun `setting max char limit marks translations stale and triggers QA check`() {
-    // Clear stale flags first so we can verify they get set by the maxCharLimit change
-    executeInNewTransaction(platformTransactionManager) {
-      val en = translationService.find(testData.enTranslation.id)!!
-      en.qaChecksStale = false
-      entityManager.persist(en)
-      val fr = translationService.find(testData.frTranslation.id)!!
-      fr.qaChecksStale = false
-      entityManager.persist(fr)
-    }
-
     performProjectAuthPut(
-      "keys/${testData.testKey.id}/complex-update",
-      mapOf("name" to testData.testKey.name, "maxCharLimit" to 5),
+      "keys/${testData.freshFrKey.id}/complex-update",
+      mapOf("name" to testData.freshFrKey.name, "maxCharLimit" to 5),
     ).andIsOk
 
     // All translations for this key should be marked stale
     waitForNotThrowing(timeout = 10_000, pollTime = 500) {
       executeInNewTransaction(platformTransactionManager) {
-        val enTranslation = translationService.find(testData.enTranslation.id)!!
+        val enTranslation = translationService.find(testData.freshEnTranslation.id)!!
         assertThat(enTranslation.qaChecksStale).isTrue()
 
-        val frTranslation = translationService.find(testData.frTranslation.id)!!
+        val frTranslation = translationService.find(testData.freshFrTranslation.id)!!
         assertThat(frTranslation.qaChecksStale).isTrue()
       }
     }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaMaxCharLimitTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaMaxCharLimitTest.kt
@@ -46,7 +46,6 @@ class QaMaxCharLimitTest : ProjectAuthControllerTest("/v2/projects/") {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
     projectSupplier = { testData.project }
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaStaleFlowTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaStaleFlowTest.kt
@@ -48,7 +48,6 @@ class QaStaleFlowTest : AuthorizedControllerTest() {
     testData = QaTestData()
     testDataService.saveTestData(testData.root)
     qa.testData = testData
-    qa.saveDefaultQaConfig()
     userAccount = testData.user
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaStaleFlowTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaStaleFlowTest.kt
@@ -146,22 +146,15 @@ class QaStaleFlowTest : AuthorizedControllerTest() {
       entityManager.persist(project)
     }
 
-    // Clear stale flag first so we can verify it gets set
-    executeInNewTransaction(platformTransactionManager) {
-      val translation = translationService.find(testData.frTranslation.id)!!
-      translation.qaChecksStale = false
-      entityManager.persist(translation)
-    }
-
     // Save translation — should still mark stale even without QA feature
     performAuthPut(
       translationsUrl,
-      mapOf("key" to "test-key", "translations" to mapOf("fr" to "Bonjour tout le monde")),
+      mapOf("key" to "fresh-fr-key", "translations" to mapOf("fr" to "Frais modifié")),
     ).andIsOk
 
     waitForNotThrowing(timeout = 5_000, pollTime = 200) {
       executeInNewTransaction(platformTransactionManager) {
-        val translation = translationService.find(testData.frTranslation.id)!!
+        val translation = translationService.find(testData.freshFrTranslation.id)!!
         assertThat(translation.qaChecksStale).isTrue()
       }
     }
@@ -179,22 +172,15 @@ class QaStaleFlowTest : AuthorizedControllerTest() {
       entityManager.persist(project)
     }
 
-    // Clear stale flag on French translation
-    executeInNewTransaction(platformTransactionManager) {
-      val translation = translationService.find(testData.frTranslation.id)!!
-      translation.qaChecksStale = false
-      entityManager.persist(translation)
-    }
-
     // Change base (English) translation — should mark French sibling as stale
     performAuthPut(
       translationsUrl,
-      mapOf("key" to "test-key", "translations" to mapOf("en" to "Hello World!")),
+      mapOf("key" to "fresh-fr-key", "translations" to mapOf("en" to "Fresh modified")),
     ).andIsOk
 
     waitForNotThrowing(timeout = 10_000, pollTime = 500) {
       executeInNewTransaction(platformTransactionManager) {
-        val frTranslation = translationService.find(testData.frTranslation.id)!!
+        val frTranslation = translationService.find(testData.freshFrTranslation.id)!!
         assertThat(frTranslation.qaChecksStale).isTrue()
       }
     }

--- a/webapp/src/ee/qa/components/SubfilterQaChecks.tsx
+++ b/webapp/src/ee/qa/components/SubfilterQaChecks.tsx
@@ -48,6 +48,14 @@ export const SubfilterQaChecks = ({
     }
   }
 
+  function handleToggleStale() {
+    if (value.filterQaChecksStale) {
+      actions.removeFilter('filterQaChecksStale');
+    } else {
+      actions.addFilter('filterQaChecksStale');
+    }
+  }
+
   return (
     <>
       <SubmenuItem
@@ -94,6 +102,12 @@ export const SubfilterQaChecks = ({
               ))}
             </div>
           ))}
+          <Divider />
+          <FilterItem
+            label={t('translation_filters_qa_checks_stale')}
+            selected={Boolean(value.filterQaChecksStale)}
+            onClick={handleToggleStale}
+          />
         </Menu>
       )}
     </>
@@ -102,8 +116,9 @@ export const SubfilterQaChecks = ({
 
 export function getQaChecksFiltersLength(value: FiltersInternal) {
   return (
-    Number(value.filterHasQaIssues !== undefined) +
-    (value.filterQaCheckTypes?.length ?? 0)
+    Number(Boolean(value.filterHasQaIssues)) +
+    (value.filterQaCheckTypes?.length ?? 0) +
+    Number(Boolean(value.filterQaChecksStale))
   );
 }
 
@@ -113,5 +128,8 @@ export function getQaChecksFiltersName(value: FiltersInternal) {
   }
   if (value.filterQaCheckTypes?.length) {
     return <CheckTypeFilterName checkType={value.filterQaCheckTypes[0]} />;
+  }
+  if (value.filterQaChecksStale) {
+    return <T keyName="translation_filters_qa_checks_stale" />;
   }
 }

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -15938,7 +15938,7 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
-        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. */
         filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
@@ -16089,7 +16089,7 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
-        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. */
         filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
@@ -16276,7 +16276,7 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
-        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. */
         filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
@@ -21015,7 +21015,7 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
-        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. */
         filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
@@ -21346,7 +21346,7 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
-        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. */
         filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -15938,6 +15938,8 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
         /** Filter keys with no suggestions in lang */
@@ -16087,6 +16089,8 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
         /** Filter keys with no suggestions in lang */
@@ -16272,6 +16276,8 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
         /** Filter keys with no suggestions in lang */
@@ -21009,6 +21015,8 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
         /** Filter keys with no suggestions in lang */
@@ -21338,6 +21346,8 @@ export interface operations {
           | "HTML_SYNTAX"
           | "ICU_SYNTAX"
         )[];
+        /** Filter keys whose QA checks are stale (pending recomputation) in lang. When set, only keys with at least one stale translation in any of the provided languages are returned. Useful for diagnosing keys whose QA recomputation is stuck. */
+        filterQaChecksStaleInLang?: string[];
         /** Filter keys with any suggestions in lang */
         filterHasSuggestionsInLang?: string[];
         /** Filter keys with no suggestions in lang */

--- a/webapp/src/views/projects/translations/TranslationFilters/tools.ts
+++ b/webapp/src/views/projects/translations/TranslationFilters/tools.ts
@@ -21,6 +21,7 @@ export type FiltersInternal = {
   filterHasComments?: boolean;
   filterHasQaIssues?: boolean;
   filterQaCheckTypes?: QaCheckType[];
+  filterQaChecksStale?: boolean;
   filterLabel?: string[];
   filterHasSuggestions?: boolean;
   filterHasNoSuggestions?: boolean;
@@ -49,6 +50,7 @@ export type AddParams =
   | ['filterHasComments']
   | ['filterHasQaIssues']
   | ['filterQaCheckTypes', QaCheckType]
+  | ['filterQaChecksStale']
   | ['filterLabel', string]
   | ['filterHasSuggestions']
   | ['filterHasNoSuggestions']

--- a/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
@@ -103,6 +103,11 @@ export const useTranslationFilters = ({
           filterQaCheckTypes: add(filters.filterQaCheckTypes, value),
           filterHasQaIssues: undefined,
         });
+      case 'filterQaChecksStale':
+        return setFilters({
+          ...filters,
+          filterQaChecksStale: true,
+        });
       case 'filterLabel':
         return setFilters({
           ...filters,
@@ -189,6 +194,11 @@ export const useTranslationFilters = ({
           ...filters,
           filterQaCheckTypes: remove(filters.filterQaCheckTypes, value),
         });
+      case 'filterQaChecksStale':
+        return setFilters({
+          ...filters,
+          filterQaChecksStale: undefined,
+        });
       case 'filterLabel':
         return setFilters({
           ...filters,
@@ -243,6 +253,12 @@ export const useTranslationFilters = ({
       if (filters.filterHasQaIssues) {
         filtersQuery.filterHasQaIssuesInLang = add(
           filtersQuery.filterHasQaIssuesInLang,
+          tag
+        );
+      }
+      if (filters.filterQaChecksStale) {
+        filtersQuery.filterQaChecksStaleInLang = add(
+          filtersQuery.filterQaChecksStaleInLang,
           tag
         );
       }


### PR DESCRIPTION
## Summary

- Adds `filterQaChecksStaleInLang` query param on the translations list endpoint and a matching "QA checks stale" toggle in the webapp's QA Checks subfilter, so users can see keys whose QA recomputation is out of date.
- Introduces `BypassableActivityListener` interface (implemented by `LanguageStatsListener` and `QaActivityListener`); `TestDataService` toggles `bypass=true` for the duration of `saveTestData` so listeners no longer mutate freshly-inserted fixtures.
- Adds `@EnableAsync(proxyTargetClass = true)` so async listeners that now implement the interface stay CGLIB-proxied and remain `@Autowired`-able by concrete class.
- `QaTestData` exposes new synthetic fixtures (`keyWithIssues`, `ignoredOnlyKey`, `freshFr*`, `staleFr*`) with seeded QA issues; QA tests no longer mutate `qaChecksStale` or run real QA checks just to seed issues.
- `LanguageServiceTest` and `ProjectHardDeletingServiceTest` migrate off post-save QA-issue persistence to the builder-driven approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Checks Stale" QA filter in UI and API to find translations with stale QA checks per language.

* **Improvements**
  * Async processing configured to use class-based proxies for more reliable background tasks.
  * Global bypass flag for activity/QA listeners to suppress side effects during test/data workflows.
  * Test-data builders extended to seed richer QA configs and scenarios.
  * Activity revision querying made safer for tests.

* **Tests**
  * QA tests updated and expanded to cover new filters and stale-check behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3649)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->