### PR TITLE
fix: remap zh-Hant to zh-TW for Google machine translation

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/GoogleTranslationProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/GoogleTranslationProvider.kt
@@ -16,6 +16,24 @@ class GoogleTranslationProvider(
   override val isEnabled: Boolean
     get() = !googleMachineTranslationProperties.apiKey.isNullOrEmpty()
 
+  /**
+   * The Cloud Translation NMT model (used by [Translate]) only recognises `zh-CN`/`zh`
+   * for Simplified and `zh-TW` for Traditional Chinese — the script-based tags
+   * `zh-Hans`/`zh-Hant` are documented for the Translation LLM model, not NMT, and
+   * silently fall back to Simplified when sent to NMT.
+   *
+   * docs: https://cloud.google.com/translate/docs/languages
+   */
+  override fun getSuitableTag(tag: String): String? {
+    if (tag.equals("zh-Hant", ignoreCase = true)) {
+      return super.getSuitableTag("zh-TW")
+    }
+    if (tag.equals("zh-Hans", ignoreCase = true)) {
+      return super.getSuitableTag("zh-CN")
+    }
+    return super.getSuitableTag(tag)
+  }
+
   override fun translateViaProvider(params: ProviderTranslateParams): MtValueProvider.MtResult {
     val result =
       translateService
@@ -53,8 +71,6 @@ class GoogleTranslationProvider(
       "ny",
       "zh-CN",
       "zh-TW",
-      "zh-Hans",
-      "zh-Hant",
       "co",
       "hr",
       "cs",

--- a/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/GoogleTranslationProviderTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/GoogleTranslationProviderTest.kt
@@ -1,0 +1,33 @@
+package io.tolgee.unit.component.machineTranslation
+
+import io.tolgee.component.machineTranslation.providers.GoogleTranslationProvider
+import io.tolgee.configuration.tolgee.machineTranslation.GoogleMachineTranslationProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class GoogleTranslationProviderTest {
+  private val provider = GoogleTranslationProvider(GoogleMachineTranslationProperties(), null)
+
+  @Test
+  fun `maps zh-Hant to zh-TW (NMT does not recognize zh-Hant)`() {
+    assertThat(provider.getSuitableTag("zh-Hant")).isEqualTo("zh-TW")
+  }
+
+  @Test
+  fun `maps zh-Hans to zh-CN (NMT does not recognize zh-Hans)`() {
+    assertThat(provider.getSuitableTag("zh-Hans")).isEqualTo("zh-CN")
+  }
+
+  @Test
+  fun `maps Chinese script subtags case-insensitively`() {
+    assertThat(provider.getSuitableTag("zh-hant")).isEqualTo("zh-TW")
+    assertThat(provider.getSuitableTag("ZH-HANT")).isEqualTo("zh-TW")
+    assertThat(provider.getSuitableTag("zh-hans")).isEqualTo("zh-CN")
+  }
+
+  @Test
+  fun `non-Chinese tags resolve normally`() {
+    assertThat(provider.getSuitableTag("en-US")).isEqualTo("en")
+    assertThat(provider.getSuitableTag("de")).isEqualTo("de")
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #3643. That PR fixed the `pt-BR` case-sensitivity bug and added `zh-Hans`/`zh-Hant` to Google's supported-language list — but users reported that Traditional Chinese (`zh-Hant`) projects still receive Simplified Chinese suggestions from Google Translate.

Root cause: the [Google Cloud Translation docs](https://cloud.google.com/translate/docs/languages) list `zh-Hans`/`zh-Hant` only in the **Translation LLM** supported-languages table. The **NMT** model — which is what Tolgee uses via `com.google.cloud.translate.Translate` — only recognises `zh-CN`/`zh` and `zh-TW`. Sending `zh-Hant` to NMT silently falls back to Simplified.

Fix mirrors the AWS workaround already present in `AwsMtValueProvider`: override `getSuitableTag` on `GoogleTranslationProvider` to remap `zh-Hant` → `zh-TW` and `zh-Hans` → `zh-CN` before the supported-list lookup, and drop the misleading `zh-Hans`/`zh-Hant` entries from `supportedLanguages`.

## Test plan

- [x] Unit tests in `GoogleTranslationProviderTest` cover the remap (case-sensitive and case-insensitive) and verify non-Chinese tags still resolve normally
- [x] Existing `AwsMtValueProviderTest` and `LanguageTagConvertorTest` still pass
- [ ] Manual verification: create a project with `en` and `zh-Hant`, request Google MT, confirm response is Traditional Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Google Translate language support for Chinese variants by properly mapping script-based and region-based language tags for accurate translations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3658)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->