### PR TITLE
fix: replace QA badge stale spinner with static dots icon

### DIFF
--- a/webapp/src/ee/qa/components/QaBadge.tsx
+++ b/webapp/src/ee/qa/components/QaBadge.tsx
@@ -1,10 +1,15 @@
-import { Badge, CircularProgress, styled } from '@mui/material';
+import { Badge, styled } from '@mui/material';
 
 import { QaBadgeProps } from '../../../eeSetup/EeModuleType';
 import { QaCheck } from 'tg.component/CustomIcons';
-import { Check } from '@untitled-ui/icons-react';
+import { Check, DotsHorizontal } from '@untitled-ui/icons-react';
+import clsx from 'clsx';
 
 const StyledBadge = styled(Badge)`
+  &.darker {
+    opacity: 0.5;
+  }
+
   display: flex;
 
   & .unresolved {
@@ -22,24 +27,16 @@ const StyledBadge = styled(Badge)`
     align-items: center;
     justify-content: center;
   }
-  & .stale {
-    overflow: hidden;
-  }
-`;
-
-const StyledSpinner = styled(CircularProgress)`
-  color: ${({ theme }) => theme.palette.emphasis[100]};
-  width: 10px !important;
-  height: 10px !important;
-  margin: -5px;
-
-  & svg {
-    width: 10px;
-    height: 10px;
-  }
 `;
 
 const StyledCheckIcon = styled(Check)`
+  color: ${({ theme }) => theme.palette.emphasis[100]};
+  width: 14px !important;
+  height: 14px !important;
+  margin: -5px;
+`;
+
+const StyledDotsIcon = styled(DotsHorizontal)`
   color: ${({ theme }) => theme.palette.emphasis[100]};
   width: 14px !important;
   height: 14px !important;
@@ -52,18 +49,14 @@ export const QaBadge = ({
   darkWhenNoIssues = false,
 }: QaBadgeProps) => {
   if (stale) {
-    const hasIssues = count !== undefined && count > 0;
     return (
       <span data-cy="qa-badge">
         <StyledBadge
-          badgeContent={<StyledSpinner size={10} thickness={5} />}
+          badgeContent={<StyledDotsIcon />}
           classes={{ badge: 'stale' }}
+          className={clsx({ darker: darkWhenNoIssues })}
         >
-          <QaCheck
-            style={
-              hasIssues || !darkWhenNoIssues ? undefined : { opacity: 0.5 }
-            }
-          />
+          <QaCheck />
         </StyledBadge>
       </span>
     );
@@ -75,8 +68,9 @@ export const QaBadge = ({
         <StyledBadge
           badgeContent={<StyledCheckIcon />}
           classes={{ badge: 'resolved' }}
+          className={clsx({ darker: darkWhenNoIssues })}
         >
-          <QaCheck style={!darkWhenNoIssues ? undefined : { opacity: 0.5 }} />
+          <QaCheck />
         </StyledBadge>
       </span>
     );

--- a/webapp/src/views/projects/DashboardProjectListItem.tsx
+++ b/webapp/src/views/projects/DashboardProjectListItem.tsx
@@ -195,7 +195,8 @@ const DashboardProjectListItem = (p: ProjectWithStatsModel) => {
                 >
                   <QaBadge
                     count={p.stats.qaIssueCount}
-                    stale={hasStaleQaChecks}
+                    stale={hasStaleQaChecks && !p.stats.qaIssueCount}
+                    darkWhenNoIssues
                   />
                 </IconButton>
               </Tooltip>

--- a/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
@@ -207,7 +207,7 @@ export const ControlsTranslation: React.FC<ControlsProps> = ({
           data-cy="translations-cell-qa-issues-button"
           className={clsx({
             [CELL_SHOW_ON_HOVER]: !qaIssueCount,
-            [CELL_HIGHLIGHT_ON_HOVER]: qaIssuesResolved,
+            [CELL_HIGHLIGHT_ON_HOVER]: qaIssuesResolved || qaChecksStale,
           })}
           tooltip={t('translation_cell_qa_issues')}
         >


### PR DESCRIPTION
## Summary

- Replace `CircularProgress` spinner in stale QA badge with static `DotsHorizontal` icon — quieter indicator that doesn't draw user attention to background QA work
- Dim the badge via a `darker` class (opacity 0.5) when `darkWhenNoIssues` is set, instead of per-element opacity on the inner `QaCheck`
- On the project dashboard, only show the badge as stale when there are no unresolved QA issues, and dim it via `darkWhenNoIssues`
- Highlight the translation cell QA button on hover when checks are stale (matching the resolved state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated QA badge icons and opacity behavior to give clearer visual feedback when no issues are present.
  * Adjusted dashboard QA badge logic to only mark badges stale when checks are stale and no issues exist.
  * Expanded QA issues control button hover highlighting to trigger for both resolved issues and stale check states for improved visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->