### PR TITLE
chore: drop stale build cache and slim release image to JRE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,6 @@ jobs:
           VERSION: ${{ steps.version.outputs.VERSION }}
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
-          DOCKER_CACHE_FROM: type=registry,ref=tolgee/tolgee:latest
-          DOCKER_CACHE_TO: type=inline
 
       - name: Pack with webapp
         if: ${{ steps.version.outputs.VERSION != '' }}

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:13.21-alpine3.22
 
 ENTRYPOINT []
 
-RUN apk --no-cache add openjdk21
+RUN apk --no-cache add openjdk21-jre
 RUN apk --no-cache add libxml2
 
 #############


### PR DESCRIPTION
## Problem

The release build uses `--cache-from type=registry,ref=tolgee/tolgee:latest`, which restores the `RUN apk add` layer from the previously published image every time. The OS-package layer hasn't genuinely re-run for months — `tolgee/tolgee:latest` still ships `openjdk 21.0.8`, `libpng 1.6.47`, `lcms2 2.16`, so the image keeps accumulating already-fixed Alpine CVEs.

## Changes

- **`release.yml`** — drop `DOCKER_CACHE_FROM` / `DOCKER_CACHE_TO` so each release re-resolves apk packages against the current Alpine repo. `dockerPublish` already treats them as optional; `prerelease-alpha.yml` already builds without cache.
- **`Dockerfile`** — `openjdk21` → `openjdk21-jre`: the app is a Spring Boot fat-jar and needs no JDK toolchain, demos, docs, or jmods.

## Impact

Rebuilding against current packages clears ~20 OS-package issues (53 → 33 on the container scan), ~7 of them high. The JRE switch trims the image ~100 MB with no functional change. Remaining issues are genuine no-fix Alpine advisories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Docker build process configuration to streamline deployments.
  * Updated Docker image base package to use Java Runtime Environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->