### PR TITLE
fix: reorder project settings tabs (Advanced before QA Checks)

### DIFF
--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -536,7 +536,7 @@ export const useAddProjectSettingsTabs = (projectId: number) => {
         },
       ],
       {
-        position: 'before',
+        position: 'after',
         value: 'advanced',
         fallbackPosition: 'start',
       }
@@ -558,7 +558,7 @@ export const useAddProjectSettingsTabs = (projectId: number) => {
       ],
       {
         position: 'after',
-        value: 'advanced',
+        value: 'qa',
         fallbackPosition: 'start',
       }
     )(tabs);


### PR DESCRIPTION
## Summary

- Reorder project settings tabs so **Advanced** appears before **QA Checks**.
- New order (EE): General → Advanced → QA Checks → Labels → (other EE tabs).
- OSS unchanged (General → Advanced).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the order of tabs in project settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3654)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->