### PR TITLE
fix: migrate stale QA_EMPTY_PLURAL_VARIANT rows to new enum

### DIFF
--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5348,4 +5348,18 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet author="anty" id="2026-05-19-migrate-qa-empty-plural-variant">
+        <sql>
+            UPDATE translation_qa_issue
+            SET type = 'MISSING_PLURAL_CATEGORIES',
+                message = 'QA_MISSING_PLURAL_CATEGORY'
+            WHERE message = 'QA_EMPTY_PLURAL_VARIANT';
+        </sql>
+        <rollback>
+            UPDATE translation_qa_issue
+            SET type = 'EMPTY_TRANSLATION',
+                message = 'QA_EMPTY_PLURAL_VARIANT'
+            WHERE message = 'QA_MISSING_PLURAL_CATEGORY';
+        </rollback>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- Production threw `No enum constant io.tolgee.model.enums.qa.QaIssueMessage.QA_EMPTY_PLURAL_VARIANT` because the EMPTY_TRANSLATION QA check split (#3660) renamed `QA_EMPTY_PLURAL_VARIANT` → `QA_MISSING_PLURAL_CATEGORY` (and the type from `EMPTY_TRANSLATION` to `MISSING_PLURAL_CATEGORIES`) without a data migration.
- Adds a Liquibase changeset that updates existing `translation_qa_issue` rows in place to the new `type`/`message`. `params` (`{variant: <form>}`), `plural_variant`, and `state` already match the new `MissingPluralCategoriesCheck` output, so they're preserved as-is (incl. user-resolved states).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the QA issue classification system for better accuracy and consistency. Updated how plural variant translation issues are categorized, labeled, and tracked to enhance overall clarity and efficiency in quality assurance workflows and issue reporting processes. All existing QA issue data has been successfully migrated to the new classification structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->