### PR TITLE
chore: fix flaky GlossaryExportControllerTest async streaming

### DIFF
--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryExportControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryExportControllerTest.kt
@@ -4,6 +4,7 @@ import io.tolgee.constants.Feature
 import io.tolgee.development.testDataBuilder.data.GlossaryTestData
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.ignoreTestOnSpringBug
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MvcResult
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -44,9 +46,12 @@ class GlossaryExportControllerTest : AuthorizedControllerTest() {
     // The export should include all three languages: en (term column), cs, fr
 
     val result =
-      performAuthGet("/v2/organizations/${testData.organization.id}/glossaries/${testData.glossary.id}/export")
-        .andIsOk
-        .andReturn()
+      ignoreTestOnSpringBug {
+        performAuthGet("/v2/organizations/${testData.organization.id}/glossaries/${testData.glossary.id}/export")
+          .andIsOk
+          .andDo { obj: MvcResult -> obj.asyncResult }
+          .andReturn()
+      }
 
     val csvContent = result.response.contentAsString
     val headerLine = csvContent.lines()[0]


### PR DESCRIPTION
## Summary

- `GlossaryExportControllerTest.exports all associated languages including empty ones` has been intermittently failing in the billing repo's nightly **Report intermittent tests** workflow (5 occurrences between May 4–9). Stack traces showed either `expected: [\"term\", …] but was: [\"\"]` (empty response body) or the known `ConcurrentModificationException` Spring streaming bug.
- Root cause: the export endpoint returns a `StreamingResponseBody`, so MockMvc's `mvc.perform(...)` returns as soon as the async dispatch starts — sometimes before the CSV is written. Reading `contentAsString` after `andReturn()` was racy.
- Fix: wrap the request in `ignoreTestOnSpringBug { … }` and chain `.andDo { obj.asyncResult }` to wait for the async body. This mirrors the established pattern in `V2ExportAllFormatsTest`.
- Verified locally with `@RepeatedTest(50)` — 50/50 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of glossary export functionality tests by updating test execution flow to better handle asynchronous operations. Existing validation of CSV content and language headers remains intact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3650)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->