### PR TITLE
fix: do not flag missing terminal punctuation in GrammarCheck

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/IsSentenceRule.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/IsSentenceRule.kt
@@ -3,13 +3,17 @@ package io.tolgee.ee.service.qa.checks.language
 import io.tolgee.ee.service.qa.LanguageToolMatch
 
 /**
- * Identifies LanguageTool rules that assume sentence context — e.g.,
- * "sentence should start with an uppercase letter" (UPPERCASE_SENTENCE_START).
+ * Identifies LanguageTool rules that assume the text is a complete, standalone
+ * sentence — e.g., "sentence should start with an uppercase letter" or "sentence
+ * should end with a punctuation mark" .
  *
- * These rules produce false positives on short, non-sentence translations
- * like button labels ("save", "click here", "add new item").
+ * These rules produce false positives on short, non-sentence translations like
+ * button labels ("save", "click here", "add new item").
  */
+private val PARAGRAPH_END_RULE_IDS = setOf("PUNCTUATION_PARAGRAPH_END", "PUNCTUATION_PARAGRAPH_END2")
+
 fun isSentenceRule(match: LanguageToolMatch): Boolean {
-  val categoryId = match.rule.category.id
-  return categoryId == "CASING"
+  if (match.rule.category.id == "CASING") return true
+  if (match.rule.id in PARAGRAPH_END_RULE_IDS) return true
+  return false
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/IsSentenceRule.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/language/IsSentenceRule.kt
@@ -5,7 +5,7 @@ import io.tolgee.ee.service.qa.LanguageToolMatch
 /**
  * Identifies LanguageTool rules that assume the text is a complete, standalone
  * sentence — e.g., "sentence should start with an uppercase letter" or "sentence
- * should end with a punctuation mark" .
+ * should end with a punctuation mark".
  *
  * These rules produce false positives on short, non-sentence translations like
  * button labels ("save", "click here", "add new item").

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/GrammarCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/GrammarCheckTest.kt
@@ -190,4 +190,40 @@ class GrammarCheckTest {
 
     check.check(params("click here")).assertNoIssues()
   }
+
+  @Test
+  fun `filters out missing-terminal-punctuation rule (PUNCTUATION_PARAGRAPH_END)`() {
+    val match =
+      LanguageToolMatch(
+        message = "Add a period at the end of the sentence.",
+        offset = 10,
+        length = 1,
+        rule =
+          LanguageToolRule(
+            id = "PUNCTUATION_PARAGRAPH_END",
+            category = LanguageToolCategory(id = "PUNCTUATION"),
+          ),
+      )
+    `when`(languageToolService.check(any(), any())).thenReturn(listOf(match))
+
+    check.check(params("Enregistrer", "fr")).assertNoIssues()
+  }
+
+  @Test
+  fun `filters out missing-terminal-punctuation rule (PUNCTUATION_PARAGRAPH_END2)`() {
+    val match =
+      LanguageToolMatch(
+        message = "Add a period at the end of the sentence.",
+        offset = 10,
+        length = 1,
+        rule =
+          LanguageToolRule(
+            id = "PUNCTUATION_PARAGRAPH_END2",
+            category = LanguageToolCategory(id = "PUNCTUATION"),
+          ),
+      )
+    `when`(languageToolService.check(any(), any())).thenReturn(listOf(match))
+
+    check.check(params("Enregistrer", "fr")).assertNoIssues()
+  }
 }


### PR DESCRIPTION
## Summary

- GrammarCheck (LanguageTool-backed translation QA) flagged French strings like `Enregistrer` for missing a final dot. App translations are routinely fragments (button labels, headings, list items) with no terminal period — these are false positives.
- Extended `isSentenceRule` to also drop LanguageTool rule IDs `PUNCTUATION_PARAGRAPH_END` and `PUNCTUATION_PARAGRAPH_END2` (both verified in upstream LanguageTool sources). Same false-positive class as the existing `CASING` filter for "sentence must start uppercase".
- Cross-language terminal-punctuation parity is still covered by the separate `PunctuationMismatchCheck`, so coverage is not lost. Other `PUNCTUATION`-category rules (e.g. French `FRENCH_WHITESPACE`) remain active.
- Added two mirror tests in `GrammarCheckTest` for both rule-id variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grammar checking to recognize additional punctuation rules that mark paragraph endings, reducing false-positive issues at sentence/paragraph boundaries.

* **Tests**
  * Added unit tests to ensure paragraph-end punctuation rules are correctly filtered during grammar validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->