### PR TITLE
perf: filter entity pre-commit events by entity type at dispatch

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/events/EntityPreCommitEvent.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/EntityPreCommitEvent.kt
@@ -2,7 +2,7 @@ package io.tolgee.events
 
 import io.tolgee.activity.iterceptor.PreCommitEventPublisher
 
-interface EntityPreCommitEvent {
+interface EntityPreCommitEvent<T : Any> {
   val source: PreCommitEventPublisher
-  val entity: Any?
+  val entity: T?
 }

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityCollectionPreUpdate.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityCollectionPreUpdate.kt
@@ -2,10 +2,15 @@ package io.tolgee.events
 
 import io.tolgee.activity.iterceptor.PreCommitEventPublisher
 import org.springframework.context.ApplicationEvent
+import org.springframework.core.ResolvableType
+import org.springframework.core.ResolvableTypeProvider
 
-class OnEntityCollectionPreUpdate(
+class OnEntityCollectionPreUpdate<T : Any>(
   override val source: PreCommitEventPublisher,
-  override val entity: Any?,
+  override val entity: T?,
   previousCollection: MutableCollection<out Any?>?,
 ) : ApplicationEvent(source),
-  EntityPreCommitEvent
+  EntityPreCommitEvent<T>,
+  ResolvableTypeProvider {
+  override fun getResolvableType(): ResolvableType = resolvableTypeFor(OnEntityCollectionPreUpdate::class.java, entity)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreDelete.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreDelete.kt
@@ -2,9 +2,14 @@ package io.tolgee.events
 
 import io.tolgee.activity.iterceptor.PreCommitEventPublisher
 import org.springframework.context.ApplicationEvent
+import org.springframework.core.ResolvableType
+import org.springframework.core.ResolvableTypeProvider
 
-class OnEntityPreDelete(
+class OnEntityPreDelete<T : Any>(
   override val source: PreCommitEventPublisher,
-  override val entity: Any?,
+  override val entity: T?,
 ) : ApplicationEvent(source),
-  EntityPreCommitEvent
+  EntityPreCommitEvent<T>,
+  ResolvableTypeProvider {
+  override fun getResolvableType(): ResolvableType = resolvableTypeFor(OnEntityPreDelete::class.java, entity)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPrePersist.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPrePersist.kt
@@ -2,9 +2,14 @@ package io.tolgee.events
 
 import io.tolgee.activity.iterceptor.PreCommitEventPublisher
 import org.springframework.context.ApplicationEvent
+import org.springframework.core.ResolvableType
+import org.springframework.core.ResolvableTypeProvider
 
-class OnEntityPrePersist(
+class OnEntityPrePersist<T : Any>(
   override val source: PreCommitEventPublisher,
-  override val entity: Any?,
+  override val entity: T?,
 ) : ApplicationEvent(source),
-  EntityPreCommitEvent
+  EntityPreCommitEvent<T>,
+  ResolvableTypeProvider {
+  override fun getResolvableType(): ResolvableType = resolvableTypeFor(OnEntityPrePersist::class.java, entity)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreUpdate.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreUpdate.kt
@@ -2,11 +2,16 @@ package io.tolgee.events
 
 import io.tolgee.activity.iterceptor.PreCommitEventPublisher
 import org.springframework.context.ApplicationEvent
+import org.springframework.core.ResolvableType
+import org.springframework.core.ResolvableTypeProvider
 
-class OnEntityPreUpdate(
+class OnEntityPreUpdate<T : Any>(
   override val source: PreCommitEventPublisher,
-  override val entity: Any?,
+  override val entity: T?,
   val previousState: Array<out Any>?,
   val propertyNames: Array<out String>?,
 ) : ApplicationEvent(source),
-  EntityPreCommitEvent
+  EntityPreCommitEvent<T>,
+  ResolvableTypeProvider {
+  override fun getResolvableType(): ResolvableType = resolvableTypeFor(OnEntityPreUpdate::class.java, entity)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/events/entityPreCommitEventResolvableType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/entityPreCommitEventResolvableType.kt
@@ -1,0 +1,18 @@
+package io.tolgee.events
+
+import org.springframework.core.ResolvableType
+
+/**
+ * Builds the [ResolvableType] reported to Spring's event multicaster so that
+ * `@EventListener` parameters typed as e.g. `EntityPreCommitEvent<Key>` are only
+ * dispatched for matching entity classes. When the entity is null the type
+ * parameter cannot be resolved at runtime, so a wildcard type is returned and
+ * the event is delivered only to listeners declared on the raw supertype.
+ */
+internal fun resolvableTypeFor(
+  eventClass: Class<*>,
+  entity: Any?,
+): ResolvableType {
+  val entityClass = entity?.javaClass ?: return ResolvableType.forClass(eventClass)
+  return ResolvableType.forClassWithGenerics(eventClass, entityClass)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/util/entityPreCommitEventUsageUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/entityPreCommitEventUsageUtil.kt
@@ -7,17 +7,17 @@ import io.tolgee.events.OnEntityPreUpdate
 import io.tolgee.model.SoftDeletable
 import io.tolgee.model.translation.Translation
 
-fun EntityPreCommitEvent.getUsageIncreaseAmount(): Long {
+fun EntityPreCommitEvent<*>.getUsageIncreaseAmount(): Long {
   return when (this) {
-    is OnEntityPrePersist -> {
+    is OnEntityPrePersist<*> -> {
       1
     }
 
-    is OnEntityPreDelete -> {
+    is OnEntityPreDelete<*> -> {
       -1
     }
 
-    is OnEntityPreUpdate -> {
+    is OnEntityPreUpdate<*> -> {
       val softDeleteChange = getSoftDeleteUsageChange()
       if (softDeleteChange != 0L) return softDeleteChange
 
@@ -43,13 +43,14 @@ fun EntityPreCommitEvent.getUsageIncreaseAmount(): Long {
   }
 }
 
-private fun OnEntityPreUpdate.getSoftDeleteUsageChange(): Long {
-  if (entity !is SoftDeletable || propertyNames == null || previousState == null) return 0
+private fun OnEntityPreUpdate<*>.getSoftDeleteUsageChange(): Long {
+  val current = entity
+  if (current !is SoftDeletable || propertyNames == null || previousState == null) return 0
   val deletedAtIndex = propertyNames!!.indexOf("deletedAt")
   if (deletedAtIndex < 0) return 0
   @Suppress("UNCHECKED_CAST")
   val oldValue = (previousState as Array<Any?>)[deletedAtIndex]
-  val newValue = entity.deletedAt
+  val newValue = current.deletedAt
   return when {
     oldValue == null && newValue != null -> -1 // soft-delete
     oldValue != null && newValue == null -> 1 // restore

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/limitsAndReporting/EeKeyCountLimitListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/limitsAndReporting/EeKeyCountLimitListener.kt
@@ -35,8 +35,8 @@ class EeKeyCountLimitListener(
   private var keyCount: Long? = null
 
   @EventListener
-  fun onActivity(event: EntityPreCommitEvent) {
-    if (billingConfProvider().enabled || event.entity !is Key) {
+  fun onActivity(event: EntityPreCommitEvent<Key>) {
+    if (billingConfProvider().enabled) {
       return
     }
 


### PR DESCRIPTION
Make EntityPreCommitEvent and its concrete subclasses generic on the entity type and implement ResolvableTypeProvider so Spring's event multicaster filters listeners by the runtime entity class. Listeners declaring a specific entity type (e.g. EntityPreCommitEvent<Key>) are no longer invoked for unrelated entity writes, skipping transaction-scoped bean resolution and @Transactional proxy entry for entities they do not care about.

EeKeyCountLimitListener is narrowed to EntityPreCommitEvent<Key>.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced event system with improved type safety for event listeners and routing. Events now carry stronger type information, enabling more precise event handler matching and reducing potential type-related issues in event processing infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->