### PR TITLE
chore: fix flaky BatchJobsGeneralWithRedisTest

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
@@ -232,10 +232,10 @@ class BatchJobTestUtil(
   }
 
   fun makePreTranslationProcessorWaitingAfter50Executions(): () -> Unit {
-    var count = 0
+    val count = AtomicInteger(0)
 
     doAnswer {
-      if (count++ > 50) {
+      if (count.getAndIncrement() > 50) {
         while (true) {
           val context = it.arguments[2] as CoroutineContext
           context.ensureActive()
@@ -247,7 +247,7 @@ class BatchJobTestUtil(
 
     return {
       waitFor {
-        count > 50
+        count.get() > 50
       }
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
@@ -52,10 +52,12 @@ class BatchJobCancellationManager(
   }
 
   /**
-   * Sends request to cancel job executions on all instances
+   * Sends request to cancel job executions on all instances.
    *
-   * If using redis, it rends a message to redis channel
-   * If not, it just cancels local jobs
+   * When using Redis, also broadcasts the cancel message so other instances cancel
+   * their running coroutines for this job. The local instance always cancels
+   * directly (not via the Redis loopback) so cancellation does not depend on
+   * the Redis pub/sub round-trip latency.
    */
   private fun cancelLocalAndRemoteExecutions(id: Long) {
     if (usingRedisProvider.areWeUsingRedis) {
@@ -63,7 +65,6 @@ class BatchJobCancellationManager(
         RedisPubSubReceiverConfiguration.JOB_CANCEL_TOPIC,
         jacksonObjectMapper().writeValueAsString(id),
       )
-      return
     }
     cancelLocalJob(id)
   }


### PR DESCRIPTION
When using Redis, BatchJobCancellationManager only published the cancel message and returned, relying on the local Redis listener to receive its own message and call cancelLocalJob. Under CI load the listener can be delayed, so running coroutines stay alive long enough that the cancellation manager exhausts cancellationTimeoutMs.

Always call cancelLocalJob locally; the Redis broadcast still goes out for other instances and cancelLocalJob is idempotent so the listener's redundant call is a no-op.

Also makes the test fixture's chunk counter atomic to remove a JMM visibility race between coroutine threads and the test main thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch job cancellation reliability in distributed environments by ensuring local cancellation always executes directly while maintaining cross-instance communication.

* **Tests**
  * Enhanced thread-safety in batch job test utilities for more stable concurrent processing validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3651)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->