### PR TITLE
fix: preserve ICU exact-match plural selectors (=0, =1) in export

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/generic/IcuToGenericFormatMessageConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/generic/IcuToGenericFormatMessageConvertor.kt
@@ -30,6 +30,7 @@ class IcuToGenericFormatMessageConvertor(
     val formsResult = converted.formsResult ?: return ""
     return formsResult
       .toIcuPluralString(
+        optimize = false,
         addNewLines = false,
         argName = converted.argName ?: DEFAULT_PLURAL_ARGUMENT_NAME,
       )

--- a/backend/data/src/main/kotlin/io/tolgee/formats/pluralFormsUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/pluralFormsUtil.kt
@@ -41,14 +41,17 @@ fun populateForms(
 
 fun orderPluralForms(pluralForms: Map<String, String>): Map<String, String> {
   return pluralForms.entries
-    .sortedBy {
-      val formIndex = formKeywords.indexOf(it.key)
-      if (formIndex == -1) {
-        "A_$it"
-      } else {
-        formIndex.toString()
-      }
-    }.associate { it.key to it.value }
+    .sortedWith(
+      compareBy(
+        // Exact-match selectors (=0, =1, =2, …) sort first, in ascending numeric order
+        { if (it.key.startsWith("=")) it.key.substring(1).toLongOrNull() ?: Long.MAX_VALUE else Long.MAX_VALUE },
+        // Standard ICU keyword selectors sort after exact-match, in canonical order
+        {
+          val i = formKeywords.indexOf(it.key)
+          if (i == -1) Int.MAX_VALUE else i
+        },
+      ),
+    ).associate { it.key to it.value }
 }
 
 val formKeywords = listOf("zero", "one", "two", "few", "many", "other")

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/PluralsFormUtilTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/PluralsFormUtilTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.formats.normalizePlurals
 import io.tolgee.formats.optimizePluralForms
 import io.tolgee.formats.optimizePossiblePlural
 import io.tolgee.formats.orderPluralForms
+import io.tolgee.formats.toIcuPluralString
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.Test
 
@@ -24,9 +25,40 @@ class PluralsFormUtilTest {
 
   @Test
   fun `orders plural forms`() {
+    // Exact-match selectors (=N) must sort before keyword forms, in ascending numeric order
     orderPluralForms(mapOf("many" to "", "one" to "", "=1" to "", "zero" to ""))
       .keys.assert
-      .containsExactly("zero", "one", "many", "=1")
+      .containsExactly("=1", "zero", "one", "many")
+  }
+
+  @Test
+  fun `orders multiple exact-match selectors numerically before keywords`() {
+    orderPluralForms(mapOf("other" to "x", "=2" to "x", "one" to "x", "=0" to "x", "=10" to "x"))
+      .keys.assert
+      .containsExactly("=0", "=2", "=10", "one", "other")
+  }
+
+  @Test
+  fun `exact-match selectors with distinct values are preserved by optimizePluralForms`() {
+    // =0 has a different value than "other" — it must not be removed
+    optimizePluralForms(mapOf("=0" to "no items", "one" to "one item", "other" to "# items"))
+      .keys.assert
+      .containsExactly("=0", "one", "other")
+  }
+
+  @Test
+  fun `export round-trip preserves exact-match plural selectors`() {
+    // Parsing and re-serialising a string with =0 must keep =0 before other keywords
+    val input = "{count, plural, =0 {You have no likes.} one {You have # like.} other {You have # likes.}}"
+    val forms = getPluralForms(input)!!.forms
+    val output = forms.toIcuPluralString(optimize = false, addNewLines = false, argName = "count")
+    // =0 must appear before one and other in the output
+    val exactZeroIdx = output.indexOf("=0")
+    val oneIdx = output.indexOf("one")
+    val otherIdx = output.indexOf("other")
+    assert(exactZeroIdx < oneIdx && exactZeroIdx < otherIdx) {
+      "=0 (at $exactZeroIdx) should come before 'one' (at $oneIdx) and 'other' (at $otherIdx) in: $output"
+    }
   }
 
   @Test


### PR DESCRIPTION
Two related issues caused push→pull round-trips to produce file diffs:

1. IcuToGenericFormatMessageConvertor.convert() called toIcuPluralString() without optimize=false, relying on the default optimize=true. This triggered optimizePluralForms + orderPluralForms on every export, silently reordering or removing plural forms that the user authored.

2. orderPluralForms sorted unknown keys (including =0, =1, =2 exact-match selectors) alphabetically after 'other', placing them last instead of first. ICU exact-match selectors should precede keyword selectors and appear in ascending numeric order.

Fix: pass optimize=false in the export path so the stored ICU string is emitted verbatim. Also update orderPluralForms to sort =N selectors before keyword forms in numeric order so that explicit optimize calls produce canonical output consistent with the ICU specification.

Fixes: https://github.com/tolgee/tolgee-platform/issues/3267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plural form ordering to correctly prioritize exact-match selectors (e.g., `=0`, `=1`) before standard keywords, ensuring they appear in ascending numeric order for more predictable and accurate localization handling.
  * Enhanced format conversion to preserve exact-match selectors during export and round-trip operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3653)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->