### PR TITLE
fix: speed up QA batch checks (branch copy, LT cache, chunk batching)

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/AbstractChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/AbstractChunkProcessor.kt
@@ -1,0 +1,12 @@
+package io.tolgee.batch
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.data.BatchJobDto
+
+abstract class AbstractChunkProcessor<RequestType, ParamsType, TargetItemType>(
+  private val objectMapper: ObjectMapper,
+) : ChunkProcessor<RequestType, ParamsType, TargetItemType> {
+  override fun getParams(job: BatchJobDto): ParamsType {
+    return objectMapper.convertValue(job.params, getParamsType())
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
@@ -384,6 +384,26 @@ class BatchJobService(
     return batchJobRepository.findAllByProjectId(projectId)
   }
 
+  fun hasActiveJobForProject(
+    projectId: Long,
+    type: BatchJobType,
+  ): Boolean {
+    return entityManager
+      .createQuery(
+        """
+        select count(j) > 0 from BatchJob j
+        where j.project.id = :projectId
+          and j.type = :type
+          and j.status not in :completedStatuses
+        """.trimIndent(),
+        java.lang.Boolean::class.java,
+      ).setParameter("projectId", projectId)
+      .setParameter("type", type)
+      .setParameter("completedStatuses", BatchJobStatus.entries.filter { it.completed })
+      .singleResult
+      .booleanValue()
+  }
+
   fun getExecutions(batchJobId: Long): List<BatchJobChunkExecution> {
     return entityManager
       .createQuery(

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessor.kt
@@ -1,6 +1,5 @@
 package io.tolgee.batch
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.tolgee.batch.data.BatchJobDto
 import java.util.Date
 import kotlin.coroutines.CoroutineContext
@@ -20,9 +19,7 @@ interface ChunkProcessor<RequestType, ParamsType, TargetItemType> {
 
   fun getParams(data: RequestType): ParamsType
 
-  fun getParams(job: BatchJobDto): ParamsType {
-    return jacksonObjectMapper().convertValue(job.params, getParamsType())
-  }
+  fun getParams(job: BatchJobDto): ParamsType
 
   fun getMaxPerJobConcurrency(): Int {
     return -1

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AbstractTranslationLabelChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AbstractTranslationLabelChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.LabelTranslationsRequest
@@ -12,7 +13,8 @@ import kotlin.coroutines.CoroutineContext
 abstract class AbstractTranslationLabelChunkProcessor(
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<LabelTranslationsRequest, TranslationLabelParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<LabelTranslationsRequest, TranslationLabelParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AiPlaygroundChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AiPlaygroundChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.JobCharacter
 import io.tolgee.batch.MtProviderCatching
 import io.tolgee.batch.ProgressManager
@@ -26,7 +27,8 @@ class AiPlaygroundChunkProcessor(
   private val aiPlaygroundResultService: AiPlaygroundResultService,
   private val mtProviderCatching: MtProviderCatching,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<MachineTranslationRequest, AiPlaygroundJobParams, BatchTranslationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<MachineTranslationRequest, AiPlaygroundJobParams, BatchTranslationTargetItem>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<BatchTranslationTargetItem>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AssignTranslationLabelChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AssignTranslationLabelChunkProcessor.kt
@@ -1,5 +1,6 @@
 package io.tolgee.batch.processors
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.tolgee.batch.ProgressManager
 import io.tolgee.service.label.LabelService
 import jakarta.persistence.EntityManager
@@ -10,7 +11,8 @@ class AssignTranslationLabelChunkProcessor(
   entityManager: EntityManager,
   progressManager: ProgressManager,
   private val labelService: LabelService,
-) : AbstractTranslationLabelChunkProcessor(entityManager, progressManager) {
+  objectMapper: ObjectMapper,
+) : AbstractTranslationLabelChunkProcessor(entityManager, progressManager, objectMapper) {
   override fun process(
     subChunk: List<Long>,
     languageIds: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.JobCharacter
 import io.tolgee.batch.MtProviderCatching
 import io.tolgee.batch.ProgressManager
@@ -19,7 +20,8 @@ class AutoTranslateChunkProcessor(
   private val mtProviderCatching: MtProviderCatching,
   private val batchProperties: BatchProperties,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<AutoTranslationRequest, AutoTranslationJobParams, BatchTranslationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<AutoTranslationRequest, AutoTranslationJobParams, BatchTranslationTargetItem>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<BatchTranslationTargetItem>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutomationChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutomationChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.data.AutomationTargetItem
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.AutomationBjRequest
@@ -12,7 +13,8 @@ import kotlin.coroutines.CoroutineContext
 @Component
 class AutomationChunkProcessor(
   private val automationRunner: AutomationRunner,
-) : ChunkProcessor<AutomationBjRequest, AutomationBjParams, AutomationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<AutomationBjRequest, AutomationBjParams, AutomationTargetItem>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<AutomationTargetItem>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/ClearTranslationsChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/ClearTranslationsChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.ClearTranslationsRequest
@@ -16,7 +17,8 @@ class ClearTranslationsChunkProcessor(
   private val translationService: TranslationService,
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<ClearTranslationsRequest, ClearTranslationsJobParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<ClearTranslationsRequest, ClearTranslationsJobParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/CopyTranslationsChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/CopyTranslationsChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.CopyTranslationRequest
@@ -16,7 +17,8 @@ class CopyTranslationsChunkProcessor(
   private val translationService: TranslationService,
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<CopyTranslationRequest, CopyTranslationJobParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<CopyTranslationRequest, CopyTranslationJobParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/DeleteKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/DeleteKeysChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.DeleteKeysRequest
@@ -17,7 +18,8 @@ class DeleteKeysChunkProcessor(
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
   private val userAccountService: UserAccountService,
-) : ChunkProcessor<DeleteKeysRequest, Any?, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<DeleteKeysRequest, Any?, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/HardDeleteKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/HardDeleteKeysChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.HardDeleteKeysRequest
@@ -15,7 +16,8 @@ class HardDeleteKeysChunkProcessor(
   private val keyService: KeyService,
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<HardDeleteKeysRequest, Any?, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<HardDeleteKeysRequest, Any?, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/MachineTranslationChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/MachineTranslationChunkProcessor.kt
@@ -1,22 +1,24 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.JobCharacter
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.MachineTranslationRequest
 import io.tolgee.configuration.tolgee.BatchProperties
 import io.tolgee.model.batch.params.MachineTranslationJobParams
-import io.tolgee.service.machineTranslation.MtServiceConfigService
 import org.springframework.stereotype.Component
 import kotlin.coroutines.CoroutineContext
 
 @Component
 class MachineTranslationChunkProcessor(
   private val genericAutoTranslationChunkProcessor: GenericAutoTranslationChunkProcessor,
-  private val mtServiceConfigService: MtServiceConfigService,
   private val batchProperties: BatchProperties,
-) : ChunkProcessor<MachineTranslationRequest, MachineTranslationJobParams, BatchTranslationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<MachineTranslationRequest, MachineTranslationJobParams, BatchTranslationTargetItem>(
+    objectMapper,
+  ) {
   override fun process(
     job: BatchJobDto,
     chunk: List<BatchTranslationTargetItem>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/NoOpChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/NoOpChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.NoOpRequest
@@ -10,7 +11,8 @@ import kotlin.coroutines.CoroutineContext
 @Component
 class NoOpChunkProcessor(
   private val progressManager: ProgressManager,
-) : ChunkProcessor<NoOpRequest, Any?, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<NoOpRequest, Any?, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/PreTranslationByTmChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.PreTranslationByTmRequest
@@ -11,7 +12,10 @@ import kotlin.coroutines.CoroutineContext
 @Component
 class PreTranslationByTmChunkProcessor(
   private val genericAutoTranslationChunkProcessor: GenericAutoTranslationChunkProcessor,
-) : ChunkProcessor<PreTranslationByTmRequest, PreTranslationByTmJobParams, BatchTranslationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<PreTranslationByTmRequest, PreTranslationByTmJobParams, BatchTranslationTargetItem>(
+    objectMapper,
+  ) {
   override fun process(
     job: BatchJobDto,
     chunk: List<BatchTranslationTargetItem>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
@@ -55,7 +55,7 @@ class QaCheckChunkProcessor(
   override fun getChunkSize(
     request: QaCheckRequest,
     projectId: Long?,
-  ): Int = 1000
+  ): Int = 100
 
   override fun getJobCharacter(
     request: QaCheckRequest,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
@@ -7,7 +7,6 @@ import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.model.batch.params.QaCheckJobParams
-import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.service.qa.QaCheckBatchService
 import kotlinx.coroutines.ensureActive
 import org.springframework.stereotype.Component
@@ -25,15 +24,20 @@ class QaCheckChunkProcessor(
   ) {
     val params = getParams(job)
     val projectId = job.projectId ?: throw IllegalArgumentException("Project id is required")
-    val enabledCheckTypesCache = mutableMapOf<Long, Set<QaCheckType>>()
-    chunk.forEach { (keyId, languageId) ->
+    val isSlow = params.checkTypes?.any { it.isSlow } ?: true
+
+    coroutineContext.ensureActive()
+
+    qaCheckBatchService.runChecksAndPersistChunk(
+      projectId = projectId,
+      checkTypes = params.checkTypes,
+      items = chunk,
+    ) {
+      // progress callback
       coroutineContext.ensureActive()
-      val enabledCheckTypes =
-        enabledCheckTypesCache.getOrPut(languageId) {
-          qaCheckBatchService.getEnabledCheckTypesForLanguage(projectId, languageId)
-        }
-      qaCheckBatchService.runChecksAndPersist(projectId, keyId, languageId, params.checkTypes, enabledCheckTypes)
-      progressManager.reportSingleChunkProgress(job.id)
+      if (isSlow) {
+        progressManager.reportSingleChunkProgress(job.id)
+      }
     }
   }
 
@@ -51,7 +55,7 @@ class QaCheckChunkProcessor(
   override fun getChunkSize(
     request: QaCheckRequest,
     projectId: Long?,
-  ): Int = 100
+  ): Int = 1000
 
   override fun getJobCharacter(
     request: QaCheckRequest,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.JobCharacter
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
@@ -16,7 +17,8 @@ import kotlin.coroutines.CoroutineContext
 class QaCheckChunkProcessor(
   private val qaCheckBatchService: QaCheckBatchService,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<QaCheckRequest, QaCheckJobParams, BatchTranslationTargetItem> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<QaCheckRequest, QaCheckJobParams, BatchTranslationTargetItem>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<BatchTranslationTargetItem>,
@@ -46,6 +48,7 @@ class QaCheckChunkProcessor(
   override fun getParams(data: QaCheckRequest): QaCheckJobParams =
     QaCheckJobParams().apply {
       checkTypes = data.checkTypes
+      handlingStuckStaleItems = data.handlingStuckStaleItems
     }
 
   override fun getParamsType(): Class<QaCheckJobParams> = QaCheckJobParams::class.java

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/RestoreKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/RestoreKeysChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.FailedDontRequeueException
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
@@ -18,7 +19,8 @@ class RestoreKeysChunkProcessor(
   private val keyService: KeyService,
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<RestoreKeysRequest, Any?, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<RestoreKeysRequest, Any?, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetKeysNamespaceChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetKeysNamespaceChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.FailedDontRequeueException
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
@@ -19,7 +20,8 @@ class SetKeysNamespaceChunkProcessor(
   private val entityManager: EntityManager,
   private val keyService: KeyService,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<SetKeysNamespaceRequest, SetKeysNamespaceParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<SetKeysNamespaceRequest, SetKeysNamespaceParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetTranslationsStateChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/SetTranslationsStateChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.SetTranslationsStateStateRequest
@@ -16,7 +17,8 @@ class SetTranslationsStateChunkProcessor(
   private val translationService: TranslationService,
   private val entityManager: EntityManager,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<SetTranslationsStateStateRequest, SetTranslationStateJobParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<SetTranslationsStateStateRequest, SetTranslationStateJobParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.TagKeysRequest
@@ -16,7 +17,8 @@ class TagKeysChunkProcessor(
   private val entityManager: EntityManager,
   private val tagService: TagService,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<TagKeysRequest, TagKeysParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<TagKeysRequest, TagKeysParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/UnassignTranslationLabelChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/UnassignTranslationLabelChunkProcessor.kt
@@ -1,5 +1,6 @@
 package io.tolgee.batch.processors
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.tolgee.batch.ProgressManager
 import io.tolgee.service.label.LabelService
 import jakarta.persistence.EntityManager
@@ -10,7 +11,8 @@ class UnassignTranslationLabelChunkProcessor(
   entityManager: EntityManager,
   progressManager: ProgressManager,
   private val labelService: LabelService,
-) : AbstractTranslationLabelChunkProcessor(entityManager, progressManager) {
+  objectMapper: ObjectMapper,
+) : AbstractTranslationLabelChunkProcessor(entityManager, progressManager, objectMapper) {
   override fun process(
     subChunk: List<Long>,
     languageIds: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
@@ -1,6 +1,7 @@
 package io.tolgee.batch.processors
 
-import io.tolgee.batch.ChunkProcessor
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.batch.AbstractChunkProcessor
 import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchJobDto
 import io.tolgee.batch.request.UntagKeysRequest
@@ -16,7 +17,8 @@ class UntagKeysChunkProcessor(
   private val entityManager: EntityManager,
   private val tagService: TagService,
   private val progressManager: ProgressManager,
-) : ChunkProcessor<UntagKeysRequest, UntagKeysParams, Long> {
+  objectMapper: ObjectMapper,
+) : AbstractChunkProcessor<UntagKeysRequest, UntagKeysParams, Long>(objectMapper) {
   override fun process(
     job: BatchJobDto,
     chunk: List<Long>,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/request/QaCheckRequest.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/request/QaCheckRequest.kt
@@ -6,4 +6,5 @@ import io.tolgee.model.enums.qa.QaCheckType
 data class QaCheckRequest(
   val target: List<BatchTranslationTargetItem>,
   val checkTypes: List<QaCheckType>? = null,
+  val handlingStuckStaleItems: Boolean = false,
 )

--- a/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
@@ -21,6 +21,7 @@ interface Caches {
     const val ORGANIZATION_ROLES = "organizationRoles"
     const val SSO_TENANTS = "ssoTenants"
     const val LLM_PROVIDERS = "llmProviders"
+    const val LANGUAGE_TOOL_RESULTS = "languageToolResults"
 
     const val EE_LAST_REPORTED_USAGE = "eeLastReportedUsage"
 
@@ -44,6 +45,7 @@ interface Caches {
         SSO_TENANTS,
         EE_LAST_REPORTED_USAGE,
         LLM_PROVIDERS,
+        LANGUAGE_TOOL_RESULTS,
       )
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BranchCopyQaIssuesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BranchCopyQaIssuesTestData.kt
@@ -15,9 +15,13 @@ class BranchCopyQaIssuesTestData : BaseTestData("branch-copy-qa", "Branch copy Q
   lateinit var openIssue: TranslationQaIssue
   lateinit var virtualIgnoredIssue: TranslationQaIssue
 
+  lateinit var staleKey: Key
+  lateinit var staleEnglishTranslation: Translation
+
   init {
     projectBuilder.apply {
       self.useBranching = true
+      self.useQaChecks = true
       addBranch {
         name = "main"
         project = projectBuilder.self
@@ -52,6 +56,19 @@ class BranchCopyQaIssuesTestData : BaseTestData("branch-copy-qa", "Branch copy Q
           }.build {
             virtualIgnoredIssue = self
           }
+        }
+      }
+      addKey {
+        name = "stale-greeting"
+        branch = defaultBranch
+      }.build {
+        staleKey = self
+        addTranslation {
+          language = englishLanguage
+          text = "Hi."
+          qaChecksStale = true
+        }.build {
+          staleEnglishTranslation = self
         }
       }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BranchCopyQaIssuesTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BranchCopyQaIssuesTestData.kt
@@ -1,0 +1,59 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.branching.Branch
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueMessage
+import io.tolgee.model.enums.qa.QaIssueState
+import io.tolgee.model.key.Key
+import io.tolgee.model.qa.TranslationQaIssue
+import io.tolgee.model.translation.Translation
+
+class BranchCopyQaIssuesTestData : BaseTestData("branch-copy-qa", "Branch copy QA test") {
+  lateinit var defaultBranch: Branch
+  lateinit var key: Key
+  lateinit var englishTranslation: Translation
+  lateinit var openIssue: TranslationQaIssue
+  lateinit var virtualIgnoredIssue: TranslationQaIssue
+
+  init {
+    projectBuilder.apply {
+      self.useBranching = true
+      addBranch {
+        name = "main"
+        project = projectBuilder.self
+        isProtected = true
+        isDefault = true
+      }.build {
+        defaultBranch = self
+      }
+      addKey {
+        name = "greeting"
+        branch = defaultBranch
+      }.build {
+        key = self
+        addTranslation {
+          language = englishLanguage
+          text = "Hello world."
+          qaChecksStale = false
+        }.build {
+          englishTranslation = self
+          addQaIssue {
+            type = QaCheckType.PUNCTUATION_MISMATCH
+            message = QaIssueMessage.QA_PUNCTUATION_ADD
+            state = QaIssueState.OPEN
+          }.build {
+            openIssue = self
+          }
+          addQaIssue {
+            type = QaCheckType.CHARACTER_CASE_MISMATCH
+            message = QaIssueMessage.QA_CASE_CAPITALIZE
+            state = QaIssueState.IGNORED
+            virtual = true
+          }.build {
+            virtualIgnoredIssue = self
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/batch/params/QaCheckJobParams.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/batch/params/QaCheckJobParams.kt
@@ -3,5 +3,8 @@ package io.tolgee.model.batch.params
 import io.tolgee.model.enums.qa.QaCheckType
 
 class QaCheckJobParams {
+  /**
+   * null -> all checks
+   */
   var checkTypes: List<QaCheckType>? = null
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/batch/params/QaCheckJobParams.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/batch/params/QaCheckJobParams.kt
@@ -7,4 +7,5 @@ class QaCheckJobParams {
    * null -> all checks
    */
   var checkTypes: List<QaCheckType>? = null
+  var handlingStuckStaleItems: Boolean = false
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaCheckType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/qa/QaCheckType.kt
@@ -2,31 +2,32 @@ package io.tolgee.model.enums.qa
 
 enum class QaCheckType(
   val defaultSeverity: QaCheckSeverity,
+  val isSlow: Boolean,
 ) {
   // TEXT category — checks about the quality of the translated text.
   // SPELLING and GRAMMAR are intentionally kept as the last two entries of this group.
-  EMPTY_TRANSLATION(QaCheckSeverity.WARNING),
-  MISSING_PLURAL_CATEGORIES(QaCheckSeverity.WARNING),
-  CHARACTER_CASE_MISMATCH(QaCheckSeverity.WARNING),
-  REPEATED_WORDS(QaCheckSeverity.WARNING),
-  PUNCTUATION_MISMATCH(QaCheckSeverity.WARNING),
-  TRIM_CHECK(QaCheckSeverity.WARNING),
-  SPACES_MISMATCH(QaCheckSeverity.WARNING),
-  UNMATCHED_NEWLINES(QaCheckSeverity.WARNING),
-  MISSING_NUMBERS(QaCheckSeverity.WARNING),
-  SPECIAL_CHARACTER_MISMATCH(QaCheckSeverity.WARNING),
-  BRACKETS_MISMATCH(QaCheckSeverity.WARNING),
-  BRACKETS_UNBALANCED(QaCheckSeverity.WARNING),
-  SPELLING(QaCheckSeverity.OFF),
-  GRAMMAR(QaCheckSeverity.OFF),
+  EMPTY_TRANSLATION(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  MISSING_PLURAL_CATEGORIES(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  CHARACTER_CASE_MISMATCH(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  REPEATED_WORDS(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  PUNCTUATION_MISMATCH(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  TRIM_CHECK(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  SPACES_MISMATCH(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  UNMATCHED_NEWLINES(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  MISSING_NUMBERS(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  SPECIAL_CHARACTER_MISMATCH(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  BRACKETS_MISMATCH(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  BRACKETS_UNBALANCED(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  SPELLING(defaultSeverity = QaCheckSeverity.OFF, isSlow = true),
+  GRAMMAR(defaultSeverity = QaCheckSeverity.OFF, isSlow = true),
 
   // TECHNICAL category — checks for technical correctness.
-  KEY_LENGTH_LIMIT(QaCheckSeverity.WARNING),
-  DIFFERENT_URLS(QaCheckSeverity.WARNING),
-  INCONSISTENT_PLACEHOLDERS(QaCheckSeverity.WARNING),
-  INCONSISTENT_HTML(QaCheckSeverity.WARNING),
-  HTML_SYNTAX(QaCheckSeverity.WARNING),
-  ICU_SYNTAX(QaCheckSeverity.WARNING),
+  KEY_LENGTH_LIMIT(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  DIFFERENT_URLS(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  INCONSISTENT_PLACEHOLDERS(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  INCONSISTENT_HTML(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  HTML_SYNTAX(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
+  ICU_SYNTAX(defaultSeverity = QaCheckSeverity.WARNING, isSlow = false),
   ;
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -215,9 +215,6 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     languagesIds: List<Long>,
   ): List<Translation>
 
-  /**
-   * Eagerly fetches `key` and `language`
-   */
   @Query(
     """
     from Translation t

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -248,6 +248,17 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
 
   @Query(
     """
+    select new io.tolgee.dtos.queryResults.qa.KeyLanguagePairView(k.id, t.language.id)
+    from Translation t
+    join t.key k
+    where k.project.id = :projectId
+      and t.qaChecksStale = true
+    """,
+  )
+  fun getStaleKeyLanguagePairsByProject(projectId: Long): List<KeyLanguagePairView>
+
+  @Query(
+    """
     from Translation t
     join t.key k
     where k.project.id = :projectId

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -214,9 +214,20 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     languagesIds: List<Long>,
   ): List<Translation>
 
-  fun getAllByKeyIdInAndLanguageIdIn(
-    keyIds: List<Long>,
-    languageIds: List<Long>,
+  /**
+   * Eagerly fetches `key` and `language`
+   */
+  @Query(
+    """
+    from Translation t
+    join fetch t.key
+    join fetch t.language
+    where t.key.id in :keyIds and t.language.id in :languageIds
+    """,
+  )
+  fun findAllWithKeyAndLanguageByKeyIdInAndLanguageIdIn(
+    keyIds: Collection<Long>,
+    languageIds: Collection<Long>,
   ): List<Translation>
 
   @Query(

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -1,5 +1,6 @@
 package io.tolgee.repository
 
+import io.tolgee.dtos.queryResults.qa.KeyLanguagePairView
 import io.tolgee.jobs.migration.translationStats.StatsMigrationTranslationView
 import io.tolgee.model.Project
 import io.tolgee.model.key.Key
@@ -229,6 +230,21 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     keyIds: Collection<Long>,
     languageIds: Collection<Long>,
   ): List<Translation>
+
+  @Query(
+    """
+    select new io.tolgee.dtos.queryResults.qa.KeyLanguagePairView(k.id, t.language.id)
+    from Translation t
+    join t.key k
+    where k.project.id = :projectId
+      and k.branch.id = :branchId
+      and t.qaChecksStale = true
+    """,
+  )
+  fun getStaleKeyLanguagePairsByBranch(
+    projectId: Long,
+    branchId: Long,
+  ): List<KeyLanguagePairView>
 
   @Query(
     """

--- a/backend/data/src/main/kotlin/io/tolgee/repository/qa/TranslationQaIssueRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/qa/TranslationQaIssueRepository.kt
@@ -77,6 +77,18 @@ interface TranslationQaIssueRepository : JpaRepository<TranslationQaIssue, Long>
   )
   fun findByTranslationIds(translationIds: Collection<Long>): List<TranslationQaIssue>
 
+  @Query(
+    """
+    select i from TranslationQaIssue i
+    where i.translation.id in :translationIds
+    and i.type in :checkTypes
+    """,
+  )
+  fun findByTranslationIdsAndCheckTypes(
+    translationIds: Collection<Long>,
+    checkTypes: List<QaCheckType>,
+  ): List<TranslationQaIssue>
+
   fun findAllByTranslationId(translationId: Long): List<TranslationQaIssue>
 
   fun findAllByTranslationIdIn(translationIds: Collection<Long>): List<TranslationQaIssue>

--- a/backend/data/src/main/kotlin/io/tolgee/repository/qa/TranslationQaIssueRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/qa/TranslationQaIssueRepository.kt
@@ -75,29 +75,11 @@ interface TranslationQaIssueRepository : JpaRepository<TranslationQaIssue, Long>
     where i.translation.id in :translationIds
     """,
   )
-  fun findByTranslationIds(translationIds: List<Long>): List<TranslationQaIssue>
+  fun findByTranslationIds(translationIds: Collection<Long>): List<TranslationQaIssue>
 
   fun findAllByTranslationId(translationId: Long): List<TranslationQaIssue>
 
-  @Modifying
-  @Query("delete from TranslationQaIssue i where i.translation.id = :translationId")
-  fun deleteAllByTranslationId(translationId: Long)
-
-  @Modifying
-  @Query("delete from TranslationQaIssue i where i.translation.id in :translationIds")
-  fun deleteAllByTranslationIdIn(translationIds: Collection<Long>)
-
-  @Modifying
-  @Query(
-    nativeQuery = true,
-    value =
-      "DELETE FROM translation_qa_issue WHERE translation_id IN (" +
-        "SELECT id FROM translation WHERE " +
-        "key_id IN (SELECT id FROM key WHERE project_id = :projectId) " +
-        "OR language_id IN (SELECT id FROM language WHERE project_id = :projectId)" +
-        ")",
-  )
-  fun deleteAllByProjectId(projectId: Long)
+  fun findAllByTranslationIdIn(translationIds: Collection<Long>): List<TranslationQaIssue>
 
   @Query(
     """
@@ -154,4 +136,27 @@ interface TranslationQaIssueRepository : JpaRepository<TranslationQaIssue, Long>
     positionEnd: Int?,
     pluralVariant: String?,
   ): TranslationQaIssue?
+
+  @Modifying
+  @Query("delete from TranslationQaIssue i where i.translation.id in :translationIds")
+  fun deleteAllByTranslationIdIn(translationIds: Collection<Long>)
+
+  @Modifying
+  @Query("delete from TranslationQaIssue i where i.translation.id in :translationIds and i.type in :types")
+  fun deleteAllByTranslationIdInAndTypeIn(
+    translationIds: Collection<Long>,
+    types: Collection<QaCheckType>,
+  )
+
+  @Modifying
+  @Query(
+    nativeQuery = true,
+    value =
+      "DELETE FROM translation_qa_issue WHERE translation_id IN (" +
+        "SELECT id FROM translation WHERE " +
+        "key_id IN (SELECT id FROM key WHERE project_id = :projectId) " +
+        "OR language_id IN (SELECT id FROM language WHERE project_id = :projectId)" +
+        ")",
+  )
+  fun deleteAllByProjectId(projectId: Long)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
@@ -416,7 +416,10 @@ class LanguageService(
     )
   }
 
-  fun findByIdIn(ids: Iterable<Long>): List<Language> {
+  fun findByIdIn(ids: Collection<Long>): List<Language> {
+    if (ids.isEmpty()) {
+      return emptyList()
+    }
     return languageRepository.findAllById(ids)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
@@ -416,10 +416,7 @@ class LanguageService(
     )
   }
 
-  fun findByIdIn(ids: Collection<Long>): List<Language> {
-    if (ids.isEmpty()) {
-      return emptyList()
-    }
+  fun findByIdIn(ids: Iterable<Long>): List<Language> {
     return languageRepository.findAllById(ids)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/qa/QaCheckBatchService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/qa/QaCheckBatchService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.qa
 
+import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.model.enums.qa.QaCheckType
 
 interface QaCheckBatchService {
@@ -8,15 +9,12 @@ interface QaCheckBatchService {
     keyId: Long,
     languageId: Long,
     checkTypes: List<QaCheckType>? = null,
-    enabledCheckTypes: Set<QaCheckType>? = null,
   )
 
-  /**
-   * Returns the set of QA check types enabled for a given language in a project,
-   * resolving per-language overrides against the project-level config.
-   */
-  fun getEnabledCheckTypesForLanguage(
+  fun runChecksAndPersistChunk(
     projectId: Long,
-    languageId: Long,
-  ): Set<QaCheckType> = emptySet()
+    checkTypes: List<QaCheckType>? = null,
+    items: List<BatchTranslationTargetItem>,
+    progressCallback: () -> Unit = {},
+  )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/qa/QaCheckBatchServiceOssStub.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/qa/QaCheckBatchServiceOssStub.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.qa
 
+import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.model.enums.qa.QaCheckType
 import org.springframework.stereotype.Service
 
@@ -10,13 +11,16 @@ class QaCheckBatchServiceOssStub : QaCheckBatchService {
     keyId: Long,
     languageId: Long,
     checkTypes: List<QaCheckType>?,
-    enabledCheckTypes: Set<QaCheckType>?,
   ) {
     // No-op: QA checks are an EE feature
   }
 
-  override fun getEnabledCheckTypesForLanguage(
+  override fun runChecksAndPersistChunk(
     projectId: Long,
-    languageId: Long,
-  ): Set<QaCheckType> = emptySet()
+    checkTypes: List<QaCheckType>?,
+    items: List<BatchTranslationTargetItem>,
+    progressCallback: () -> Unit,
+  ) {
+    // No-op: QA checks are an EE feature
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -690,6 +690,14 @@ class TranslationService(
   }
 
   @Transactional(readOnly = true)
+  fun getStaleKeyLanguagePairsByBranch(
+    projectId: Long,
+    branchId: Long,
+  ): List<KeyLanguagePairView> {
+    return translationRepository.getStaleKeyLanguagePairsByBranch(projectId, branchId)
+  }
+
+  @Transactional(readOnly = true)
   fun getKeyLanguagePairsForQaRecheck(
     projectId: Long,
     languageIds: List<Long>? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -478,7 +478,7 @@ class TranslationService(
   fun getTranslations(
     keyIds: List<Long>,
     languageIds: List<Long>,
-  ) = translationRepository.getAllByKeyIdInAndLanguageIdIn(keyIds, languageIds)
+  ) = translationRepository.findAllByKeyIdInAndLanguageIdIn(keyIds, languageIds)
 
   @Transactional(readOnly = true)
   fun getAllByKeyId(keyId: Long): List<Translation> = translationRepository.getAllByKeyIdIn(listOf(keyId)).toList()

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -698,6 +698,11 @@ class TranslationService(
   }
 
   @Transactional(readOnly = true)
+  fun getStaleKeyLanguagePairsByProject(projectId: Long): List<KeyLanguagePairView> {
+    return translationRepository.getStaleKeyLanguagePairsByProject(projectId)
+  }
+
+  @Transactional(readOnly = true)
   fun getKeyLanguagePairsForQaRecheck(
     projectId: Long,
     languageIds: List<Long>? = null,

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5591,4 +5591,17 @@
             <sql>DROP INDEX CONCURRENTLY IF EXISTS ix_tm_entry_lower_target_trgm;</sql>
         </rollback>
     </changeSet>
+    <changeSet author="anty" id="qa-batch-perf-translation-stale-partial-idx">
+        <comment>
+            Partial index for stale-translation lookups.
+        </comment>
+        <sql>
+            CREATE INDEX IF NOT EXISTS translation_qa_checks_stale_partial_idx
+            ON translation (key_id)
+            WHERE qa_checks_stale = true
+        </sql>
+        <rollback>
+            DROP INDEX IF EXISTS translation_qa_checks_stale_partial_idx
+        </rollback>
+    </changeSet>
 </databaseChangeLog>

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5591,17 +5591,17 @@
             <sql>DROP INDEX CONCURRENTLY IF EXISTS ix_tm_entry_lower_target_trgm;</sql>
         </rollback>
     </changeSet>
-    <changeSet author="anty" id="qa-batch-perf-translation-stale-partial-idx">
+    <changeSet author="anty" id="qa-batch-perf-translation-stale-partial-idx" runInTransaction="false">
         <comment>
             Partial index for stale-translation lookups.
         </comment>
-        <sql>
-            CREATE INDEX IF NOT EXISTS translation_qa_checks_stale_partial_idx
+        <sql dbms="postgresql">
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS translation_qa_checks_stale_partial_idx
             ON translation (key_id)
-            WHERE qa_checks_stale = true
+            WHERE qa_checks_stale = true;
         </sql>
         <rollback>
-            DROP INDEX IF EXISTS translation_qa_checks_stale_partial_idx
+            DROP INDEX CONCURRENTLY IF EXISTS translation_qa_checks_stale_partial_idx;
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/backend/data/src/test/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/processors/QaCheckChunkProcessorTest.kt
@@ -1,10 +1,8 @@
 package io.tolgee.batch.processors
 
 import io.tolgee.batch.JobCharacter
-import io.tolgee.batch.ProgressManager
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.QaCheckRequest
-import io.tolgee.service.qa.QaCheckBatchService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -12,8 +10,9 @@ import org.mockito.kotlin.mock
 class QaCheckChunkProcessorTest {
   private val processor =
     QaCheckChunkProcessor(
-      qaCheckBatchService = mock<QaCheckBatchService>(),
-      progressManager = mock<ProgressManager>(),
+      qaCheckBatchService = mock(),
+      progressManager = mock(),
+      objectMapper = mock(),
     )
 
   private fun request(targetSize: Int): QaCheckRequest =

--- a/ee/backend/app/build.gradle
+++ b/ee/backend/app/build.gradle
@@ -59,6 +59,10 @@ dependencies {
     implementation libs.springDocOpenApiUi
     implementation libs.springDocOpenApiCommon
 
+    /**
+     * DB
+     */
+    implementation 'org.postgresql:postgresql'
 
     /**
      * MISC

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -6,6 +6,7 @@ import io.tolgee.batch.BatchJobService
 import io.tolgee.batch.data.BatchJobType
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.events.OnBatchJobFinalized
+import io.tolgee.batch.processors.QaCheckChunkProcessor
 import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
 import io.tolgee.component.eventListeners.BypassableActivityListener
@@ -47,6 +48,7 @@ class QaActivityListener(
   private val translationService: TranslationService,
   private val qaRecheckService: QaRecheckService,
   private val enabledFeaturesProvider: EnabledFeaturesProvider,
+  private val qaCheckChunkProcessor: QaCheckChunkProcessor,
 ) : BypassableActivityListener {
   @Volatile
   override var bypass = false
@@ -104,6 +106,11 @@ class QaActivityListener(
     if (bypass) return
     if (event.job.type != BatchJobType.QA_CHECK) return
     val projectId = event.job.projectId ?: return
+    val params = qaCheckChunkProcessor.getParams(event.job)
+    if (params.handlingStuckStaleItems) {
+      // Avoid endless loop
+      return
+    }
     runSentryCatching {
       qaRecheckService.recheckStuckStaleTranslationsInProject(projectId)
     }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -191,8 +191,10 @@ class QaActivityListener(
             .getProjectLanguages(projectId)
             .map { it.id }
             .filter { it != baseLanguage.id }
-        baseLanguageKeyIds.flatMap { keyId ->
-          otherLanguageIds.map { langId -> BatchTranslationTargetItem(keyId = keyId, languageId = langId) }
+        otherLanguageIds.flatMap { langId ->
+          baseLanguageKeyIds.map { keyId ->
+            BatchTranslationTargetItem(keyId = keyId, languageId = langId)
+          }
         }
       } else {
         emptyList()
@@ -227,8 +229,10 @@ class QaActivityListener(
     if (keyIds.isEmpty()) return emptyList()
 
     val allLanguageIds = languageService.getProjectLanguages(projectId).map { it.id }
-    return keyIds.flatMap { keyId ->
-      allLanguageIds.map { langId -> BatchTranslationTargetItem(keyId = keyId, languageId = langId) }
+    return allLanguageIds.flatMap { langId ->
+      keyIds.map { keyId ->
+        BatchTranslationTargetItem(keyId = keyId, languageId = langId)
+      }
     }
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -99,6 +99,16 @@ class QaActivityListener(
     }
   }
 
+  @EventListener
+  fun onQaBatchJobFinalizedSelfHeal(event: OnBatchJobFinalized) {
+    if (bypass) return
+    if (event.job.type != BatchJobType.QA_CHECK) return
+    val projectId = event.job.projectId ?: return
+    runSentryCatching {
+      qaRecheckService.recheckStuckStaleTranslationsInProject(projectId)
+    }
+  }
+
   // endregion
 
   // region Batch job processing (feature-gated)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -175,6 +175,14 @@ class QaTestData(
     }
   }
 
+  fun clearAllStaleFlags() {
+    projectBuilder.data.translations.forEach { it.self.qaChecksStale = false }
+  }
+
+  fun disableQaChecks() {
+    project.useQaChecks = false
+  }
+
   /**
    * Creates QA config with all check types enabled at WARNING, except SPELLING and GRAMMAR
    * which are OFF (they depend on an external LanguageTool container).

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCopyServiceSql.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchCopyServiceSql.kt
@@ -101,6 +101,10 @@ class BranchCopyServiceSql(
       traceLogMeasureTime("branchCopyService: copyTranslationComments batch $batchIndex") {
         copyTranslationComments(targetBranch)
       }
+
+      traceLogMeasureTime("branchCopyService: copyTranslationQaIssues batch $batchIndex") {
+        copyTranslationQaIssues(targetBranch)
+      }
     }
   }
 
@@ -325,20 +329,44 @@ class BranchCopyServiceSql(
 
   /**
    * Copies translations using the pre-computed key mapping.
-   * Much simpler and faster than the original 4-way join.
    */
   private fun copyTranslations(targetBranch: Branch) {
     val sql = """
       INSERT INTO translation (
-        id, text, key_id, language_id, state, auto, mt_provider, 
-        word_count, character_count, outdated, created_at, updated_at
+        id, text, key_id, language_id, state, auto, mt_provider,
+        word_count, character_count, outdated, qa_checks_stale, created_at, updated_at
       )
       SELECT nextval('hibernate_sequence') AS id,
              t.text, m.target_key_id, t.language_id, t.state, t.auto, t.mt_provider,
-             t.word_count, t.character_count, t.outdated, 
+             t.word_count, t.character_count, t.outdated, t.qa_checks_stale,
              :targetBranchCreatedAt, :targetBranchCreatedAt
       FROM translation t
       JOIN temp_key_mapping m ON m.source_key_id = t.key_id
+    """
+    entityManager
+      .createNativeQuery(sql)
+      .setParameter("targetBranchCreatedAt", targetBranch.createdAt)
+      .executeUpdate()
+  }
+
+  /**
+   * Copies QA issues using the pre-computed key mapping.
+   */
+  private fun copyTranslationQaIssues(targetBranch: Branch) {
+    val sql = """
+      INSERT INTO translation_qa_issue (
+        id, type, message, replacement, position_start, position_end, state, params,
+        virtual, plural_variant, translation_id, created_at, updated_at
+      )
+      SELECT nextval('hibernate_sequence') AS id,
+             qi.type, qi.message, qi.replacement, qi.position_start, qi.position_end,
+             qi.state, qi.params, qi.virtual, qi.plural_variant, tgt_t.id,
+             :targetBranchCreatedAt, :targetBranchCreatedAt
+      FROM translation_qa_issue qi
+      JOIN translation src_t ON src_t.id = qi.translation_id
+      JOIN temp_key_mapping m ON m.source_key_id = src_t.key_id
+      JOIN translation tgt_t ON tgt_t.key_id = m.target_key_id
+                            AND tgt_t.language_id = src_t.language_id
     """
     entityManager
       .createNativeQuery(sql)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -12,6 +12,7 @@ import io.tolgee.dtos.request.branching.ResolveAllBranchMergeConflictsRequest
 import io.tolgee.dtos.request.branching.ResolveBranchMergeConflictRequest
 import io.tolgee.ee.repository.branching.BranchRepository
 import io.tolgee.ee.service.TaskService
+import io.tolgee.ee.service.qa.QaRecheckService
 import io.tolgee.events.OnBranchSoftDeleted
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
@@ -26,6 +27,7 @@ import io.tolgee.service.branching.AbstractBranchService
 import io.tolgee.service.branching.BranchCopyService
 import jakarta.persistence.EntityManager
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.annotation.Primary
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -47,6 +49,8 @@ class BranchServiceImpl(
   private val activityHolder: ActivityHolder,
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val metrics: Metrics,
+  @Lazy
+  private val qaRecheckService: QaRecheckService,
 ) : AbstractBranchService(branchRepository, branchMergeService) {
   override fun getBranches(
     projectId: Long,
@@ -128,6 +132,9 @@ class BranchServiceImpl(
 
       branchCopyService.copy(projectId, originBranch, branch)
       branchSnapshotService.createInitialSnapshot(projectId, originBranch, branch)
+
+      qaRecheckService.recheckStaleTranslationsOnBranch(projectId, branch.id)
+
       branch
     }!!
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -45,7 +45,6 @@ class BranchServiceImpl(
   private val authenticationFacade: AuthenticationFacade,
   private val projectBranchingMigrationService: ProjectBranchingMigrationService,
   private val activityHolder: ActivityHolder,
-  private val branchCleanupService: BranchCleanupService,
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val metrics: Metrics,
 ) : AbstractBranchService(branchRepository, branchMergeService) {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClient.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClient.kt
@@ -1,0 +1,134 @@
+package io.tolgee.ee.service.qa
+
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.constants.Caches
+import io.tolgee.util.logger
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.getForObject
+import org.springframework.web.client.postForObject
+import java.time.Duration
+import java.util.concurrent.Semaphore
+
+@Component
+class LanguageToolApiClient(
+  private val tolgeeProperties: TolgeeProperties,
+  private val restTemplateBuilder: RestTemplateBuilder,
+) {
+  private val restTemplate: RestTemplate by lazy {
+    restTemplateBuilder
+      .connectTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.connectTimeoutSeconds))
+      .readTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.readTimeoutSeconds))
+      .build()
+  }
+
+  /**
+   * Per-instance concurrency gate for `/v2/check` calls.
+   */
+  private val requestSemaphore: Semaphore by lazy {
+    Semaphore(tolgeeProperties.languageTool.maxConcurrentRequests.coerceAtLeast(1), true)
+  }
+
+  val isConfigured: Boolean
+    get() = tolgeeProperties.languageTool.url.isNotBlank()
+
+  fun checkConfigured() {
+    if (!isConfigured) {
+      throw LanguageToolNotConfiguredException()
+    }
+  }
+
+  @Cacheable(Caches.LANGUAGE_TOOL_RESULTS, key = "{#resolvedTag, #text}")
+  fun callCheck(
+    resolvedTag: String,
+    text: String,
+  ): List<LanguageToolMatch> {
+    checkConfigured()
+    return callCheckWithRetry(tolgeeProperties.languageTool.url, text, resolvedTag)
+  }
+
+  fun getLanguages(): List<LanguageToolLanguageInfo>? {
+    checkConfigured()
+    val response = getLanguagesApi(tolgeeProperties.languageTool.url) ?: return null
+    return response.toList()
+  }
+
+  private fun callCheckWithRetry(
+    baseUrl: String,
+    text: String,
+    languageTag: String,
+  ): List<LanguageToolMatch> {
+    repeat(LANGUAGE_TOOL_RETRY_ATTEMPTS - 1) { i ->
+      try {
+        return callCheckApi(baseUrl, text, languageTag)
+      } catch (e: HttpClientErrorException) {
+        // 4xx — unrecoverable; do not retry.
+        throw e
+      } catch (e: RestClientException) {
+        logger.warn(
+          "LanguageTool /v2/check failed (attempt {}/{}): {}",
+          i + 1,
+          LANGUAGE_TOOL_RETRY_ATTEMPTS,
+          e.message,
+        )
+        Thread.sleep(LANGUAGE_TOOL_RETRY_BACKOFF_MS)
+      }
+    }
+    return callCheckApi(baseUrl, text, languageTag)
+  }
+
+  private fun callCheckApi(
+    baseUrl: String,
+    text: String,
+    languageTag: String,
+  ): List<LanguageToolMatch> {
+    val headers = HttpHeaders()
+    headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+
+    val body =
+      LinkedMultiValueMap<String, String>().apply {
+        add("text", text)
+        add("language", languageTag)
+      }
+
+    val request = HttpEntity(body, headers)
+    val response =
+      requestSemaphore.use {
+        restTemplate.postForObject<LanguageToolResponse?>(
+          "$baseUrl/v2/check",
+          request,
+        )
+      }
+
+    return response?.matches ?: emptyList()
+  }
+
+  private fun getLanguagesApi(baseUrl: String): Array<LanguageToolLanguageInfo>? {
+    return restTemplate.getForObject<Array<LanguageToolLanguageInfo>?>(
+      "$baseUrl/v2/languages",
+    )
+  }
+
+  fun <T : Semaphore, R> T.use(block: (T) -> R): R {
+    acquire()
+    try {
+      return block(this)
+    } finally {
+      release()
+    }
+  }
+
+  companion object {
+    private val logger = logger()
+    const val LANGUAGE_TOOL_RETRY_ATTEMPTS = 3
+    const val LANGUAGE_TOOL_RETRY_BACKOFF_MS = 100L
+  }
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClient.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClient.kt
@@ -46,7 +46,10 @@ class LanguageToolApiClient(
     }
   }
 
-  @Cacheable(Caches.LANGUAGE_TOOL_RESULTS, key = "{#resolvedTag, #text}")
+  @Cacheable(
+    Caches.LANGUAGE_TOOL_RESULTS,
+    key = "{#resolvedTag, T(org.apache.commons.codec.digest.DigestUtils).sha256Hex(#text)}",
+  )
   fun callCheck(
     resolvedTag: String,
     text: String,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolCacheKey.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolCacheKey.kt
@@ -1,6 +1,0 @@
-package io.tolgee.ee.service.qa
-
-data class LanguageToolCacheKey(
-  val languageTag: String,
-  val text: String,
-)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/LanguageToolService.kt
@@ -1,50 +1,14 @@
 package io.tolgee.ee.service.qa
 
-import com.github.benmanes.caffeine.cache.Cache
-import com.github.benmanes.caffeine.cache.Caffeine
 import io.sentry.Sentry
-import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.util.logger
-import org.slf4j.LoggerFactory
-import org.springframework.boot.web.client.RestTemplateBuilder
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
-import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestClientException
-import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.getForObject
-import org.springframework.web.client.postForObject
-import java.time.Duration
-import java.util.concurrent.Semaphore
 
 @Service
 class LanguageToolService(
-  private val tolgeeProperties: TolgeeProperties,
-  private val restTemplateBuilder: RestTemplateBuilder,
+  private val languageToolApiClient: LanguageToolApiClient,
 ) {
-  private val restTemplate: RestTemplate by lazy {
-    restTemplateBuilder
-      .connectTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.connectTimeoutSeconds))
-      .readTimeout(Duration.ofSeconds(tolgeeProperties.languageTool.readTimeoutSeconds))
-      .build()
-  }
-
-  /**
-   * Per-instance concurrency gate for `/v2/check` calls.
-   */
-  private val requestSemaphore: Semaphore by lazy {
-    Semaphore(tolgeeProperties.languageTool.maxConcurrentRequests.coerceAtLeast(1), true)
-  }
-
-  private val resultCache: Cache<LanguageToolCacheKey, List<LanguageToolMatch>> =
-    Caffeine
-      .newBuilder()
-      .expireAfterWrite(Duration.ofMinutes(5))
-      .maximumSize(200)
-      .build()
-
   /**
    * Cache of supported languages fetched from the LanguageTool server.
    * Maps base language code (e.g., "en") to its default long code (e.g., "en-US").
@@ -58,18 +22,9 @@ class LanguageToolService(
     languageTag: String,
   ): List<LanguageToolMatch> {
     if (text.isBlank()) return emptyList()
-
-    val url = tolgeeProperties.languageTool.url
-    if (url.isBlank()) {
-      throw LanguageToolNotConfiguredException()
-    }
-
+    languageToolApiClient.checkConfigured()
     val resolvedTag = resolveLanguageTag(languageTag) ?: return emptyList()
-
-    val key = LanguageToolCacheKey(resolvedTag, text)
-    return resultCache.get(key) {
-      callApi(url, text, resolvedTag)
-    }
+    return languageToolApiClient.callCheck(resolvedTag, text)
   }
 
   /**
@@ -105,10 +60,9 @@ class LanguageToolService(
     synchronized(this) {
       supportedLanguages?.let { return it }
 
-      val url = tolgeeProperties.languageTool.url
-      if (url.isBlank()) return emptyMap()
+      if (!languageToolApiClient.isConfigured) return emptyMap()
 
-      val languages = fetchSupportedLanguages(url)
+      val languages = fetchSupportedLanguages()
       if (languages.isNotEmpty()) {
         supportedLanguages = languages
       }
@@ -116,18 +70,14 @@ class LanguageToolService(
     }
   }
 
-  private fun fetchSupportedLanguages(baseUrl: String): Map<String, String> {
-    return try {
-      val response =
-        restTemplate.getForObject<Array<LanguageToolLanguageInfo>?>(
-          "$baseUrl/v2/languages",
-        ) ?: return emptyMap()
-
-      buildLanguageMap(response.toList())
+  private fun fetchSupportedLanguages(): Map<String, String> {
+    try {
+      val supportedLanguages = languageToolApiClient.getLanguages() ?: return emptyMap()
+      return buildLanguageMap(supportedLanguages)
     } catch (e: RestClientException) {
       Sentry.captureException(e)
       logger.warn("Failed to fetch supported languages from LanguageTool: ${e.message}")
-      emptyMap()
+      return emptyMap()
     }
   }
 
@@ -159,35 +109,6 @@ class LanguageToolService(
     }
 
     return map
-  }
-
-  private fun callApi(
-    baseUrl: String,
-    text: String,
-    languageTag: String,
-  ): List<LanguageToolMatch> {
-    val headers = HttpHeaders()
-    headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
-
-    val body =
-      LinkedMultiValueMap<String, String>().apply {
-        add("text", text)
-        add("language", languageTag)
-      }
-
-    val request = HttpEntity(body, headers)
-    requestSemaphore.acquire()
-    try {
-      val response =
-        restTemplate.postForObject<LanguageToolResponse?>(
-          "$baseUrl/v2/check",
-          request,
-        )
-
-      return response?.matches ?: emptyList()
-    } finally {
-      requestSemaphore.release()
-    }
   }
 
   companion object {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
@@ -113,6 +113,7 @@ class QaCheckBatchServiceImpl(
     return items.mapNotNull { item ->
       // If the key has been deleted between job enqueue and processing, skip it
       val key = keyById[item.keyId] ?: return@mapNotNull null
+      val languageTag = languageTagById[item.languageId] ?: return@mapNotNull null
 
       val translation = translationByKeyAndLanguage[item.keyId to item.languageId]
       val text = translation?.text ?: ""
@@ -128,10 +129,6 @@ class QaCheckBatchServiceImpl(
         baseText?.takeIf { isPlural }?.let {
           runCatching { getPluralForms(it) }.getOrNull()
         }
-
-      val languageTag =
-        languageTagById[item.languageId]
-          ?: error("Language tag missing for languageId=${item.languageId}")
 
       // This is probably the most expensive thing we do for each item
       // In the future, we will probably switch to persisting glossary terms for each translation,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
@@ -1,15 +1,17 @@
 package io.tolgee.ee.service.qa
 
 import io.sentry.Sentry
+import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
 import io.tolgee.component.reporting.BusinessEventPublisher
 import io.tolgee.component.reporting.OnBusinessEventToCaptureEvent
 import io.tolgee.constants.Feature
+import io.tolgee.dtos.cacheable.ProjectDto
 import io.tolgee.ee.service.glossary.GlossaryTermService
 import io.tolgee.formats.getPluralForms
 import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.repository.KeyRepository
 import io.tolgee.repository.TranslationRepository
-import io.tolgee.service.key.KeyService
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.project.ProjectFeatureRegistry
 import io.tolgee.service.project.ProjectService
@@ -30,7 +32,7 @@ class QaCheckBatchServiceImpl(
   private val qaIssueService: QaIssueService,
   private val translationService: TranslationService,
   private val translationRepository: TranslationRepository,
-  private val keyService: KeyService,
+  private val keyRepository: KeyRepository,
   private val languageService: LanguageService,
   private val businessEventPublisher: BusinessEventPublisher,
   private val transactionManager: PlatformTransactionManager,
@@ -45,101 +47,185 @@ class QaCheckBatchServiceImpl(
     keyId: Long,
     languageId: Long,
     checkTypes: List<QaCheckType>?,
-    enabledCheckTypes: Set<QaCheckType>?,
   ) {
-    val project = projectService.getDto(projectId)
+    runChecksAndPersistChunk(
+      projectId = projectId,
+      checkTypes = checkTypes,
+      items = listOf(BatchTranslationTargetItem(keyId = keyId, languageId = languageId)),
+    )
+  }
 
+  override fun runChecksAndPersistChunk(
+    projectId: Long,
+    checkTypes: List<QaCheckType>?,
+    items: List<BatchTranslationTargetItem>,
+    progressCallback: () -> Unit,
+  ) {
+    if (items.isEmpty()) return
+    val project = projectService.getDto(projectId)
     if (!ProjectFeatureRegistry.isEnabledOnProject(Feature.QA_CHECKS, project)) {
       return
     }
 
-    val existingTranslation =
-      translationRepository.findOneByProjectIdAndKeyIdAndLanguageId(projectId, keyId, languageId)
-
-    val baseLanguage = languageService.getProjectBaseLanguage(projectId)
-    val isBaseLanguage = languageId == baseLanguage.id
-    val language = if (isBaseLanguage) baseLanguage else languageService.getEntity(languageId, projectId)
-
-    val baseText =
-      if (!isBaseLanguage) {
-        translationService
-          .getTranslations(
-            listOf(keyId),
-            listOf(baseLanguage.id),
-          ).firstOrNull()
-          ?.text
-      } else {
-        null
-      }
-
-    val translationText = existingTranslation?.text ?: ""
-    val key = keyService.get(keyId)
-    val isPlural = key.isPlural
-    val textParsed =
-      translationText.takeIf { isPlural }?.let {
-        runCatching { getPluralForms(it) }.getOrNull()
-      }
-    val baseParsed =
-      baseText?.takeIf { isPlural }?.let {
-        runCatching { getPluralForms(it) }.getOrNull()
-      }
-
-    val glossaryTerms = findGlossaryTerms(project.organizationOwnerId, projectId, translationText, language.tag)
-
-    val params =
-      QaCheckParams(
-        baseText = baseText,
-        text = translationText,
-        baseLanguageTag = if (!isBaseLanguage) baseLanguage.tag else null,
-        languageTag = language.tag,
-        isPlural = isPlural,
-        textVariants = textParsed?.forms,
-        textVariantOffsets = textParsed?.offsets,
-        baseTextVariants = baseParsed?.forms,
-        maxCharLimit = key.maxCharLimit,
-        icuPlaceholders = project.icuPlaceholders,
-        glossaryTerms = glossaryTerms,
-      )
-
-    val results =
-      qaCheckRunnerService.runEnabledChecks(
-        projectId,
-        params,
-        checkTypes,
-        languageId = languageId,
-        enabledCheckTypes = enabledCheckTypes,
-      )
-
-    if (results.isEmpty() && existingTranslation == null) return
-
-    executeInNewRepeatableTransaction(transactionManager) {
-      val translation = translationService.getOrCreate(projectId, keyId, languageId)
-
-      // Only clear the stale flag if the translation text hasn't changed since we collected inputs.
-      // If it changed, QaActivityListener already marked it stale again, and a new batch job
-      // will re-check with the updated text.
-      if (checkTypes == null && (translation.text ?: "") == translationText) {
-        translation.qaChecksStale = false
-      }
-
-      // Disable activity logging — no content changes are happening here.
-      // Without this, when we create a new empty translation (so we can reference it from QA issues),
-      // it gets logged.
-      translation.disableActivityLogging = true
-      translationService.save(translation)
-
-      qaIssueService.replaceIssuesForTranslation(translation, results, checkTypes)
-
-      qaIssueService.publishQaIssuesUpdated(translation)
-    }
-
+    val results = runChecksForChunk(project, checkTypes, items, progressCallback)
+    persistChunkResults(projectId, results, checkTypes)
     publishBusinessEvent(projectId)
   }
 
-  override fun getEnabledCheckTypesForLanguage(
+  private fun runChecksForChunk(
+    project: ProjectDto,
+    checkTypes: List<QaCheckType>?,
+    items: List<BatchTranslationTargetItem>,
+    progressCallback: () -> Unit,
+  ): List<ItemResult> {
+    val baseLanguage = languageService.getProjectBaseLanguage(project.id)
+    val keyIds = items.map { it.keyId }.toSet()
+    val languageIds = items.map { it.languageId }.toSet()
+
+    val translations =
+      translationRepository.findAllWithKeyAndLanguageByKeyIdInAndLanguageIdIn(
+        keyIds,
+        languageIds + baseLanguage.id,
+      )
+
+    val wantedPairs = items.map { it.keyId to it.languageId }.toSet()
+    val translationByKeyAndLanguage =
+      translations
+        .filter { it.key.id to it.language.id in wantedPairs }
+        .associateBy { it.key.id to it.language.id }
+
+    val baseTextByKey =
+      translations
+        .filter { it.language.id == baseLanguage.id }
+        .associate { it.key.id to it.text }
+
+    val tagsFromTranslations =
+      translations.associate { it.language.id to it.language.tag } + (baseLanguage.id to baseLanguage.tag)
+    val missingLanguageIds = languageIds.filter { it !in tagsFromTranslations }
+    val missingLanguageTags = languageService.findByIdIn(missingLanguageIds).associate { it.id to it.tag }
+    val languageTagById = tagsFromTranslations + missingLanguageTags
+
+    val keyById = keyRepository.findAllByIdIn(keyIds).associateBy { it.id }
+
+    val enabledCheckTypesByLanguage: Map<Long, Set<QaCheckType>> =
+      languageIds.associateWith { projectQaConfigService.getEnabledCheckTypesForLanguage(project.id, it) }
+
+    return items.mapNotNull { item ->
+      // If the key has been deleted between job enqueue and processing, skip it
+      val key = keyById[item.keyId] ?: return@mapNotNull null
+
+      val translation = translationByKeyAndLanguage[item.keyId to item.languageId]
+      val text = translation?.text ?: ""
+      val isBaseLanguage = item.languageId == baseLanguage.id
+      val baseText = if (isBaseLanguage) null else baseTextByKey[item.keyId]
+      val isPlural = key.isPlural
+
+      val textParsed =
+        text.takeIf { isPlural }?.let {
+          runCatching { getPluralForms(it) }.getOrNull()
+        }
+      val baseParsed =
+        baseText?.takeIf { isPlural }?.let {
+          runCatching { getPluralForms(it) }.getOrNull()
+        }
+
+      val languageTag =
+        languageTagById[item.languageId]
+          ?: error("Language tag missing for languageId=${item.languageId}")
+
+      // This is probably the most expensive thing we do for each item
+      // In the future, we will probably switch to persisting glossary terms for each translation,
+      // so optimizing it right now might be premature
+      val glossaryTerms =
+        findGlossaryTerms(project.organizationOwnerId, project.id, text, languageTag)
+
+      val params =
+        QaCheckParams(
+          baseText = baseText,
+          text = text,
+          baseLanguageTag = if (!isBaseLanguage) baseLanguage.tag else null,
+          languageTag = languageTag,
+          isPlural = isPlural,
+          textVariants = textParsed?.forms,
+          textVariantOffsets = textParsed?.offsets,
+          baseTextVariants = baseParsed?.forms,
+          maxCharLimit = key.maxCharLimit,
+          icuPlaceholders = project.icuPlaceholders,
+          glossaryTerms = glossaryTerms,
+        )
+
+      val enabledCheckTypes = enabledCheckTypesByLanguage[item.languageId]
+      val results =
+        qaCheckRunnerService.runEnabledChecks(
+          project.id,
+          params,
+          checkTypes,
+          languageId = item.languageId,
+          enabledCheckTypes = enabledCheckTypes,
+        )
+
+      progressCallback()
+
+      ItemResult(
+        keyId = item.keyId,
+        languageId = item.languageId,
+        languageTag = languageTag,
+        textSnapshot = text,
+        hadExistingTranslation = translation != null,
+        results = results,
+      )
+    }
+  }
+
+  private fun persistChunkResults(
     projectId: Long,
-    languageId: Long,
-  ): Set<QaCheckType> = projectQaConfigService.getEnabledCheckTypesForLanguage(projectId, languageId)
+    results: List<ItemResult>,
+    checkTypes: List<QaCheckType>?,
+  ) {
+    executeInNewRepeatableTransaction(transactionManager) {
+      results
+        .mapNotNull { result ->
+          // Create / Get translation entities
+
+          if (result.results.isEmpty() && !result.hadExistingTranslation) return@mapNotNull null
+
+          // Second most expensive operation here - we deal with each translation separately
+          // Might be worth batching this in single query in future
+          val translation = translationService.getOrCreate(projectId, result.keyId, result.languageId)
+
+          // Only clear the stale flag if the translation text hasn't changed since we collected inputs.
+          // If it changed, QaActivityListener already marked it stale again, and a new batch job
+          // will re-check with the updated text.
+          if (checkTypes == null && (translation.text ?: "") == result.textSnapshot) {
+            translation.qaChecksStale = false
+          }
+
+          // Disable activity logging — no content changes are happening here.
+          // Without this, when we create a new empty translation (so we can reference it from QA issues),
+          // it gets logged.
+          translation.disableActivityLogging = true
+          translationService.save(translation)
+
+          translation to result
+        }.also {
+          // Save QA issues
+
+          val resultsByTranslationId = it.associate { (t, itemResult) -> t.id to itemResult.results }
+          qaIssueService.replaceIssuesForTranslations(
+            resultsByTranslationId = resultsByTranslationId,
+            checkTypes = checkTypes,
+          )
+        }.map { (translation, result) ->
+          // Create events for updated QA issues
+
+          QaIssuesUpdatedEvent(translation.id, result.keyId, result.languageTag, translation.qaChecksStale)
+        }.also { events ->
+          // Send events
+
+          qaIssueService.publishQaIssuesUpdated(projectId, events)
+        }
+    }
+  }
 
   private fun findGlossaryTerms(
     organizationOwnerId: Long,
@@ -173,5 +259,14 @@ class QaCheckBatchServiceImpl(
 
   companion object {
     private val logger = LoggerFactory.getLogger(QaCheckBatchServiceImpl::class.java)
+
+    private data class ItemResult(
+      val keyId: Long,
+      val languageId: Long,
+      val languageTag: String,
+      val textSnapshot: String,
+      val hadExistingTranslation: Boolean,
+      val results: List<QaCheckResult>,
+    )
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueBulkInsert.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueBulkInsert.kt
@@ -1,0 +1,9 @@
+package io.tolgee.ee.service.qa
+
+import io.tolgee.model.enums.qa.QaIssueState
+
+data class QaIssueBulkInsert(
+  val translationId: Long,
+  val result: QaCheckResult,
+  val state: QaIssueState,
+)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
@@ -1,22 +1,30 @@
 package io.tolgee.ee.service.qa
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.reporting.BusinessEventPublisher
 import io.tolgee.component.reporting.OnBusinessEventToCaptureEvent
 import io.tolgee.ee.data.qa.QaCheckIssueIgnoreRequest
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.hateoas.qa.QaIssueModelAssembler
+import io.tolgee.model.ALLOCATION_SIZE
+import io.tolgee.model.SEQUENCE_NAME
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.model.enums.qa.QaIssueState
 import io.tolgee.model.qa.TranslationQaIssue
 import io.tolgee.model.translation.Translation
 import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.service.translation.TranslationService
+import io.tolgee.util.SequenceIdProvider
 import io.tolgee.websocket.WebsocketEvent
 import io.tolgee.websocket.WebsocketEventPublisher
 import io.tolgee.websocket.WebsocketEventType
+import org.postgresql.util.PGobject
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Timestamp
+import java.sql.Types
 
 @Service
 class QaIssueService(
@@ -26,41 +34,44 @@ class QaIssueService(
   private val currentDateProvider: CurrentDateProvider,
   private val qaIssueModelAssembler: QaIssueModelAssembler,
   private val businessEventPublisher: BusinessEventPublisher,
+  private val jdbcTemplate: JdbcTemplate,
+  private val objectMapper: ObjectMapper,
 ) {
   @Transactional
   fun replaceIssuesForTranslation(
-    translation: Translation,
+    translationId: Long,
     results: List<QaCheckResult>,
     checkTypes: List<QaCheckType>? = null,
-  ): List<TranslationQaIssue> {
-    val existingIssues = qaIssueRepository.findAllByTranslationId(translation.id)
+  ) {
+    replaceIssuesForTranslations(
+      resultsByTranslationId = mapOf(translationId to results),
+      checkTypes = checkTypes,
+    )
+  }
 
-    if (checkTypes == null) {
-      qaIssueRepository.deleteAllByTranslationId(translation.id)
-    } else {
-      val toDelete = existingIssues.filter { it.type in checkTypes }
-      toDelete.forEach { it.disableActivityLogging = true }
-      if (toDelete.isNotEmpty()) qaIssueRepository.deleteAll(toDelete)
-    }
+  @Transactional
+  fun replaceIssuesForTranslations(
+    resultsByTranslationId: Map<Long, List<QaCheckResult>>,
+    checkTypes: List<QaCheckType>? = null,
+  ) {
+    if (resultsByTranslationId.isEmpty()) return
+    val translationIds = resultsByTranslationId.keys
+    val existingIssuesByTranslationId = findExistingIssuesByTranslationIds(translationIds)
+
+    deleteByTranslationIdInAndTypeIn(translationIds, checkTypes)
     qaIssueRepository.flush()
 
-    val entities =
-      results.map { result ->
-        val matchingExisting = existingIssues.find { existing -> result.matches(existing) }
-        TranslationQaIssue(
-          type = result.type,
-          message = result.message,
-          replacement = result.replacement,
-          positionStart = result.positionStart,
-          positionEnd = result.positionEnd,
-          params = result.params,
-          state = matchingExisting?.state ?: QaIssueState.OPEN,
-          pluralVariant = result.pluralVariant,
-          translation = translation,
-        ).also { it.disableActivityLogging = true }
+    val newEntities =
+      resultsByTranslationId.flatMap { (tId, results) ->
+        val existingIssues = existingIssuesByTranslationId[tId].orEmpty()
+        results.map { result ->
+          val matchingExisting = existingIssues.find { result.matches(it) }
+          val issueState = matchingExisting?.state ?: QaIssueState.OPEN
+          QaIssueBulkInsert(tId, result, issueState)
+        }
       }
-    qaIssueRepository.saveAll(entities)
-    return entities
+
+    insertIssues(newEntities)
   }
 
   @Transactional(readOnly = true)
@@ -72,8 +83,9 @@ class QaIssueService(
   }
 
   @Transactional(readOnly = true)
-  fun getIssuesForTranslation(translationId: Long): List<TranslationQaIssue> {
-    return qaIssueRepository.findByTranslationIds(listOf(translationId))
+  fun findExistingIssuesByTranslationIds(translationIds: Collection<Long>): Map<Long, List<TranslationQaIssue>> {
+    if (translationIds.isEmpty()) return emptyMap()
+    return qaIssueRepository.findByTranslationIds(translationIds).groupBy { it.translation.id }
   }
 
   @Transactional
@@ -183,25 +195,111 @@ class QaIssueService(
     )
   }
 
+  /**
+   * types == null -> all check types
+   */
+  @Transactional
+  fun deleteByTranslationIdInAndTypeIn(
+    translationIds: Collection<Long>,
+    types: Collection<QaCheckType>? = null,
+  ) {
+    if (types == null) {
+      qaIssueRepository.deleteAllByTranslationIdIn(translationIds)
+      return
+    }
+
+    qaIssueRepository.deleteAllByTranslationIdInAndTypeIn(translationIds, types)
+  }
+
+  @Transactional
+  fun insertIssues(rows: List<QaIssueBulkInsert>) {
+    if (rows.isEmpty()) return
+
+    val sequenceIdProvider = SequenceIdProvider(SEQUENCE_NAME, ALLOCATION_SIZE)
+    jdbcTemplate.batchUpdate(
+      """
+      INSERT INTO translation_qa_issue (
+        id, created_at, updated_at,
+        translation_id, type, message, replacement,
+        position_start, position_end, state, params, virtual, plural_variant
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, ?)
+      """.trimIndent(),
+      rows,
+      100,
+    ) { ps, row ->
+      val r = row.result
+      val id = sequenceIdProvider.next(ps.connection)
+      ps.setLong(1, id)
+      ps.setTimestamp(2, Timestamp(currentDateProvider.date.time))
+      ps.setTimestamp(3, Timestamp(currentDateProvider.date.time))
+      ps.setLong(4, row.translationId)
+      ps.setString(5, r.type.name)
+      ps.setString(6, r.message.name)
+      ps.setObject(7, r.replacement, Types.VARCHAR)
+      ps.setObject(8, r.positionStart, Types.INTEGER)
+      ps.setObject(9, r.positionEnd, Types.INTEGER)
+      ps.setString(10, row.state.name)
+      ps.setObject(
+        11,
+        PGobject().apply {
+          type = "jsonb"
+          value = r.params?.let { objectMapper.writeValueAsString(it) }
+        },
+      )
+      ps.setObject(12, r.pluralVariant, Types.VARCHAR)
+    }
+  }
+
   fun publishQaIssuesUpdated(translation: Translation) {
     val projectId = translation.key.project.id
+    publishQaIssuesUpdated(
+      projectId,
+      listOf(
+        QaIssuesUpdatedEvent(
+          translation.id,
+          translation.key.id,
+          translation.language.tag,
+          translation.qaChecksStale,
+        ),
+      ),
+    )
+  }
+
+  fun publishQaIssuesUpdated(
+    projectId: Long,
+    events: Collection<QaIssuesUpdatedEvent>,
+  ) {
     qaIssueRepository.flush()
-    val allIssues = qaIssueRepository.findAllByTranslationId(translation.id)
+    val data =
+      events.withIssues().map { event ->
+        val issues = event.issues?.map { qaIssueModelAssembler.toModel(it) } ?: emptyList()
+        val issueCount = issues.count { it.state == QaIssueState.OPEN }
+        mapOf(
+          "translationId" to event.translationId,
+          "keyId" to event.keyId,
+          "languageTag" to event.languageTag,
+          "qaIssueCount" to issueCount,
+          "qaChecksStale" to event.qaChecksStale,
+          "qaIssues" to issues,
+        )
+      }
     websocketEventPublisher(
       "/projects/$projectId/${WebsocketEventType.QA_ISSUES_UPDATED.typeName}",
       WebsocketEvent(
-        data =
-          mapOf(
-            "translationId" to translation.id,
-            "keyId" to translation.key.id,
-            "languageTag" to translation.language.tag,
-            "qaIssueCount" to allIssues.count { it.state == QaIssueState.OPEN },
-            "qaChecksStale" to translation.qaChecksStale,
-            "qaIssues" to allIssues.map { qaIssueModelAssembler.toModel(it) },
-          ),
+        data = data,
         timestamp = currentDateProvider.date.time,
       ),
     )
+  }
+
+  private fun Collection<QaIssuesUpdatedEvent>.withIssues(): Collection<QaIssuesUpdatedEvent> {
+    val missing = filter { it.issues == null }.map { it.translationId }
+    if (missing.isEmpty()) return this
+    val issues = qaIssueRepository.findAllByTranslationIdIn(missing)
+    val issuesByTranslationId = issues.groupBy { it.translation.id }
+    return map {
+      it.takeIf { it.issues != null } ?: it.copy(issues = issuesByTranslationId[it.translationId] ?: emptyList())
+    }
   }
 
   private fun publishQaIssueStateChange(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
@@ -225,7 +225,7 @@ class QaIssueService(
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, false, ?)
       """.trimIndent(),
       rows,
-      100,
+      1000,
     ) { ps, row ->
       val r = row.result
       val id = sequenceIdProvider.next(ps.connection)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
@@ -208,6 +208,10 @@ class QaIssueService(
       return
     }
 
+    if (types.isEmpty()) {
+      return
+    }
+
     qaIssueRepository.deleteAllByTranslationIdInAndTypeIn(translationIds, types)
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssueService.kt
@@ -56,7 +56,7 @@ class QaIssueService(
   ) {
     if (resultsByTranslationId.isEmpty()) return
     val translationIds = resultsByTranslationId.keys
-    val existingIssuesByTranslationId = findExistingIssuesByTranslationIds(translationIds)
+    val existingIssuesByTranslationId = findExistingIssuesByTranslationIdsAndCheckTypes(translationIds, checkTypes)
 
     deleteByTranslationIdInAndTypeIn(translationIds, checkTypes)
     qaIssueRepository.flush()
@@ -83,9 +83,15 @@ class QaIssueService(
   }
 
   @Transactional(readOnly = true)
-  fun findExistingIssuesByTranslationIds(translationIds: Collection<Long>): Map<Long, List<TranslationQaIssue>> {
+  fun findExistingIssuesByTranslationIdsAndCheckTypes(
+    translationIds: Collection<Long>,
+    checkTypes: List<QaCheckType>? = null,
+  ): Map<Long, List<TranslationQaIssue>> {
     if (translationIds.isEmpty()) return emptyMap()
-    return qaIssueRepository.findByTranslationIds(translationIds).groupBy { it.translation.id }
+    if (checkTypes == null) {
+      return qaIssueRepository.findByTranslationIds(translationIds).groupBy { it.translation.id }
+    }
+    return qaIssueRepository.findByTranslationIdsAndCheckTypes(translationIds, checkTypes).groupBy { it.translation.id }
   }
 
   @Transactional

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssuesUpdatedEvent.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaIssuesUpdatedEvent.kt
@@ -1,0 +1,11 @@
+package io.tolgee.ee.service.qa
+
+import io.tolgee.model.qa.TranslationQaIssue
+
+data class QaIssuesUpdatedEvent(
+  val translationId: Long,
+  val keyId: Long,
+  val languageTag: String,
+  val qaChecksStale: Boolean,
+  val issues: List<TranslationQaIssue>? = null,
+)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
@@ -4,8 +4,11 @@ import io.tolgee.batch.BatchJobService
 import io.tolgee.batch.data.BatchJobType
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.QaCheckRequest
+import io.tolgee.constants.Feature
 import io.tolgee.model.Project
 import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.service.project.ProjectFeatureRegistry
+import io.tolgee.service.project.ProjectService
 import io.tolgee.service.translation.TranslationService
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Service
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 class QaRecheckService(
   private val batchJobService: BatchJobService,
   private val translationService: TranslationService,
+  private val projectService: ProjectService,
   private val entityManager: EntityManager,
 ) {
   @Transactional
@@ -51,11 +55,36 @@ class QaRecheckService(
     }
   }
 
+  @Transactional
+  fun recheckStaleTranslationsOnBranch(
+    projectId: Long,
+    branchId: Long,
+  ) {
+    val projectDto = projectService.getDto(projectId)
+    if (!ProjectFeatureRegistry.isEnabledOnProject(Feature.QA_CHECKS, projectDto)) return
+
+    val pairs = translationService.getStaleKeyLanguagePairsByBranch(projectId, branchId)
+    if (pairs.isEmpty()) return
+
+    val allTargetItems = pairs.map { BatchTranslationTargetItem(keyId = it.keyId, languageId = it.languageId) }
+    val project = entityManager.getReference(Project::class.java, projectId)
+
+    for (targetChunk in allTargetItems.chunked(MAX_BATCH_JOB_TARGET_SIZE)) {
+      batchJobService.startJob(
+        request = QaCheckRequest(target = targetChunk),
+        project = project,
+        author = null,
+        type = BatchJobType.QA_CHECK,
+        isHidden = true,
+      )
+    }
+  }
+
   companion object {
     /**
      * Maximum number of target items per batch job to prevent large JSONB payloads
      * in the batch_job table and excessive memory usage during serialization.
      */
-    const val MAX_BATCH_JOB_TARGET_SIZE = 10_000
+    const val MAX_BATCH_JOB_TARGET_SIZE = 32_000
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
@@ -1,10 +1,13 @@
 package io.tolgee.ee.service.qa
 
+import io.sentry.Sentry
+import io.sentry.SentryLevel
 import io.tolgee.batch.BatchJobService
 import io.tolgee.batch.data.BatchJobType
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.constants.Feature
+import io.tolgee.dtos.queryResults.qa.KeyLanguagePairView
 import io.tolgee.model.Project
 import io.tolgee.model.enums.qa.QaCheckType
 import io.tolgee.service.project.ProjectFeatureRegistry
@@ -41,18 +44,7 @@ class QaRecheckService(
       }
     }
 
-    val allTargetItems = pairs.map { BatchTranslationTargetItem(keyId = it.keyId, languageId = it.languageId) }
-    val project = entityManager.getReference(Project::class.java, projectId)
-
-    for (targetChunk in allTargetItems.chunked(MAX_BATCH_JOB_TARGET_SIZE)) {
-      batchJobService.startJob(
-        request = QaCheckRequest(target = targetChunk, checkTypes = checkTypes),
-        project = project,
-        author = null,
-        type = BatchJobType.QA_CHECK,
-        isHidden = true,
-      )
-    }
+    recheckFromKeyLanguagePairs(projectId, pairs, checkTypes = checkTypes)
   }
 
   @Transactional
@@ -66,12 +58,38 @@ class QaRecheckService(
     val pairs = translationService.getStaleKeyLanguagePairsByBranch(projectId, branchId)
     if (pairs.isEmpty()) return
 
+    recheckFromKeyLanguagePairs(projectId, pairs)
+  }
+
+  @Transactional
+  fun recheckStuckStaleTranslationsInProject(projectId: Long) {
+    val projectDto = projectService.getDto(projectId)
+    if (!ProjectFeatureRegistry.isEnabledOnProject(Feature.QA_CHECKS, projectDto)) return
+    if (batchJobService.hasActiveJobForProject(projectId, BatchJobType.QA_CHECK)) return
+
+    val pairs = translationService.getStaleKeyLanguagePairsByProject(projectId)
+    if (pairs.isEmpty()) return
+
+    Sentry.captureMessage(
+      "Found ${pairs.size} stuck-stale translation(s) after QA batch job finished; " +
+        "enqueueing self-heal QA recheck. projectId=$projectId",
+      SentryLevel.WARNING,
+    )
+
+    recheckFromKeyLanguagePairs(projectId, pairs)
+  }
+
+  private fun recheckFromKeyLanguagePairs(
+    projectId: Long,
+    pairs: List<KeyLanguagePairView>,
+    checkTypes: List<QaCheckType>? = null,
+  ) {
     val allTargetItems = pairs.map { BatchTranslationTargetItem(keyId = it.keyId, languageId = it.languageId) }
     val project = entityManager.getReference(Project::class.java, projectId)
 
     for (targetChunk in allTargetItems.chunked(MAX_BATCH_JOB_TARGET_SIZE)) {
       batchJobService.startJob(
-        request = QaCheckRequest(target = targetChunk),
+        request = QaCheckRequest(target = targetChunk, checkTypes = checkTypes),
         project = project,
         author = null,
         type = BatchJobType.QA_CHECK,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
@@ -76,20 +76,26 @@ class QaRecheckService(
       SentryLevel.WARNING,
     )
 
-    recheckFromKeyLanguagePairs(projectId, pairs)
+    recheckFromKeyLanguagePairs(projectId, pairs, isHandlingStuckStaleItems = true)
   }
 
   private fun recheckFromKeyLanguagePairs(
     projectId: Long,
     pairs: List<KeyLanguagePairView>,
     checkTypes: List<QaCheckType>? = null,
+    isHandlingStuckStaleItems: Boolean = false,
   ) {
     val allTargetItems = pairs.map { BatchTranslationTargetItem(keyId = it.keyId, languageId = it.languageId) }
     val project = entityManager.getReference(Project::class.java, projectId)
 
     for (targetChunk in allTargetItems.chunked(MAX_BATCH_JOB_TARGET_SIZE)) {
       batchJobService.startJob(
-        request = QaCheckRequest(target = targetChunk, checkTypes = checkTypes),
+        request =
+          QaCheckRequest(
+            target = targetChunk,
+            checkTypes = checkTypes,
+            handlingStuckStaleItems = isHandlingStuckStaleItems,
+          ),
         project = project,
         author = null,
         type = BatchJobType.QA_CHECK,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
@@ -1,6 +1,8 @@
 package io.tolgee.ee.service.branching
 
 import io.tolgee.AbstractSpringTest
+import io.tolgee.batch.BatchJobService
+import io.tolgee.batch.data.BatchJobType
 import io.tolgee.development.testDataBuilder.data.BranchCopyQaIssuesTestData
 import io.tolgee.model.branching.Branch
 import io.tolgee.model.enums.qa.QaCheckType
@@ -29,6 +31,9 @@ class BranchCopyQaIssuesTest : AbstractSpringTest() {
 
   @Autowired
   lateinit var qaIssueRepository: TranslationQaIssueRepository
+
+  @Autowired
+  lateinit var batchJobService: BatchJobService
 
   private lateinit var testData: BranchCopyQaIssuesTestData
 
@@ -80,6 +85,45 @@ class BranchCopyQaIssuesTest : AbstractSpringTest() {
       val sourceIssues = qaIssueRepository.findAllByTranslationId(sourceTranslationId)
       sourceIssues.assert.hasSize(2)
     }
+  }
+
+  @Test
+  fun `enqueues QA batch job for stale translations on new branch`() {
+    // Snapshot QA job count before the act so we measure only what create-branch enqueues.
+    val initialQaJobCount =
+      executeInNewTransaction(platformTransactionManager) {
+        batchJobService.getAllByProjectId(testData.project.id).count { it.type == BatchJobType.QA_CHECK }
+      }
+
+    val newBranch =
+      branchService.createBranch(
+        projectId = testData.project.id,
+        name = "feature-stale",
+        originBranchId = testData.defaultBranch.id,
+        author = testData.user,
+      )
+
+    // The created branch has one stale translation (copied from source) → one QA batch job.
+    val newJobs =
+      executeInNewTransaction(platformTransactionManager) {
+        batchJobService
+          .getAllByProjectId(testData.project.id)
+          .filter { it.type == BatchJobType.QA_CHECK }
+      }
+    newJobs.size.assert.isEqualTo(initialQaJobCount + 1)
+
+    val enqueued = newJobs.first()
+    // Target is the new branch's stale translation only (not the non-stale one).
+    enqueued.totalItems.assert.isEqualTo(1)
+
+    // Sanity: the resolved target points to the new branch's `stale-greeting` translation.
+    val expectedTranslation = findTranslationOnBranch(newBranch, testData.staleKey.name)
+    val targetKeyIds =
+      (enqueued.target as List<*>).map { item ->
+        // Each item serialises to a JSON map { "keyId": ..., "languageId": ... }
+        (item as Map<*, *>)["keyId"]!!.toString().toLong()
+      }
+    targetKeyIds.assert.containsExactly(expectedTranslation.key.id)
   }
 
   private fun findTranslationOnBranch(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
@@ -1,0 +1,106 @@
+package io.tolgee.ee.service.branching
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.BranchCopyQaIssuesTestData
+import io.tolgee.model.branching.Branch
+import io.tolgee.model.enums.qa.QaCheckType
+import io.tolgee.model.enums.qa.QaIssueState
+import io.tolgee.model.key.Key
+import io.tolgee.model.translation.Translation
+import io.tolgee.repository.qa.TranslationQaIssueRepository
+import io.tolgee.service.branching.BranchService
+import io.tolgee.testing.assert
+import io.tolgee.util.executeInNewTransaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Verifies that creating a branch copies the source branch's QA issues forward and
+ * preserves each translation's `qa_checks_stale` flag, so the new branch does not
+ * need a redundant QA recheck (translations are identical to the source).
+ */
+@SpringBootTest
+class BranchCopyQaIssuesTest : AbstractSpringTest() {
+  @Autowired
+  lateinit var branchService: BranchService
+
+  @Autowired
+  lateinit var qaIssueRepository: TranslationQaIssueRepository
+
+  private lateinit var testData: BranchCopyQaIssuesTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = BranchCopyQaIssuesTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `copies QA issues to new branch and preserves qa_checks_stale`() {
+    val sourceTranslationId = testData.englishTranslation.id
+    val sourceKey = testData.key
+
+    // Act: create a new branch from the default branch.
+    val newBranch =
+      branchService.createBranch(
+        projectId = testData.project.id,
+        name = "feature-x",
+        originBranchId = testData.defaultBranch.id,
+        author = testData.user,
+      )
+
+    // Assert: new branch translation got both QA issues, with correct fields and states.
+    executeInNewTransaction(platformTransactionManager) {
+      val targetTranslation = findTranslationOnBranch(newBranch, sourceKey.name)
+      val copiedIssues = qaIssueRepository.findAllByTranslationId(targetTranslation.id)
+      copiedIssues.assert.hasSize(2)
+
+      val open = copiedIssues.single { it.type == QaCheckType.PUNCTUATION_MISMATCH }
+      open.state.assert.isEqualTo(QaIssueState.OPEN)
+      open.virtual.assert.isFalse()
+      open.translation.id.assert
+        .isEqualTo(targetTranslation.id)
+
+      val virtual = copiedIssues.single { it.type == QaCheckType.CHARACTER_CASE_MISMATCH }
+      virtual.state.assert.isEqualTo(QaIssueState.IGNORED)
+      virtual.virtual.assert.isTrue()
+
+      // qa_checks_stale carried over (not reset to DB default of `true`).
+      targetTranslation.qaChecksStale.assert.isFalse()
+
+      // Source's issues are unchanged (we copied, not moved).
+      val sourceIssues = qaIssueRepository.findAllByTranslationId(sourceTranslationId)
+      sourceIssues.assert.hasSize(2)
+    }
+  }
+
+  private fun findTranslationOnBranch(
+    branch: Branch,
+    keyName: String,
+  ): Translation {
+    val key =
+      entityManager
+        .createQuery(
+          "select k from Key k where k.project.id = :pid and k.branch.id = :bid and k.name = :name",
+          Key::class.java,
+        ).setParameter("pid", testData.project.id)
+        .setParameter("bid", branch.id)
+        .setParameter("name", keyName)
+        .singleResult
+    return entityManager
+      .createQuery(
+        "select t from Translation t where t.key.id = :kid and t.language.id = :lid",
+        Translation::class.java,
+      ).setParameter("kid", key.id)
+      .setParameter("lid", testData.englishLanguage.id)
+      .singleResult
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/branching/BranchCopyQaIssuesTest.kt
@@ -87,45 +87,6 @@ class BranchCopyQaIssuesTest : AbstractSpringTest() {
     }
   }
 
-  @Test
-  fun `enqueues QA batch job for stale translations on new branch`() {
-    // Snapshot QA job count before the act so we measure only what create-branch enqueues.
-    val initialQaJobCount =
-      executeInNewTransaction(platformTransactionManager) {
-        batchJobService.getAllByProjectId(testData.project.id).count { it.type == BatchJobType.QA_CHECK }
-      }
-
-    val newBranch =
-      branchService.createBranch(
-        projectId = testData.project.id,
-        name = "feature-stale",
-        originBranchId = testData.defaultBranch.id,
-        author = testData.user,
-      )
-
-    // The created branch has one stale translation (copied from source) → one QA batch job.
-    val newJobs =
-      executeInNewTransaction(platformTransactionManager) {
-        batchJobService
-          .getAllByProjectId(testData.project.id)
-          .filter { it.type == BatchJobType.QA_CHECK }
-      }
-    newJobs.size.assert.isEqualTo(initialQaJobCount + 1)
-
-    val enqueued = newJobs.first()
-    // Target is the new branch's stale translation only (not the non-stale one).
-    enqueued.totalItems.assert.isEqualTo(1)
-
-    // Sanity: the resolved target points to the new branch's `stale-greeting` translation.
-    val expectedTranslation = findTranslationOnBranch(newBranch, testData.staleKey.name)
-    val targetKeyIds =
-      (enqueued.target as List<*>).map { item ->
-        // Each item serialises to a JSON map { "keyId": ..., "languageId": ... }
-        (item as Map<*, *>)["keyId"]!!.toString().toLong()
-      }
-    targetKeyIds.assert.containsExactly(expectedTranslation.key.id)
-  }
-
   private fun findTranslationOnBranch(
     branch: Branch,
     keyName: String,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClientRetryTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/LanguageToolApiClientRetryTest.kt
@@ -1,0 +1,98 @@
+package io.tolgee.ee.service.qa
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.tolgee.configuration.tolgee.LanguageToolProperties
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.method
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withServerError
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestClientException
+import org.springframework.web.client.RestTemplate
+
+class LanguageToolApiClientRetryTest {
+  private lateinit var client: LanguageToolApiClient
+  private lateinit var mockServer: MockRestServiceServer
+  private val mapper = ObjectMapper()
+
+  @BeforeEach
+  fun setup() {
+    val restTemplate = RestTemplate()
+    mockServer = MockRestServiceServer.createServer(restTemplate)
+    val builder =
+      object : RestTemplateBuilder() {
+        override fun build(): RestTemplate = restTemplate
+
+        override fun connectTimeout(connectTimeout: java.time.Duration): RestTemplateBuilder = this
+
+        override fun readTimeout(readTimeout: java.time.Duration): RestTemplateBuilder = this
+      }
+    val props = TolgeeProperties(languageTool = LanguageToolProperties(url = "http://localhost:8010"))
+    client = LanguageToolApiClient(props, builder)
+  }
+
+  private fun mockCheckSuccess() {
+    val json = mapper.writeValueAsString(LanguageToolResponse(matches = emptyList()))
+    mockServer
+      .expect(requestTo("http://localhost:8010/v2/check"))
+      .andExpect(method(HttpMethod.POST))
+      .andRespond(withSuccess(json, MediaType.APPLICATION_JSON))
+  }
+
+  private fun mockCheckServerError() {
+    mockServer
+      .expect(requestTo("http://localhost:8010/v2/check"))
+      .andExpect(method(HttpMethod.POST))
+      .andRespond(withServerError())
+  }
+
+  private fun mockCheckClientError() {
+    mockServer
+      .expect(requestTo("http://localhost:8010/v2/check"))
+      .andExpect(method(HttpMethod.POST))
+      .andRespond(withStatus(HttpStatus.BAD_REQUEST))
+  }
+
+  @Test
+  fun `retries on transient failure and succeeds on third attempt`() {
+    mockCheckServerError()
+    mockCheckServerError()
+    mockCheckSuccess()
+
+    val result = client.callCheck("en-US", "Hello world.")
+
+    assertThat(result).isEmpty()
+    mockServer.verify()
+  }
+
+  @Test
+  fun `gives up after three attempts and propagates the exception`() {
+    mockCheckServerError()
+    mockCheckServerError()
+    mockCheckServerError()
+
+    assertThatThrownBy { client.callCheck("en-US", "Hello world.") }
+      .isInstanceOf(RestClientException::class.java)
+    mockServer.verify()
+  }
+
+  @Test
+  fun `does not retry on 4xx client errors`() {
+    mockCheckClientError()
+
+    assertThatThrownBy { client.callCheck("en-US", "Hello world.") }
+      .isInstanceOf(HttpClientErrorException::class.java)
+    mockServer.verify()
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/LanguageToolServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/LanguageToolServiceTest.kt
@@ -40,7 +40,8 @@ class LanguageToolServiceTest {
         override fun readTimeout(readTimeout: java.time.Duration): RestTemplateBuilder = this
       }
 
-    service = LanguageToolService(tolgeeProperties, builder)
+    val apiClient = LanguageToolApiClient(tolgeeProperties, builder)
+    service = LanguageToolService(apiClient)
   }
 
   private fun mockLanguagesResponse(vararg languages: LanguageToolLanguageInfo) {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaSelfHealStaleTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaSelfHealStaleTest.kt
@@ -7,7 +7,6 @@ import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.ee.development.QaTestData
 import io.tolgee.model.Project
-import io.tolgee.model.translation.Translation
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
 import org.junit.jupiter.api.AfterEach
@@ -31,7 +30,6 @@ class QaSelfHealStaleTest : AbstractSpringTest() {
   @BeforeEach
   fun setup() {
     testData = QaTestData()
-    testDataService.saveTestData(testData.root)
   }
 
   @AfterEach
@@ -41,6 +39,7 @@ class QaSelfHealStaleTest : AbstractSpringTest() {
 
   @Test
   fun `enqueues self-heal QA job when stale translations exist`() {
+    testDataService.saveTestData(testData.root)
     val baseline = qaJobCount()
 
     qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
@@ -50,15 +49,8 @@ class QaSelfHealStaleTest : AbstractSpringTest() {
 
   @Test
   fun `does not enqueue when no stale translations`() {
-    executeInNewTransaction(platformTransactionManager) {
-      // FIXME: This should be a function in test data to optionally modify it's state before we save the test data
-      entityManager
-        .createQuery(
-          "update Translation t set t.qaChecksStale = false " +
-            "where t.key.project.id = :pid",
-        ).setParameter("pid", testData.project.id)
-        .executeUpdate()
-    }
+    testData.clearAllStaleFlags()
+    testDataService.saveTestData(testData.root)
     val baseline = qaJobCount()
 
     qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
@@ -68,19 +60,8 @@ class QaSelfHealStaleTest : AbstractSpringTest() {
 
   @Test
   fun `does not enqueue when another QA job is already active`() {
-    val staleTranslation =
-      executeInNewTransaction(platformTransactionManager) {
-        // FIXME: This should be exposed by test data as it's propety - no need to query for stuff created by test data
-        // when it isn't required by the test itself
-        entityManager
-          .createQuery(
-            "select t from Translation t " +
-              "where t.key.project.id = :pid and t.qaChecksStale = true",
-            Translation::class.java,
-          ).setParameter("pid", testData.project.id)
-          .resultList
-          .first()
-      }
+    testDataService.saveTestData(testData.root)
+    val staleTranslation = testData.staleFrTranslation
     // Manually enqueue a QA job so `hasActiveJobForProject` returns true.
     executeInNewTransaction(platformTransactionManager) {
       val projectRef = entityManager.getReference(Project::class.java, testData.project.id)
@@ -110,11 +91,8 @@ class QaSelfHealStaleTest : AbstractSpringTest() {
 
   @Test
   fun `does not enqueue when QA checks are disabled on project`() {
-    executeInNewTransaction(platformTransactionManager) {
-      // FIXME: This should be a function in test data to optionally modify it's state before we save the test data
-      val project = entityManager.find(Project::class.java, testData.project.id)
-      project.useQaChecks = false
-    }
+    testData.disableQaChecks()
+    testDataService.saveTestData(testData.root)
     val baseline = qaJobCount()
 
     qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaSelfHealStaleTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaSelfHealStaleTest.kt
@@ -1,0 +1,129 @@
+package io.tolgee.ee.service.qa
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.batch.BatchJobService
+import io.tolgee.batch.data.BatchJobType
+import io.tolgee.batch.data.BatchTranslationTargetItem
+import io.tolgee.batch.request.QaCheckRequest
+import io.tolgee.ee.development.QaTestData
+import io.tolgee.model.Project
+import io.tolgee.model.translation.Translation
+import io.tolgee.testing.assert
+import io.tolgee.util.executeInNewTransaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class QaSelfHealStaleTest : AbstractSpringTest() {
+  @Autowired
+  private lateinit var qaRecheckService: QaRecheckService
+
+  @Autowired
+  private lateinit var batchJobService: BatchJobService
+
+  private lateinit var testData: QaTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = QaTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `enqueues self-heal QA job when stale translations exist`() {
+    val baseline = qaJobCount()
+
+    qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
+
+    qaJobCount().assert.isEqualTo(baseline + 1)
+  }
+
+  @Test
+  fun `does not enqueue when no stale translations`() {
+    executeInNewTransaction(platformTransactionManager) {
+      // FIXME: This should be a function in test data to optionally modify it's state before we save the test data
+      entityManager
+        .createQuery(
+          "update Translation t set t.qaChecksStale = false " +
+            "where t.key.project.id = :pid",
+        ).setParameter("pid", testData.project.id)
+        .executeUpdate()
+    }
+    val baseline = qaJobCount()
+
+    qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
+
+    qaJobCount().assert.isEqualTo(baseline)
+  }
+
+  @Test
+  fun `does not enqueue when another QA job is already active`() {
+    val staleTranslation =
+      executeInNewTransaction(platformTransactionManager) {
+        // FIXME: This should be exposed by test data as it's propety - no need to query for stuff created by test data
+        // when it isn't required by the test itself
+        entityManager
+          .createQuery(
+            "select t from Translation t " +
+              "where t.key.project.id = :pid and t.qaChecksStale = true",
+            Translation::class.java,
+          ).setParameter("pid", testData.project.id)
+          .resultList
+          .first()
+      }
+    // Manually enqueue a QA job so `hasActiveJobForProject` returns true.
+    executeInNewTransaction(platformTransactionManager) {
+      val projectRef = entityManager.getReference(Project::class.java, testData.project.id)
+      batchJobService.startJob(
+        request =
+          QaCheckRequest(
+            target =
+              listOf(
+                BatchTranslationTargetItem(
+                  keyId = staleTranslation.key.id,
+                  languageId = staleTranslation.language.id,
+                ),
+              ),
+          ),
+        project = projectRef,
+        author = null,
+        type = BatchJobType.QA_CHECK,
+        isHidden = true,
+      )
+    }
+    val baseline = qaJobCount()
+
+    qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
+
+    qaJobCount().assert.isEqualTo(baseline)
+  }
+
+  @Test
+  fun `does not enqueue when QA checks are disabled on project`() {
+    executeInNewTransaction(platformTransactionManager) {
+      // FIXME: This should be a function in test data to optionally modify it's state before we save the test data
+      val project = entityManager.find(Project::class.java, testData.project.id)
+      project.useQaChecks = false
+    }
+    val baseline = qaJobCount()
+
+    qaRecheckService.recheckStuckStaleTranslationsInProject(testData.project.id)
+
+    qaJobCount().assert.isEqualTo(baseline)
+  }
+
+  private fun qaJobCount(): Int =
+    executeInNewTransaction(platformTransactionManager) {
+      batchJobService.getAllByProjectId(testData.project.id).count { it.type == BatchJobType.QA_CHECK }
+    }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/QaTestUtil.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/QaTestUtil.kt
@@ -39,7 +39,7 @@ class QaTestUtil(
         languageTag = "fr",
       )
     val results = qaCheckRunnerService.runEnabledChecks(testData.project.id, params)
-    qaIssueService.replaceIssuesForTranslation(translation, results)
+    qaIssueService.replaceIssuesForTranslation(translation.id, results)
   }
 
   fun getPersistedIssues(translation: Translation): List<TranslationQaIssue> =

--- a/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
+++ b/webapp/src/views/projects/translations/context/services/useWebsocketService.ts
@@ -57,16 +57,18 @@ export const useWebsocketService = (
 
   function updateQaIssues(events: QaIssuesUpdatedData[]) {
     translationService.changeTranslations(
-      events.map((event) => ({
-        keyId: event.data.keyId,
-        language: event.data.languageTag,
-        value: {
-          id: event.data.translationId,
-          qaIssueCount: event.data.qaIssueCount,
-          qaChecksStale: event.data.qaChecksStale,
-          qaIssues: event.data.qaIssues,
-        },
-      }))
+      events.flatMap((event) =>
+        event.data.map((update) => ({
+          keyId: update.keyId,
+          language: update.languageTag,
+          value: {
+            id: update.translationId,
+            qaIssueCount: update.qaIssueCount,
+            qaChecksStale: update.qaChecksStale,
+            qaIssues: update.qaIssues,
+          },
+        }))
+      )
     );
   }
 

--- a/webapp/src/websocket-client/WebsocketClient.ts
+++ b/webapp/src/websocket-client/WebsocketClient.ts
@@ -188,14 +188,15 @@ export type NotificationsChanged = WebsocketEvent<{
   newNotification?: components['schemas']['NotificationModel'];
 }>;
 
-export type QaIssuesUpdatedData = WebsocketEvent<{
+export type QaIssueUpdate = {
   translationId: number;
   keyId: number;
   languageTag: string;
   qaIssueCount: number;
   qaChecksStale: boolean;
   qaIssues: components['schemas']['QaIssueModel'][];
-}>;
+};
+export type QaIssuesUpdatedData = WebsocketEvent<QaIssueUpdate[]>;
 
 export type EntityModification<T> = T extends keyof schemas
   ? {


### PR DESCRIPTION
## Summary

Performance and reliability improvements for QA batch checks, motivated by slow runs on real projects (especially those with multiple branches and/or LanguageTool enabled).

### Performance

- **Branch creation copies QA state forward.** New branches inherit `translation_qa_issue` rows and `qa_checks_stale` from their source branch, so freshly created branches no longer trigger a redundant project-wide QA recheck on first activity.
- **LanguageTool responses cached in Redis.** `/v2/check` results are now cached via Spring `@Cacheable` so the cache is shared across backend nodes and survives restarts. The HTTP call is wrapped in a small retry to ride out transient failures (e.g. a LanguageTool instance restarting mid-request).
- **Chunk-batched QA processing.** The QA batch processor now reads inputs and persists issues for a whole chunk at once: bulk-loaded translations, keys, base translations, and existing issues per chunk; checks run outside the DB transaction so network-bound checks (LanguageTool) do not hold row locks; new issues persisted via a single batched insert per chunk.

### Reliability — make sure translations don't get stuck stale

- **After branch creation,** if QA is enabled on the project and any translation on the new branch is `qa_checks_stale = true`, a targeted QA batch job is enqueued for those translations.
- **After every QA batch job finalizes,** if there are still stuck-stale translations in the project (and no other QA job is already queued for it), a follow-up QA batch job is enqueued for them and a Sentry warning is logged. Catches edge cases where a translation might otherwise sit unrechecked.

### Benchmark

Two workloads:

- **50k**: 1000 keys × 50 languages = 50 000 translations.
- **1k**: 100 keys × 10 languages = 1 000 translations.

In both: SPELLING/GRAMMAR off (LT tested separately below), `tolgee.batch.concurrency = 1`, one run per cell, localhost, single backend node, Caffeine for the non-LT cells.

| variant                                  | wall 50k  | wall 1k  | vs main (50k) | vs main (1k) |
|------------------------------------------|----------:|---------:|--------------:|-------------:|
| main, default knobs (chunk=1000, jdbc=100) | 1 428 s | 28.6 s   | 1.00×         | 1.00×        |
| perf branch, chunk=1000, jdbc=100        | 1 225 s   |   3.0 s  | 1.17×         | 9.5×         |
| perf branch, **chunk=100, jdbc=1000** ★  | **496 s** | **2.6 s**| **2.88×**     | **11×**      |

The same-config gap between main and the perf branch is much larger at the small scale (~9.5×) than at large scale (~1.17×). Per-translation runtime drops from ~27 ms (main, chunk=1000) to ~1.5 ms (perf branch, chunk=100) at 1k — at 50k the per-translation cost grows because of dataset-size-dependent effects (more existing rows scanned per chunk, larger working set).

Driven by sweeping the two new tunables.

**Chunk size (jdbc=1000 at 1k; jdbc=100 at 50k):**

| chunk | wall 50k (s) | wall 1k (ms) |
|------:|-------------:|-------------:|
| 50    | 595          | 2 480        |
| **100** | **509**    | **2 601**  ← default |
| 250   | 899          | 2 614        |
| 1000  | 1 225        | 3 001        |
| 2000  | 1 236        | 2 600        |
| 5000  | 2 401        | 4 425        |

Per-item cost grows with chunk size, and the growth is much steeper at the 50k scale than at 1k (chunk=5000 is 4.7× slower than chunk=100 at 50k vs only 1.7× at 1k). Likely culprits (not measured precisely, candidates ordered by likelihood): Postgres planner switching from index scan to seq scan once the bulk-`SELECT … WHERE id IN (…)` list crosses a threshold; N²-ish in-memory work merging existing-vs-new issues; longer-held Hibernate session for one fat transaction. Sweet spot is 100 on both scales; smaller (50) starts paying back per-chunk overhead.

**JDBC bulk-insert batch (chunk=100):**

| jdbc | wall 50k (s) | wall 1k (ms) |
|-----:|-------------:|-------------:|
| 100  | 509          | 2 547        |
| 500  | 519          | 2 619        |
| 1000 | **496**      | **2 601** ← default |

Marginal effect, but free improvement — bumped to 1000 to align with `hibernate.jdbc.batch_size`.

**Glossary impact** (50k, relative to no-glossary, best knobs):

| glossary terms | overhead |
|---------------:|---------:|
| 100            | +20 %    |
| 500            | +52 %    |

`QaCheckBatchServiceImpl.findGlossaryTerms` currently queries per (text, language) for every translation. Scales linearly with `translations × matching_terms`. Acceptable today; future opportunity is to hoist the lookup to a per-chunk batch query if a customer with a large glossary reports slow QA.

**LanguageTool** (1 000 translations, SPELLING + GRAMMAR on):

| variant                             | wall time | vs main |
|-------------------------------------|----------:|--------:|
| main baseline                       |    640 s  | 1.00×   |
| perf branch, cold LT cache          |    512 s  | 1.25×   |
| perf branch, **warm Redis cache**   |  **1.3 s**| **~490×** |

S0 → S1 is the chunk-batching speedup (LT round-trips dominate). S1 → S2 is the new Redis-backed LT cache — once a text has been checked, every subsequent check of the same text is a cache hit.

### Recommended defaults

Landed in this PR:

- `QaCheckChunkProcessor.getChunkSize`: **100**
- `QaIssueService.insertIssues` `jdbcTemplate.batchUpdate` batch size: **1000**

### Caveats on the numbers

Single-machine, localhost, single backend node, one run per cell — directionally correct, ±10 % noise expected (DB state also accumulated across cells). 50k and 1k runs were separate sessions, so absolute numbers across the two scales are comparable directionally but not to better than ~15 %.

### Tests

- New tests for branch QA issue/flag carry-over, branch-creation stale recheck, LanguageTool retry behaviour, the multi-translation chunk path, and the self-heal listener.
- Existing QA and branching test suites continue to pass.

### Breaking change — frontend websocket payload

`qa-issues-updated` events now carry `data` as a list of per-translation updates instead of a single object (the backend emits one event per batch-job chunk). The webapp consumer has been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * QA checks run as chunked batches for faster, more efficient processing.
  * LanguageTool integration added with retry and configurable timeouts.
  * Automatic recheck of stale translations when branches are created and self-heal rechecks on batch finalization.

* **Improvements**
  * QA issues are copied during branch operations and preserved correctly.
  * Stale-translation queries improved with a targeted DB index.
  * Websocket payload handling updated to support multiple QA issue updates per event.

* **Tests**
  * New integration and unit tests covering QA batching, LanguageTool retries, and branch QA copying.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
