### PR TITLE
chore(observability): raise local Tempo per-trace cap, align local pipeline with prod

### DIFF
--- a/docker/local-observability-stack/otel-collector-config.yaml
+++ b/docker/local-observability-stack/otel-collector-config.yaml
@@ -2,12 +2,15 @@
 # LOCAL DEVELOPMENT ONLY - Do not use in production.
 # =============================================================================
 #
-# OpenTelemetry Collector - Trace Ingestion & Sampling
+# OpenTelemetry Collector - Trace Ingestion
 #
 # Purpose:
-#   Receives traces from the OTEL Java Agent, applies tail-based sampling
-#   (keeping errors, slow traces, and a percentage of normal traces),
-#   then forwards to Tempo.
+#   Receives traces from the OTEL Java Agent and forwards them to Tempo.
+#   100% of traces are kept — matches production behaviour (Alloy also
+#   forwards 100%). No tail_sampling: at 100% it adds memory pressure and
+#   30s of visibility delay for zero benefit (see deployment/azure/production
+#   /alloy/values.yaml for the longer explanation and the prerequisites for
+#   re-enabling it cluster-wide).
 #
 # Part of: Tolgee Local Observability Stack
 #   See: docs/observability/
@@ -27,25 +30,6 @@ processors:
     timeout: 1s
     send_batch_size: 1024
 
-  tail_sampling:
-    decision_wait: 10s
-    num_traces: 100000
-    expected_new_traces_per_sec: 100
-    policies:
-      - name: errors-policy
-        type: status_code
-        status_code:
-          status_codes:
-            - ERROR
-      - name: latency-policy
-        type: latency
-        latency:
-          threshold_ms: 2000
-      - name: probabilistic-policy
-        type: probabilistic
-        probabilistic:
-          sampling_percentage: 10
-
 exporters:
   otlp/tempo:
     endpoint: tempo:4317
@@ -64,5 +48,5 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [tail_sampling, batch]
+      processors: [batch]
       exporters: [otlp/tempo, debug]

--- a/docker/local-observability-stack/tempo-config.yaml
+++ b/docker/local-observability-stack/tempo-config.yaml
@@ -17,6 +17,26 @@ stream_over_http_enabled: true
 server:
   http_listen_port: 3200
   log_level: info
+  # Default 16 MiB is too small to fetch any trace that approaches our
+  # 20 MB max_bytes_per_trace cap. The /api/traces/<id> HTTP handler proxies
+  # through internal gRPC calls (query_frontend → querier → ingester); every
+  # hop must accept the larger message size. 32 MiB matches the per-trace
+  # ceiling with comfortable headroom.
+  grpc_server_max_send_msg_size: 33554432
+  grpc_server_max_recv_msg_size: 33554432
+  http_server_read_timeout: 60s
+  http_server_write_timeout: 60s
+
+querier:
+  frontend_worker:
+    grpc_client_config:
+      max_send_msg_size: 33554432
+      max_recv_msg_size: 33554432
+
+ingester_client:
+  grpc_client_config:
+    max_send_msg_size: 33554432
+    max_recv_msg_size: 33554432
 
 query_frontend:
   search:
@@ -78,5 +98,11 @@ storage:
 
 overrides:
   defaults:
+    global:
+      # Default 5 MB is too small once Tolgee batch jobs produce traces with
+      # large db.statement / activity-log spans. 20 MB gives ~5x headroom over
+      # observed peak (100k-key import ≈ 4.4 MB) while still tripping fast on
+      # any regression that re-introduces framework noise.
+      max_bytes_per_trace: 20971520  # 20 MB
     metrics_generator:
       processors: [service-graphs, span-metrics, local-blocks]


### PR DESCRIPTION
## Summary

- \`tempo-config.yaml\`: raise \`overrides.defaults.global.max_bytes_per_trace\` from the 5 MB default to **20 MB**. With framework noise filtered (Hibernate + Spring Data spans off — see companion PR in platform-dev-start), a 100k-key Tolgee import is ~4 MB; 20 MB gives ~5x headroom while still tripping fast on regression.
- \`tempo-config.yaml\`: raise internal gRPC server + querier/ingester-client message sizes from 16 MB to 32 MB so the trace-by-id API can return any trace that fits within \`max_bytes_per_trace\`.
- \`otel-collector-config.yaml\`: remove \`tail_sampling\` from the traces pipeline. Production Alloy already forwards 100% of traces; the local stack now mirrors that. Tail sampling at 100% was pure latency + memory overhead (30 s \`decision_wait\` window) for zero benefit.

## Companion PRs

- platform-dev-start (root repo, IDE run config): https://github.com/tolgee/platform-dev-start/pull/40
- deployment (production Tempo + Tolgee values): https://github.com/tolgee/deployment/pull/684

## Test plan

- [ ] Start the local stack and run an import
- [ ] Verify trace appears in Grafana → Tempo with no Hibernate / Spring Data spans
- [ ] Verify trace-by-id fetch (\`GET /api/traces/<id>\`) returns 200 for the largest traces the stack produces
- [ ] Verify no \`tempo_discarded_spans_total{reason="trace_too_large"}\` increments during normal workload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry Collector local configuration to streamline trace ingestion and forwarding to Tempo
  * Enhanced Tempo configuration with increased gRPC message size limits across server and ingester components
  * Added explicit communication timeouts and increased maximum trace payload size to accommodate larger trace data from local batch jobs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->