### PR TITLE
fix: update outdated CSV format help link in glossary import dialog

### DIFF
--- a/webapp/src/ee/glossary/components/GlossaryImportDialog.tsx
+++ b/webapp/src/ee/glossary/components/GlossaryImportDialog.tsx
@@ -106,7 +106,7 @@ export const GlossaryImportDialog: React.VFC<Props> = ({
           onFileSelect={setFile}
           acceptedFileTypes={[{ extension: '.csv', icon: CsvLogo }]}
           helpLink={{
-            href: 'https://docs.tolgee.io/platform/projects_and_organizations/managing_glossaries#importing-terms-to-a-glossary',
+            href: 'https://docs.tolgee.io/platform/glossaries/importing_and_exporting_glossaries#format-of-the-csv-file',
             text: <T keyName="glossary_import_csv_formatting_guide" />,
           }}
         />


### PR DESCRIPTION
## Summary
- "How to format CSV" button in the glossary import dialog pointed to an outdated docs URL/anchor.
- Updated link to `https://docs.tolgee.io/platform/glossaries/importing_and_exporting_glossaries#format-of-the-csv-file`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the help documentation link in the glossary import dialog to point to more specific guidance on CSV file formatting requirements for importing glossaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3674?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->