### PR TITLE
chore(ci): detect flaky tests via test retries

### DIFF
--- a/.github/workflows/reportIntermittentTests.yml
+++ b/.github/workflows/reportIntermittentTests.yml
@@ -61,6 +61,7 @@ jobs:
         env:
           SKIP_SERVER_BUILD: true
           SKIP_EMAIL_BUILD: true
+          DETECT_FLAKY_TESTS: true
 
       - name: Get report name
         id: reportName
@@ -85,27 +86,19 @@ jobs:
           fail-on-error: false
           reporter: java-junit
 
-      - name: Collect failed tests
-        if: failure()
-        run: |
-          python3 -c "
-          import xml.etree.ElementTree as ET
-          import glob
-          for f in glob.glob('**/build/test-results/**/TEST-*.xml', recursive=True):
-              try:
-                  tree = ET.parse(f)
-              except ET.ParseError:
-                  continue
-              for tc in tree.findall('.//testcase'):
-                  if tc.find('failure') is not None or tc.find('error') is not None:
-                      print(f'{tc.get(\"classname\")}.{tc.get(\"name\")}')
-          " > failed-tests-${{ steps.reportName.outputs.reportName }}.txt || true
+      - name: Collect flaky and failed tests
+        if: always()
+        continue-on-error: true
+        run: python3 scripts/collect-flaky-tests.py "${{ steps.reportName.outputs.reportName }}"
 
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
-          name: failed_tests_${{ steps.reportName.outputs.reportName }}
-          path: failed-tests-${{ steps.reportName.outputs.reportName }}.txt
+          name: flaky_tests_${{ steps.reportName.outputs.reportName }}
+          path: |
+            flaky-tests-${{ steps.reportName.outputs.reportName }}.txt
+            failed-tests-${{ steps.reportName.outputs.reportName }}.txt
+          if-no-files-found: ignore
 
   frontend-build:
     name: Build frontend 🏗️
@@ -214,19 +207,16 @@ jobs:
           SKIP_INSTALL_E2E_DEPS: true
           E2E_TOTAL_JOBS: ${{matrix.total_jobs}}
           E2E_JOB_INDEX: ${{matrix.job_index}}
-
-      - name: Collect failed tests
-        if: failure()
-        run: |
-          find ./e2e/cypress/screenshots -name "*.png" 2>/dev/null \
-            | sed 's|.*/screenshots/||; s| (failed)\.png$||; s| -- | > |' \
-            | sort -u > failed-tests-e2e-${{ matrix.job_index }}.txt || true
+          DETECT_FLAKY_TESTS: true
 
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
-          name: failed_tests_e2e_${{ matrix.job_index }}
-          path: failed-tests-e2e-${{ matrix.job_index }}.txt
+          name: flaky_tests_e2e_${{ matrix.job_index }}
+          path: |
+            ./e2e/flaky-tests-e2e-${{ matrix.job_index }}.txt
+            ./e2e/failed-tests-e2e-${{ matrix.job_index }}.txt
+          if-no-files-found: ignore
 
       - uses: actions/upload-artifact@v4
         if: failure()
@@ -261,7 +251,7 @@ jobs:
   notify:
     name: Report flaky tests 🔔
     needs: [backend-test, e2e]
-    if: failure()
+    if: always()
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -270,13 +260,48 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: failed_tests_*
+          pattern: flaky_tests_*
           merge-multiple: true
-          path: ./failures
+          path: ./flaky
         continue-on-error: true
 
-      - name: Report to project board
+      # Flaky tests (failed then passed on retry) and hard failures (failed
+      # every retry) are collected into separate artifacts. Only flaky tests
+      # are reported to the board; hard failures are surfaced in Slack only.
+      - name: Summarize results
+        id: summary
+        run: |
+          flaky=""
+          failed=""
+          if compgen -G './flaky/flaky-tests-*.txt' > /dev/null; then
+            flaky=$(cat ./flaky/flaky-tests-*.txt | sed '/^[[:space:]]*$/d' | sort -u)
+          fi
+          if compgen -G './flaky/failed-tests-*.txt' > /dev/null; then
+            failed=$(cat ./flaky/failed-tests-*.txt | sed '/^[[:space:]]*$/d' | sort -u)
+          fi
+          flaky_count=0
+          failed_count=0
+          if [ -n "$flaky" ]; then
+            flaky_count=$(printf '%s\n' "$flaky" | wc -l | tr -d ' ')
+          fi
+          if [ -n "$failed" ]; then
+            failed_count=$(printf '%s\n' "$failed" | wc -l | tr -d ' ')
+          fi
+          echo "Found $flaky_count flaky, $failed_count consistently failing tests"
+          {
+            echo "flaky_count=$flaky_count"
+            echo "failed_count=$failed_count"
+            echo 'flaky_list<<EOF'
+            [ -n "$flaky" ] && printf '%s\n' "$flaky" | head -30 | sed 's/.*/• `&`/'
+            echo 'EOF'
+            echo 'failed_list<<EOF'
+            [ -n "$failed" ] && printf '%s\n' "$failed" | head -30 | sed 's/.*/• `&`/'
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Report flaky tests to project board
         id: project
+        if: steps.summary.outputs.flaky_count != '0'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
@@ -285,38 +310,35 @@ jobs:
           TEAM_ORG: tolgee
           TEAM_SLUG: coders
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: python3 scripts/report-flaky-tests.py ./failures .
-
-      - name: Build failure list
-        id: failures
-        if: always()
-        run: |
-          {
-            echo 'list<<EOF'
-            if compgen -G './failures/failed-tests-*.txt' > /dev/null; then
-              cat ./failures/failed-tests-*.txt | sort -u | head -30 | sed 's/.*/• `&`/'
-            fi
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
+        run: python3 scripts/report-flaky-tests.py ./flaky .
 
       - name: Send Slack notification
-        if: always()
+        if: steps.summary.outputs.flaky_count != '0' || steps.summary.outputs.failed_count != '0'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FLAKY_TESTS_WEBHOOK_URL }}
-          FAILED_TESTS: ${{ steps.failures.outputs.list }}
+          FLAKY_TESTS: ${{ steps.summary.outputs.flaky_list }}
+          FAILED_TESTS: ${{ steps.summary.outputs.failed_list }}
+          FLAKY_COUNT: ${{ steps.summary.outputs.flaky_count }}
+          FAILED_COUNT: ${{ steps.summary.outputs.failed_count }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PROJECT_URL: ${{ steps.project.outputs.project_url }}
           NEW_COUNT: ${{ steps.project.outputs.new_count }}
           RECURRING_COUNT: ${{ steps.project.outputs.recurring_count }}
         run: |
           {
-            echo "🔴 Flaky tests detected in *${{ github.repository }}*"
-            if [ -n "$FAILED_TESTS" ]; then
+            if [ "${FLAKY_COUNT:-0}" != "0" ]; then
+              echo "🟡 ${FLAKY_COUNT} flaky test(s) detected in *${{ github.repository }}*"
+              echo ""
+              echo "$FLAKY_TESTS"
+            fi
+            if [ "${FAILED_COUNT:-0}" != "0" ]; then
+              if [ "${FLAKY_COUNT:-0}" != "0" ]; then echo ""; fi
+              echo "🔴 ${FAILED_COUNT} test(s) failing on every retry — broken, not flaky"
               echo ""
               echo "$FAILED_TESTS"
             fi
             echo ""
-            echo "<${RUN_URL}|View failed run>"
+            echo "<${RUN_URL}|View run>"
             if [ -n "$PROJECT_URL" ]; then
               echo "<${PROJECT_URL}|Flaky tests board> — ${NEW_COUNT:-0} new, ${RECURRING_COUNT:-0} recurring"
             fi

--- a/.github/workflows/reportIntermittentTests.yml
+++ b/.github/workflows/reportIntermittentTests.yml
@@ -299,9 +299,11 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      # Always run so the sweep pass cleans up stale Suspected items even on
+      # nights with no flaky detections.
       - name: Report flaky tests to project board
         id: project
-        if: steps.summary.outputs.flaky_count != '0'
+        if: always()
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.PROJECTS_TOKEN }}
@@ -312,27 +314,31 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: python3 scripts/report-flaky-tests.py ./flaky .
 
+      # Newly confirmed flakes and hard failures are the actionable signals;
+      # raw per-run flaky counts (unpromoted Suspected items) don't trigger
+      # Slack on their own.
       - name: Send Slack notification
-        if: steps.summary.outputs.flaky_count != '0' || steps.summary.outputs.failed_count != '0'
+        if: steps.project.outputs.newly_confirmed_count != '0' || steps.summary.outputs.failed_count != '0'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FLAKY_TESTS_WEBHOOK_URL }}
-          FLAKY_TESTS: ${{ steps.summary.outputs.flaky_list }}
+          NEWLY_CONFIRMED_TESTS: ${{ steps.project.outputs.newly_confirmed_list }}
+          NEWLY_CONFIRMED_COUNT: ${{ steps.project.outputs.newly_confirmed_count }}
           FAILED_TESTS: ${{ steps.summary.outputs.failed_list }}
-          FLAKY_COUNT: ${{ steps.summary.outputs.flaky_count }}
           FAILED_COUNT: ${{ steps.summary.outputs.failed_count }}
+          TOTAL_CONFIRMED: ${{ steps.project.outputs.total_confirmed_count }}
+          TOTAL_SUSPECTED: ${{ steps.project.outputs.total_suspected_count }}
+          DELETED_SUSPECT: ${{ steps.project.outputs.deleted_suspect_count }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PROJECT_URL: ${{ steps.project.outputs.project_url }}
-          NEW_COUNT: ${{ steps.project.outputs.new_count }}
-          RECURRING_COUNT: ${{ steps.project.outputs.recurring_count }}
         run: |
           {
-            if [ "${FLAKY_COUNT:-0}" != "0" ]; then
-              echo "🟡 ${FLAKY_COUNT} flaky test(s) detected in *${{ github.repository }}*"
+            if [ "${NEWLY_CONFIRMED_COUNT:-0}" != "0" ]; then
+              echo "🟡 ${NEWLY_CONFIRMED_COUNT} newly confirmed flaky test(s) in *${{ github.repository }}*"
               echo ""
-              echo "$FLAKY_TESTS"
+              echo "$NEWLY_CONFIRMED_TESTS"
             fi
             if [ "${FAILED_COUNT:-0}" != "0" ]; then
-              if [ "${FLAKY_COUNT:-0}" != "0" ]; then echo ""; fi
+              if [ "${NEWLY_CONFIRMED_COUNT:-0}" != "0" ]; then echo ""; fi
               echo "🔴 ${FAILED_COUNT} test(s) failing on every retry — broken, not flaky"
               echo ""
               echo "$FAILED_TESTS"
@@ -340,7 +346,11 @@ jobs:
             echo ""
             echo "<${RUN_URL}|View run>"
             if [ -n "$PROJECT_URL" ]; then
-              echo "<${PROJECT_URL}|Flaky tests board> — ${NEW_COUNT:-0} new, ${RECURRING_COUNT:-0} recurring"
+              board="<${PROJECT_URL}|Flaky tests board> — ${TOTAL_CONFIRMED:-0} confirmed, ${TOTAL_SUSPECTED:-0} suspected"
+              if [ "${DELETED_SUSPECT:-0}" != "0" ]; then
+                board="$board (${DELETED_SUSPECT} stale suspected cleaned up)"
+              fi
+              echo "$board"
             fi
           } > /tmp/slack-message.txt
 

--- a/backend/data/build.gradle
+++ b/backend/data/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id "kotlin-allopen"
     id "org.hibernate.orm"
     id "io.sentry.jvm.gradle"
+    id "org.gradle.test-retry"
 }
 
 group = 'io.tolgee'
@@ -243,6 +244,7 @@ dependencies {
 tasks.named('test', Test) {
     useJUnitPlatform()
     maxHeapSize = "4096m"
+    rootProject.setTestRetry(it)
 }
 
 sourceSets {

--- a/backend/ktlint/build.gradle
+++ b/backend/ktlint/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm'
     id 'io.spring.dependency-management'
+    id "org.gradle.test-retry"
 }
 
 group = 'io.tolgee.testing.ktlint'
@@ -42,6 +43,7 @@ dependencies {
 
 tasks.named('test', Test) {
     useJUnitPlatform()
+    rootProject.setTestRetry(it)
 }
 
 dependencyManagement {

--- a/backend/security/build.gradle
+++ b/backend/security/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'org.springframework.boot' apply false
     id "kotlin-allopen"
     id "io.sentry.jvm.gradle"
+    id "org.gradle.test-retry"
 }
 
 group = 'io.tolgee.security'
@@ -81,6 +82,7 @@ dependencies {
 tasks.named('test', Test) {
     useJUnitPlatform()
     maxHeapSize = "4096m"
+    rootProject.setTestRetry(it)
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -186,12 +186,22 @@ subprojects {
 ext.setTestRetry = { test ->
     boolean isCiServer = System.getenv().containsKey("CI")
     boolean isRelease = System.getenv().get("CI_RELEASE") == "true"
+    boolean detectFlaky = System.getenv().get("DETECT_FLAKY_TESTS") == "true"
 
     test.retry {
         if (isCiServer) {
             maxFailures = 20
             maxRetries = 5
         }
-        failOnPassedAfterRetry = !isRelease
+        // Flaky-detection runs collect flakes from the test reports instead of
+        // failing the build, so a run with only flaky tests stays green.
+        failOnPassedAfterRetry = !isRelease && !detectFlaky
+    }
+
+    if (detectFlaky) {
+        // Merge retries into a single <testcase> so a test that failed then
+        // passed is recorded as <flakyFailure> while a test that failed every
+        // attempt is recorded as <failure>.
+        test.reports.junitXml.mergeReruns = true
     }
 }

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import { GLOBAL_RETRIES } from './cypress/common/globalRetries';
+import { registerFlakyReport } from './cypress/common/flakyReport';
 
 export default defineConfig({
   scrollBehavior: 'center',
@@ -12,6 +13,7 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      registerFlakyReport(on);
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       return require('./cypress/plugins/index.js')(on, config);
     },

--- a/e2e/cypress/common/flakyReport.ts
+++ b/e2e/cypress/common/flakyReport.ts
@@ -16,6 +16,12 @@ import * as path from 'path';
  * Test ids use the `<spec>/<title>` format expected by report-flaky-tests.py.
  */
 export function registerFlakyReport(on: Cypress.PluginEvents): void {
+  // No-op outside the flaky-detection workflow so local `cypress run` and
+  // other CI workflows don't write stray report files.
+  if (process.env.DETECT_FLAKY_TESTS !== 'true') {
+    return;
+  }
+
   on('after:run', (results) => {
     // A run that failed to start (CypressFailedRunResult) has no `runs`.
     if (!('runs' in results)) {

--- a/e2e/cypress/common/flakyReport.ts
+++ b/e2e/cypress/common/flakyReport.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Registers an `after:run` handler that records which e2e tests were flaky and
+ * which failed outright, so the reportIntermittentTests workflow can tell them
+ * apart.
+ *
+ * A test is flaky when it failed at least one attempt but ultimately passed;
+ * it is a hard failure when every attempt failed. Two files are written to the
+ * e2e working directory:
+ *
+ *   - flaky-tests-e2e-<index>.txt   flaky tests -> reported to the project board
+ *   - failed-tests-e2e-<index>.txt  hard failures -> reported to Slack only
+ *
+ * Test ids use the `<spec>/<title>` format expected by report-flaky-tests.py.
+ */
+export function registerFlakyReport(on: Cypress.PluginEvents): void {
+  on('after:run', (results) => {
+    // A run that failed to start (CypressFailedRunResult) has no `runs`.
+    if (!('runs' in results)) {
+      return;
+    }
+
+    const flaky: string[] = [];
+    const failed: string[] = [];
+
+    for (const run of results.runs) {
+      for (const test of run.tests) {
+        const id = `${run.spec.relative}/${test.title.join(' > ')}`;
+        const failedAttempts = test.attempts.filter(
+          (attempt) => attempt.state === 'failed'
+        ).length;
+
+        if (test.state === 'passed' && failedAttempts > 0) {
+          flaky.push(id);
+        } else if (test.state === 'failed') {
+          failed.push(id);
+        }
+      }
+    }
+
+    const index = process.env.E2E_JOB_INDEX ?? '0';
+    writeReport(`flaky-tests-e2e-${index}.txt`, flaky);
+    writeReport(`failed-tests-e2e-${index}.txt`, failed);
+  });
+}
+
+function writeReport(fileName: string, ids: string[]): void {
+  const unique = [...new Set(ids)].sort();
+  const content = unique.length > 0 ? `${unique.join('\n')}\n` : '';
+  fs.writeFileSync(path.resolve(process.cwd(), fileName), content);
+}

--- a/e2e/cypress/common/globalRetries.ts
+++ b/e2e/cypress/common/globalRetries.ts
@@ -1,3 +1,6 @@
-// get CI_RELEASE env variable
+// Retries are enabled on release runs, and on flaky-detection runs
+// (the reportIntermittentTests workflow) so that a test which fails then
+// passes can be identified as flaky and reported.
 const CI_RELEASE = process.env.CI_RELEASE === 'true';
-export const GLOBAL_RETRIES = CI_RELEASE ? 10 : 0;
+const DETECT_FLAKY_TESTS = process.env.DETECT_FLAKY_TESTS === 'true';
+export const GLOBAL_RETRIES = CI_RELEASE || DETECT_FLAKY_TESTS ? 10 : 0;

--- a/scripts/collect-flaky-tests.py
+++ b/scripts/collect-flaky-tests.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Classify failed backend tests from merged JUnit XML into flaky vs hard failures.
+
+The Gradle test-retry plugin, with `reports.junitXml.mergeReruns = true`,
+records a test that failed then passed on retry as `<flakyFailure>` (or
+`<flakyError>`) and a test that failed every attempt as `<failure>` (or
+`<error>`), all within a single `<testcase>`.
+
+This script scans the JUnit XML reports under the current directory and writes
+two files:
+
+  flaky-tests-<report>.txt    genuinely flaky tests  -> reported to the board
+  failed-tests-<report>.txt   hard failures          -> reported to Slack only
+
+Each line is a `<classname>.<name>` test id.
+
+Usage:
+  collect-flaky-tests.py <report-name>
+"""
+from __future__ import annotations
+
+import glob
+import sys
+import xml.etree.ElementTree as ET
+
+XML_GLOB = "**/build/test-results/**/TEST-*.xml"
+
+
+def collect() -> tuple[set[str], set[str]]:
+    """Return (flaky, hard-failed) test ids found in the JUnit XML reports."""
+    flaky: set[str] = set()
+    failed: set[str] = set()
+    for path in glob.glob(XML_GLOB, recursive=True):
+        try:
+            tree = ET.parse(path)
+        except ET.ParseError:
+            continue
+        for tc in tree.findall(".//testcase"):
+            name = f'{tc.get("classname")}.{tc.get("name")}'
+            has_failure = (
+                tc.find("failure") is not None or tc.find("error") is not None
+            )
+            has_flaky = (
+                tc.find("flakyFailure") is not None
+                or tc.find("flakyError") is not None
+            )
+            if has_failure:
+                failed.add(name)
+            elif has_flaky:
+                flaky.add(name)
+    # A hard failure is authoritative: if the same test is reported both flaky
+    # and hard-failed (e.g. across reruns), never mislabel it as flaky.
+    flaky -= failed
+    return flaky, failed
+
+
+def write(file_name: str, names: set[str]) -> None:
+    with open(file_name, "w") as fh:
+        for name in sorted(names):
+            fh.write(f"{name}\n")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    report = sys.argv[1]
+    flaky, failed = collect()
+    write(f"flaky-tests-{report}.txt", flaky)
+    write(f"failed-tests-{report}.txt", failed)
+    print(f"{report}: {len(flaky)} flaky, {len(failed)} hard failures")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/report-flaky-tests.py
+++ b/scripts/report-flaky-tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Report flaky tests to the 'Flaky tests' org project.
 
-Reads failed-test lines from files in <failures-dir>, resolves each to an
+Reads flaky-test lines from files in <flaky-dir>, resolves each to an
 owning developer via git blame (constrained to members of a GitHub team),
 and creates or updates a draft issue on the org project.
 
@@ -14,9 +14,9 @@ Env vars:
   GH_TOKEN         token with project:rw + org:members:read (required)
 
 Usage:
-  report-flaky-tests.py <failures-dir> [<search-root>...]
+  report-flaky-tests.py <flaky-dir> [<search-root>...]
 
-If search-root is omitted, '.' is used. Each failed test is resolved by
+If search-root is omitted, '.' is used. Each flaky test is resolved by
 searching each root in order for a matching source file; git blame runs
 in that root.
 """
@@ -409,9 +409,9 @@ def update_draft_body(item_id: str, title: str, body: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
-def read_failures(failures_dir: Path) -> list[str]:
+def read_flaky_tests(flaky_dir: Path) -> list[str]:
     lines: set[str] = set()
-    for f in sorted(failures_dir.glob("failed-tests-*.txt")):
+    for f in sorted(flaky_dir.glob("flaky-tests-*.txt")):
         for raw in f.read_text(errors="replace").splitlines():
             line = raw.strip()
             if line:
@@ -423,22 +423,22 @@ def main() -> int:
     if len(sys.argv) < 2:
         print(__doc__, file=sys.stderr)
         return 2
-    failures_dir = Path(sys.argv[1])
+    flaky_dir = Path(sys.argv[1])
     roots = [Path(r) for r in sys.argv[2:]] or [Path(".")]
 
-    if not failures_dir.is_dir():
-        print(f"no failures dir: {failures_dir}", file=sys.stderr)
+    if not flaky_dir.is_dir():
+        print(f"no flaky-tests dir: {flaky_dir}", file=sys.stderr)
         return 0
 
-    failures = read_failures(failures_dir)
-    if not failures:
-        print("no failed tests to report")
+    flaky_tests = read_flaky_tests(flaky_dir)
+    if not flaky_tests:
+        print("no flaky tests to report")
         return 0
 
-    print(f"::group::flaky-test-tracker: {len(failures)} failed tests")
-    for line in failures[:MAX_ITEMS_PER_RUN]:
+    print(f"::group::flaky-test-tracker: {len(flaky_tests)} flaky tests")
+    for line in flaky_tests[:MAX_ITEMS_PER_RUN]:
         print(f"  - {line}")
-    if len(failures) > MAX_ITEMS_PER_RUN:
+    if len(flaky_tests) > MAX_ITEMS_PER_RUN:
         print(f"  (capped at {MAX_ITEMS_PER_RUN})")
     print("::endgroup::")
 
@@ -476,7 +476,7 @@ def main() -> int:
     today = date.today().isoformat()
     new_count = recurring_count = 0
 
-    for line in failures[:MAX_ITEMS_PER_RUN]:
+    for line in flaky_tests[:MAX_ITEMS_PER_RUN]:
         title = f"Flaky: {line}"
         existing = by_title.get(title)
         if existing:

--- a/scripts/report-flaky-tests.py
+++ b/scripts/report-flaky-tests.py
@@ -5,13 +5,25 @@ Reads flaky-test lines from files in <flaky-dir>, resolves each to an
 owning developer via git blame (constrained to members of a GitHub team),
 and creates or updates a draft issue on the org project.
 
+Each item carries a `Flakiness` status (Suspected / Confirmed). A test is
+promoted to Confirmed only after it has been seen at least
+`FLAKY_THRESHOLD` times within the last `FLAKY_WINDOW_DAYS` days, which
+filters out one-off GitHub Actions infrastructure hiccups. Suspected items
+that aren't promoted within `SUSPECTED_TTL_DAYS` days are deleted so the
+board stays clean.
+
 Env vars:
-  PROJECT_OWNER    org login (default: tolgee)
-  PROJECT_NUMBER   project number (default: 4)
-  TEAM_ORG         team org (default: tolgee)
-  TEAM_SLUG        eligible-assignees team slug (default: coders)
-  RUN_URL          CI run URL to record on the item
-  GH_TOKEN         token with project:rw + org:members:read (required)
+  PROJECT_OWNER       org login (default: tolgee)
+  PROJECT_NUMBER      project number (default: 4)
+  TEAM_ORG            team org (default: tolgee)
+  TEAM_SLUG           eligible-assignees team slug (default: coders)
+  RUN_URL             CI run URL to record on the item
+  FLAKY_THRESHOLD     detections in the window required to promote
+                      Suspected -> Confirmed (default: 3)
+  FLAKY_WINDOW_DAYS   rolling-window length in days (default: 7)
+  SUSPECTED_TTL_DAYS  delete Suspected items not seen for this many
+                      days (default: 14)
+  GH_TOKEN            token with project:rw + org:members:read (required)
 
 Usage:
   report-flaky-tests.py <flaky-dir> [<search-root>...]
@@ -27,7 +39,8 @@ import os
 import re
 import subprocess
 import sys
-from datetime import date
+import tempfile
+from datetime import date, timedelta
 from pathlib import Path
 
 PROJECT_OWNER = os.environ.get("PROJECT_OWNER", "tolgee")
@@ -36,6 +49,19 @@ TEAM_ORG = os.environ.get("TEAM_ORG", "tolgee")
 TEAM_SLUG = os.environ.get("TEAM_SLUG", "coders")
 RUN_URL = os.environ.get("RUN_URL", "")
 MAX_ITEMS_PER_RUN = int(os.environ.get("MAX_ITEMS_PER_RUN", "30"))
+
+# Confirmation gate: a test is promoted to Confirmed only after it has been
+# seen at least FLAKY_THRESHOLD times within the last FLAKY_WINDOW_DAYS days.
+FLAKY_THRESHOLD = int(os.environ.get("FLAKY_THRESHOLD", "3"))
+FLAKY_WINDOW_DAYS = int(os.environ.get("FLAKY_WINDOW_DAYS", "7"))
+SUSPECTED_TTL_DAYS = int(os.environ.get("SUSPECTED_TTL_DAYS", "14"))
+
+FLAKINESS_FIELD = "Flakiness"
+STATUS_SUSPECTED = "Suspected"
+STATUS_CONFIRMED = "Confirmed"
+
+# Run-log lines in the item body look like `- 2026-05-25: <run-url>`.
+DATE_LINE_RE = re.compile(r"^- (\d{4}-\d{2}-\d{2}):", re.MULTILINE)
 
 
 def run(cmd: list[str], **kwargs) -> str:
@@ -57,7 +83,13 @@ def write_output(**kwargs) -> None:
         return
     with open(gho, "a") as fh:
         for k, v in kwargs.items():
-            fh.write(f"{k}={v}\n")
+            s = str(v)
+            # GITHUB_OUTPUT requires the <<DELIM ... DELIM heredoc form for any
+            # value containing newlines; use it for newly_confirmed_list etc.
+            if "\n" in s:
+                fh.write(f"{k}<<__OUTPUT_EOF__\n{s}\n__OUTPUT_EOF__\n")
+            else:
+                fh.write(f"{k}={s}\n")
 
 
 def gql(query: str, **variables) -> dict:
@@ -138,6 +170,11 @@ def list_items(project_id: str) -> list[dict]:
                     field { ... on ProjectV2FieldCommon { name } }
                     users(first: 10) { nodes { login } }
                   }
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    field { ... on ProjectV2FieldCommon { name } }
+                    optionId
+                    name
+                  }
                 }
               }
             }
@@ -164,6 +201,9 @@ def item_field(item: dict, name: str):
             for k in ("text", "number", "date"):
                 if k in fv:
                     return fv[k]
+            if "optionId" in fv:
+                # Single-select: return the option's display name (e.g. "Confirmed").
+                return fv.get("name")
             users = (fv.get("users") or {}).get("nodes")
             if users is not None:
                 return [u["login"] for u in users]
@@ -405,6 +445,111 @@ def update_draft_body(item_id: str, title: str, body: str) -> None:
     gql(q, i=draft_id, t=title, b=body)
 
 
+def set_single_select(
+    project_id: str, item_id: str, field_id: str, option_id: str
+) -> None:
+    q = """
+    mutation($p:ID!,$i:ID!,$f:ID!,$v:String!) {
+      updateProjectV2ItemFieldValue(input:{
+        projectId:$p, itemId:$i, fieldId:$f, value:{singleSelectOptionId:$v}
+      }) { projectV2Item { id } }
+    }
+    """
+    gql(q, p=project_id, i=item_id, f=field_id, v=option_id)
+
+
+def delete_item(project_id: str, item_id: str) -> None:
+    q = """
+    mutation($p:ID!,$i:ID!) {
+      deleteProjectV2Item(input:{projectId:$p, itemId:$i}) { deletedItemId }
+    }
+    """
+    gql(q, p=project_id, i=item_id)
+
+
+def gql_with_input(query: str, variables: dict) -> dict:
+    """Run a GraphQL operation that takes list/object variables (`gh` CLI's
+    `-f`/`-F` flags only handle scalars)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+        json.dump({"query": query, "variables": variables}, fh)
+        path = fh.name
+    try:
+        resp = json.loads(run(["gh", "api", "graphql", "--input", path]))
+        if resp.get("errors"):
+            raise RuntimeError(f"graphql errors: {resp['errors']}")
+        return resp["data"]
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def ensure_flakiness_field(project_id: str, fields: dict) -> dict:
+    """Create the Flakiness single-select field if it doesn't exist yet.
+
+    Returns the (possibly refreshed) fields dict.
+    """
+    if FLAKINESS_FIELD in fields:
+        return fields
+    q = """
+    mutation($project:ID!,$name:String!,$opts:[ProjectV2SingleSelectFieldOptionInput!]!) {
+      createProjectV2Field(input:{
+        projectId:$project, dataType:SINGLE_SELECT, name:$name,
+        singleSelectOptions:$opts
+      }) { projectV2Field { ... on ProjectV2SingleSelectField { id name } } }
+    }
+    """
+    opts = [
+        {
+            "name": STATUS_SUSPECTED,
+            "color": "GRAY",
+            "description": (
+                f"Detected fewer than {FLAKY_THRESHOLD} times in the past "
+                f"{FLAKY_WINDOW_DAYS} days"
+            ),
+        },
+        {
+            "name": STATUS_CONFIRMED,
+            "color": "RED",
+            "description": (
+                f"Detected at least {FLAKY_THRESHOLD} times in the past "
+                f"{FLAKY_WINDOW_DAYS} days"
+            ),
+        },
+    ]
+    gql_with_input(
+        q, {"project": project_id, "name": FLAKINESS_FIELD, "opts": opts}
+    )
+    print(f"created project field '{FLAKINESS_FIELD}' with options "
+          f"{STATUS_SUSPECTED}, {STATUS_CONFIRMED}")
+    # Re-fetch to pick up the new field and its option IDs.
+    return discover_project()[2]
+
+
+# ---------------------------------------------------------------------------
+# Confirmation gate (rolling-window classification)
+# ---------------------------------------------------------------------------
+
+def parse_body_dates(body: str) -> list[date]:
+    """Extract dates from `- YYYY-MM-DD:` lines in the item body."""
+    out: list[date] = []
+    for m in DATE_LINE_RE.finditer(body or ""):
+        try:
+            out.append(date.fromisoformat(m.group(1)))
+        except ValueError:
+            pass
+    return out
+
+
+def classify(dates: list[date]) -> str:
+    """Return Confirmed if `dates` has FLAKY_THRESHOLD entries within the
+    rolling window, otherwise Suspected."""
+    cutoff = date.today() - timedelta(days=FLAKY_WINDOW_DAYS)
+    recent = sum(1 for d in dates if d >= cutoff)
+    return STATUS_CONFIRMED if recent >= FLAKY_THRESHOLD else STATUS_SUSPECTED
+
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -426,14 +571,9 @@ def main() -> int:
     flaky_dir = Path(sys.argv[1])
     roots = [Path(r) for r in sys.argv[2:]] or [Path(".")]
 
-    if not flaky_dir.is_dir():
-        print(f"no flaky-tests dir: {flaky_dir}", file=sys.stderr)
-        return 0
-
-    flaky_tests = read_flaky_tests(flaky_dir)
-    if not flaky_tests:
-        print("no flaky tests to report")
-        return 0
+    # An empty/missing flaky dir is fine — the sweep pass still runs so
+    # stale Suspected items get cleaned up.
+    flaky_tests = read_flaky_tests(flaky_dir) if flaky_dir.is_dir() else []
 
     print(f"::group::flaky-test-tracker: {len(flaky_tests)} flaky tests")
     for line in flaky_tests[:MAX_ITEMS_PER_RUN]:
@@ -447,40 +587,66 @@ def main() -> int:
         return 0
 
     project_id, project_url, fields = discover_project()
+    fields = ensure_flakiness_field(project_id, fields)
     write_output(project_url=project_url)
-    required = ["Test", "Assignees", "Last run", "Fail count", "First seen"]
+    required = [
+        "Test", "Assignees", "Last run", "Fail count", "First seen",
+        FLAKINESS_FIELD,
+    ]
     missing = [n for n in required if n not in fields]
     if missing:
         print(f"project is missing fields: {missing}", file=sys.stderr)
         return 1
 
-    eligible = team_members()
-    if not eligible:
-        print(
-            f"team {TEAM_ORG}/{TEAM_SLUG} has no members readable with this "
-            "token; cannot assign",
-            file=sys.stderr,
-        )
-        return 1
+    flakiness_options = {
+        o["name"]: o["id"]
+        for o in fields[FLAKINESS_FIELD].get("options", [])
+    }
+    for required_opt in (STATUS_SUSPECTED, STATUS_CONFIRMED):
+        if required_opt not in flakiness_options:
+            print(
+                f"{FLAKINESS_FIELD} field is missing required option: "
+                f"{required_opt}",
+                file=sys.stderr,
+            )
+            return 1
+    suspected_opt = flakiness_options[STATUS_SUSPECTED]
+    confirmed_opt = flakiness_options[STATUS_CONFIRMED]
 
     items = list_items(project_id)
     by_title = items_by_title(items)
 
-    # Load per assignee (for balancing) based on open items
-    load: dict[str, int] = {}
-    for it in items:
-        assignees = item_field(it, "Assignees") or []
-        for login in assignees:
-            load[login] = load.get(login, 0) + 1
+    if flaky_tests:
+        eligible = team_members()
+        if not eligible:
+            print(
+                f"team {TEAM_ORG}/{TEAM_SLUG} has no members readable with "
+                "this token; cannot assign",
+                file=sys.stderr,
+            )
+            return 1
+        # Load per assignee (for balancing) based on open items
+        load: dict[str, int] = {}
+        for it in items:
+            assignees = item_field(it, "Assignees") or []
+            for login in assignees:
+                load[login] = load.get(login, 0) + 1
+    else:
+        eligible = []
+        load = {}
 
-    today = date.today().isoformat()
-    new_count = recurring_count = 0
+    today_d = date.today()
+    today = today_d.isoformat()
+    new_count = recurring_count = newly_confirmed_count = 0
+    newly_confirmed_ids: list[str] = []
+    touched_ids: set[str] = set()
 
     for line in flaky_tests[:MAX_ITEMS_PER_RUN]:
         title = f"Flaky: {line}"
         existing = by_title.get(title)
         if existing:
             recurring_count += 1
+            touched_ids.add(existing["id"])
             count = int(item_field(existing, "Fail count") or 0) + 1
             set_number(
                 project_id, existing["id"], fields["Fail count"]["id"], count
@@ -489,13 +655,32 @@ def main() -> int:
                 project_id, existing["id"], fields["Last run"]["id"], RUN_URL
             )
             body = (existing.get("content") or {}).get("body") or ""
-            body = body.rstrip() + f"\n- {today}: {RUN_URL}"
+            new_body = body.rstrip() + f"\n- {today}: {RUN_URL}"
             try:
-                update_draft_body(existing["id"], title, body)
+                update_draft_body(existing["id"], title, new_body)
             except RuntimeError as e:
                 # Item may be a real Issue/PR, not a DraftIssue — skip body log
                 print(f"  (skipped body update for {title}: {e})")
-            print(f"  recurring ({count}x): {line}")
+            # Always classify against today's detection, even if the body
+            # update didn't persist — the status reflects what we observed.
+            new_status = classify(parse_body_dates(new_body))
+            old_status = item_field(existing, FLAKINESS_FIELD)
+            if new_status != old_status:
+                set_single_select(
+                    project_id, existing["id"],
+                    fields[FLAKINESS_FIELD]["id"],
+                    confirmed_opt if new_status == STATUS_CONFIRMED
+                    else suspected_opt,
+                )
+            if (
+                old_status != STATUS_CONFIRMED
+                and new_status == STATUS_CONFIRMED
+            ):
+                newly_confirmed_count += 1
+                newly_confirmed_ids.append(line)
+                print(f"  promoted -> Confirmed ({count}x total): {line}")
+            else:
+                print(f"  recurring ({count}x, {new_status}): {line}")
             continue
 
         new_count += 1
@@ -528,14 +713,71 @@ def main() -> int:
         if not node_id:
             print(f"  (could not resolve node id for @{owner})")
         item_id = create_draft(project_id, title, body, assignees)
+        touched_ids.add(item_id)
         set_text(project_id, item_id, fields["Test"]["id"], line)
         set_text(project_id, item_id, fields["Last run"]["id"], RUN_URL)
         set_number(project_id, item_id, fields["Fail count"]["id"], 1)
         set_date(project_id, item_id, fields["First seen"]["id"], today)
-        print(f"  new -> @{owner}: {line}")
+        # First detection is normally Suspected; only Confirmed if threshold==1.
+        initial_status = classify([today_d])
+        set_single_select(
+            project_id, item_id, fields[FLAKINESS_FIELD]["id"],
+            confirmed_opt if initial_status == STATUS_CONFIRMED else suspected_opt,
+        )
+        if initial_status == STATUS_CONFIRMED:
+            newly_confirmed_count += 1
+            newly_confirmed_ids.append(line)
+        print(f"  new -> @{owner} ({initial_status}): {line}")
 
-    write_output(new_count=new_count, recurring_count=recurring_count)
-    print(f"done: {new_count} new, {recurring_count} recurring")
+    # Sweep: delete Suspected items whose most recent detection is older
+    # than SUSPECTED_TTL_DAYS — they were one-off hiccups that never recurred.
+    deleted_suspect_count = 0
+    suspected_cutoff = today_d - timedelta(days=SUSPECTED_TTL_DAYS)
+    for it in items:
+        if it["id"] in touched_ids:
+            continue
+        if item_field(it, FLAKINESS_FIELD) != STATUS_SUSPECTED:
+            continue
+        body = (it.get("content") or {}).get("body") or ""
+        dates = parse_body_dates(body)
+        if not dates or max(dates) >= suspected_cutoff:
+            continue
+        title = (it.get("content") or {}).get("title") or "?"
+        try:
+            delete_item(project_id, it["id"])
+            deleted_suspect_count += 1
+            print(f"  deleted stale suspected item: {title}")
+        except RuntimeError as e:
+            print(f"  (failed to delete {title}: {e})")
+
+    # Board totals reflect the pre-run snapshot — close enough for Slack stats.
+    total_confirmed = sum(
+        1 for it in items
+        if item_field(it, FLAKINESS_FIELD) == STATUS_CONFIRMED
+    )
+    total_suspected = sum(
+        1 for it in items
+        if item_field(it, FLAKINESS_FIELD) == STATUS_SUSPECTED
+    )
+
+    newly_confirmed_list = "\n".join(
+        f"• `{n}`" for n in newly_confirmed_ids[:30]
+    )
+
+    write_output(
+        new_count=new_count,
+        recurring_count=recurring_count,
+        newly_confirmed_count=newly_confirmed_count,
+        newly_confirmed_list=newly_confirmed_list,
+        deleted_suspect_count=deleted_suspect_count,
+        total_confirmed_count=total_confirmed,
+        total_suspected_count=total_suspected,
+    )
+    print(
+        f"done: {new_count} new, {recurring_count} recurring, "
+        f"{newly_confirmed_count} newly confirmed, "
+        f"{deleted_suspect_count} stale suspected removed"
+    )
     return 0
 
 

--- a/scripts/report-flaky-tests.py
+++ b/scripts/report-flaky-tests.py
@@ -750,13 +750,17 @@ def main() -> int:
         except RuntimeError as e:
             print(f"  (failed to delete {title}: {e})")
 
-    # Board totals reflect the pre-run snapshot — close enough for Slack stats.
+    # Re-fetch items so the totals reflect this run's writes (newly-created
+    # items, promotions, swept deletions) — the pre-run `items` snapshot
+    # doesn't include any of them, and on the very first run no item had a
+    # Flakiness value at fetch time.
+    items_after = list_items(project_id)
     total_confirmed = sum(
-        1 for it in items
+        1 for it in items_after
         if item_field(it, FLAKINESS_FIELD) == STATUS_CONFIRMED
     )
     total_suspected = sum(
-        1 for it in items
+        1 for it in items_after
         if item_field(it, FLAKINESS_FIELD) == STATUS_SUSPECTED
     )
 


### PR DESCRIPTION
## Problem

`reportIntermittentTests.yml` added a test to the flaky-tests board on its **first** failure. A test that fails once and never fails again is not flaky — it is a one-off run failure — yet it stayed on the board forever as a false positive.

## Approach

Use the per-test retry signal to tell genuine flakes apart from one-off failures, holding the commit constant:

- **fails then passes on retry** → genuinely flaky → reported to the board
- **fails every retry** → hard failure (broken on `main`) → sent to Slack only, never boarded

## Changes

- **`build.gradle`** — under a new `DETECT_FLAKY_TESTS` flag, `setTestRetry` merges reruns into the JUnit XML (`mergeReruns`), so a flaky test is recorded as `<flakyFailure>` and a broken one as `<failure>`. It also sets `failOnPassedAfterRetry = false`, so a flaky-only nightly stays **green** — the workflow goes red only on genuine breakage.
- Applied the `test-retry` plugin to the **data**, **security** and **ktlint** modules (previously only `server-app`/`ee-test` retried).
- **E2E** — Cypress retries are enabled for detection runs; a new `after:run` reporter records each test as flaky or hard-failed.
- **`scripts/collect-flaky-tests.py`** (new) — splits merged JUnit XML into a flaky list and a hard-failure list.
- **`scripts/report-flaky-tests.py`** — now reads `flaky-tests-*.txt`, so only genuine flakes reach the board.
- **Workflow** — collects on `always()` (Cypress passes when a flake recovers), `notify` runs on `always()`, and Slack reports flaky (🟡) and hard failures (🔴) separately, only when something is found.

## Net effect

A test that fails once and recovers on retry → flaky → boarded. A test that fails once and never reproduces → fails all retries → hard failure → Slack only, never boarded. The first-failure noise on the board is eliminated by construction.

## Notes

- Companion change for the billing repo: `tolgee/billing`, branch `dkrizan/retry-based-flaky-detection`. Billing's nightly checks out tolgee-platform `main`, so **this PR should merge first** (or together).
- Verified: e2e `eslint` + `tsc`, a Gradle dry-run of the test tasks, and the two Python scripts (functional test on synthetic merged JUnit XML).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced flaky-test detection and retry behavior for backend and E2E runs, producing per-shard artifacts that separate flaky from consistently failing tests and improving how reruns are represented.

* **New Features**
  * Reporting job now aggregates those artifacts, updates project tracking with flakiness status and counts, and sends refined notifications that surface newly confirmed flaky tests and consistent failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->