### PR TITLE
fix: run doubled-spaces QA check on base translation and filter placeholders/HTML

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheck.kt
@@ -25,29 +25,31 @@ class SpacesMismatchCheck : QaCheck {
     text: String,
     baseText: String?,
   ): List<QaCheckResult> {
-    val base = baseText ?: return emptyList()
-    if (base.isBlank()) return emptyList()
     if (text.isBlank()) return emptyList()
 
     val results = mutableListOf<QaCheckResult>()
 
-    checkSegmentMatches(
-      base,
-      text,
-      results,
-      QaIssueMessage.QA_SPACES_LEADING_ADDED,
-      QaIssueMessage.QA_SPACES_LEADING_REMOVED,
-      ::extractLeadingWhitespace,
-    )
-    checkSegmentMatches(
-      base,
-      text,
-      results,
-      QaIssueMessage.QA_SPACES_TRAILING_ADDED,
-      QaIssueMessage.QA_SPACES_TRAILING_REMOVED,
-      ::extractTrailingWhitespace,
-    )
-    checkDoubledSpaces(text, results)
+    results += filterResultsInBlockedRanges(checkDoubledSpaces(text), text)
+
+    // Source-comparison checks — only when a base text is available.
+    if (!baseText.isNullOrBlank()) {
+      checkSegmentMatches(
+        baseText,
+        text,
+        results,
+        QaIssueMessage.QA_SPACES_LEADING_ADDED,
+        QaIssueMessage.QA_SPACES_LEADING_REMOVED,
+        ::extractLeadingWhitespace,
+      )
+      checkSegmentMatches(
+        baseText,
+        text,
+        results,
+        QaIssueMessage.QA_SPACES_TRAILING_ADDED,
+        QaIssueMessage.QA_SPACES_TRAILING_REMOVED,
+        ::extractTrailingWhitespace,
+      )
+    }
 
     return results
   }
@@ -56,8 +58,8 @@ class SpacesMismatchCheck : QaCheck {
     base: String,
     text: String,
     results: MutableList<QaCheckResult>,
-    addingTextMessage: QaIssueMessage,
-    removingTextMessage: QaIssueMessage,
+    messageWhenAdded: QaIssueMessage,
+    messageWhenRemoved: QaIssueMessage,
     extractSegment: (String) -> Pair<String, Int>,
   ) {
     val (baseSegment, _) = extractSegment(base)
@@ -76,9 +78,9 @@ class SpacesMismatchCheck : QaCheck {
 
     val message =
       if (replacement.length <= (editEnd - editStart)) {
-        addingTextMessage
+        messageWhenAdded
       } else {
-        removingTextMessage
+        messageWhenRemoved
       }
 
     results.add(
@@ -92,28 +94,29 @@ class SpacesMismatchCheck : QaCheck {
     )
   }
 
-  private fun checkDoubledSpaces(
-    text: String,
-    results: MutableList<QaCheckResult>,
-  ) {
+  private fun checkDoubledSpaces(text: String): List<QaCheckResult> {
     val interiorStart = text.length - text.trimStart(*WHITESPACE_CHARS).length
     val interiorEnd = text.trimEnd(*WHITESPACE_CHARS).length
-    if (interiorStart >= interiorEnd) return
+    if (interiorStart >= interiorEnd) return emptyList()
 
+    val results = mutableListOf<QaCheckResult>()
     val interior = text.substring(interiorStart, interiorEnd)
     for (match in DOUBLED_SPACES_REGEX.findAll(interior)) {
-      val absStart = interiorStart + match.range.first
-      val absEnd = interiorStart + match.range.last + 1
+      val runStart = interiorStart + match.range.first
+      val runEnd = interiorStart + match.range.last + 1
+      // Keep the first space; flag only the extras as removable.
+      val firstExtraSpace = runStart + 1
       results.add(
         QaCheckResult(
           type = QaCheckType.SPACES_MISMATCH,
           message = QaIssueMessage.QA_SPACES_DOUBLED,
           replacement = "",
-          positionStart = absStart + 1,
-          positionEnd = absEnd,
+          positionStart = firstExtraSpace,
+          positionEnd = runEnd,
         ),
       )
     }
+    return results
   }
 
   companion object {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheckTest.kt
@@ -163,4 +163,46 @@ class SpacesMismatchCheckTest {
   fun `all types are SPACES_MISMATCH`() {
     check.check(params("  Hello  world  ", "Hello world")).assertAllHaveType(QaCheckType.SPACES_MISMATCH)
   }
+
+  @Test
+  fun `detects doubled spaces when base text is null`() {
+    check.check(params("Hello  world", base = null)).assertSingleIssue {
+      message(QaIssueMessage.QA_SPACES_DOUBLED)
+      position(6, 7)
+      replacement("")
+    }
+  }
+
+  @Test
+  fun `does not report leading or trailing space issues when base text is null`() {
+    val results = check.check(params("  Hello  ", base = null))
+    val sourceComparisonMessages =
+      setOf(
+        QaIssueMessage.QA_SPACES_LEADING_ADDED,
+        QaIssueMessage.QA_SPACES_LEADING_REMOVED,
+        QaIssueMessage.QA_SPACES_TRAILING_ADDED,
+        QaIssueMessage.QA_SPACES_TRAILING_REMOVED,
+      )
+    results.filter { it.message in sourceComparisonMessages }.assertNoIssues()
+  }
+
+  @Test
+  fun `does not report doubled spaces inside ICU placeholders`() {
+    val text = "Hello {name,  select,  a {x} other {y}} world"
+    val base = "Hello {name, select, a {x} other {y}} world"
+    check
+      .check(params(text, base))
+      .filter { it.message == QaIssueMessage.QA_SPACES_DOUBLED }
+      .assertNoIssues()
+  }
+
+  @Test
+  fun `does not report doubled spaces inside HTML tags`() {
+    val text = "Hello <b  class=\"x\">world</b>"
+    val base = "Hello <b class=\"x\">world</b>"
+    check
+      .check(params(text, base))
+      .filter { it.message == QaIssueMessage.QA_SPACES_DOUBLED }
+      .assertNoIssues()
+  }
 }


### PR DESCRIPTION
## Summary

- `SpacesMismatchCheck.checkDoubledSpaces` now runs source-independently, so doubled-space typos in the **base translation** are reported (previously the whole check returned early when `baseText` was `null`).
- Doubled-space results are post-filtered through the shared `filterResultsInBlockedRanges` helper, eliminating false positives inside ICU placeholders, HTML tags, and URLs.
- Leading/trailing/nbsp source-comparison branches remain gated on the base text being present — no behavior change for non-base translations.
- Added tests covering the null-base case and the placeholder/HTML filtering.
- Translation rewording for `qa_issue_spaces_doubled` (currently *"Fix doubled spaces in the translation to match the source."* → *"Remove doubled spaces from the text."*) needs to be applied separately via Tolgee — not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced spaces mismatch QA check to improve detection of doubled spaces in translations
  * Fixed false positives where spacing validation was incorrectly triggered inside ICU placeholders and HTML tags
  * Improved handling of spacing validation when base text context is unavailable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3656)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->