### PR TITLE
fix: chunk soft delete to avoid PostgreSQL parameter limit

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -373,13 +373,15 @@ class KeyService(
     deletedBy: UserAccount? = null,
   ) {
     val actualDeletedBy = deletedBy ?: authenticationFacade.authenticatedUserEntityOrNull
-    val keys = keyRepository.findAllByIdIn(ids.toList())
     val now = currentDateProvider.date
-    keys.forEach {
-      it.deletedAt = now
-      it.deletedBy = actualDeletedBy
+    ids.chunked(SOFT_DELETE_CHUNK_SIZE).forEach { chunk ->
+      val keys = keyRepository.findAllByIdIn(chunk)
+      keys.forEach {
+        it.deletedAt = now
+        it.deletedBy = actualDeletedBy
+      }
+      keyRepository.saveAll(keys)
     }
-    keyRepository.saveAll(keys)
   }
 
   @Transactional
@@ -727,5 +729,9 @@ class KeyService(
     val found = resolved.mapNotNull { it.second }
     val notFound = resolved.filter { it.second == null }.map { it.first }
     return found to notFound
+  }
+
+  companion object {
+    private const val SOFT_DELETE_CHUNK_SIZE = 10_000
   }
 }


### PR DESCRIPTION
## Summary

- `KeyService.softDeleteMultiple` issued a single `findAllByIdIn(ids)`, which expanded into an IN clause with one parameter per id.
- PostgreSQL's wire protocol caps prepared-statement parameters at 65,535, so soft-deleting that many keys at once fails with `PreparedStatement can have at most 65,535 parameters`.
- Chunk the operation at 10,000 ids per query (constant `SOFT_DELETE_CHUNK_SIZE`) to stay safely under the cap. Same pattern as the existing `getByIds` helper in this file.

## Test plan

- [ ] Soft-delete >65k keys via the batch endpoint or service call and verify it completes without a JDBC parameter-count error.
- [ ] Existing soft-delete tests (`SoftDeleteTest`, `BatchDeleteKeysTest`, `KeyTrashPurgeSchedulerTest`) still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized bulk key deletion operations to process in smaller batches, improving performance and reducing memory consumption during large-scale deletion tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->