### PR TITLE
fix: handle ICU plural # in QA checks

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaPluralCheckHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaPluralCheckHelper.kt
@@ -17,13 +17,13 @@ object QaPluralCheckHelper {
    */
   fun runPerVariant(
     params: QaCheckParams,
-    checkFn: (text: String, baseText: String?) -> List<QaCheckResult>,
+    checkFn: (text: String, baseText: String?, isVariant: Boolean) -> List<QaCheckResult>,
   ): List<QaCheckResult> {
     val textVariants = params.textVariants
     val offsets = params.textVariantOffsets
 
     if (!params.isPlural || textVariants == null) {
-      return checkFn(params.text, params.baseText)
+      return checkFn(params.text, params.baseText, false)
     }
 
     val baseVariants = params.baseTextVariants
@@ -40,7 +40,7 @@ object QaPluralCheckHelper {
       val baseVariantText = baseVariants?.get(variantKey) ?: baseVariants?.get("other")
       val offset = offsets?.get(variantKey) ?: 0
 
-      val variantResults = checkFn(variantText, baseVariantText)
+      val variantResults = checkFn(variantText, baseVariantText, true)
       results.addAll(
         variantResults.map { result ->
           result.copy(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/BracketsBalanceCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/BracketsBalanceCheck.kt
@@ -14,7 +14,7 @@ class BracketsBalanceCheck : QaCheck {
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
     val bracketSets = getBracketSets(params.icuPlaceholders)
-    return QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
       checkVariant(text, bracketSets)
     }
   }
@@ -34,6 +34,7 @@ class BracketsBalanceCheck : QaCheck {
         ch in bracketSets.opening -> {
           stack.addLast(BracketInfo(ch, i))
         }
+
         ch in bracketSets.closing -> {
           val expectedOpening = bracketSets.closingToOpening[ch]
           if (stack.isNotEmpty() && stack.last().char == expectedOpening) {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/BracketsMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/BracketsMismatchCheck.kt
@@ -14,7 +14,7 @@ class BracketsMismatchCheck : QaCheck {
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
     val bracketChars = getBracketChars(params.icuPlaceholders)
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText, bracketChars)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheck.kt
@@ -14,7 +14,7 @@ class CharacterCaseMismatchCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.CHARACTER_CASE_MISMATCH
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText, params.languageTag)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/DifferentUrlsCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/DifferentUrlsCheck.kt
@@ -13,7 +13,7 @@ class DifferentUrlsCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.DIFFERENT_URLS
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/HtmlSyntaxCheck.kt
@@ -13,7 +13,7 @@ class HtmlSyntaxCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.HTML_SYNTAX
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
       checkVariant(text)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/InconsistentHtmlCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/InconsistentHtmlCheck.kt
@@ -13,7 +13,7 @@ class InconsistentHtmlCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.INCONSISTENT_HTML
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/InconsistentPlaceholdersCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/InconsistentPlaceholdersCheck.kt
@@ -13,8 +13,8 @@ class InconsistentPlaceholdersCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.INCONSISTENT_PLACEHOLDERS
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
-      checkVariant(text, baseText)
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, isVariant ->
+      checkVariant(text, baseText, isVariant)
     }
   }
 
@@ -31,13 +31,13 @@ class InconsistentPlaceholdersCheck : QaCheck {
   private fun checkVariant(
     text: String,
     baseText: String?,
+    isPluralVariant: Boolean,
   ): List<QaCheckResult> {
     val base = baseText ?: return emptyList()
-    if (base.isBlank()) return emptyList()
-    if (text.isBlank()) return emptyList()
+    if (base.isBlank() || text.isBlank()) return emptyList()
 
-    val baseArgs = deduplicateNestedArgs(extractArgs(base) ?: return emptyList())
-    val textArgs = deduplicateNestedArgs(extractArgs(text) ?: return emptyList())
+    val baseArgs = deduplicateNestedArgs(extractArgs(base, isPluralVariant) ?: return emptyList())
+    val textArgs = deduplicateNestedArgs(extractArgs(text, isPluralVariant) ?: return emptyList())
 
     val baseCounts = baseArgs.groupingBy { it.name }.eachCount()
     val textCounts = textArgs.groupingBy { it.name }.eachCount()

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheck.kt
@@ -13,7 +13,7 @@ class MissingNumbersCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.MISSING_NUMBERS
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/PlaceholderExtractor.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/PlaceholderExtractor.kt
@@ -8,11 +8,28 @@ data class ArgInfo(
   val positionEnd: Int? = null,
 )
 
-fun extractArgs(text: String): List<ArgInfo>? {
+/**
+ * Virtual placeholder name used for the ICU plural `#` token (REPLACE_NUMBER).
+ * Safe as a name because real ICU argument names are restricted to `[\p{L}\p{N}_]+`
+ * — so a user-defined argument named `#` is impossible.
+ */
+const val REPLACE_NUMBER_PLACEHOLDER_NAME = "#"
+
+/**
+ * Synthetic plural wrapper that makes the ICU parser treat the variant body as it
+ * would inside a real plural — unquoted `#` chars become REPLACE_NUMBER tokens.
+ */
+private const val PLURAL_WRAPPER_PREFIX = "{n,plural,other{"
+private const val PLURAL_WRAPPER_SUFFIX = "}}"
+
+fun extractArgs(
+  text: String,
+  isPluralVariant: Boolean = false,
+): List<ArgInfo>? {
   return try {
-    val node = MessagePatternUtil.buildMessageNode(text)
+    val rootMessage = buildMessageNode(text, isPluralVariant) ?: return emptyList()
     val args = mutableListOf<ArgInfo>()
-    collectArgsWithPositions(node, 0, args)
+    collectArgsWithPositions(rootMessage, 0, args)
     args
   } catch (_: Exception) {
     // Broad catch is intentional — parsing failures are surfaced by IcuSyntaxCheck,
@@ -21,11 +38,29 @@ fun extractArgs(text: String): List<ArgInfo>? {
   }
 }
 
+private fun buildMessageNode(
+  text: String,
+  isPluralVariant: Boolean,
+): MessagePatternUtil.MessageNode? {
+  if (!isPluralVariant) {
+    return MessagePatternUtil.buildMessageNode(text)
+  }
+
+  // Wrap as plural, then unwrap the original message node - to correctly parse plural variants
+  val wrappedNode = MessagePatternUtil.buildMessageNode(PLURAL_WRAPPER_PREFIX + text + PLURAL_WRAPPER_SUFFIX)
+  val pluralArg = wrappedNode.contents.firstOrNull() as? MessagePatternUtil.ArgNode ?: return null
+  return pluralArg.complexStyle
+    ?.variants
+    ?.firstOrNull()
+    ?.message
+}
+
 /**
- * Collects arg names with positions by accumulating patternString lengths.
- * Top-level args get accurate positions. Args nested inside complex styles
- * (select/plural/choice) are collected with position null,null (name only) since
- * QaPluralCheckHelper handles per-variant splitting for plural messages.
+ * Collects arg names with positions by accumulating patternString lengths starting
+ * from [offset]. Top-level args (and top-level REPLACE_NUMBER `#` tokens) get accurate
+ * positions. Args nested inside complex styles (select/plural/choice) are collected
+ * with null positions via [collectNamesOnly] since QaPluralCheckHelper handles
+ * per-variant splitting for plural messages.
  */
 private fun collectArgsWithPositions(
   node: MessagePatternUtil.MessageNode,
@@ -35,30 +70,44 @@ private fun collectArgsWithPositions(
   var pos = offset
   for (content in node.contents) {
     val len = content.patternString.length
-    if (content is MessagePatternUtil.ArgNode) {
-      content.name?.let { name ->
-        args.add(ArgInfo(name, pos, pos + len))
+    when {
+      content is MessagePatternUtil.ArgNode -> {
+        content.name?.let { name ->
+          args.add(ArgInfo(name, pos, pos + len))
+        }
+        content.complexStyle?.variants?.forEach { variant ->
+          variant.message?.let { collectNamesOnly(it, args) }
+        }
       }
-      content.complexStyle?.variants?.forEach { variant ->
-        variant.message?.let { collectNamesOnly(it, args) }
+
+      content.type == MessagePatternUtil.MessageContentsNode.Type.REPLACE_NUMBER -> {
+        args.add(ArgInfo(REPLACE_NUMBER_PLACEHOLDER_NAME, pos, pos + len))
       }
     }
     pos += len
   }
 }
 
-/** Recursively collects arg names from nested messages without position tracking. */
+/**
+ * Recursively collects arg names from nested messages without position tracking.
+ */
 private fun collectNamesOnly(
   node: MessagePatternUtil.MessageNode,
   args: MutableList<ArgInfo>,
 ) {
   for (content in node.contents) {
-    if (content is MessagePatternUtil.ArgNode) {
-      content.name?.let { name ->
-        args.add(ArgInfo(name))
+    when {
+      content is MessagePatternUtil.ArgNode -> {
+        content.name?.let { name ->
+          args.add(ArgInfo(name))
+        }
+        content.complexStyle?.variants?.forEach { variant ->
+          variant.message?.let { collectNamesOnly(it, args) }
+        }
       }
-      content.complexStyle?.variants?.forEach { variant ->
-        variant.message?.let { collectNamesOnly(it, args) }
+
+      content.type == MessagePatternUtil.MessageContentsNode.Type.REPLACE_NUMBER -> {
+        args.add(ArgInfo(REPLACE_NUMBER_PLACEHOLDER_NAME))
       }
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/PunctuationMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/PunctuationMismatchCheck.kt
@@ -13,7 +13,7 @@ class PunctuationMismatchCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.PUNCTUATION_MISMATCH
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/RepeatedWordsCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/RepeatedWordsCheck.kt
@@ -13,7 +13,7 @@ class RepeatedWordsCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.REPEATED_WORDS
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
       checkVariant(text)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpacesMismatchCheck.kt
@@ -16,7 +16,7 @@ class SpacesMismatchCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.SPACES_MISMATCH
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheck.kt
@@ -13,21 +13,22 @@ class SpecialCharacterMismatchCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.SPECIAL_CHARACTER_MISMATCH
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
-      checkVariant(text, baseText)
+    val activeChars = getActiveSpecialChars(params.icuPlaceholders)
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
+      checkVariant(text, baseText, activeChars)
     }
   }
 
   private fun checkVariant(
     text: String,
     baseText: String?,
+    activeChars: Set<Char>,
   ): List<QaCheckResult> {
     val base = baseText ?: return emptyList()
-    if (base.isBlank()) return emptyList()
-    if (text.isBlank()) return emptyList()
+    if (base.isBlank() || text.isBlank()) return emptyList()
 
-    val baseChars = extractSpecialChars(base)
-    val textChars = extractSpecialChars(text)
+    val baseChars = extractSpecialChars(base, activeChars)
+    val textChars = extractSpecialChars(text, activeChars)
 
     val results = mutableListOf<QaCheckResult>()
 
@@ -50,8 +51,7 @@ class SpecialCharacterMismatchCheck : QaCheck {
 
     // Characters in translation but not in base
     val addedChars = subtractMultiset(textChars, baseChars)
-    for (char in addedChars.toSet()) {
-      val count = addedChars.count { it == char }
+    for ((char, count) in addedChars.groupingBy { it }.eachCount()) {
       val positions = findAllOccurrences(text, char)
       // Report the last N occurrences as the "extra" ones
       positions.takeLast(count).forEach { index ->
@@ -87,8 +87,14 @@ class SpecialCharacterMismatchCheck : QaCheck {
         '°',
       )
 
-    fun extractSpecialChars(text: String): List<Char> {
-      return text.filter { it in SPECIAL_CHARS }.toList()
+    fun getActiveSpecialChars(icuPlaceholders: Boolean): Set<Char> =
+      if (icuPlaceholders) SPECIAL_CHARS - '#' else SPECIAL_CHARS
+
+    fun extractSpecialChars(
+      text: String,
+      activeChars: Set<Char> = SPECIAL_CHARS,
+    ): List<Char> {
+      return text.filter { it in activeChars }.toList()
     }
 
     private fun subtractMultiset(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/GrammarCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/GrammarCheck.kt
@@ -20,7 +20,7 @@ class GrammarCheck(
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
     val results =
-      QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+      QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
         checkVariant(text, params.languageTag)
       }
     return filterByGlossaryTerms(results, params.glossaryTerms)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/SpellingCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/SpellingCheck.kt
@@ -20,7 +20,7 @@ class SpellingCheck(
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
     val results =
-      QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+      QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
         checkVariant(text, params.languageTag)
       }
     return filterByGlossaryTerms(results, params.glossaryTerms)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/lines/UnmatchedNewlinesCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/lines/UnmatchedNewlinesCheck.kt
@@ -13,7 +13,7 @@ class UnmatchedNewlinesCheck : QaCheck {
   override val type: QaCheckType = QaCheckType.UNMATCHED_NEWLINES
 
   override fun check(params: QaCheckParams): List<QaCheckResult> {
-    return QaPluralCheckHelper.runPerVariant(params) { text, baseText ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, baseText, _ ->
       checkVariant(text, baseText)
     }
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/whitespace/TrimCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/whitespace/TrimCheck.kt
@@ -18,7 +18,7 @@ class TrimCheck : QaCheck {
     // whatever preference the user sets up in base translation to all translations.
     if (params.baseLanguageTag != null) return emptyList()
 
-    return QaPluralCheckHelper.runPerVariant(params) { text, _ ->
+    return QaPluralCheckHelper.runPerVariant(params) { text, _, _ ->
       checkVariant(text)
     }
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/InconsistentPlaceholdersCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/InconsistentPlaceholdersCheckTest.kt
@@ -226,6 +226,210 @@ class InconsistentPlaceholdersCheckTest {
   }
 
   @Test
+  fun `detects missing hash placeholder in plural variants`() {
+    // Base has # in both variants, translation has none in either.
+    check
+      .check(
+        params(
+          text = "{count, plural, one {polozka} other {polozek}}",
+          base = "{count, plural, one {# polozka} other {# polozek}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "polozka", "other" to "polozek"),
+          baseTextVariants = mapOf("one" to "# polozka", "other" to "# polozek"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 37),
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+          param("placeholder", "#")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+          param("placeholder", "#")
+          pluralVariant("other")
+        }
+      }
+  }
+
+  @Test
+  fun `detects extra hash placeholder in plural variants`() {
+    check
+      .check(
+        params(
+          text = "{count, plural, one {# polozka} other {# polozek}}",
+          base = "{count, plural, one {polozka} other {polozek}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "# polozka", "other" to "# polozek"),
+          baseTextVariants = mapOf("one" to "polozka", "other" to "polozek"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 39),
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_EXTRA)
+          param("placeholder", "#")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_EXTRA)
+          param("placeholder", "#")
+          pluralVariant("other")
+        }
+      }
+  }
+
+  @Test
+  fun `does not flag hash placeholder when both base and translation have it`() {
+    check
+      .check(
+        params(
+          text = "{count, plural, one {# polozka} other {# polozek}}",
+          base = "{count, plural, one {# item} other {# items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "# polozka", "other" to "# polozek"),
+          baseTextVariants = mapOf("one" to "# item", "other" to "# items"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 39),
+        ),
+      ).assertNoIssues()
+  }
+
+  @Test
+  fun `counts hash occurrences within a single plural variant`() {
+    // Base has # twice in 'one' (e.g. "# orders, # total"), translation has it once —
+    // one # is missing. Top-level # gets a position just like a regular {arg}, so each
+    // occurrence is tracked individually rather than collapsed by name.
+    check
+      .check(
+        params(
+          text = "{count, plural, one {# polozek celkem} other {# polozek}}",
+          base = "{count, plural, one {# polozek, # celkem} other {# polozek}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "# polozek celkem", "other" to "# polozek"),
+          baseTextVariants = mapOf("one" to "# polozek, # celkem", "other" to "# polozek"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 46),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+        param("placeholder", "#")
+        pluralVariant("one")
+      }
+  }
+
+  @Test
+  fun `reports position of extra hash placeholder`() {
+    // Base has no # — translation added one in 'one'. The extra-issue path should
+    // include the # position (offset back into the full ICU text) and a "" replacement
+    // so the editor can offer to delete it.
+    check
+      .check(
+        params(
+          text = "{count, plural, one {# polozka} other {polozek}}",
+          base = "{count, plural, one {polozka} other {polozek}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "# polozka", "other" to "polozek"),
+          baseTextVariants = mapOf("one" to "polozka", "other" to "polozek"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 39),
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_PLACEHOLDERS_EXTRA)
+        param("placeholder", "#")
+        pluralVariant("one")
+        position(21, 22)
+        replacement("")
+      }
+  }
+
+  @Test
+  fun `detects missing hash placeholder in non-plural ICU text`() {
+    // Inline ICU plural inside a non-plural string. `#` inside should still be tracked.
+    check
+      .check(
+        params(
+          text = "You have {count, plural, one {an item} other {many items}}",
+          base = "You have {count, plural, one {# item} other {# items}}",
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+        param("placeholder", "#")
+      }
+  }
+
+  @Test
+  fun `escaped hash in plural variant is not a placeholder`() {
+    // Asymmetric escaping: base uses real `#` (a placeholder), translation uses `'#'`
+    // (literal hash, NOT a placeholder). Should report missing `#`.
+    check
+      .check(
+        params(
+          text = "{count, plural, one {'#' polozka} other {'#' polozek}}",
+          base = "{count, plural, one {# item} other {# items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "'#' polozka", "other" to "'#' polozek"),
+          baseTextVariants = mapOf("one" to "# item", "other" to "# items"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 41),
+        ),
+      ).assertIssues {
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+          param("placeholder", "#")
+          pluralVariant("one")
+        }
+        issue {
+          message(QaIssueMessage.QA_PLACEHOLDERS_MISSING)
+          param("placeholder", "#")
+          pluralVariant("other")
+        }
+      }
+  }
+
+  @Test
+  fun `symmetric escaped hash in plural variant produces no issue`() {
+    // Both sides use `'#'` (escaped literal hash, not a placeholder) — no mismatch.
+    check
+      .check(
+        params(
+          text = "{count, plural, one {'#' polozka} other {'#' polozek}}",
+          base = "{count, plural, one {'#' item} other {'#' items}}",
+          isPlural = true,
+          textVariants = mapOf("one" to "'#' polozka", "other" to "'#' polozek"),
+          baseTextVariants = mapOf("one" to "'#' item", "other" to "'#' items"),
+          textVariantOffsets = mapOf("one" to 21, "other" to 41),
+        ),
+      ).assertNoIssues()
+  }
+
+  @Test
+  fun `hash inside select nested in plural is treated as literal`() {
+    // Per ICU MessageFormat, `#` only refers to the plural argument when it appears
+    // directly inside a plural variant body. Once nested inside another complex arg
+    // (here a select), `#` is just literal text — so it should NOT be tracked as a
+    // placeholder, and a missing `#` inside the nested select is not flagged.
+    check
+      .check(
+        params(
+          text =
+            "{count, plural, one {{g, select, m {polozka} other {polozka}}} " +
+              "other {{g, select, m {polozek} other {polozek}}}}",
+          base =
+            "{count, plural, one {{g, select, m {# item} other {# item}}} " +
+              "other {{g, select, m {# items} other {# items}}}}",
+          isPlural = true,
+          textVariants =
+            mapOf(
+              "one" to "{g, select, m {polozka} other {polozka}}",
+              "other" to "{g, select, m {polozek} other {polozek}}",
+            ),
+          baseTextVariants =
+            mapOf(
+              "one" to "{g, select, m {# item} other {# item}}",
+              "other" to "{g, select, m {# items} other {# items}}",
+            ),
+          textVariantOffsets = mapOf("one" to 21, "other" to 71),
+        ),
+      ).assertNoIssues()
+  }
+
+  @Test
   fun `detects missing placeholder in one plural variant only`() {
     check
       .check(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheckTest.kt
@@ -15,11 +15,13 @@ class SpecialCharacterMismatchCheckTest {
   private fun params(
     text: String,
     base: String? = null,
+    icuPlaceholders: Boolean = true,
   ) = QaCheckParams(
     baseText = base,
     text = text,
     baseLanguageTag = "en",
     languageTag = "cs",
+    icuPlaceholders = icuPlaceholders,
   )
 
   @Test
@@ -116,13 +118,53 @@ class SpecialCharacterMismatchCheckTest {
   }
 
   @Test
-  fun `detects all supported special characters`() {
-    for (char in SpecialCharacterMismatchCheck.SPECIAL_CHARS) {
-      check.check(params("text", "text$char")).assertSingleIssue {
-        param("characters", char.toString())
+  fun `detects copyright trademark and degree characters`() {
+    // A spread of less common special chars, to exercise the full check (not just $).
+    check.check(params("text", "Copyright © 2024, registered ®, 100°F, brand ™")).assertSingleIssue {
+      message(QaIssueMessage.QA_SPECIAL_CHAR_MISSING)
+      param("count", "4")
+    }
+  }
+
+  @Test
+  fun `flags missing hash when ICU is disabled`() {
+    // Issue tag dropped from translation.
+    check.check(params("Cislo objednavky 123", "Order #123", icuPlaceholders = false)).assertSingleIssue {
+      message(QaIssueMessage.QA_SPECIAL_CHAR_MISSING)
+      param("characters", "#")
+      param("count", "1")
+    }
+  }
+
+  @Test
+  fun `skips missing hash when ICU is enabled`() {
+    // With ICU enabled, # is owned by the Inconsistent placeholders check to avoid
+    // double-reporting. Even a literal "#123" outside any plural is intentionally
+    // skipped — the simplification we accept in exchange for a single owner of #.
+    check.check(params("Cislo objednavky 123", "Order #123", icuPlaceholders = true)).assertNoIssues()
+  }
+
+  @Test
+  fun `skips extra hash when ICU is enabled`() {
+    check.check(params("Order #1 confirmed", "Order 1 confirmed", icuPlaceholders = true)).assertNoIssues()
+  }
+
+  @Test
+  fun `with ICU enabled still flags other chars when hash also differs`() {
+    // Translation dropped both `#` (issue tag) and `@` (handle). With ICU we ignore the
+    // missing `#` but the `@` should still be reported.
+    check
+      .check(
+        params(
+          text = "Objednavka 5 od support",
+          base = "Order #5 from @support",
+          icuPlaceholders = true,
+        ),
+      ).assertSingleIssue {
+        message(QaIssueMessage.QA_SPECIAL_CHAR_MISSING)
+        param("characters", "@")
         param("count", "1")
       }
-    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **Inconsistent placeholders** check now treats the ICU plural `#` (REPLACE_NUMBER) as a placeholder inside plural variants. Missing or extra `#` between base and translation is reported, with position + replacement on the extra path so editors can offer to delete it. Escaped `'#'` is correctly ignored (the variant body is wrapped in a synthetic plural so the ICU parser handles quoting), and `#` nested inside a select-inside-plural stays a literal — matching ICU's actual semantics.
- **Special character mismatch** check now skips `#` for projects with ICU placeholder support enabled (mirrors how brackets checks already use `params.icuPlaceholders`). This avoids double-reporting once Inconsistent placeholders owns `#`.
- **`QaPluralCheckHelper.runPerVariant`** signals whether each invocation is inside a plural variant body, so the extractor knows when to switch on REPLACE_NUMBER detection. All other QA checks pick up the new lambda parameter.
- Tooltip for "Special character mismatch" updated in Tolgee Cloud (branch `fix-qa-icu-hash-handling`) to explain the new ICU-aware behavior.

### Tradeoff worth flagging

When ICU is enabled, `#` is dropped from the Special character mismatch check *everywhere* — even outside any plural (e.g. literal `#hashtag` in regular text). Simpler than locating `#` only inside plurals and avoids any risk of double-reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced QA checks to better validate plural form consistency, including improved detection of missing or extra placeholders in plural variants.
  * Improved ICU plural placeholder support with more accurate argument tracking across variant forms.

* **Tests**
  * Expanded test coverage for plural form validation and special character detection in QA checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3664)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->