### PR TITLE
feat: show QA issues for all plural variants in the side panel

### DIFF
--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -734,6 +734,7 @@ declare namespace DataCy {
         "qa-badge" |
         "qa-badge-unresolved" |
         "qa-check-item" |
+        "qa-check-item-variant-badge" |
         "qa-enabled-toggle" |
         "qa-issue-highlight" |
         "qa-issue-marker" |

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
@@ -73,7 +73,6 @@ class QaCheckPreviewWebSocketHandler(
     session: WebSocketSession,
     state: QaPreviewWsSessionState,
     text: String,
-    activeVariant: String? = null,
   ) {
     try {
       val persistedIssues = fetchPersistedIssues(state)
@@ -92,7 +91,6 @@ class QaCheckPreviewWebSocketHandler(
           textVariants = textParsed?.forms,
           textVariantOffsets = textParsed?.offsets,
           baseTextVariants = state.baseVariants,
-          activeVariant = activeVariant,
           maxCharLimit = state.maxCharLimit,
           icuPlaceholders = state.icuPlaceholders,
           glossaryTerms = glossaryTerms,
@@ -130,10 +128,9 @@ class QaCheckPreviewWebSocketHandler(
     }
 
     val text = json.get("text")?.asText() ?: ""
-    val variant = json.get("variant")?.asText()
 
     state.cancelAndSetJob {
-      scope.launch { runChecks(session, state, text, activeVariant = variant) }
+      scope.launch { runChecks(session, state, text) }
     }
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckParams.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckParams.kt
@@ -9,7 +9,6 @@ data class QaCheckParams(
   val textVariants: Map<String, String>? = null,
   val textVariantOffsets: Map<String, Int>? = null,
   val baseTextVariants: Map<String, String>? = null,
-  val activeVariant: String? = null,
   val maxCharLimit: Int? = null,
   val icuPlaceholders: Boolean = true,
   val glossaryTerms: List<QaGlossaryTerm>? = null,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaPluralCheckHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaPluralCheckHelper.kt
@@ -7,11 +7,11 @@ object QaPluralCheckHelper {
    * For non-plural text (or when `textVariants` is null): passes through to `checkFn` with
    * the full `text`/`baseText` and returns results as-is.
    *
-   * For plural text: iterates over variants (or only [params.activeVariant] if specified),
-   * finds the best matching base variant, calls `checkFn` with per-variant text,
-   * and maps result positions from variant-relative to full-ICU-text-relative.
+   * For plural text: iterates over all variants, finds the best matching base variant,
+   * calls `checkFn` with per-variant text, and maps result positions from variant-relative
+   * to full-ICU-text-relative.
    *
-   * @param params The QA check params containing text, variants, offsets, and activeVariant
+   * @param params The QA check params containing text, variants, and offsets
    * @param checkFn The per-variant check logic. Receives (`variantText`, `baseVariantText`)
    *                and returns issues with positions relative to the variant text.
    */
@@ -29,14 +29,7 @@ object QaPluralCheckHelper {
     val baseVariants = params.baseTextVariants
     val results = mutableListOf<QaCheckResult>()
 
-    val variantsToCheck =
-      if (params.activeVariant != null) {
-        textVariants.filterKeys { it == params.activeVariant }
-      } else {
-        textVariants
-      }
-
-    for ((variantKey, variantText) in variantsToCheck) {
+    for ((variantKey, variantText) in textVariants) {
       val baseVariantText = baseVariants?.get(variantKey) ?: baseVariants?.get("other")
       val offset = offsets?.get(variantKey) ?: 0
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheck.kt
@@ -32,14 +32,7 @@ class EmptyTranslationCheck : QaCheck {
   private fun checkPluralVariants(params: QaCheckParams): List<QaCheckResult> {
     val requiredForms = getPluralFormsForLocale(params.languageTag)
 
-    val formsToCheck =
-      if (params.activeVariant != null) {
-        requiredForms.filter { it == params.activeVariant }
-      } else {
-        requiredForms
-      }
-
-    return formsToCheck.mapNotNull { form ->
+    return requiredForms.mapNotNull { form ->
       val variantText = params.textVariants?.get(form)
       if (variantText.isNullOrBlank()) {
         QaCheckResult(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/EmptyTranslationCheckTest.kt
@@ -15,7 +15,6 @@ class EmptyTranslationCheckTest {
     languageTag: String = "en",
     isPlural: Boolean = false,
     textVariants: Map<String, String>? = null,
-    activeVariant: String? = null,
   ) = QaCheckParams(
     baseText = null,
     text = text,
@@ -23,7 +22,6 @@ class EmptyTranslationCheckTest {
     languageTag = languageTag,
     isPlural = isPlural,
     textVariants = textVariants,
-    activeVariant = activeVariant,
   )
 
   @Test
@@ -125,59 +123,6 @@ class EmptyTranslationCheckTest {
   }
 
   @Test
-  fun `activeVariant filters to only that variant - blank`() {
-    // English requires: one, other — both blank, but only checking "one"
-    check
-      .check(
-        params(
-          text = "{count, plural, one {} other {}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("one" to "", "other" to ""),
-          activeVariant = "one",
-        ),
-      ).assertSingleIssue {
-        message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-        param("variant", "one")
-        pluralVariant("one")
-      }
-  }
-
-  @Test
-  fun `activeVariant filters to only that variant - filled`() {
-    // "one" is filled, "other" is blank — but we're only checking "one"
-    check
-      .check(
-        params(
-          text = "{count, plural, one {item} other {}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("one" to "item", "other" to ""),
-          activeVariant = "one",
-        ),
-      ).assertNoIssues()
-  }
-
-  @Test
-  fun `activeVariant set to variant missing from textVariants`() {
-    // "one" is required for English but missing from textVariants
-    check
-      .check(
-        params(
-          text = "{count, plural, other {items}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("other" to "items"),
-          activeVariant = "one",
-        ),
-      ).assertSingleIssue {
-        message(QaIssueMessage.QA_EMPTY_PLURAL_VARIANT)
-        param("variant", "one")
-        pluralVariant("one")
-      }
-  }
-
-  @Test
   fun `fully empty plural text fires generic empty translation only`() {
     // text is blank, textVariants is null (getPluralForms("") returns null)
     check
@@ -229,21 +174,6 @@ class EmptyTranslationCheckTest {
           languageTag = "en",
           isPlural = true,
           textVariants = null,
-        ),
-      ).assertNoIssues()
-  }
-
-  @Test
-  fun `activeVariant set to non-required form returns no issues`() {
-    // "zero" is not required for English — editing it should not flag anything
-    check
-      .check(
-        params(
-          text = "{count, plural, =0 {} one {item} other {items}}",
-          languageTag = "en",
-          isPlural = true,
-          textVariants = mapOf("=0" to "", "one" to "item", "other" to "items"),
-          activeVariant = "zero",
         ),
       ).assertNoIssues()
   }

--- a/webapp/src/ee/qa/components/QaCheckItem.tsx
+++ b/webapp/src/ee/qa/components/QaCheckItem.tsx
@@ -22,7 +22,7 @@ const StyledItem = styled(Box)`
   margin: ${({ theme }) => theme.spacing(0.5)};
 `;
 
-const StyledIgnoredItem = styled(StyledItem)`
+const StyledDisabledItem = styled(StyledItem)`
   opacity: 0.5;
 `;
 
@@ -30,6 +30,29 @@ const StyledHeader = styled(Box)`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spacing(1.5)};
+`;
+
+const StyledTypeLine = styled(Box)`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(0.75)};
+  min-width: 0;
+`;
+
+const StyledVariantBadge = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  height: ${({ theme }) => theme.spacing(2.5)};
+  padding: 0 ${({ theme }) => theme.spacing(1)};
+  border-radius: ${({ theme }) => theme.spacing(1.5)};
+  font-size: 11px;
+  line-height: 1;
+  background: ${({ theme }) =>
+    theme.palette.mode === 'light'
+      ? theme.palette.emphasis[100]
+      : theme.palette.emphasis[200]};
+  color: ${({ theme }) => theme.palette.text.primary};
+  flex-shrink: 0;
 `;
 
 const StyledIndexCircle = styled(Box)`
@@ -51,6 +74,11 @@ const StyledIcon = styled(Box)`
   align-items: center;
   color: ${({ theme }) => theme.palette.text.primary};
   flex-shrink: 0;
+`;
+
+const StyledIconButton = styled(IconButton)`
+  margin: ${({ theme }) => theme.spacing(-0.5)}
+    ${({ theme }) => theme.spacing(-0.2)};
 `;
 
 const StyledContent = styled(Box)`
@@ -157,6 +185,7 @@ type Props = {
   text: string;
   locale?: string;
   slim?: boolean;
+  disabled?: boolean;
   onCorrect?: () => void;
   onIgnore?: () => void;
 };
@@ -167,6 +196,7 @@ export const QaCheckItem = ({
   text,
   locale,
   slim = false,
+  disabled = false,
   onCorrect,
   onIgnore,
 }: Props) => {
@@ -178,33 +208,34 @@ export const QaCheckItem = ({
     issue.positionStart != null &&
     issue.positionEnd != null;
 
-  const showDiff = hasReplacement && issue.state === 'OPEN';
+  const showDiff = !disabled && hasReplacement && issue.state === 'OPEN';
 
-  const Container = issue.state === 'IGNORED' ? StyledIgnoredItem : StyledItem;
+  const Container =
+    disabled || issue.state === 'IGNORED' ? StyledDisabledItem : StyledItem;
 
   const buttonCorrectSmall = onCorrect && (
     <Tooltip title={t('qa_check_action_correct')}>
-      <IconButton
+      <StyledIconButton
         size="small"
         color="primary"
         onClick={onCorrect}
         data-cy="qa-action-correct"
       >
         <Check width={20} height={20} />
-      </IconButton>
+      </StyledIconButton>
     </Tooltip>
   );
 
   const buttonIgnoreSmall = onIgnore && (
     <Tooltip title={t('qa_check_action_ignore')}>
-      <IconButton
+      <StyledIconButton
         size="small"
         onClick={onIgnore}
         data-cy="qa-action-ignore"
         data-cy-state={issue.state}
       >
         <XClose width={20} height={20} />
-      </IconButton>
+      </StyledIconButton>
     </Tooltip>
   );
 
@@ -237,12 +268,13 @@ export const QaCheckItem = ({
     </Button>
   );
 
-  const textActions = slim ? (
-    <>
-      {buttonCorrectSmall}
-      {buttonIgnoreSmall}
-    </>
-  ) : undefined;
+  const textActions =
+    slim && !disabled ? (
+      <>
+        {buttonCorrectSmall}
+        {buttonIgnoreSmall}
+      </>
+    ) : undefined;
 
   return (
     <Container data-cy="qa-check-item">
@@ -255,10 +287,17 @@ export const QaCheckItem = ({
           </StyledIcon>
         )}
         <StyledContent>
-          <Typography variant="body2">{typeLabel}</Typography>
+          <StyledTypeLine>
+            <Typography variant="body2">{typeLabel}</Typography>
+            {issue.pluralVariant && (
+              <StyledVariantBadge data-cy="qa-check-item-variant-badge">
+                {issue.pluralVariant}
+              </StyledVariantBadge>
+            )}
+          </StyledTypeLine>
           <StyledMessage>{messageText}</StyledMessage>
         </StyledContent>
-        {slim && !showDiff && buttonIgnoreBig}
+        {slim && !showDiff && !disabled && buttonIgnoreBig}
       </StyledHeader>
 
       {showDiff && (
@@ -275,7 +314,7 @@ export const QaCheckItem = ({
         </TextBlock>
       )}
 
-      {!slim && (
+      {!slim && !disabled && (
         <StyledNormalActions>
           {issue.state === 'OPEN' && buttonCorrectBig}
           {buttonIgnoreBig}

--- a/webapp/src/ee/qa/components/QaChecksPanel.tsx
+++ b/webapp/src/ee/qa/components/QaChecksPanel.tsx
@@ -7,14 +7,15 @@ import {
 } from 'tg.views/projects/translations/ToolsPanel/common/types';
 import { TabMessage } from 'tg.views/projects/translations/ToolsPanel/common/TabMessage';
 import { useQaChecksForPanel } from '../hooks/useQaChecksForPanel';
+import { QaPreviewIssue } from 'tg.ee.module/qa/models/QaPreviewWsModels';
 import { useApiMutation } from 'tg.service/http/useQueryApi';
 import { useProject } from 'tg.hooks/useProject';
 import { useEnabledFeatures } from 'tg.globalContext/helpers';
 import { QaCheckItem } from './QaCheckItem';
-import { applyQaReplacement } from 'tg.fixtures/qaUtils';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useReportEvent } from 'tg.hooks/useReportEvent';
 import { LinkExternal } from 'tg.component/LinkExternal';
+import { applyQaReplacement } from 'tg.fixtures/qaUtils';
 
 const StyledWrapper = styled('div')`
   margin-top: 4px;
@@ -38,12 +39,14 @@ export const useQaChecksCount = (data: PanelContentData) => {
   return translation?.qaIssueCount ?? 0;
 };
 
-function isCorrectable(issue: {
-  replacement?: string | null;
-  positionStart?: number | null;
-  positionEnd?: number | null;
-  state: string;
-}) {
+function isCorrectable(
+  issue: QaPreviewIssue,
+  keyIsPlural: boolean,
+  activeVariant: string | undefined
+): boolean {
+  if (keyIsPlural && issue.pluralVariant !== activeVariant) {
+    return false;
+  }
   return (
     issue.replacement != null &&
     issue.positionStart != null &&
@@ -143,12 +146,12 @@ export const QaChecksPanel: FC<PanelContentProps> = (data) => {
     );
   }
 
-  const handleCorrect = (issue: (typeof issues)[0]) => {
+  const handleCorrect = (issue: QaPreviewIssue) => {
     data.setValue(applyQaReplacement(text, issue));
     reportEvent('QA_ISSUE_CORRECTED_INLINE', { checkType: issue.type });
   };
 
-  const handleIgnoreToggle = (issue: (typeof issues)[0]) => {
+  const handleIgnoreToggle = (issue: QaPreviewIssue) => {
     const translationId = data.keyData.translations[data.language.tag]?.id;
     if (translationId == null) return;
 
@@ -181,11 +184,6 @@ export const QaChecksPanel: FC<PanelContentProps> = (data) => {
             <T keyName="translation_tools_qa_connection_lost" />
           </TabMessage>
         )}
-        {data.activeVariant && (
-          <TabMessage>
-            <T keyName="translation_tools_qa_plural_variant_note" />
-          </TabMessage>
-        )}
         {issues.map((issue, index) => (
           <QaCheckItem
             key={`${issue.type}-${issue.message}-${
@@ -196,8 +194,15 @@ export const QaChecksPanel: FC<PanelContentProps> = (data) => {
             text={text}
             locale={data.language.tag}
             slim
+            disabled={
+              data.activeVariant !== undefined &&
+              issue.pluralVariant !== undefined &&
+              issue.pluralVariant !== data.activeVariant
+            }
             onCorrect={
-              isCorrectable(issue) ? () => handleCorrect(issue) : undefined
+              isCorrectable(issue, data.keyData.keyIsPlural, data.activeVariant)
+                ? () => handleCorrect(issue)
+                : undefined
             }
             onIgnore={() => handleIgnoreToggle(issue)}
           />

--- a/webapp/src/ee/qa/hooks/useQaChecksForPanel.ts
+++ b/webapp/src/ee/qa/hooks/useQaChecksForPanel.ts
@@ -1,81 +1,72 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { getTolgeeFormat, tolgeeFormatGenerateIcu } from '@tginternal/editor';
 import { PanelContentData } from 'tg.views/projects/translations/ToolsPanel/common/types';
 import { useQaCheckPreview } from './useQaCheckPreview';
 import { QaPreviewIssue } from 'tg.ee.module/qa/models/QaPreviewWsModels';
 import { useProject } from 'tg.hooks/useProject';
-import { adjustQaIssuesForVariant } from 'tg.fixtures/qaUtils';
+import { offsetQaIssue } from 'tg.fixtures/qaUtils';
 
 export const useQaChecksForPanel = (data: PanelContentData) => {
   const { keyData, language, editingText, activeVariant, isModified } = data;
   const project = useProject();
-  const raw = !project.icuPlaceholders;
+  const textIsRaw = !project.icuPlaceholders;
 
   // For plurals, reconstruct the full ICU text from all variants
-  const text = useMemo(() => {
+  const fullIcuText = useMemo(() => {
     if (keyData.keyIsPlural && data.editingFullValue) {
-      return tolgeeFormatGenerateIcu(data.editingFullValue, raw);
+      return tolgeeFormatGenerateIcu(data.editingFullValue, textIsRaw);
     }
     return editingText ?? '';
-  }, [keyData.keyIsPlural, data.editingFullValue, editingText, raw]);
+  }, [keyData.keyIsPlural, data.editingFullValue, editingText, textIsRaw]);
 
-  const variantOffset = useMemo(() => {
-    if (!activeVariant || !keyData.keyIsPlural || !text) return 0;
-    const parsed = getTolgeeFormat(text, true, raw);
-    return parsed.variantOffsets?.[activeVariant as Intl.LDMLPluralRule] ?? 0;
-  }, [activeVariant, text, keyData.keyIsPlural, raw]);
+  const variantOffsets = useMemo(() => {
+    if (!keyData.keyIsPlural || !fullIcuText) return undefined;
+    const parsed = getTolgeeFormat(fullIcuText, true, textIsRaw);
+    return parsed.variantOffsets;
+  }, [fullIcuText, keyData.keyIsPlural, textIsRaw]);
 
   const translation = keyData.translations[language.tag];
-  const allPersistedIssues: QaPreviewIssue[] =
-    translation?.qaIssues ?? EMPTY_ISSUES;
-
-  // For plurals, filter persisted issues to the active variant
-  const persistedIssues = useMemo(() => {
-    if (activeVariant) {
-      return allPersistedIssues.filter(
-        (i) => i.pluralVariant === activeVariant
-      );
-    }
-    return allPersistedIssues;
-  }, [allPersistedIssues, activeVariant]);
 
   const qaChecksStale = translation?.qaChecksStale ?? false;
 
+  // Once we start using the preview websocket, don't stop until user switches
+  // to different translation
+  const editingKey = `${keyData.keyId}:${language.tag}`;
+  const wsLatchRef = useRef({ key: editingKey, enabled: false });
+  if (wsLatchRef.current.key !== editingKey) {
+    wsLatchRef.current = { key: editingKey, enabled: false };
+  }
+  if (isModified || qaChecksStale) {
+    wsLatchRef.current.enabled = true;
+  }
+  const wsEnabled = wsLatchRef.current.enabled;
+
   const result = useQaCheckPreview({
-    text,
+    text: fullIcuText,
     languageTag: language.tag,
     keyId: keyData.keyId,
     variant: activeVariant,
-    enabled: isModified || qaChecksStale,
-    initialIssues: persistedIssues,
+    enabled: wsEnabled,
+    initialIssues: translation?.qaIssues,
   });
 
   // Adjust positions from full-ICU to variant-relative for the panel
-  const adjustedIssues = useMemo(
-    () => adjustQaIssuesForVariant(result.issues, activeVariant, variantOffset),
-    [result.issues, activeVariant, variantOffset]
-  );
+  const adjustedIssues = useMemo(() => {
+    return result?.issues?.map((issue) => {
+      const offset =
+        variantOffsets?.[issue.pluralVariant as Intl.LDMLPluralRule];
+      return offsetQaIssue(issue, offset ?? 0);
+    });
+  }, [result.issues, variantOffsets]);
 
   const updateIssueState = useCallback(
-    (adjustedIssue: QaPreviewIssue, newState: QaPreviewIssue['state']) => {
+    (issue: QaPreviewIssue, newState: QaPreviewIssue['state']) => {
       // Reverse position adjustment
-      const originalIssue =
-        variantOffset === 0
-          ? adjustedIssue
-          : {
-              ...adjustedIssue,
-              positionStart:
-                adjustedIssue.positionStart != null
-                  ? adjustedIssue.positionStart + variantOffset
-                  : adjustedIssue.positionStart,
-              positionEnd:
-                adjustedIssue.positionEnd != null
-                  ? adjustedIssue.positionEnd + variantOffset
-                  : adjustedIssue.positionEnd,
-            };
-      result.updateIssueState(originalIssue, newState);
+      const offset =
+        variantOffsets?.[issue.pluralVariant as Intl.LDMLPluralRule];
+      result.updateIssueState(offsetQaIssue(issue, -(offset ?? 0)), newState);
     },
-    [result.updateIssueState, variantOffset]
+    [result.updateIssueState, variantOffsets]
   );
 
   return {
@@ -85,5 +76,3 @@ export const useQaChecksForPanel = (data: PanelContentData) => {
     updateIssueState,
   };
 };
-
-const EMPTY_ISSUES: QaPreviewIssue[] = [];

--- a/webapp/src/ee/qa/hooks/useQaPreviewWebsocket.ts
+++ b/webapp/src/ee/qa/hooks/useQaPreviewWebsocket.ts
@@ -7,6 +7,7 @@ import {
   QaPreviewResult,
   WsMessage,
 } from 'tg.ee.module/qa/models/QaPreviewWsModels';
+import { getPluralVariants } from '@tginternal/editor';
 
 export const useQaPreviewWebsocket = ({
   projectId,
@@ -29,8 +30,6 @@ export const useQaPreviewWebsocket = ({
   initialIssuesRef.current = initialIssues;
   const latestTextRef = useRef(text);
   latestTextRef.current = text;
-  const latestVariantRef = useRef(variant);
-  latestVariantRef.current = variant;
 
   useEffect(() => {
     // Re-seed from persisted issues when params change
@@ -58,12 +57,7 @@ export const useQaPreviewWebsocket = ({
       // initial text update message
       const currentText = latestTextRef.current;
       if (currentText != null) {
-        ws.send(
-          JSON.stringify({
-            text: currentText,
-            variant: latestVariantRef.current,
-          })
-        );
+        ws.send(JSON.stringify({ text: currentText }));
       } else {
         setIsLoading(false);
       }
@@ -130,9 +124,7 @@ export const useQaPreviewWebsocket = ({
     (t: string) => {
       pendingTextUpdateRef.current = false;
       if (wsRef.current?.readyState === WebSocket.OPEN) {
-        wsRef.current.send(
-          JSON.stringify({ text: t, variant: latestVariantRef.current })
-        );
+        wsRef.current.send(JSON.stringify({ text: t }));
       }
     },
     200,
@@ -145,7 +137,7 @@ export const useQaPreviewWebsocket = ({
       pendingTextUpdateRef.current = true;
       sendText(text);
     }
-  }, [text, variant, enabled]);
+  }, [text, enabled]);
 
   const updateIssueState = useCallback(
     (targetIssue: QaPreviewIssue, newState: QaPreviewIssue['state']) => {
@@ -172,15 +164,27 @@ export const useQaPreviewWebsocket = ({
     []
   );
 
+  // First generic issues, then current variant, then rest sorted by
+  // default order of plural variants
+  const pluralVariantsOrder: (string | undefined)[] = useMemo(
+    () => [undefined, variant, ...getPluralVariants(languageTag)],
+    [languageTag, variant]
+  );
+
   const issues = useMemo(() => {
+    const getVariantIndex = (variant: string | undefined) => {
+      const i = pluralVariantsOrder.indexOf(variant);
+      return i === -1 ? pluralVariantsOrder.length : i;
+    };
     const all = Array.from(issuesByType.values()).flat();
     return all.sort(
       (a, b) =>
+        getVariantIndex(a.pluralVariant) - getVariantIndex(b.pluralVariant) ||
         (a.positionStart ?? Infinity) - (b.positionStart ?? Infinity) ||
         (a.positionEnd ?? Infinity) - (b.positionEnd ?? Infinity) ||
         a.type.localeCompare(b.type)
     );
-  }, [issuesByType]);
+  }, [issuesByType, pluralVariantsOrder]);
 
   return { issues, isLoading, isDisconnected, updateIssueState };
 };

--- a/webapp/src/ee/qa/models/QaPreviewWsModels.ts
+++ b/webapp/src/ee/qa/models/QaPreviewWsModels.ts
@@ -1,8 +1,6 @@
-import { components } from 'tg.service/apiSchema.generated';
+import { QaIssueModel } from 'tg.service/apiSchemaTypes.generated';
 
-type QaIssue = components['schemas']['QaIssueModel'];
-
-export type QaPreviewIssue = Omit<QaIssue, 'id'>;
+export type QaPreviewIssue = Omit<QaIssueModel, 'id'>;
 
 export type WsResultMessage = {
   type: 'result';

--- a/webapp/src/fixtures/qaUtils.ts
+++ b/webapp/src/fixtures/qaUtils.ts
@@ -40,15 +40,25 @@ export function adjustQaIssuesForVariant<T extends QaVariantIssue>(
   }
   return issues
     .filter((i) => !variant || i.pluralVariant === variant || !i.pluralVariant)
-    .map((i) => ({
-      ...i,
-      positionStart:
-        i.positionStart != null
-          ? i.positionStart - variantOffset
-          : i.positionStart,
-      positionEnd:
-        i.positionEnd != null ? i.positionEnd - variantOffset : i.positionEnd,
-    }));
+    .map((i) => offsetQaIssue(i, variantOffset));
+}
+
+export function offsetQaIssue<T extends QaVariantIssue>(
+  issue: T,
+  offset: number
+) {
+  if (offset === 0) return issue;
+  return {
+    ...issue,
+    positionStart:
+      issue.positionStart != null
+        ? issue.positionStart - offset
+        : issue.positionStart,
+    positionEnd:
+      issue.positionEnd != null
+        ? issue.positionEnd - offset
+        : issue.positionEnd,
+  };
 }
 
 export function getFirstPluralVariantWithQaIssues(


### PR DESCRIPTION
## Summary

- QA panel now renders issues for every plural variant instead of only the active one
- Off-variant issues are read-only (no Correct/Ignore buttons, no diff) and grayed out
- Variant issues carry a small pill showing their plural category; generic and active-variant issues stay interactive
- Issues are ordered: generic first, then active variant, then the rest in natural plural order
- Backend no longer filters QA checks by `activeVariant` — the preview WS always returns issues for every variant
- Once the preview WS engages it stays open until the user switches translation, so undoing all edits no longer reverts to potentially stale persisted issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added variant badges to QA check items for improved clarity.
  * QA checks now report issues across all plural variants, not just the active one.

* **Bug Fixes**
  * Fixed QA check behavior to properly validate all required plural forms in translations.

* **Refactor**
  * Simplified QA check preview messaging and variant handling logic.
  * Enhanced QA check item disabled state for non-active variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->