### PR TITLE
fix: TM suggestion panel overflowing its container & e2e tests fixes

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/StartBatchJobController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/batch/StartBatchJobController.kt
@@ -52,7 +52,7 @@ class StartBatchJobController(
 ) {
   @PostMapping(value = ["/pre-translate-by-tm"])
   @Operation(
-    summary = "Pre-translate by TM",
+    summary = "Translate from memory",
     description = "Pre-translate provided keys to provided languages by TM.",
   )
   @RequiresProjectPermissions([Scope.BATCH_PRE_TRANSLATE_BY_TM])

--- a/e2e/cypress/common/permissions/batchOperations.ts
+++ b/e2e/cypress/common/permissions/batchOperations.ts
@@ -63,7 +63,7 @@ export function testBatchOperations(projectInfo: ProjectInfo) {
         'translations.batch-machine',
         () => checkTargetLanguages(translateLanguageIds, projectInfo),
       ],
-      'Pre-translate by TM': [
+      'Translate from memory': [
         'translations.batch-by-tm',
         () => checkTargetLanguages(translateLanguageIds, projectInfo),
       ],

--- a/e2e/cypress/e2e/translations/batchJobs.cy.ts
+++ b/e2e/cypress/e2e/translations/batchJobs.cy.ts
@@ -116,7 +116,7 @@ describe('Batch jobs', { scrollBehavior: false }, () => {
 
   it('will pre-translate with TM', () => {
     cy.gcy('translations-row-checkbox').first().click();
-    selectOperation('Pre-translate by TM');
+    selectOperation('Translate from memory');
     assertLanguagesSelected(['German']);
     executeBatchOperation();
   });

--- a/webapp/src/views/projects/translations/ToolsPanel/ToolsPanel.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/ToolsPanel.tsx
@@ -27,12 +27,14 @@ const StyledTitle = styled(Box)`
 
 const StyledWrapper = styled('div')`
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   padding: 8px 0px 8px 0px;
   padding-bottom: 100px;
 `;
 
 const StyledPanelList = styled(Box)`
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   position: relative;
 `;
 

--- a/webapp/src/views/projects/translations/ToolsPanel/common/Panel.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/common/Panel.tsx
@@ -5,6 +5,10 @@ import { PanelHeader } from './PanelHeader';
 
 const StyledContainer = styled(Box)`
   display: grid;
+  /* Bound the column to the available width (minmax min of 0, not the implicit
+     auto = min-content) so a panel with long unbreakable content can't widen
+     the shared column and push its siblings out. */
+  grid-template-columns: minmax(0, 1fr);
 `;
 
 const StyledContent = styled(Box)`

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -111,11 +111,30 @@ const StyledMeta = styled('div')`
   overflow: hidden;
 `;
 
-const StyledMetaItem = styled('span')`
+// The meta line has three parts of unequal importance. Rather than letting them
+// all shrink uniformly (which collapses every part to a useless "D…" stub), only
+// the key reference yields space — it is the longest and noisiest. The TM name
+// and timestamp keep their natural width; each still ellipsis-truncates on its
+// own as a last resort so a pathological value can't break the line.
+const StyledMetaTmName = styled('span')`
+  flex-shrink: 0;
+  max-width: 140px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+`;
+
+const StyledMetaKey = styled('span')`
+  flex-shrink: 1;
   min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const StyledMetaTime = styled('span')`
+  flex-shrink: 0;
+  white-space: nowrap;
 `;
 
 const StyledMetaSeparator = styled('span')`
@@ -249,29 +268,28 @@ export const TranslationMemoryItem = ({
             const parts: React.ReactNode[] = [];
             if (item.translationMemoryName) {
               parts.push(
-                <StyledMetaItem
-                  key="tm"
-                  data-cy="translation-tools-translation-memory-item-tm-name"
-                >
-                  {item.translationMemoryName}
-                </StyledMetaItem>
+                <Tooltip key="tm" title={item.translationMemoryName}>
+                  <StyledMetaTmName data-cy="translation-tools-translation-memory-item-tm-name">
+                    {item.translationMemoryName}
+                  </StyledMetaTmName>
+                </Tooltip>
               );
             }
             if (item.keyName) {
               parts.push(
                 <Tooltip key="key" title={item.keyName}>
-                  <StyledMetaItem data-cy="translation-tools-translation-memory-item-key-name">
+                  <StyledMetaKey data-cy="translation-tools-translation-memory-item-key-name">
                     {item.keyName}
-                  </StyledMetaItem>
+                  </StyledMetaKey>
                 </Tooltip>
               );
             }
             if (updatedAtLabel) {
               parts.push(
                 <Tooltip key="time" title={updatedAtAbsolute ?? ''}>
-                  <StyledMetaItem data-cy="translation-tools-translation-memory-item-updated">
+                  <StyledMetaTime data-cy="translation-tools-translation-memory-item-updated">
                     {updatedAtLabel}
-                  </StyledMetaItem>
+                  </StyledMetaTime>
                 </Tooltip>
               );
             }

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -53,7 +53,7 @@ const StyledHead = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
+  gap: 20px;
 `;
 
 // Three-tier scheme matching the pre-PR design (green / orange / grey at 1.0 / 0.7


### PR DESCRIPTION
Follow-up fixes for the Translation Memory feature (#3596).

## 1. TM tools panel overflowing its container

A TM suggestion with a long key reference widened the tools sidebar, and every other panel (Machine Translation, Glossary, …) got dragged to that width too — clipping content.

**Cause:** the sidebar is three nested `display: grid` containers (`StyledWrapper` → `StyledPanelList` → `Panel`'s `StyledContainer`), each with an implicit `auto` column that sizes to max-content. The TM panel's long, unbreakable meta line widened the shared column.

**Fix:**
- `grid-template-columns: minmax(0, 1fr)` on the three grid containers — columns are bounded to the available width and inner content can shrink.
- The TM suggestion meta line (`TM name · key reference · timestamp`) previously shrank all three parts uniformly into useless `D…` stubs. Now only the key reference yields space; TM name (capped at 140px, tooltip) and timestamp keep their natural width.

## 2. Rename the TM batch operation to "Translate from memory"

The "Pre-translate by TM" batch operation is renamed to **"Translate from memory"**. Updates the API `@Operation` summary in `StartBatchJobController` and the matching e2e references (`batchJobs.cy.ts`, `permissions/batchOperations.ts`).

## Test plan

- [x] Frontend static checks (ESLint + tsc) — webapp and e2e
- [x] Panel overflow verified live: with an 84-char key name, all tool panels render at identical width, no horizontal overflow; key reference truncates, TM name + timestamp stay readable
- [ ] e2e batch-job suite green in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout stability in the tools panel to prevent long content from breaking the layout.
  * Enhanced spacing, text truncation and overflow handling in Translation Memory items for better readability.

* **Documentation**
  * Updated UI terminology from "Pre-translate by TM" to "Translate from memory".

* **Tests**
  * Updated end-to-end tests to reflect the terminology change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->