### PR TITLE
fix: orphan batch job redis locks

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
@@ -16,12 +16,17 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.Date
 
+private const val DUMMY_LOCKED_JOB_ID = 999_999_999L
+
 @SpringBootTest(
   properties = ["tolgee.batch.old-job-cleanup-enabled=true"],
 )
 class OldBatchJobCleanerTest : AbstractSpringTest() {
   @Autowired
   lateinit var oldBatchJobCleaner: OldBatchJobCleaner
+
+  @Autowired
+  lateinit var lockingManager: BatchJobProjectLockingManager
 
   lateinit var testData: BaseTestData
 
@@ -149,6 +154,33 @@ class OldBatchJobCleanerTest : AbstractSpringTest() {
     assertJobDeleted(cancelledJob.id)
     assertJobExists(failedJob.id)
     assertJobExists(runningJob.id)
+  }
+
+  @Test
+  fun `releases project lock pointing at a deleted job`() {
+    val oldDate = Date().addDays(-5)
+    val job = createJobWithStatus(BatchJobStatus.SUCCESS, oldDate)
+    val projectId = testData.project.id
+    lockingManager.getMap()[projectId] = job.id
+
+    oldBatchJobCleaner.cleanup()
+
+    assertJobDeleted(job.id)
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(0L)
+  }
+
+  @Test
+  fun `leaves project lock untouched when it points at a different (live) job`() {
+    val oldDate = Date().addDays(-5)
+    val oldJob = createJobWithStatus(BatchJobStatus.SUCCESS, oldDate)
+    val projectId = testData.project.id
+    // Simulate a different live job currently holding the lock for this project.
+    lockingManager.getMap()[projectId] = DUMMY_LOCKED_JOB_ID
+
+    oldBatchJobCleaner.cleanup()
+
+    assertJobDeleted(oldJob.id)
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(DUMMY_LOCKED_JOB_ID)
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
@@ -20,10 +20,6 @@ import java.util.Date
   properties = ["tolgee.batch.old-job-cleanup-enabled=true"],
 )
 class OldBatchJobCleanerTest : AbstractSpringTest() {
-  companion object {
-    private const val DUMMY_LOCKED_JOB_ID = 999_999_999L
-  }
-
   @Autowired
   lateinit var oldBatchJobCleaner: OldBatchJobCleaner
 
@@ -175,14 +171,14 @@ class OldBatchJobCleanerTest : AbstractSpringTest() {
   fun `leaves project lock untouched when it points at a different (live) job`() {
     val oldDate = Date().addDays(-5)
     val oldJob = createJobWithStatus(BatchJobStatus.SUCCESS, oldDate)
+    val liveJob = createJobWithStatus(BatchJobStatus.RUNNING, Date())
     val projectId = testData.project.id
-    // Simulate a different live job currently holding the lock for this project.
-    lockingManager.getMap()[projectId] = DUMMY_LOCKED_JOB_ID
+    lockingManager.getMap()[projectId] = liveJob.id
 
     oldBatchJobCleaner.cleanup()
 
     assertJobDeleted(oldJob.id)
-    lockingManager.getLockedForProject(projectId).assert.isEqualTo(DUMMY_LOCKED_JOB_ID)
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(liveJob.id)
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/OldBatchJobCleanerTest.kt
@@ -16,12 +16,14 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.Date
 
-private const val DUMMY_LOCKED_JOB_ID = 999_999_999L
-
 @SpringBootTest(
   properties = ["tolgee.batch.old-job-cleanup-enabled=true"],
 )
 class OldBatchJobCleanerTest : AbstractSpringTest() {
+  companion object {
+    private const val DUMMY_LOCKED_JOB_ID = 999_999_999L
+  }
+
   @Autowired
   lateinit var oldBatchJobCleaner: OldBatchJobCleaner
 

--- a/backend/app/src/test/kotlin/io/tolgee/batch/ScheduledJobCleanerOrphanLocksTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/ScheduledJobCleanerOrphanLocksTest.kt
@@ -1,0 +1,73 @@
+package io.tolgee.batch
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.batch.cleaning.ScheduledJobCleaner
+import io.tolgee.development.testDataBuilder.data.BaseTestData
+import io.tolgee.model.batch.BatchJob
+import io.tolgee.model.batch.BatchJobStatus
+import io.tolgee.testing.assert
+import io.tolgee.util.executeInNewTransaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class ScheduledJobCleanerOrphanLocksTest : AbstractSpringTest() {
+  @Autowired
+  lateinit var scheduledJobCleaner: ScheduledJobCleaner
+
+  @Autowired
+  lateinit var lockingManager: BatchJobProjectLockingManager
+
+  lateinit var testData: BaseTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = BaseTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @Test
+  fun `clears orphan project lock pointing at a non-existent job`() {
+    val projectId = testData.project.id
+    val deletedJobId = 9_876_543_210L
+    lockingManager.getMap()[projectId] = deletedJobId
+
+    scheduledJobCleaner.cleanup()
+
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(0L)
+  }
+
+  @Test
+  fun `keeps project lock pointing at an existing job`() {
+    val projectId = testData.project.id
+    val liveJob = createJob(BatchJobStatus.PENDING)
+    lockingManager.getMap()[projectId] = liveJob.id
+
+    scheduledJobCleaner.cleanup()
+
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(liveJob.id)
+  }
+
+  @Test
+  fun `leaves freed lock slots (value zero) alone`() {
+    val projectId = testData.project.id
+    lockingManager.getMap()[projectId] = 0L
+
+    scheduledJobCleaner.cleanup()
+
+    lockingManager.getLockedForProject(projectId).assert.isEqualTo(0L)
+  }
+
+  private fun createJob(status: BatchJobStatus): BatchJob =
+    executeInNewTransaction(platformTransactionManager) {
+      val job =
+        BatchJob().apply {
+          this.status = status
+          this.project = testData.project
+          this.totalChunks = 0
+        }
+      entityManager.persist(job)
+      entityManager.flush()
+      job
+    }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
@@ -426,6 +426,21 @@ class BatchJobService(
     before: Date,
   ): List<BatchJob> = batchJobRepository.getCompletedJobs(lockedJobIds, before)
 
+  fun findExistingJobIds(jobIds: Iterable<Long>): Set<Long> {
+    val idList = jobIds.toList()
+    if (idList.isEmpty()) return emptySet()
+    @Suppress("UNCHECKED_CAST")
+    return entityManager
+      .createNativeQuery(
+        """
+        SELECT id FROM tolgee_batch_job WHERE id IN :ids
+        """,
+      ).setParameter("ids", idList)
+      .resultList
+      .map { (it as Number).toLong() }
+      .toSet()
+  }
+
   fun getStuckJobIds(jobIds: MutableSet<Long>): List<Long> {
     return batchJobRepository.getStuckJobIds(jobIds, currentDateProvider.date.addMinutes(-2))
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/OldBatchJobCleaner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/OldBatchJobCleaner.kt
@@ -2,6 +2,7 @@ package io.tolgee.batch.cleaning
 
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import io.tolgee.batch.BatchJobProjectLockingManager
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.LockingProvider
 import io.tolgee.component.SchedulingManager
@@ -13,6 +14,7 @@ import io.tolgee.util.logger
 import io.tolgee.util.runSentryCatching
 import jakarta.persistence.EntityManager
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import org.springframework.transaction.PlatformTransactionManager
@@ -29,6 +31,8 @@ class OldBatchJobCleaner(
   private val lockingProvider: LockingProvider,
   private val transactionManager: PlatformTransactionManager,
   private val schedulingManager: SchedulingManager,
+  @Lazy
+  private val lockingManager: BatchJobProjectLockingManager,
 ) : Logging {
   @EventListener(ApplicationReadyEvent::class)
   fun scheduleCleanup() {
@@ -98,27 +102,29 @@ class OldBatchJobCleaner(
     statuses: List<String>,
     cutoffDate: Date,
   ): Pair<Int, Int> {
-    val jobIds = findJobIdsToDelete(statuses, cutoffDate)
-    if (jobIds.isEmpty()) return Pair(0, 0)
+    val jobs = findJobsToDelete(statuses, cutoffDate)
+    if (jobs.isEmpty()) return Pair(0, 0)
 
+    val jobIds = jobs.map { it.jobId }
     val executionIds = findExecutionIds(jobIds)
     nullifyActivityRevisionReferences(jobIds, executionIds)
     deleteChunkExecutions(jobIds, executionIds)
     deleteBatchJobs(jobIds)
+    releaseProjectLocks(jobs)
 
     return Pair(jobIds.size, executionIds.size)
   }
 
-  private fun findJobIdsToDelete(
+  private fun findJobsToDelete(
     statuses: List<String>,
     cutoffDate: Date,
-  ): List<Long> {
+  ): List<JobToDelete> {
     val statusesPlaceholder = statuses.mapIndexed { index, _ -> ":status$index" }.joinToString(", ")
     val query =
       entityManager
         .createNativeQuery(
           """
-          SELECT id FROM tolgee_batch_job
+          SELECT id, project_id FROM tolgee_batch_job
           WHERE status IN ($statusesPlaceholder)
           AND updated_at < :cutoffDate
           LIMIT :batchSize
@@ -130,11 +136,35 @@ class OldBatchJobCleaner(
     }
 
     @Suppress("UNCHECKED_CAST")
-    return query
-      .setParameter("cutoffDate", cutoffDate)
-      .setParameter("batchSize", batchProperties.jobCleanupBatchSize)
-      .resultList as List<Long>
+    val rows =
+      query
+        .setParameter("cutoffDate", cutoffDate)
+        .setParameter("batchSize", batchProperties.jobCleanupBatchSize)
+        .resultList as List<Array<Any?>>
+
+    return rows.map {
+      JobToDelete(
+        jobId = (it[0] as Number).toLong(),
+        projectId = (it[1] as Number?)?.toLong(),
+      )
+    }
   }
+
+  /**
+   * Releases any project lock still held by the deleted jobs. Normally the lock is released
+   * when the job completes, but if that ever failed (process crash, exception in the cancel
+   * path, etc.), the entry in `project_batch_job_locks` would point at a job id whose DB row
+   * is now gone — permanently blocking every future batch job for that project. This is a
+   * belt-and-suspenders cleanup tied to the same transaction boundary as the row deletion.
+   */
+  private fun releaseProjectLocks(jobs: List<JobToDelete>) {
+    jobs.forEach { lockingManager.unlockJobForProject(it.projectId, it.jobId) }
+  }
+
+  private data class JobToDelete(
+    val jobId: Long,
+    val projectId: Long?,
+  )
 
   private fun findExecutionIds(jobIds: List<Long>): List<Long> {
     @Suppress("UNCHECKED_CAST")

--- a/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/ScheduledJobCleaner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/ScheduledJobCleaner.kt
@@ -41,7 +41,35 @@ class ScheduledJobCleaner(
     runSentryCatching {
       handleCompletedJobsCacheState()
       handleStuckJobs()
+      handleOrphanProjectLocks()
     }
+  }
+
+  /**
+   * Detects entries in `project_batch_job_locks` that point at a job id no longer present in
+   * `tolgee_batch_job` and resets them. This protects against orphan locks that survived job
+   * deletion through any path — the deletion cleanup is the first line of defense, this is
+   * the safety net for future regressions and pre-existing stale entries.
+   */
+  private fun handleOrphanProjectLocks() {
+    val lockedEntries =
+      lockingManager
+        .getMap()
+        .entries
+        .mapNotNull { entry ->
+          val jobId = entry.value ?: return@mapNotNull null
+          if (jobId == 0L) return@mapNotNull null
+          entry.key to jobId
+        }
+    if (lockedEntries.isEmpty()) return
+
+    val existingJobIds = batchJobService.findExistingJobIds(lockedEntries.map { it.second })
+    lockedEntries
+      .filter { it.second !in existingJobIds }
+      .forEach { (projectId, jobId) ->
+        logger.warn("Releasing orphan project lock: project=$projectId points at deleted job=$jobId")
+        lockingManager.unlockJobForProject(projectId, jobId)
+      }
   }
 
   private fun handleStuckJobs() {


### PR DESCRIPTION
When `OldBatchJobCleaner` deletes a job whose row still owned a project lock in `project_batch_job_locks`, the lock was left pointing at a now-deleted job id, permanently blocking every subsequent batch job for that project until manually cleared in Redis.

Two complementary fixes:

1. `OldBatchJobCleaner` now releases the project lock for every job it deletes (no-op when the lock is already free or held by a different live job), preventing the orphan from being created in the first place.
2. `ScheduledJobCleaner.handleOrphanProjectLocks()` scans the lock map on its existing 10-second cadence and resets any entry whose owning job id no longer exists in the database — a safety net that also self-heals pre-existing stale entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch job cleanup now releases project locks for deleted jobs and detects/removes stale orphan locks that reference non-existent batch jobs.
* **Tests**
  * Added tests verifying locks are released when jobs are deleted, preserved for existing jobs, and that freed (zero) lock slots remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->