### PR TITLE
fix: translation memory UI issues

### DIFF
--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -892,6 +892,7 @@ declare namespace DataCy {
         "tm-empty-wizard-import" |
         "tm-empty-wizard-manual" |
         "tm-entries-header" |
+        "tm-entries-header-base-badge" |
         "tm-entries-language-filter" |
         "tm-entries-language-select-item" |
         "tm-entries-layout-flat" |

--- a/webapp/src/component/languages/BaseLanguageSelect.tsx
+++ b/webapp/src/component/languages/BaseLanguageSelect.tsx
@@ -61,6 +61,7 @@ type Props = {
   disabled?: boolean;
   label?: React.ReactNode;
   minHeight?: boolean;
+  autoSelectFirst?: boolean;
 } & Omit<ComponentProps<typeof Box>, 'children' | 'minHeight'>;
 
 export const BaseLanguageSelect: React.VFC<Props> = ({
@@ -69,6 +70,7 @@ export const BaseLanguageSelect: React.VFC<Props> = ({
   disabled,
   label,
   minHeight,
+  autoSelectFirst = true,
   ...boxProps
 }) => {
   const { preferredOrganization } = usePreferredOrganization();
@@ -76,8 +78,12 @@ export const BaseLanguageSelect: React.VFC<Props> = ({
   const { t } = useTranslate();
   const [field, meta] = useField(name);
   const value = field.value as SelectedLanguageModel | undefined;
-  // Formik returns error as object - schema is incorrect...
-  const error = (meta.error as any)?.tag;
+
+  const error = React.isValidElement(meta.error)
+    ? meta.error
+    : (meta.error as any)?.tag;
+
+  const showError = (meta.touched || context.submitCount > 0) && error;
 
   const [search, setSearch] = useState('');
   const [searchDebounced] = useDebounce(search, 500);
@@ -129,7 +135,13 @@ export const BaseLanguageSelect: React.VFC<Props> = ({
   // The ref prevents re-triggering after setSelected updates the Formik field.
   const hasAutoSelected = useRef(false);
   useEffect(() => {
-    if (!value && data && data.length > 0 && !hasAutoSelected.current) {
+    if (
+      autoSelectFirst &&
+      !value &&
+      data &&
+      data.length > 0 &&
+      !hasAutoSelected.current
+    ) {
       hasAutoSelected.current = true;
       setSelected(data[0]);
     }
@@ -216,7 +228,7 @@ export const BaseLanguageSelect: React.VFC<Props> = ({
         labelItem={labelItem}
         inputComponent={FlaggedInput}
         label={label ?? t('field_base_language', 'Base language')}
-        error={meta.touched && error}
+        error={showError}
         searchPlaceholder={t('language_search_placeholder')}
         disabled={disabled}
         minHeight={minHeight}

--- a/webapp/src/component/languages/BaseLanguageSelect.tsx
+++ b/webapp/src/component/languages/BaseLanguageSelect.tsx
@@ -79,7 +79,13 @@ export const BaseLanguageSelect: React.VFC<Props> = ({
   const [field, meta] = useField(name);
   const value = field.value as SelectedLanguageModel | undefined;
 
+  // meta.error shape depends on which Yup rule fired:
+  //   - object-level `.required()` (field cleared / undefined) → string
+  //   - shape `{ tag: ... }` validation → { tag: string }
+  //   - localized message → ReactElement
   const error = React.isValidElement(meta.error)
+    ? meta.error
+    : typeof meta.error === 'string'
     ? meta.error
     : (meta.error as any)?.tag;
 

--- a/webapp/src/ee/translationMemory/components/content/TmEntriesListHeader.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TmEntriesListHeader.tsx
@@ -48,10 +48,8 @@ export const TmEntriesListHeader: React.VFC<Props> = ({
           checked={selectionService.isAllSelected}
           indeterminate={selectionService.isSomeSelected}
           disabled={selectionService.isLoading}
-          // `toggleSelectAll` keys off `isAllSelected`, which can never be true here:
-          // `totalCount` counts virtual rows but only stored entries are selectable, so the
-          // selected count never reaches it. Toggle on "anything selected" instead — a click
-          // clears the selection when something is selected, otherwise selects all.
+          // Not `toggleSelectAll`: virtual rows inflate `totalCount`, so `isAllSelected`
+          // never flips on and toggle would always re-select.
           onChange={() =>
             selectionService.isAnySelected
               ? selectionService.unselectAll()
@@ -76,7 +74,7 @@ export const TmEntriesListHeader: React.VFC<Props> = ({
         label={
           <T keyName="translation_memory_header_base" defaultValue="Base" />
         }
-      ></DefaultChip>
+      />
     </StyledDataCell>
     {displayLanguages.map((tag) => {
       const info = languageInfo[tag];

--- a/webapp/src/ee/translationMemory/components/content/TmEntriesListHeader.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TmEntriesListHeader.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, styled, Typography } from '@mui/material';
+import { Checkbox, styled } from '@mui/material';
 import { T } from '@tolgee/react';
 import { FlagImage } from '@tginternal/library/components/languages/FlagImage';
 import { languageInfo } from '@tginternal/language-util/lib/generated/languageInfo';
@@ -9,6 +9,7 @@ import {
   HeaderRow,
 } from 'tg.component/entriesList/headerChrome';
 import { flatGridColumns } from './TranslationMemoryEntryRow';
+import { DefaultChip } from 'tg.component/common/chips/DefaultChip';
 
 const StyledDataCell = styled(HeaderDataCell)`
   gap: 8px;
@@ -47,7 +48,15 @@ export const TmEntriesListHeader: React.VFC<Props> = ({
           checked={selectionService.isAllSelected}
           indeterminate={selectionService.isSomeSelected}
           disabled={selectionService.isLoading}
-          onChange={selectionService.toggleSelectAll}
+          // `toggleSelectAll` keys off `isAllSelected`, which can never be true here:
+          // `totalCount` counts virtual rows but only stored entries are selectable, so the
+          // selected count never reaches it. Toggle on "anything selected" instead — a click
+          // clears the selection when something is selected, otherwise selects all.
+          onChange={() =>
+            selectionService.isAnySelected
+              ? selectionService.unselectAll()
+              : selectionService.selectAll()
+          }
           data-cy="tm-entries-select-all"
         />
       )}
@@ -62,9 +71,12 @@ export const TmEntriesListHeader: React.VFC<Props> = ({
       <span style={{ fontWeight: 500 }}>
         {languageInfo[sourceLanguageTag]?.englishName || sourceLanguageTag}
       </span>
-      <Typography variant="caption" color="text.secondary">
-        <T keyName="translation_memory_header_source" defaultValue="Source" />
-      </Typography>
+      <DefaultChip
+        data-cy="tm-entries-header-base-badge"
+        label={
+          <T keyName="translation_memory_header_base" defaultValue="Base" />
+        }
+      ></DefaultChip>
     </StyledDataCell>
     {displayLanguages.map((tag) => {
       const info = languageInfo[tag];

--- a/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
@@ -39,7 +39,7 @@ type Props = {
   onLayoutChange: (layout: EntryRowLayout) => void;
   languages: OrganizationLanguageModel[] | undefined;
   languagesLoadable: LanguagesLoadable;
-  selectedLanguages: string[] | undefined;
+  selectedLanguages: string[];
   langSearch: string;
   onLangSearchChange: (s: string) => void;
   onFetchMoreLanguages: () => void;
@@ -84,7 +84,7 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
   const { t } = useTranslate();
   const renderLangItem = (props: object, item: OrganizationLanguageModel) => {
     const isBase = item.tag === sourceLanguageTag;
-    const selected = isBase || (selectedLanguages?.includes(item.tag) ?? false);
+    const selected = isBase || selectedLanguages.includes(item.tag);
     return (
       <MultiselectItem
         {...props}
@@ -168,7 +168,7 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
             <Box data-cy="tm-entries-language-filter" sx={{ width: 250 }}>
               <InfiniteMultiSearchSelect
                 items={languages}
-                selected={selectedLanguages ?? []}
+                selected={selectedLanguages}
                 queryResult={languagesLoadable}
                 itemKey={(item) => item.tag}
                 search={langSearch}

--- a/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
@@ -39,7 +39,6 @@ type Props = {
   onLayoutChange: (layout: EntryRowLayout) => void;
   languages: OrganizationLanguageModel[] | undefined;
   languagesLoadable: LanguagesLoadable;
-  isAllSelected: boolean;
   selectedLanguages: string[] | undefined;
   langSearch: string;
   onLangSearchChange: (s: string) => void;
@@ -68,7 +67,6 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
   onLayoutChange,
   languages,
   languagesLoadable,
-  isAllSelected,
   selectedLanguages,
   langSearch,
   onLangSearchChange,
@@ -86,10 +84,7 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
   const { t } = useTranslate();
   const renderLangItem = (props: object, item: OrganizationLanguageModel) => {
     const isBase = item.tag === sourceLanguageTag;
-    const selected =
-      isBase ||
-      isAllSelected ||
-      (selectedLanguages?.includes(item.tag) ?? false);
+    const selected = isBase || (selectedLanguages?.includes(item.tag) ?? false);
     return (
       <MultiselectItem
         {...props}
@@ -173,11 +168,7 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
             <Box data-cy="tm-entries-language-filter">
               <InfiniteMultiSearchSelect
                 items={languages}
-                selected={
-                  isAllSelected
-                    ? (languages ?? []).map((l) => l.tag)
-                    : selectedLanguages
-                }
+                selected={selectedLanguages ?? []}
                 queryResult={languagesLoadable}
                 itemKey={(item) => item.tag}
                 search={langSearch}

--- a/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TmEntriesToolbar.tsx
@@ -165,7 +165,7 @@ export const TmEntriesToolbar: React.VFC<Props> = ({
                 </Button>
               </Tooltip>
             </ButtonGroup>
-            <Box data-cy="tm-entries-language-filter">
+            <Box data-cy="tm-entries-language-filter" sx={{ width: 250 }}>
               <InfiniteMultiSearchSelect
                 items={languages}
                 selected={selectedLanguages ?? []}

--- a/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
@@ -116,8 +116,6 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
     return [...tags];
   }, [entries.data]);
 
-  // One-time seed: when nothing is stored for this TM, set the selection from the first
-  // page's languages and persist it.
   useLayoutEffect(() => {
     if (
       selectedLanguages === undefined &&
@@ -178,8 +176,6 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
         editingLang={editingLangForRow}
         canManage={canManage}
         layout={layout}
-        // Passed for every row — the row itself renders a real checkbox for editable
-        // rows and a disabled one (with tooltip) for virtual rows.
         selectionService={selectionService}
         groupId={groupId}
         onEditStart={(langTag) => setEditingCell(`${rowKey}|||${langTag}`)}

--- a/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
@@ -252,9 +252,23 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
         <TranslationMemoryCreateEntryDialog
           open={createDialogOpen}
           onClose={() => setCreateDialogOpen(false)}
-          onFinished={() => {
+          onFinished={(createdLanguageTags) => {
             setCreateDialogOpen(false);
-            entries.refetch();
+            // A new entry can introduce target languages outside the current filter — add
+            // them so the just-created translations stay visible. When nothing is selected
+            // yet, the refetched first page (now including the new entry) lets the one-time
+            // seed pick them up.
+            const current = selectedLanguages;
+            const missing = current
+              ? createdLanguageTags.filter(
+                  (tag) => tag !== sourceLanguageTag && !current.includes(tag)
+                )
+              : [];
+            if (current && missing.length > 0) {
+              updateSelectedLanguages([...current, ...missing]);
+            } else {
+              entries.refetch();
+            }
           }}
           organizationId={organizationId}
           translationMemoryId={translationMemoryId}

--- a/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntriesList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Box, Button, styled, Typography } from '@mui/material';
 import { languageInfo } from '@tginternal/language-util/lib/generated/languageInfo';
 import { T, useTranslate } from '@tolgee/react';
@@ -81,13 +81,13 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
   const {
     languages,
     languagesLoadable,
-    isAllSelected,
     selectedLanguages,
     langSearch,
     setLangSearch,
     fetchMoreLanguages,
     toggleLanguage,
     updateSelectedLanguages,
+    seedAutoDefault,
     allNonBaseLanguageTags,
     displayLanguages,
     targetLanguageTag,
@@ -104,6 +104,28 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
     search,
     targetLanguageTag,
   });
+
+  const firstPageEntryLanguages = useMemo(() => {
+    const firstPage =
+      entries.data?.pages?.[0]?._embedded?.translationMemoryRows;
+    if (!firstPage) return undefined;
+    const tags = new Set<string>();
+    firstPage.forEach((r) =>
+      r.cells.forEach((c) => tags.add(c.targetLanguageTag))
+    );
+    return [...tags];
+  }, [entries.data]);
+
+  // One-time seed: when nothing is stored for this TM, set the selection from the first
+  // page's languages and persist it.
+  useLayoutEffect(() => {
+    if (
+      selectedLanguages === undefined &&
+      firstPageEntryLanguages !== undefined
+    ) {
+      seedAutoDefault(firstPageEntryLanguages);
+    }
+  }, [selectedLanguages, firstPageEntryLanguages, seedAutoDefault]);
 
   const selectionService = useSelectionService<number>({
     totalCount: totalElements,
@@ -156,7 +178,9 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
         editingLang={editingLangForRow}
         canManage={canManage}
         layout={layout}
-        selectionService={row.editable ? selectionService : undefined}
+        // Passed for every row — the row itself renders a real checkbox for editable
+        // rows and a disabled one (with tooltip) for virtual rows.
+        selectionService={selectionService}
         groupId={groupId}
         onEditStart={(langTag) => setEditingCell(`${rowKey}|||${langTag}`)}
         onEditEnd={() => {
@@ -209,8 +233,7 @@ export const TranslationMemoryEntriesList: React.VFC<Props> = ({
         onLayoutChange={setLayoutParam}
         languages={languages}
         languagesLoadable={languagesLoadable}
-        isAllSelected={isAllSelected}
-        selectedLanguages={selectedLanguages}
+        selectedLanguages={displayLanguages}
         langSearch={langSearch}
         onLangSearchChange={setLangSearch}
         onFetchMoreLanguages={fetchMoreLanguages}

--- a/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntryRow.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntryRow.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Checkbox, styled } from '@mui/material';
+import { Checkbox, styled, Tooltip } from '@mui/material';
 import { T } from '@tolgee/react';
 import { FlagImage } from '@tginternal/library/components/languages/FlagImage';
 import { languageInfo } from '@tginternal/language-util/lib/generated/languageInfo';
@@ -122,22 +122,39 @@ export const TranslationMemoryEntryRow: React.VFC<Props> = ({
       data-cy="translation-memory-entry-row"
     >
       {(() => {
-        const hasCheckbox = Boolean(
-          selectionService && selectable && canManage
-        );
-        // Always reserve the selection column in both layouts so non-editable rows (no
-        // checkbox) line up with editable rows. Without this they would shift 44px left
-        // of editable rows in stacked layout once a TM mixed both kinds.
-        return (
-          <StyledSelectionCell $layout={layout}>
-            {hasCheckbox && (
+        if (!selectionService || !canManage) {
+          return <StyledSelectionCell $layout={layout} />;
+        }
+        if (selectable) {
+          return (
+            <StyledSelectionCell $layout={layout}>
               <Checkbox
                 size="small"
-                checked={selectionService!.isSelected(groupId!)}
-                onChange={() => selectionService!.toggle(groupId!)}
+                checked={selectionService.isSelected(groupId!)}
+                onChange={() => selectionService.toggle(groupId!)}
                 data-cy="tm-entry-row-checkbox"
               />
-            )}
+            </StyledSelectionCell>
+          );
+        }
+        return (
+          <StyledSelectionCell $layout={layout}>
+            <Tooltip
+              title={
+                <T
+                  keyName="tm_entry_select_disabled_virtual"
+                  defaultValue="Synced entries from a project can't be selected."
+                />
+              }
+            >
+              <span>
+                <Checkbox
+                  size="small"
+                  disabled
+                  data-cy="tm-entry-row-checkbox"
+                />
+              </span>
+            </Tooltip>
           </StyledSelectionCell>
         );
       })()}

--- a/webapp/src/ee/translationMemory/components/form/fields/BaseLanguageFieldWithHint.tsx
+++ b/webapp/src/ee/translationMemory/components/form/fields/BaseLanguageFieldWithHint.tsx
@@ -22,6 +22,7 @@ export const BaseLanguageFieldWithHint = ({ disabled }: Props) => {
       name="baseLanguage"
       disabled={disabled || hasAssignedProjects}
       minHeight={false}
+      autoSelectFirst={false}
       label={
         <LabelHint
           title={

--- a/webapp/src/ee/translationMemory/hooks/useTmLanguageFilter.ts
+++ b/webapp/src/ee/translationMemory/hooks/useTmLanguageFilter.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useDebounce } from 'use-debounce';
 
 import { useApiInfiniteQuery } from 'tg.service/http/useQueryApi';
@@ -17,13 +17,10 @@ type Args = {
 };
 
 /**
- * State + queries for the per-TM language filter:
- *   - the paginated org-languages query (with debounced search)
- *   - persisted user selection (per-TM, undefined = "all", [] = explicit "all", [t,…] = subset)
- *   - derived values for downstream consumers (filter param, display order, dialog defaults)
+ * State + queries for the per-TM language filter.
  *
- * Mutators (`toggleLanguage`, `updateSelectedLanguages`) persist through `tmPreferencesService`
- * so selection is sticky across page reloads.
+ * The selection is persisted per-TM and seeded once: on the first visit (nothing stored),
+ * `seedAutoDefault` sets it from the first page's entry languages and persists it.
  */
 export function useTmLanguageFilter({
   organizationId,
@@ -33,6 +30,10 @@ export function useTmLanguageFilter({
   const [selectedLanguages, setSelectedLanguages] = useState<
     string[] | undefined
   >(() => tmPreferencesService.getForTm(translationMemoryId));
+
+  // True only between the one-time auto-seed and the first explicit change. Keeps the
+  // backend filter off so seeding doesn't re-fetch the entries.
+  const [isAutoDefault, setIsAutoDefault] = useState(false);
 
   const [langSearch, setLangSearch] = useState('');
   const [langSearchDebounced] = useDebounce(
@@ -75,30 +76,37 @@ export function useTmLanguageFilter({
     }
   };
 
+  // One-time seed of the persisted selection from the first page of entries. The single
+  // caller guards on `selectedLanguages === undefined`, so this only runs when nothing is
+  // stored yet and never overrides a saved or user-edited choice. The seed is persisted so
+  // every later visit reuses it as-is rather than re-deriving from the entries.
+  const seedAutoDefault = useCallback(
+    (entryLanguageTags: string[]) => {
+      const langs = entryLanguageTags.filter((t) => t !== sourceLanguageTag);
+      setSelectedLanguages(langs);
+      setIsAutoDefault(true);
+      tmPreferencesService.setForTm(translationMemoryId, langs);
+    },
+    [sourceLanguageTag, translationMemoryId]
+  );
+
   const updateSelectedLanguages = (langs: string[]) => {
     setSelectedLanguages(langs);
+    setIsAutoDefault(false);
     tmPreferencesService.setForTm(translationMemoryId, langs);
   };
 
-  const isAllSelected = selectedLanguages === undefined;
-
   const toggleLanguage = (item: OrganizationLanguageModel) => {
     if (item.tag === sourceLanguageTag) return;
-    if (isAllSelected) {
-      // Switching from "all" to explicit — deselect this one language
-      const allTags = (languages ?? [])
-        .map((l) => l.tag)
-        .filter((t) => t !== sourceLanguageTag && t !== item.tag);
-      updateSelectedLanguages(allTags);
-      return;
-    }
-    if (selectedLanguages!.includes(item.tag)) {
-      updateSelectedLanguages(selectedLanguages!.filter((t) => t !== item.tag));
-      return;
-    }
-    updateSelectedLanguages([...selectedLanguages!, item.tag]);
+    const current = selectedLanguages ?? [];
+    const next = current.includes(item.tag)
+      ? current.filter((t) => t !== item.tag)
+      : [...current, item.tag];
+    updateSelectedLanguages(next);
   };
 
+  // Every loaded org language except the base — offered to the create-entry dialog and the
+  // empty-state wizard as the full set of pickable target languages.
   const allNonBaseLanguageTags = useMemo(
     () =>
       (languages ?? [])
@@ -107,34 +115,37 @@ export function useTmLanguageFilter({
     [languages, sourceLanguageTag]
   );
 
-  const displayLanguages = useMemo(() => {
-    if (isAllSelected) return allNonBaseLanguageTags;
-    return allNonBaseLanguageTags.filter((t) => selectedLanguages!.includes(t));
-  }, [allNonBaseLanguageTags, isAllSelected, selectedLanguages]);
+  // The displayed / checked set: the stored selection, base language excluded.
+  const displayLanguages = useMemo(
+    () => (selectedLanguages ?? []).filter((t) => t !== sourceLanguageTag),
+    [selectedLanguages, sourceLanguageTag]
+  );
 
-  // The targetLanguageTag query param: comma-separated when narrowed, undefined for "all".
-  const targetLanguageTag =
-    selectedLanguages && selectedLanguages.length > 0
-      ? selectedLanguages.join(',')
-      : undefined;
+  // The targetLanguageTag query param: undefined while the selection is the freshly-seeded
+  // auto-default (filtering by every first-page language == no filter) or empty; a
+  // comma-separated list once the selection is an explicit/stored choice.
+  const targetLanguageTag = useMemo(() => {
+    if (isAutoDefault) return undefined;
+    if (!selectedLanguages || selectedLanguages.length === 0) return undefined;
+    return selectedLanguages.join(',');
+  }, [isAutoDefault, selectedLanguages]);
 
-  // First two of the user's filter selection, used as the Create-entry dialog's default. Empty
-  // when the filter is in "All" mode — the dialog falls back to the first 2 of all langs.
-  const createDialogInitialTags = useMemo(() => {
-    if (!selectedLanguages || selectedLanguages.length === 0) return [];
-    return selectedLanguages.slice(0, 2);
-  }, [selectedLanguages]);
+  // First two of the selection, used as the Create-entry dialog's default.
+  const createDialogInitialTags = useMemo(
+    () => displayLanguages.slice(0, 2),
+    [displayLanguages]
+  );
 
   return {
     languages,
     languagesLoadable,
-    isAllSelected,
     selectedLanguages,
     langSearch,
     setLangSearch,
     fetchMoreLanguages,
     toggleLanguage,
     updateSelectedLanguages,
+    seedAutoDefault,
     allNonBaseLanguageTags,
     displayLanguages,
     targetLanguageTag,

--- a/webapp/src/ee/translationMemory/hooks/useTmLanguageFilter.ts
+++ b/webapp/src/ee/translationMemory/hooks/useTmLanguageFilter.ts
@@ -76,10 +76,6 @@ export function useTmLanguageFilter({
     }
   };
 
-  // One-time seed of the persisted selection from the first page of entries. The single
-  // caller guards on `selectedLanguages === undefined`, so this only runs when nothing is
-  // stored yet and never overrides a saved or user-edited choice. The seed is persisted so
-  // every later visit reuses it as-is rather than re-deriving from the entries.
   const seedAutoDefault = useCallback(
     (entryLanguageTags: string[]) => {
       const langs = entryLanguageTags.filter((t) => t !== sourceLanguageTag);

--- a/webapp/src/ee/translationMemory/views/TranslationMemoryCreateEntryDialog.tsx
+++ b/webapp/src/ee/translationMemory/views/TranslationMemoryCreateEntryDialog.tsx
@@ -49,7 +49,9 @@ const StyledDialogTitle = styled(DialogTitle)`
 type Props = {
   open: boolean;
   onClose: () => void;
-  onFinished: () => void;
+  /** Receives the target language tags of the just-created entry so the caller can make
+   *  sure those languages stay visible in the list. */
+  onFinished: (createdLanguageTags: string[]) => void;
   organizationId: number;
   translationMemoryId: number;
   sourceLanguageTag: string;
@@ -137,7 +139,7 @@ export const TranslationMemoryCreateEntryDialog: React.VFC<Props> = ({
           defaultValue="Entry created"
         />
       );
-      onFinished();
+      onFinished(translations.map((tr) => tr.targetLanguageTag));
     } catch {
       messageService.error(
         <T


### PR DESCRIPTION
## Translation Memory UI fixes

- **Language filter** — no longer pre-selects every org language. The selection is seeded once from the languages on the first page of entries, then persisted and kept sticky across visits (manual changes stick too).
- **Virtual entry checkboxes** — project-mirrored entries now show a *disabled* checkbox with an explanatory tooltip, instead of no checkbox at all.
- **"Base" badge** — the header's "Source" caption next to the base translation is replaced by a grey "Base" badge.
- **New TM dialog** — the base language field has no default selection, forcing the user to choose one explicitly (avoids accidentally picking the wrong base language).
- **Base-language validation** — the required error now appears after a submit attempt even when the field was selected and then cleared.
- **Select-all checkbox** — the header checkbox can now deselect all entries (previously it could only ever select).

### Notes

Two new translation keys are used — `translation_memory_header_base` and `tm_entry_select_disabled_virtual`. Both have `defaultValue`s in code and still need to be registered in Tolgee.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-seed language filters from visible entries; newly created entry languages are added to the filter.
  * Create-entry flow now returns created language tags so the UI can update filters.

* **UI/UX Improvements**
  * Base language shown as a compact chip in the translation memory header.
  * Language selection is explicit (no “all languages” mode).
  * Select-all toggles select/unselect all; virtual/synced rows show explanatory tooltips.
  * Option to disable auto-selecting the first language in selectors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->