### PR TITLE
fix: add tooltip and responsive wrapping for long language names (#3611)

### DIFF
--- a/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
@@ -52,7 +52,8 @@ export const LanguagesSelect: FunctionComponent<Props> = (props) => {
     variant: 'menu',
     PaperProps: {
       style: {
-        width: 250,
+        minWidth: 200,
+        maxWidth: 350,
       },
     },
     id: `language-select-${props.context}-menu`,

--- a/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
@@ -51,10 +51,10 @@ export const LanguagesSelect: FunctionComponent<Props> = (props) => {
   const menuProps: Partial<MenuProps> = {
     variant: 'menu',
     PaperProps: {
-      style: {
+      sx: (theme) => ({
         minWidth: 200,
-        maxWidth: 350,
-      },
+        maxWidth: 300,
+      }),
     },
     id: `language-select-${props.context}-menu`,
     anchorOrigin: {

--- a/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
@@ -51,10 +51,9 @@ export const LanguagesSelect: FunctionComponent<Props> = (props) => {
   const menuProps: Partial<MenuProps> = {
     variant: 'menu',
     PaperProps: {
-      sx: (theme) => ({
-        minWidth: 200,
-        maxWidth: 300,
-      }),
+      sx: {
+        width:250,
+      }
     },
     id: `language-select-${props.context}-menu`,
     anchorOrigin: {

--- a/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/LanguagesSelect.tsx
@@ -52,8 +52,9 @@ export const LanguagesSelect: FunctionComponent<Props> = (props) => {
     variant: 'menu',
     PaperProps: {
       sx: {
-        width:250,
-      }
+        minWidth: 200,
+        maxWidth: 250,
+      },
     },
     id: `language-select-${props.context}-menu`,
     anchorOrigin: {

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -74,29 +74,31 @@ export const getLanguagesContent = ({
 
   const languageItems = languages.map((lang) => (
     <Tooltip key={lang.tag} title={lang.name} placement="right">
-      <MenuItem
-        value={lang.tag}
-        data-cy="translations-language-select-item"
-        onClick={handleLanguageChange(lang.tag)}
-        disabled={disabledLanguages?.includes(lang.id)}
-      >
-        <Checkbox checked={value?.includes(lang.tag)} size="small" />
-        <ListItemText
-          primary={lang.name}
-          sx={{
-            '& .MuiListItemText-primary': {
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-              '@media (max-width: 600px)': {
-                whiteSpace: 'normal',
-                textOverflow: 'unset',
-                overflow: 'visible',
+      <span style={{ display: 'inline-block', width: '100%' }}>
+        <MenuItem
+          value={lang.tag}
+          data-cy="translations-language-select-item"
+          onClick={handleLanguageChange(lang.tag)}
+          disabled={disabledLanguages?.includes(lang.id)}
+        >
+          <Checkbox checked={value?.includes(lang.tag)} size="small" />
+          <ListItemText
+            primary={lang.name}
+            sx={(theme) => ({
+              '& .MuiListItemText-primary': {
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                [theme.breakpoints.down('sm')]: {
+                  whiteSpace: 'normal',
+                  textOverflow: 'unset',
+                  overflow: 'visible',
+                },
               },
-            },
-          }}
-        />
-      </MenuItem>
+            })}
+          />
+        </MenuItem>
+      </span>
     </Tooltip>
   ));
 

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -1,4 +1,10 @@
-import { Checkbox, ListItemText, MenuItem, Divider } from '@mui/material';
+import {
+  Checkbox,
+  ListItemText,
+  MenuItem,
+  Divider,
+  Tooltip,
+} from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 
 import { putBaseLangFirst } from 'tg.fixtures/putBaseLangFirst';
@@ -67,16 +73,31 @@ export const getLanguagesContent = ({
   const isBatchOperation = context === 'batch-operations';
 
   const languageItems = languages.map((lang) => (
-    <MenuItem
-      key={lang.tag}
-      value={lang.tag}
-      data-cy="translations-language-select-item"
-      onClick={handleLanguageChange(lang.tag)}
-      disabled={disabledLanguages?.includes(lang.id)}
-    >
-      <Checkbox checked={value?.includes(lang.tag)} size="small" />
-      <ListItemText primary={lang.name} />
-    </MenuItem>
+    <Tooltip key={lang.tag} title={lang.name} placement="right">
+      <MenuItem
+        value={lang.tag}
+        data-cy="translations-language-select-item"
+        onClick={handleLanguageChange(lang.tag)}
+        disabled={disabledLanguages?.includes(lang.id)}
+      >
+        <Checkbox checked={value?.includes(lang.tag)} size="small" />
+        <ListItemText
+          primary={lang.name}
+          sx={{
+            '& .MuiListItemText-primary': {
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              '@media (max-width: 600px)': {
+                whiteSpace: 'normal',
+                textOverflow: 'unset',
+                overflow: 'visible',
+              },
+            },
+          }}
+        />
+      </MenuItem>
+    </Tooltip>
   ));
 
   if (isBatchOperation) {

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -73,7 +73,7 @@ export const getLanguagesContent = ({
   const isBatchOperation = context === 'batch-operations';
 
   const languageItems = languages.map((lang) => (
-    <span style={{ display: 'inline-block', width: '100%' }}>
+    <span key={lang.tag} style={{ display: 'inline-block', width: '100%' }}>
       <MenuItem
         value={lang.tag}
         data-cy="translations-language-select-item"

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -73,15 +73,15 @@ export const getLanguagesContent = ({
   const isBatchOperation = context === 'batch-operations';
 
   const languageItems = languages.map((lang) => (
-    <Tooltip key={lang.tag} title={lang.name} placement="right">
-      <span style={{ display: 'inline-block', width: '100%' }}>
-        <MenuItem
-          value={lang.tag}
-          data-cy="translations-language-select-item"
-          onClick={handleLanguageChange(lang.tag)}
-          disabled={disabledLanguages?.includes(lang.id)}
-        >
-          <Checkbox checked={value?.includes(lang.tag)} size="small" />
+    <span style={{ display: 'inline-block', width: '100%' }}>
+      <MenuItem
+        value={lang.tag}
+        data-cy="translations-language-select-item"
+        onClick={handleLanguageChange(lang.tag)}
+        disabled={disabledLanguages?.includes(lang.id)}
+      >
+        <Checkbox checked={value?.includes(lang.tag)} size="small" />
+        <Tooltip title={lang.name} placement="right" >
           <ListItemText
             primary={lang.name}
             sx={(theme) => ({
@@ -97,9 +97,9 @@ export const getLanguagesContent = ({
               },
             })}
           />
-        </MenuItem>
-      </span>
-    </Tooltip>
+        </Tooltip>
+      </MenuItem>
+    </span>
   ));
 
   if (isBatchOperation) {

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Checkbox,
   ListItemText,
@@ -12,6 +13,45 @@ import { components } from 'tg.service/apiSchema.generated';
 import { messageService } from 'tg.service/MessageService';
 
 type LanguageModel = components['schemas']['LanguageModel'];
+
+const LanguageName = ({ name }: { name: string }) => {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const handleMouseEnter = (event: React.MouseEvent<HTMLElement>) => {
+    setShowTooltip(
+      event.currentTarget.scrollWidth > event.currentTarget.clientWidth
+    );
+  };
+
+  return (
+    <Tooltip
+      title={name}
+      placement="right"
+      open={showTooltip}
+      onClose={() => setShowTooltip(false)}
+    >
+      <ListItemText
+        primary={name}
+        primaryTypographyProps={{
+          onMouseEnter: handleMouseEnter,
+          onMouseLeave: () => setShowTooltip(false),
+        }}
+        sx={(theme) => ({
+          '& .MuiListItemText-primary': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            [theme.breakpoints.down('sm')]: {
+              whiteSpace: 'normal',
+              textOverflow: 'unset',
+              overflow: 'visible',
+            },
+          },
+        })}
+      />
+    </Tooltip>
+  );
+};
 
 type Props = {
   onChange: (value: string[]) => void;
@@ -73,33 +113,16 @@ export const getLanguagesContent = ({
   const isBatchOperation = context === 'batch-operations';
 
   const languageItems = languages.map((lang) => (
-    <span key={lang.tag} style={{ display: 'inline-block', width: '100%' }}>
-      <MenuItem
-        value={lang.tag}
-        data-cy="translations-language-select-item"
-        onClick={handleLanguageChange(lang.tag)}
-        disabled={disabledLanguages?.includes(lang.id)}
-      >
-        <Checkbox checked={value?.includes(lang.tag)} size="small" />
-        <Tooltip title={lang.name} placement="right" >
-          <ListItemText
-            primary={lang.name}
-            sx={(theme) => ({
-              '& .MuiListItemText-primary': {
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                [theme.breakpoints.down('sm')]: {
-                  whiteSpace: 'normal',
-                  textOverflow: 'unset',
-                  overflow: 'visible',
-                },
-              },
-            })}
-          />
-        </Tooltip>
-      </MenuItem>
-    </span>
+    <MenuItem
+      key={lang.tag}
+      value={lang.tag}
+      data-cy="translations-language-select-item"
+      onClick={handleLanguageChange(lang.tag)}
+      disabled={disabledLanguages?.includes(lang.id)}
+    >
+      <Checkbox checked={value?.includes(lang.tag)} size="small" />
+      <LanguageName name={lang.name} />
+    </MenuItem>
   ));
 
   if (isBatchOperation) {


### PR DESCRIPTION
- Add tooltip on hover for full language name
- Expand dropdown width (minWidth: 200px, maxWidth: 350px)
- Use ellipsis on large screens, wrapping on small screens


<img width="942" height="832" alt="Screenshot (284)" src="https://github.com/user-attachments/assets/52d1c640-1e33-43d1-b5ce-b63a4794078d" />

browser-chrome, brave

Fixes #3611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved language dropdown sizing with responsive minimum and maximum widths.
  * Added full-name tooltips for language options when labels are truncated.
  * Enhanced label wrapping and truncation behavior for clearer display across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->