### PR TITLE
feat: split EMPTY_TRANSLATION QA check into two checks

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaCheckType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaCheckType.kt
@@ -6,6 +6,7 @@ enum class QaCheckType(
   // TEXT category — checks about the quality of the translated text.
   // SPELLING and GRAMMAR are intentionally kept as the last two entries of this group.
   EMPTY_TRANSLATION(QaCheckSeverity.WARNING),
+  MISSING_PLURAL_CATEGORIES(QaCheckSeverity.WARNING),
   CHARACTER_CASE_MISMATCH(QaCheckSeverity.WARNING),
   REPEATED_WORDS(QaCheckSeverity.WARNING),
   PUNCTUATION_MISMATCH(QaCheckSeverity.WARNING),
@@ -34,6 +35,7 @@ enum class QaCheckType(
         QaCheckCategory.TEXT to
           listOf(
             EMPTY_TRANSLATION,
+            MISSING_PLURAL_CATEGORIES,
             CHARACTER_CASE_MISMATCH,
             REPEATED_WORDS,
             PUNCTUATION_MISMATCH,

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaIssueMessage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaIssueMessage.kt
@@ -5,7 +5,7 @@ import java.util.Locale
 
 enum class QaIssueMessage {
   QA_EMPTY_TRANSLATION,
-  QA_EMPTY_PLURAL_VARIANT,
+  QA_MISSING_PLURAL_CATEGORY,
   QA_CHECK_FAILED,
 
   // Spaces mismatch

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheck.kt
@@ -3,7 +3,6 @@ package io.tolgee.ee.service.qa.checks
 import io.tolgee.ee.service.qa.QaCheck
 import io.tolgee.ee.service.qa.QaCheckParams
 import io.tolgee.ee.service.qa.QaCheckResult
-import io.tolgee.formats.getPluralFormsForLocale
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.model.enums.qa.QaIssueMessage
 import org.springframework.stereotype.Component
@@ -14,36 +13,30 @@ class EmptyTranslationCheck : QaCheck {
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
     if (params.text.isBlank()) {
-      return listOf(
-        QaCheckResult(
-          type = QaCheckType.EMPTY_TRANSLATION,
-          message = QaIssueMessage.QA_EMPTY_TRANSLATION,
-        ),
-      )
+      return emptyTranslationIssue
     }
 
-    if (params.isPlural && params.textVariants != null) {
-      return checkPluralVariants(params)
+    if (
+      params.isPlural &&
+      allVariantsBlank(params)
+    ) {
+      return emptyTranslationIssue
     }
 
     return emptyList()
   }
 
-  private fun checkPluralVariants(params: QaCheckParams): List<QaCheckResult> {
-    val requiredForms = getPluralFormsForLocale(params.languageTag)
-
-    return requiredForms.mapNotNull { form ->
-      val variantText = params.textVariants?.get(form)
-      if (variantText.isNullOrBlank()) {
-        QaCheckResult(
-          type = QaCheckType.EMPTY_TRANSLATION,
-          message = QaIssueMessage.QA_EMPTY_PLURAL_VARIANT,
-          params = mapOf("variant" to form),
-          pluralVariant = form,
-        )
-      } else {
-        null
-      }
-    }
+  private fun allVariantsBlank(params: QaCheckParams): Boolean {
+    // No error when variants failed to parse — ICU syntax check should scream for that already.
+    val variants = params.textVariants ?: return false
+    return variants.values.all { it.isBlank() }
   }
+
+  private val emptyTranslationIssue =
+    listOf(
+      QaCheckResult(
+        type = QaCheckType.EMPTY_TRANSLATION,
+        message = QaIssueMessage.QA_EMPTY_TRANSLATION,
+      ),
+    )
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingPluralCategoriesCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingPluralCategoriesCheck.kt
@@ -1,0 +1,35 @@
+package io.tolgee.ee.service.qa.checks
+
+import io.tolgee.ee.service.qa.QaCheck
+import io.tolgee.ee.service.qa.QaCheckParams
+import io.tolgee.ee.service.qa.QaCheckResult
+import io.tolgee.formats.getPluralFormsForLocale
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
+import org.springframework.stereotype.Component
+
+@Component
+class MissingPluralCategoriesCheck : QaCheck {
+  override val type: QaCheckType = QaCheckType.MISSING_PLURAL_CATEGORIES
+
+  override fun check(params: QaCheckParams): List<QaCheckResult> {
+    if (!params.isPlural) {
+      return emptyList()
+    }
+
+    val requiredForms = getPluralFormsForLocale(params.languageTag)
+    return requiredForms.mapNotNull { form ->
+      val variantText = params.textVariants?.get(form)
+      if (variantText.isNullOrBlank()) {
+        QaCheckResult(
+          type = QaCheckType.MISSING_PLURAL_CATEGORIES,
+          message = QaIssueMessage.QA_MISSING_PLURAL_CATEGORY,
+          params = mapOf("variant" to form),
+          pluralVariant = form,
+        )
+      } else {
+        null
+      }
+    }
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheckTest.kt
@@ -1,7 +1,5 @@
 package io.tolgee.ee.service.qa.checks
 
-import io.tolgee.ee.service.qa.QaCheckParams
-import io.tolgee.ee.service.qa.assertIssues
 import io.tolgee.ee.service.qa.assertNoIssues
 import io.tolgee.ee.service.qa.assertSingleIssue
 import io.tolgee.model.enums.qa.QaIssueMessage
@@ -10,23 +8,9 @@ import org.junit.jupiter.api.Test
 class EmptyTranslationCheckTest {
   private val check = EmptyTranslationCheck()
 
-  private fun params(
-    text: String,
-    languageTag: String = "en",
-    isPlural: Boolean = false,
-    textVariants: Map<String, String>? = null,
-  ) = QaCheckParams(
-    baseText = null,
-    text = text,
-    baseLanguageTag = null,
-    languageTag = languageTag,
-    isPlural = isPlural,
-    textVariants = textVariants,
-  )
-
   @Test
   fun `detects empty non-plural translation`() {
-    check.check(params("")).assertSingleIssue {
+    check.check(qaCheckParams("")).assertSingleIssue {
       message(QaIssueMessage.QA_EMPTY_TRANSLATION)
       noPosition()
     }
@@ -34,7 +18,7 @@ class EmptyTranslationCheckTest {
 
   @Test
   fun `detects blank non-plural translation`() {
-    check.check(params("   ")).assertSingleIssue {
+    check.check(qaCheckParams("   ")).assertSingleIssue {
       message(QaIssueMessage.QA_EMPTY_TRANSLATION)
       noPosition()
     }
@@ -42,7 +26,7 @@ class EmptyTranslationCheckTest {
 
   @Test
   fun `no issues for non-empty non-plural translation`() {
-    check.check(params("Hello world")).assertNoIssues()
+    check.check(qaCheckParams("Hello world")).assertNoIssues()
   }
 
   @Test
@@ -50,9 +34,8 @@ class EmptyTranslationCheckTest {
     // English requires: one, other
     check
       .check(
-        params(
+        qaCheckParams(
           text = "{count, plural, one {item} other {items}}",
-          languageTag = "en",
           isPlural = true,
           textVariants = mapOf("one" to "item", "other" to "items"),
         ),
@@ -60,74 +43,53 @@ class EmptyTranslationCheckTest {
   }
 
   @Test
-  fun `detects blank required plural variant`() {
-    // English requires: one, other
+  fun `no issue when at least one plural variant is filled`() {
     check
       .check(
-        params(
+        qaCheckParams(
           text = "{count, plural, one {} other {items}}",
-          languageTag = "en",
           isPlural = true,
           textVariants = mapOf("one" to "", "other" to "items"),
-        ),
-      ).assertSingleIssue {
-        message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-        param("variant", "one")
-        pluralVariant("one")
-        noPosition()
-      }
-  }
-
-  @Test
-  fun `detects missing required plural variant`() {
-    // Czech requires: one, few, many, other
-    check
-      .check(
-        params(
-          text = "{count, plural, other {polozek}}",
-          languageTag = "cs",
-          isPlural = true,
-          textVariants = mapOf("other" to "polozek"),
-        ),
-      ).assertIssues {
-        issue {
-          message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-          param("variant", "one")
-          pluralVariant("one")
-        }
-        issue {
-          message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-          param("variant", "few")
-          pluralVariant("few")
-        }
-        issue {
-          message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-          param("variant", "many")
-          pluralVariant("many")
-        }
-      }
-  }
-
-  @Test
-  fun `no issue for blank non-required variant`() {
-    // English requires: one, other — "zero" is not required
-    check
-      .check(
-        params(
-          text = "{count, plural, =0 {} one {item} other {items}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("=0" to "", "one" to "item", "other" to "items"),
         ),
       ).assertNoIssues()
   }
 
   @Test
-  fun `fully empty plural text fires generic empty translation only`() {
+  fun `fires when all plural variants are blank`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, one {} other {}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "", "other" to ""),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_EMPTY_TRANSLATION)
+        noPosition()
+      }
+  }
+
+  @Test
+  fun `fires when textVariants is empty for plural`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, }",
+          isPlural = true,
+          textVariants = emptyMap(),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_EMPTY_TRANSLATION)
+        noPosition()
+      }
+  }
+
+  @Test
+  fun `fully empty plural text fires generic empty translation`() {
     // text is blank, textVariants is null (getPluralForms("") returns null)
     check
       .check(
-        params(
+        qaCheckParams(
           text = "",
           languageTag = "cs",
           isPlural = true,
@@ -140,38 +102,12 @@ class EmptyTranslationCheckTest {
   }
 
   @Test
-  fun `empty textVariants map reports all required forms as missing`() {
-    // English requires: one, other
-    check
-      .check(
-        params(
-          text = "{count, plural, }",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = emptyMap(),
-        ),
-      ).assertIssues {
-        issue {
-          message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-          param("variant", "one")
-          pluralVariant("one")
-        }
-        issue {
-          message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-          param("variant", "other")
-          pluralVariant("other")
-        }
-      }
-  }
-
-  @Test
   fun `non-blank plural text with null textVariants returns no issues`() {
     // isPlural is true but textVariants is null (e.g., unparseable ICU string)
     check
       .check(
-        params(
+        qaCheckParams(
           text = "some non-blank text",
-          languageTag = "en",
           isPlural = true,
           textVariants = null,
         ),
@@ -179,30 +115,11 @@ class EmptyTranslationCheckTest {
   }
 
   @Test
-  fun `whitespace-only variant text is detected as blank`() {
-    check
-      .check(
-        params(
-          text = "{count, plural, one {   } other {items}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("one" to "   ", "other" to "items"),
-        ),
-      ).assertSingleIssue {
-        message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-        param("variant", "one")
-        pluralVariant("one")
-      }
-  }
-
-  @Test
   fun `non-plural key with textVariants ignores variants`() {
-    // isPlural is false — textVariants should be irrelevant
     check
       .check(
-        params(
+        qaCheckParams(
           text = "Hello world",
-          languageTag = "en",
           isPlural = false,
           textVariants = mapOf("one" to "", "other" to ""),
         ),

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/MissingPluralCategoriesCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/MissingPluralCategoriesCheckTest.kt
@@ -1,0 +1,160 @@
+package io.tolgee.ee.service.qa.checks
+
+import io.tolgee.ee.service.qa.assertIssues
+import io.tolgee.ee.service.qa.assertNoIssues
+import io.tolgee.ee.service.qa.assertSingleIssue
+import io.tolgee.model.enums.qa.QaIssueMessage
+import org.junit.jupiter.api.Test
+
+class MissingPluralCategoriesCheckTest {
+  private val check = MissingPluralCategoriesCheck()
+
+  @Test
+  fun `no issues when all required plural variants are filled`() {
+    // English requires: one, other
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, one {item} other {items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "item", "other" to "items"),
+        ),
+      ).assertNoIssues()
+  }
+
+  @Test
+  fun `detects blank required plural variant`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, one {} other {items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "", "other" to "items"),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+        param("variant", "one")
+        pluralVariant("one")
+        noPosition()
+      }
+  }
+
+  @Test
+  fun `detects missing required plural variant`() {
+    // Czech requires: one, few, many, other
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, other {polozek}}",
+          languageTag = "cs",
+          isPlural = true,
+          textVariants = mapOf("other" to "polozek"),
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "one")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "few")
+          pluralVariant("few")
+        }
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "many")
+          pluralVariant("many")
+        }
+      }
+  }
+
+  @Test
+  fun `no issue for blank non-required variant`() {
+    // English requires: one, other — "zero" / "=0" is not required
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, =0 {} one {item} other {items}}",
+          isPlural = true,
+          textVariants = mapOf("=0" to "", "one" to "item", "other" to "items"),
+        ),
+      ).assertNoIssues()
+  }
+
+  @Test
+  fun `whitespace-only variant text is detected as blank`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, one {   } other {items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "   ", "other" to "items"),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+        param("variant", "one")
+        pluralVariant("one")
+      }
+  }
+
+  @Test
+  fun `fully empty plural text reports all required forms as missing`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "",
+          isPlural = true,
+          textVariants = null,
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "one")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "other")
+          pluralVariant("other")
+        }
+      }
+  }
+
+  @Test
+  fun `all required plural variants blank reports each one`() {
+    // Parseable plural with every required variant blank — the realistic shape
+    // for "user created a plural key but hasn't filled anything in".
+    check
+      .check(
+        qaCheckParams(
+          text = "{count, plural, one {} other {}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "", "other" to ""),
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "one")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_MISSING_PLURAL_CATEGORY)
+          param("variant", "other")
+          pluralVariant("other")
+        }
+      }
+  }
+
+  @Test
+  fun `non-plural key with textVariants returns no issues`() {
+    check
+      .check(
+        qaCheckParams(
+          text = "Hello world",
+          isPlural = false,
+          textVariants = mapOf("one" to "", "other" to ""),
+        ),
+      ).assertNoIssues()
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/QaCheckParamsFactory.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/QaCheckParamsFactory.kt
@@ -1,0 +1,30 @@
+package io.tolgee.ee.service.qa.checks
+
+import io.tolgee.ee.service.qa.QaCheckParams
+import io.tolgee.ee.service.qa.QaGlossaryTerm
+
+fun qaCheckParams(
+  text: String,
+  baseText: String? = null,
+  baseLanguageTag: String? = null,
+  languageTag: String = "en",
+  isPlural: Boolean = false,
+  textVariants: Map<String, String>? = null,
+  textVariantOffsets: Map<String, Int>? = null,
+  baseTextVariants: Map<String, String>? = null,
+  maxCharLimit: Int? = null,
+  icuPlaceholders: Boolean = true,
+  glossaryTerms: List<QaGlossaryTerm>? = null,
+) = QaCheckParams(
+  baseText = baseText,
+  text = text,
+  baseLanguageTag = baseLanguageTag,
+  languageTag = languageTag,
+  isPlural = isPlural,
+  textVariants = textVariants,
+  textVariantOffsets = textVariantOffsets,
+  baseTextVariants = baseTextVariants,
+  maxCharLimit = maxCharLimit,
+  icuPlaceholders = icuPlaceholders,
+  glossaryTerms = glossaryTerms,
+)

--- a/webapp/src/ee/qa/hooks/useQaCheckTypeLabel.ts
+++ b/webapp/src/ee/qa/hooks/useQaCheckTypeLabel.ts
@@ -8,6 +8,8 @@ export function useQaCheckTypeLabel(type: QaCheckType): string {
   switch (type) {
     case 'EMPTY_TRANSLATION':
       return t('qa_check_type_empty_translation');
+    case 'MISSING_PLURAL_CATEGORIES':
+      return t('qa_check_type_missing_plural_categories');
     case 'SPACES_MISMATCH':
       return t('qa_check_type_spaces_mismatch');
     case 'UNMATCHED_NEWLINES':

--- a/webapp/src/ee/qa/hooks/useQaIssueMessage.ts
+++ b/webapp/src/ee/qa/hooks/useQaIssueMessage.ts
@@ -13,10 +13,10 @@ export function useQaIssueMessage(
   switch (message) {
     case 'qa_empty_translation':
       return t('qa_issue_empty_translation');
-    case 'qa_empty_plural_variant':
+    case 'qa_missing_plural_category':
       return normalizedParams?.variant
-        ? t('qa_issue_empty_plural_variant', normalizedParams)
-        : t('qa_issue_empty_plural_variant_no_params');
+        ? t('qa_issue_missing_plural_category', normalizedParams)
+        : t('qa_issue_missing_plural_category_no_params');
     case 'qa_check_failed':
       return t('qa_check_failed');
     case 'qa_spaces_leading_added':

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -5566,6 +5566,7 @@ export interface components {
       category: "TEXT" | "TECHNICAL";
       checkTypes: (
         | "EMPTY_TRANSLATION"
+        | "MISSING_PLURAL_CATEGORIES"
         | "CHARACTER_CASE_MISMATCH"
         | "REPEATED_WORDS"
         | "PUNCTUATION_MISMATCH"
@@ -5590,7 +5591,7 @@ export interface components {
       /** @enum {string} */
       message:
         | "qa_empty_translation"
-        | "qa_empty_plural_variant"
+        | "qa_missing_plural_category"
         | "qa_check_failed"
         | "qa_spaces_leading_added"
         | "qa_spaces_leading_removed"
@@ -5643,6 +5644,7 @@ export interface components {
       /** @enum {string} */
       type:
         | "EMPTY_TRANSLATION"
+        | "MISSING_PLURAL_CATEGORIES"
         | "CHARACTER_CASE_MISMATCH"
         | "REPEATED_WORDS"
         | "PUNCTUATION_MISMATCH"
@@ -5671,7 +5673,7 @@ export interface components {
       /** @enum {string} */
       message:
         | "qa_empty_translation"
-        | "qa_empty_plural_variant"
+        | "qa_missing_plural_category"
         | "qa_check_failed"
         | "qa_spaces_leading_added"
         | "qa_spaces_leading_removed"
@@ -5726,6 +5728,7 @@ export interface components {
       /** @enum {string} */
       type:
         | "EMPTY_TRANSLATION"
+        | "MISSING_PLURAL_CATEGORIES"
         | "CHARACTER_CASE_MISMATCH"
         | "REPEATED_WORDS"
         | "PUNCTUATION_MISMATCH"
@@ -15919,6 +15922,7 @@ export interface operations {
         /** Filter keys with specific QA check type issues */
         filterQaCheckType?: (
           | "EMPTY_TRANSLATION"
+          | "MISSING_PLURAL_CATEGORIES"
           | "CHARACTER_CASE_MISMATCH"
           | "REPEATED_WORDS"
           | "PUNCTUATION_MISMATCH"
@@ -16070,6 +16074,7 @@ export interface operations {
         /** Filter keys with specific QA check type issues */
         filterQaCheckType?: (
           | "EMPTY_TRANSLATION"
+          | "MISSING_PLURAL_CATEGORIES"
           | "CHARACTER_CASE_MISMATCH"
           | "REPEATED_WORDS"
           | "PUNCTUATION_MISMATCH"
@@ -16257,6 +16262,7 @@ export interface operations {
         /** Filter keys with specific QA check type issues */
         filterQaCheckType?: (
           | "EMPTY_TRANSLATION"
+          | "MISSING_PLURAL_CATEGORIES"
           | "CHARACTER_CASE_MISMATCH"
           | "REPEATED_WORDS"
           | "PUNCTUATION_MISMATCH"
@@ -20996,6 +21002,7 @@ export interface operations {
         /** Filter keys with specific QA check type issues */
         filterQaCheckType?: (
           | "EMPTY_TRANSLATION"
+          | "MISSING_PLURAL_CATEGORIES"
           | "CHARACTER_CASE_MISMATCH"
           | "REPEATED_WORDS"
           | "PUNCTUATION_MISMATCH"
@@ -21327,6 +21334,7 @@ export interface operations {
         /** Filter keys with specific QA check type issues */
         filterQaCheckType?: (
           | "EMPTY_TRANSLATION"
+          | "MISSING_PLURAL_CATEGORIES"
           | "CHARACTER_CASE_MISMATCH"
           | "REPEATED_WORDS"
           | "PUNCTUATION_MISMATCH"


### PR DESCRIPTION
## Summary

- Split the `EMPTY_TRANSLATION` QA check into two distinct checks
- `EMPTY_TRANSLATION` now fires only when the translation as a whole is empty — for plurals: when all plural variants are blank
- `MISSING_PLURAL_CATEGORIES` (new) fires once per missing or blank required CLDR plural category, so users see exactly which forms they still need to fill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a QA check that flags missing plural form categories so required plural variants are validated per language.

* **Bug Fixes**
  * Improved empty-translation detection: consolidated handling for plural vs non-plural entries and reduced false positives when some plural variants are present.

* **Tests**
  * Added and reorganized tests covering missing/blank plural variants and empty-translation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3660?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->