### PR TITLE
fix: pass URI to RestTemplate in Bunny cache purge 

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/cachePurging/bunny/BunnyContentDeliveryCachePurging.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/cachePurging/bunny/BunnyContentDeliveryCachePurging.kt
@@ -8,6 +8,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 import java.net.URLEncoder
 
 class BunnyContentDeliveryCachePurging(
@@ -29,11 +30,14 @@ class BunnyContentDeliveryCachePurging(
     val entity: HttpEntity<String> = getHttpEntity()
     val encodedPath = URLEncoder.encode("$prefix/${contentDeliveryConfig.slug}/*", Charsets.UTF_8)
 
-    val url = "https://api.bunny.net/purge?url=$encodedPath"
+    // Use URI directly to bypass RestTemplate's URI template processing, which would
+    // re-encode the percent-encoded characters in `encodedPath` and produce a double-encoded
+    // URL that Bunny rejects with `purge.urls_invalid`.
+    val uri = URI("https://api.bunny.net/purge?url=$encodedPath")
 
     val response =
       restTemplate.exchange(
-        url,
+        uri,
         HttpMethod.GET,
         entity,
         String::class.java,

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/BunnyContentStorageConfigCachePurgingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/BunnyContentStorageConfigCachePurgingTest.kt
@@ -17,19 +17,20 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 
 class BunnyContentStorageConfigCachePurgingTest {
   @Test
   fun `correctly purges`() {
     val config =
       ContentDeliveryBunnyProperties(
-        urlPrefix = "fake-url-prefix",
+        urlPrefix = "https://cdn.example.com",
         apiKey = "token",
       )
     val restTemplateMock: RestTemplate = mock()
     val purging = BunnyContentDeliveryCachePurging(config, restTemplateMock)
     val responseMock: ResponseEntity<*> = Mockito.mock(ResponseEntity::class.java)
-    whenever(restTemplateMock.exchange(any<String>(), any<HttpMethod>(), any(), eq(String::class.java))).doAnswer {
+    whenever(restTemplateMock.exchange(any<URI>(), any<HttpMethod>(), any(), eq(String::class.java))).doAnswer {
       responseMock as ResponseEntity<String>
     }
     whenever(responseMock.statusCode).thenReturn(HttpStatusCode.valueOf(200))
@@ -55,10 +56,14 @@ class BunnyContentStorageConfigCachePurgingTest {
 
   private fun getHttpEntity(invocation: Invocation) = invocation.arguments[2] as HttpEntity<*>
 
+  // The first argument must be a URI rather than a String — passing a String would route through
+  // RestTemplate's URI template engine and re-encode the already percent-encoded characters in
+  // the `url` query parameter, producing a double-encoded URL that Bunny rejects.
   private fun assertUrl(invocation: Invocation) {
-    val url = invocation.arguments[0]
-    url.assert.isEqualTo(
-      "https://api.bunny.net/purge?url=fake-url-prefix%2Ffake-slug%2F*",
+    val uri = invocation.arguments[0]
+    uri.assert.isInstanceOf(URI::class.java)
+    uri.assert.isEqualTo(
+      URI("https://api.bunny.net/purge?url=https%3A%2F%2Fcdn.example.com%2Ffake-slug%2F*"),
     )
   }
 }


### PR DESCRIPTION
to avoid double-encoding

The Bunny purge URL is built with a pre-encoded `url` query parameter (e.g. `https%3A%2F%2Fcdn.example.com%2F<slug>%2F*`). When passed as a String to `restTemplate.exchange`, Spring's URI template engine re-encodes the percent signs, producing a double-encoded URL that Bunny rejects with `purge.urls_invalid` and a 500 response to the user.

Passing a `URI` instead bypasses template processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Bunny CDN cache purging to properly handle URL encoding, resolving issues where paths with special characters were rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->