### PR TITLE
feat: support gettext msgctxt in PO import/export and UI

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PoMsgctxtTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PoMsgctxtTestData.kt
@@ -1,0 +1,19 @@
+package io.tolgee.development.testDataBuilder.data
+
+class PoMsgctxtTestData : BaseTestData() {
+  init {
+    projectBuilder.apply {
+      addKey {
+        name = "plain.key"
+      }.build {
+        addTranslation("en", "Plain key without msgctxt")
+      }
+
+      addKey {
+        name = "menu\u0004Open"
+      }.build {
+        addTranslation("en", "Open file from the menu")
+      }
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/contsants.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/contsants.kt
@@ -1,3 +1,5 @@
 package io.tolgee.formats.po
 
 const val PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY = "_poFileMsgIdPlural"
+
+const val PO_MSGCTXT_KEY_SEPARATOR = "\u0004"

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoFileProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoFileProcessor.kt
@@ -6,6 +6,7 @@ import io.tolgee.formats.ImportFileProcessor
 import io.tolgee.formats.MessageConvertorResult
 import io.tolgee.formats.importCommon.ImportFormat
 import io.tolgee.formats.po.PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY
+import io.tolgee.formats.po.PO_MSGCTXT_KEY_SEPARATOR
 import io.tolgee.formats.po.`in`.data.PoParsedTranslation
 import io.tolgee.formats.po.`in`.data.PoParserResult
 import io.tolgee.model.dataImport.ImportLanguage
@@ -26,7 +27,7 @@ class PoFileProcessor(
       context.languages[languageId] = ImportLanguage(languageId, context.fileEntity)
 
       parsed.translations.forEachIndexed { idx, poTranslation ->
-        val keyName = poTranslation.msgid.toString()
+        val keyName = buildKeyName(poTranslation)
 
         if (poTranslation.msgidPlural.isNotEmpty()) {
           addPlural(poTranslation, idx)
@@ -72,7 +73,7 @@ class PoFileProcessor(
     val plurals = poTranslation.msgstrPlurals?.map { it.key to it.value.toString() }?.toMap()
     plurals?.let {
       val (converted, convertedBy) = getConvertedMessage(poTranslation, plurals)
-      val keyName = poTranslation.msgid.toString()
+      val keyName = buildKeyName(poTranslation)
       poTranslation.msgidPlural.toString().nullIfEmpty?.let {
         context.setCustom(keyName, PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY, it)
       }
@@ -86,6 +87,15 @@ class PoFileProcessor(
         convertedBy = convertedBy,
       )
     }
+  }
+
+  private fun buildKeyName(poTranslation: PoParsedTranslation): String {
+    val msgid = poTranslation.msgid.toString()
+    val msgctxt = poTranslation.msgctxt.toString()
+    if (msgctxt.isEmpty()) {
+      return msgid
+    }
+    return "$msgctxt$PO_MSGCTXT_KEY_SEPARATOR$msgid"
   }
 
   private fun getConvertedMessage(

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoParser.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoParser.kt
@@ -4,14 +4,13 @@ import io.tolgee.exceptions.PoParserException
 import io.tolgee.formats.po.`in`.data.PoParsedTranslation
 import io.tolgee.formats.po.`in`.data.PoParserMeta
 import io.tolgee.formats.po.`in`.data.PoParserResult
-import io.tolgee.model.dataImport.issues.issueTypes.FileIssueType
-import io.tolgee.model.dataImport.issues.paramTypes.FileIssueParamType
 import io.tolgee.service.dataImport.processors.FileProcessorContext
 import java.util.Locale
 
 class PoParser(
   private val context: FileProcessorContext,
 ) {
+  private var expectMsgCtxt = false
   private var expectMsgId = false
   private var expectMsgStr = false
   private var expectMsgIdPlural = false
@@ -50,7 +49,7 @@ class PoParser(
 
   private fun processHeader(): PoParserMeta {
     val result = PoParserMeta()
-    translations.filter { it.msgid.toString() == "" }.forEach {
+    translations.filter { it.msgid.toString() == "" && it.msgctxt.toString() == "" }.forEach {
       it.msgstr.split("\n").map { metaLine ->
         val trimmed = metaLine.trim()
         if (trimmed.isBlank()) {
@@ -253,10 +252,8 @@ class PoParser(
       }
 
       isKeyword("msgctxt") -> {
-        context.fileEntity.addIssue(
-          FileIssueType.PO_MSGCTXT_NOT_SUPPORTED,
-          mapOf(FileIssueParamType.LINE to currentLine.toString()),
-        )
+        possibleEndTranslationBefore()
+        expectMsgCtxt = true
       }
 
       current.matches("^msgstr\\[\\d+]$".toRegex()) -> {
@@ -294,6 +291,10 @@ class PoParser(
 
   private fun storeCurrent() {
     createdTranslation.apply {
+      if (expectMsgCtxt) {
+        this.msgctxt.append(currentSequence)
+      }
+
       if (expectMsgId) {
         this.msgid.append(currentSequence)
       }
@@ -322,6 +323,7 @@ class PoParser(
 
   private fun resetValueExpectations() {
     expectValue = false
+    expectMsgCtxt = false
     expectMsgId = false
     expectMsgStr = false
     expectMsgIdPlural = false

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/data/PoParsedTranslation.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/data/PoParsedTranslation.kt
@@ -1,6 +1,7 @@
 package io.tolgee.formats.po.`in`.data
 
 class PoParsedTranslation {
+  var msgctxt: StringBuilder = StringBuilder()
   var msgid: StringBuilder = StringBuilder()
   var msgidPlural: StringBuilder = StringBuilder()
   var msgstr: StringBuilder = StringBuilder()

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
@@ -53,7 +53,7 @@ class PoFileExporter(
   }
 
   private fun StringBuilder.writeMsgCtxt(msgctxt: String?) {
-    if (msgctxt != null) {
+    if (!msgctxt.isNullOrEmpty()) {
       this.append(convertToPoMultilineString("msgctxt", msgctxt))
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/out/PoFileExporter.kt
@@ -4,11 +4,13 @@ import io.tolgee.dtos.IExportParams
 import io.tolgee.formats.ExportMessageFormat
 import io.tolgee.formats.getPluralData
 import io.tolgee.formats.po.PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY
+import io.tolgee.formats.po.PO_MSGCTXT_KEY_SEPARATOR
 import io.tolgee.model.ILanguage
 import io.tolgee.service.export.ExportFilePathProvider
 import io.tolgee.service.export.dataProvider.ExportTranslationView
 import io.tolgee.service.export.exporters.FileExporter
 import java.io.InputStream
+import kotlin.text.split
 
 class PoFileExporter(
   val translations: List<ExportTranslationView>,
@@ -33,7 +35,8 @@ class PoFileExporter(
       val resultBuilder = getResultStringBuilder(translation)
       val converted = convertMessage(translation)
       resultBuilder.appendLine()
-      resultBuilder.writeMsgId(translation.key.name)
+      resultBuilder.writeMsgCtxt(translation.key.name.getMsgCtxt())
+      resultBuilder.writeMsgId(translation.key.name.getMsgId())
       resultBuilder.writeMsgIdPlural(translation, converted)
       resultBuilder.writeMsgStr(converted)
     }
@@ -47,6 +50,12 @@ class PoFileExporter(
       forceIsPlural = translation.key.isPlural,
       projectIcuPlaceholdersSupport = projectIcuPlaceholdersSupport,
     ).convert()
+  }
+
+  private fun StringBuilder.writeMsgCtxt(msgctxt: String?) {
+    if (msgctxt != null) {
+      this.append(convertToPoMultilineString("msgctxt", msgctxt))
+    }
   }
 
   private fun StringBuilder.writeMsgId(keyName: String) {
@@ -101,7 +110,8 @@ class PoFileExporter(
     translation: ExportTranslationView,
     converted: ToPoConversionResult,
   ) {
-    val msgIdPlural = translation.key.custom?.get(PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY) as? String ?: translation.key.name
+    val msgIdPlural =
+      translation.key.custom?.get(PO_FILE_MSG_ID_PLURAL_CUSTOM_KEY) as? String ?: translation.key.name.getMsgId()
     if (converted.isPlural()) {
       this.append(
         convertToPoMultilineString(
@@ -110,5 +120,15 @@ class PoFileExporter(
         ),
       )
     }
+  }
+
+  private fun String.getMsgId(): String {
+    val parts = split(PO_MSGCTXT_KEY_SEPARATOR, limit = 2)
+    return parts.last()
+  }
+
+  private fun String.getMsgCtxt(): String? {
+    val parts = split(PO_MSGCTXT_KEY_SEPARATOR, limit = 2)
+    return parts.takeIf { parts.size > 1 }?.first()
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFileProcessorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFileProcessorTest.kt
@@ -180,6 +180,44 @@ class PoFileProcessorTest {
   }
 
   @Test
+  fun `joins msgctxt and msgid into keyName via separator`() {
+    mockImportFile("example_msgctxt.po")
+    PoFileProcessor(mockUtil.fileProcessorContext).process()
+    val keys = mockUtil.fileProcessorContext.translations.keys
+    assertThat(keys).contains(
+      "menu\u0004Open",
+      "verb\u0004Open",
+      "Open",
+      "items\u0004%d item",
+    )
+  }
+
+  @Test
+  fun `drops msgctxt-only entry whose msgid is empty`() {
+    mockImportFile("example_msgctxt_only.po")
+    PoFileProcessor(mockUtil.fileProcessorContext).process()
+    assertThat(mockUtil.fileProcessorContext.translations.keys)
+      .containsExactly("menu\u0004Open")
+  }
+
+  @Test
+  fun `treats empty msgctxt as no msgctxt`() {
+    mockImportFile("example_msgctxt.po")
+    PoFileProcessor(mockUtil.fileProcessorContext).process()
+    val keys = mockUtil.fileProcessorContext.translations.keys
+    assertThat(keys).contains("Cancel")
+    assertThat(keys).doesNotContain("\u0004Cancel")
+  }
+
+  @Test
+  fun `preserves msgctxt escapes in keyName`() {
+    mockImportFile("example_msgctxt_escapes.po")
+    PoFileProcessor(mockUtil.fileProcessorContext).process()
+    val expected = "a \"quoted\" ctx\nwith newline\u0004Save"
+    assertThat(mockUtil.fileProcessorContext.translations.keys).contains(expected)
+  }
+
+  @Test
   fun `respects provided format`() {
     mockUtil.mockIt("en.json", "src/test/resources/import/po/example.po")
     mockUtil.fileProcessorContext.params =

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
@@ -1,6 +1,7 @@
 package io.tolgee.unit.formats.po.`in`
 
 import io.tolgee.formats.po.`in`.PoParser
+import io.tolgee.model.dataImport.issues.issueTypes.FileIssueType
 import io.tolgee.util.FileProcessorContextMockUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -12,11 +13,11 @@ class PoParserTest {
   @BeforeEach
   fun setup() {
     mockUtil = FileProcessorContextMockUtil()
-    mockUtil.mockIt("example.po", "src/test/resources/import/po/example.po")
   }
 
   @Test
   fun `returns correct parsed result`() {
+    mockUtil.mockIt("example.po", "src/test/resources/import/po/example.po")
     val result = PoParser(mockUtil.fileProcessorContext)()
     assertThat(result.translations).hasSizeGreaterThan(8)
     assertThat(result.translations[5].msgstrPlurals).hasSize(2)
@@ -29,5 +30,46 @@ class PoParserTest {
     assertThat(result.translations[9].msgid.toString()).isEqualTo("This is a \"quote\"")
     assertThat(result.translations[10].msgstr.toString()).isEqualTo("This\nis\na\nmultiline\nstring")
     assertThat(result.translations[11].msgstr.toString()).isEqualTo("This\r\nis\r\na\r\nmultiline\r\nstring")
+  }
+
+  @Test
+  fun `parses msgctxt for each entry`() {
+    mockUtil.mockIt("example_msgctxt.po", "src/test/resources/import/po/example_msgctxt.po")
+    val result = PoParser(mockUtil.fileProcessorContext)()
+    val byMsgid =
+      result.translations
+        .filter { it.msgid.toString().isNotEmpty() }
+        .associateBy { it.msgctxt.toString() to it.msgid.toString() }
+
+    assertThat(byMsgid).containsKey("menu" to "Open")
+    assertThat(byMsgid).containsKey("verb" to "Open")
+    assertThat(byMsgid).containsKey("" to "Open")
+    assertThat(byMsgid["items" to "%d item"]?.msgidPlural?.toString()).isEqualTo("%d items")
+  }
+
+  @Test
+  fun `parses msgctxt containing escaped quotes and newlines`() {
+    mockUtil.mockIt("example_msgctxt_escapes.po", "src/test/resources/import/po/example_msgctxt_escapes.po")
+    val result = PoParser(mockUtil.fileProcessorContext)()
+    val entry = result.translations.first { it.msgid.toString() == "Save" }
+    assertThat(entry.msgctxt.toString()).isEqualTo("a \"quoted\" ctx\nwith newline")
+  }
+
+  @Test
+  fun `does not emit PO_MSGCTXT_NOT_SUPPORTED issue`() {
+    mockUtil.mockIt("example_msgctxt.po", "src/test/resources/import/po/example_msgctxt.po")
+    PoParser(mockUtil.fileProcessorContext)()
+    val emittedTypes = mockUtil.fileProcessorContext.fileEntity.issues.map { it.type }
+    assertThat(emittedTypes).doesNotContain(FileIssueType.PO_MSGCTXT_NOT_SUPPORTED)
+  }
+
+  @Test
+  fun `does not promote msgctxt-only entry with empty msgid to header`() {
+    mockUtil.mockIt("example_msgctxt_only.po", "src/test/resources/import/po/example_msgctxt_only.po")
+    val result = PoParser(mockUtil.fileProcessorContext)()
+    // The msgctxt-only-with-empty-msgid entry must not contribute header metadata
+    // (would otherwise be parsed as Key: value lines from its msgstr).
+    assertThat(result.meta.language).isEqualTo("de")
+    assertThat(result.meta.other).doesNotContainKey("garbage")
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoParserTest.kt
@@ -59,7 +59,9 @@ class PoParserTest {
   fun `does not emit PO_MSGCTXT_NOT_SUPPORTED issue`() {
     mockUtil.mockIt("example_msgctxt.po", "src/test/resources/import/po/example_msgctxt.po")
     PoParser(mockUtil.fileProcessorContext)()
-    val emittedTypes = mockUtil.fileProcessorContext.fileEntity.issues.map { it.type }
+    val emittedTypes =
+      mockUtil.fileProcessorContext.fileEntity.issues
+        .map { it.type }
     assertThat(emittedTypes).doesNotContain(FileIssueType.PO_MSGCTXT_NOT_SUPPORTED)
   }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoFileExporterTest.kt
@@ -3,6 +3,7 @@ package io.tolgee.unit.formats.po.out
 import io.tolgee.dtos.request.export.ExportParams
 import io.tolgee.formats.ExportFormat
 import io.tolgee.formats.ExportMessageFormat
+import io.tolgee.formats.po.PO_MSGCTXT_KEY_SEPARATOR
 import io.tolgee.formats.po.out.PoFileExporter
 import io.tolgee.model.ILanguage
 import io.tolgee.model.enums.TranslationState
@@ -168,6 +169,114 @@ class PoFileExporterTest {
       """.trimIndent(),
     )
   }
+
+  @Test
+  fun `exports msgctxt for keys containing separator`() {
+    val data =
+      getExported(
+        getExporter(
+          listOf(
+            translationView(1, "menu${PO_MSGCTXT_KEY_SEPARATOR}Open", "Öffnen"),
+            translationView(2, "verb${PO_MSGCTXT_KEY_SEPARATOR}Open", "Öffnen (Verb)"),
+            translationView(3, "Open", "Öffnen (kein Kontext)"),
+          ),
+        ),
+      )
+    data.assertFile(
+      "de.po",
+      """
+    |msgid ""
+    |msgstr ""
+    |"Language: de\n"
+    |"MIME-Version: 1.0\n"
+    |"Content-Type: text/plain; charset=UTF-8\n"
+    |"Content-Transfer-Encoding: 8bit\n"
+    |"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+    |"X-Generator: Tolgee\n"
+    |
+    |msgctxt "menu"
+    |msgid "Open"
+    |msgstr "Öffnen"
+    |
+    |msgctxt "verb"
+    |msgid "Open"
+    |msgstr "Öffnen (Verb)"
+    |
+    |msgid "Open"
+    |msgstr "Öffnen (kein Kontext)"
+    |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `exports plural with msgctxt and uses split msgid as msgid_plural fallback`() {
+    val data =
+      getExported(
+        getExporter(
+          listOf(
+            translationView(
+              keyId = 1,
+              keyName = "items${PO_MSGCTXT_KEY_SEPARATOR}%d item",
+              text = "{count, plural, one {# Element} other {# Elemente}}",
+              isPlural = true,
+            ),
+          ),
+        ),
+      )
+    data.assertFile(
+      "de.po",
+      """
+    |msgid ""
+    |msgstr ""
+    |"Language: de\n"
+    |"MIME-Version: 1.0\n"
+    |"Content-Type: text/plain; charset=UTF-8\n"
+    |"Content-Transfer-Encoding: 8bit\n"
+    |"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+    |"X-Generator: Tolgee\n"
+    |
+    |msgctxt "items"
+    |msgid "%d item"
+    |msgid_plural "%d item"
+    |msgstr[0] "%d Element"
+    |msgstr[1] "%d Elemente"
+    |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `escapes quotes and newlines inside msgctxt`() {
+    val data =
+      getExported(
+        getExporter(
+          listOf(
+            translationView(
+              keyId = 1,
+              keyName = "a \"quoted\" ctx\nwith newline${PO_MSGCTXT_KEY_SEPARATOR}Save",
+              text = "Speichern",
+            ),
+          ),
+        ),
+      )
+    data["de.po"].assert.contains("msgctxt ")
+    data["de.po"].assert.contains("\\\"quoted\\\"")
+    data["de.po"].assert.contains("msgid \"Save\"")
+  }
+
+  private fun translationView(
+    keyId: Long,
+    keyName: String,
+    text: String,
+    isPlural: Boolean = false,
+  ) = ExportTranslationView(
+    keyId,
+    text,
+    TranslationState.TRANSLATED,
+    ExportKeyView(keyId, keyName, isPlural = isPlural),
+    "de",
+  )
 
   @Test
   fun `honors the provided fileStructureTemplate`() {

--- a/backend/data/src/test/resources/import/po/example_msgctxt.po
+++ b/backend/data/src/test/resources/import/po/example_msgctxt.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "menu"
+msgid "Open"
+msgstr "Öffnen"
+
+msgctxt "verb"
+msgid "Open"
+msgstr "Öffnen (Verb)"
+
+msgid "Open"
+msgstr "Öffnen (kein Kontext)"
+
+msgctxt "items"
+msgid "%d item"
+msgid_plural "%d items"
+msgstr[0] "%d Element"
+msgstr[1] "%d Elemente"
+
+msgctxt ""
+msgid "Cancel"
+msgstr "Abbrechen"

--- a/backend/data/src/test/resources/import/po/example_msgctxt_escapes.po
+++ b/backend/data/src/test/resources/import/po/example_msgctxt_escapes.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n \!= 1);\n"
+
+msgctxt "a \"quoted\" ctx\nwith newline"
+msgid "Save"
+msgstr "Speichern"

--- a/backend/data/src/test/resources/import/po/example_msgctxt_escapes.po
+++ b/backend/data/src/test/resources/import/po/example_msgctxt_escapes.po
@@ -4,7 +4,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n \!= 1);\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgctxt "a \"quoted\" ctx\nwith newline"
 msgid "Save"

--- a/backend/data/src/test/resources/import/po/example_msgctxt_only.po
+++ b/backend/data/src/test/resources/import/po/example_msgctxt_only.po
@@ -1,0 +1,14 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgctxt "stray"
+msgid ""
+msgstr "garbage: should-not-leak-to-header\n"
+
+msgctxt "menu"
+msgid "Open"
+msgstr "Öffnen"

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PoMsgctxtE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PoMsgctxtE2eDataController.kt
@@ -1,0 +1,11 @@
+package io.tolgee.controllers.internal.e2eData
+
+import io.tolgee.controllers.internal.InternalController
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.development.testDataBuilder.data.PoMsgctxtTestData
+
+@InternalController(["internal/e2e-data/po-msgctxt"])
+class PoMsgctxtE2eDataController : AbstractE2eDataController() {
+  override val testData: TestDataBuilder
+    get() = PoMsgctxtTestData().root
+}

--- a/e2e/cypress/common/apiCalls/testData/testData.ts
+++ b/e2e/cypress/common/apiCalls/testData/testData.ts
@@ -31,6 +31,8 @@ export const commentsTestData = generateTestDataObject('translation-comments');
 export const translationSingleTestData =
   generateTestDataObject('translation-single');
 
+export const poMsgctxtTestData = generateTestDataObject('po-msgctxt');
+
 export const importTestData = {
   clean: () => cleanTestData('import'),
   generateBasic: () => internalFetch('e2e-data/import/generate'),

--- a/e2e/cypress/e2e/translations/poMsgctxt.cy.ts
+++ b/e2e/cypress/e2e/translations/poMsgctxt.cy.ts
@@ -1,0 +1,72 @@
+import { poMsgctxtTestData } from '../../common/apiCalls/testData/testData';
+import { login } from '../../common/apiCalls/common';
+import { visitTranslations } from '../../common/translations';
+import { waitForGlobalLoading } from '../../common/loading';
+import { E2TranslationsView } from '../../compounds/E2TranslationsView';
+
+const PO_MSGCTXT_KEY_SEPARATOR = '\u0004';
+
+describe('PO msgctxt key names', () => {
+  let projectId: number;
+
+  beforeEach(() => {
+    poMsgctxtTestData.clean({ failOnStatusCode: false });
+    poMsgctxtTestData
+      .generateStandard()
+      .then((r) => {
+        projectId = r.body.projects[0].id;
+      })
+      .then(() => login('test_username'));
+  });
+
+  afterEach(() => {
+    poMsgctxtTestData.clean({ failOnStatusCode: false });
+  });
+
+  it('renders msgctxt as chip in the translations grid', () => {
+    visitTranslations(projectId);
+    waitForGlobalLoading();
+
+    cy.gcy('translations-key-name')
+      .contains('Open')
+      .closest('[data-cy="translations-key-name"]')
+      .findDcy('key-name-msgctxt')
+      .should('be.visible')
+      .and('have.text', 'menu');
+
+    cy.gcy('translations-key-name')
+      .contains('plain.key')
+      .closest('[data-cy="translations-key-name"]')
+      .findDcy('key-name-msgctxt')
+      .should('not.exist');
+  });
+
+  it('pasting EOT into the key-name editor renders an msgctxt chip', () => {
+    visitTranslations(projectId);
+    waitForGlobalLoading();
+
+    const translationsView = new E2TranslationsView();
+    const dialog = translationsView.openKeyCreateDialog();
+
+    dialog.getKeyNameInput().find('.cm-content').as('keyInput');
+
+    cy.get('@keyInput').click();
+    cy.get('@keyInput').then(($el) => {
+      const text = `pasted${PO_MSGCTXT_KEY_SEPARATOR}Save`;
+      const clipboardData = new DataTransfer();
+      clipboardData.setData('text/plain', text);
+      const event = new ClipboardEvent('paste', {
+        clipboardData,
+        bubbles: true,
+        cancelable: true,
+      });
+      $el[0].dispatchEvent(event);
+    });
+
+    dialog
+      .getKeyNameInput()
+      .find('.keyname-msgctxt-widget')
+      .should('be.visible')
+      .and('have.text', 'pasted');
+  });
+});

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -359,6 +359,7 @@ declare namespace DataCy {
         "key-edit-tab-context": true;
         "key-edit-tab-custom-properties": true;
         "key-edit-tab-general": true;
+        "key-name-msgctxt": true;
         "key-plural-checkbox": true;
         "key-plural-variable-name": true;
         "label-autocomplete-option": true;

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -29,7 +29,7 @@
         "@sentry/react": "^10.31.0",
         "@sentry/vite-plugin": "^4.6.1",
         "@stomp/stompjs": "^6.1.2",
-        "@tginternal/editor": "1.16.1",
+        "@tginternal/editor": "1.17.0",
         "@tginternal/library": "file:../library",
         "@tolgee/format-icu": "^5.27.0",
         "@tolgee/react": "^5.27.0",
@@ -3719,9 +3719,9 @@
       }
     },
     "node_modules/@tginternal/editor": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@tginternal/editor/-/editor-1.16.1.tgz",
-      "integrity": "sha512-851Mheo3oIfVWpU3vPzV39xzQAc0gzRJ9hXOgYVMMfblmCcUJGIIKs8OZJGg+OXA4LVrZP1XcVzsEBPgLqvVIg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@tginternal/editor/-/editor-1.17.0.tgz",
+      "integrity": "sha512-SNsPqjKIwV6vg2Yr36cPxOc8R32uCAxrwC1kOVTSUM1lALNZQQMnGVIkJR8VxvoMNtb5CEfRhV5oaZJ4lttIFg==",
       "peerDependencies": {
         "@codemirror/lint": "^6.4.2",
         "@codemirror/state": "^6.4.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,7 +28,7 @@
     "@sentry/react": "^10.31.0",
     "@sentry/vite-plugin": "^4.6.1",
     "@stomp/stompjs": "^6.1.2",
-    "@tginternal/editor": "1.16.1",
+    "@tginternal/editor": "1.17.0",
     "@tginternal/library": "file:../library",
     "@tolgee/format-icu": "^5.27.0",
     "@tolgee/react": "^5.27.0",

--- a/webapp/src/component/KeyName/KeyName.tsx
+++ b/webapp/src/component/KeyName/KeyName.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react';
+import { styled, Tooltip, useTheme } from '@mui/material';
+import { T } from '@tolgee/react';
+import { LinkReadMore } from 'tg.component/LinkReadMore';
+import { DOCS_LINKS } from 'tg.constants/docLinks';
+import { generateKeyNameStyle } from '@tginternal/editor';
+
+import { splitKeyName } from 'tg.fixtures/keyName';
+
+const StyledRoot = styled('span')`
+  display: inline;
+`;
+
+type Props = {
+  name: string;
+  className?: string;
+  ['data-cy']?: string;
+};
+
+export const KeyName: React.FC<Props> = ({
+  name,
+  className,
+  'data-cy': dataCy,
+}) => {
+  const theme = useTheme();
+  const { msgctxt, msgid } = splitKeyName(name);
+
+  const Wrapper = useMemo(
+    () =>
+      generateKeyNameStyle({
+        styled,
+        component: StyledRoot,
+      }),
+    [theme.palette.mode]
+  );
+
+  if (!msgctxt) {
+    return (
+      <span className={className} data-cy={dataCy}>
+        {name}
+      </span>
+    );
+  }
+
+  return (
+    <Wrapper className={className} data-cy={dataCy}>
+      <Tooltip
+        title={
+          <T
+            keyName="translations_key_msgctxt_tooltip"
+            params={{
+              LearnMore: <LinkReadMore url={DOCS_LINKS.poMsgctxt} />,
+            }}
+          />
+        }
+        enterDelay={200}
+        leaveDelay={200}
+      >
+        <span className="keyname-msgctxt-widget" data-cy="key-name-msgctxt">
+          {msgctxt}
+        </span>
+      </Tooltip>
+      {msgid}
+    </Wrapper>
+  );
+};

--- a/webapp/src/component/ScreenshotWithLabels.tsx
+++ b/webapp/src/component/ScreenshotWithLabels.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-unknown-property */
 import { Tooltip, useTheme } from '@mui/material';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { CSSProperties, useEffect, useState } from 'react';
 import { useImagePreload } from 'tg.fixtures/useImagePreload';
 
@@ -113,7 +114,11 @@ export const ScreenshotWithLabels: React.FC<Props> = ({
                 );
                 if (showTooltips) {
                   return (
-                    <Tooltip key={i} title={key.keyName} placement="right">
+                    <Tooltip
+                      key={i}
+                      title={<KeyName name={key.keyName} />}
+                      placement="right"
+                    >
                       {rectangle}
                     </Tooltip>
                   );

--- a/webapp/src/component/activity/references/KeyReference.tsx
+++ b/webapp/src/component/activity/references/KeyReference.tsx
@@ -8,6 +8,7 @@ import { useProject } from 'tg.hooks/useProject';
 import { queryEncode } from 'tg.hooks/useUrlSearchState';
 import { KeyReferenceData } from '../types';
 import { CircledLanguageIcon } from 'tg.component/languages/CircledLanguageIcon';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 
 type Props = {
   data: KeyReferenceData;
@@ -50,7 +51,7 @@ export const KeyReference: React.FC<Props> = ({ data }) => {
         {data.namespace && (
           <span className="referencePrefix">{data.namespace}</span>
         )}
-        {data.keyName}
+        <KeyName name={data.keyName} />
         {data.languages && ' '}
       </span>
       {uniqueLanguages.map((l, i) => (

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -112,19 +112,21 @@ export const Editor: React.FC<EditorProps> = ({
   const languageCompartment = useRef<Compartment>(new Compartment());
 
   const StyledEditorWrapper = useMemo(() => {
-    if (mode === 'keyName') {
-      return generateKeyNameStyle({
-        styled,
-        colors: theme.palette.placeholders.variant,
-        component: StyledEditor,
-      });
-    }
-    return generatePlaceholdersStyle({
+    // Compose both placeholder and keyName styles unconditionally — switching
+    // the wrapper based on `mode` would unmount the styled component on every
+    // mode change and tear down the underlying CodeMirror EditorView with it,
+    // breaking any test or interaction that toggles modes mid-edit.
+    const withPlaceholders = generatePlaceholdersStyle({
       styled,
       colors: theme.palette.placeholders,
       component: StyledEditor,
     });
-  }, [theme.palette.placeholders, mode]);
+    return generateKeyNameStyle({
+      styled,
+      colors: theme.palette.placeholders.variant,
+      component: withPlaceholders,
+    });
+  }, [theme.palette.placeholders]);
 
   keyBindings.current = shortcuts;
 

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -1,6 +1,6 @@
 import { RefObject, useEffect, useMemo, useRef } from 'react';
 import { minimalSetup } from 'codemirror';
-import { Compartment, EditorState, Prec } from '@codemirror/state';
+import { Compartment, EditorState, Prec, Extension } from '@codemirror/state';
 import { EditorView, ViewUpdate, keymap, KeyBinding } from '@codemirror/view';
 import { styled, useTheme } from '@mui/material';
 import {
@@ -9,6 +9,8 @@ import {
   TolgeeHighlight,
   htmlIsolatesPlugin,
   generatePlaceholdersStyle,
+  KeyNamePlugin,
+  generateKeyNameStyle,
 } from '@tginternal/editor';
 
 import { Direction } from 'tg.fixtures/getLanguageDirection';
@@ -59,7 +61,7 @@ export type EditorProps = {
   value: string;
   onChange?: (val: string) => void;
   background?: string;
-  mode: 'placeholders' | 'syntax' | 'plain';
+  mode: 'placeholders' | 'syntax' | 'plain' | 'keyName';
   autofocus?: boolean;
   minHeight?: number | string;
   onBlur?: () => void;
@@ -110,12 +112,19 @@ export const Editor: React.FC<EditorProps> = ({
   const languageCompartment = useRef<Compartment>(new Compartment());
 
   const StyledEditorWrapper = useMemo(() => {
+    if (mode === 'keyName') {
+      return generateKeyNameStyle({
+        styled,
+        colors: theme.palette.placeholders.variant,
+        component: StyledEditor,
+      });
+    }
     return generatePlaceholdersStyle({
       styled,
       colors: theme.palette.placeholders,
       component: StyledEditor,
     });
-  }, [theme.palette.placeholders]);
+  }, [theme.palette.placeholders, mode]);
 
   keyBindings.current = shortcuts;
 
@@ -169,22 +178,29 @@ export const Editor: React.FC<EditorProps> = ({
   }, [theme.palette.mode]);
 
   useEffect(() => {
-    const placholderPlugins =
-      mode === 'placeholders'
-        ? [
-            PlaceholderPlugin({
-              examplePluralNum,
-              nested: Boolean(nested),
-              tooltips: true,
-            }),
-          ]
-        : [];
+    const placeholderPlugins: Extension[] = [];
+    switch (mode) {
+      case 'placeholders':
+        placeholderPlugins.push(
+          PlaceholderPlugin({
+            examplePluralNum,
+            nested: Boolean(nested),
+            tooltips: true,
+          })
+        );
+        break;
+      case 'keyName':
+        placeholderPlugins.push(KeyNamePlugin());
+        break;
+    }
     const syntaxPlugins =
-      mode === 'plain' ? [] : [tolgeeSyntax(Boolean(nested))];
+      mode === 'plain' || mode === 'keyName'
+        ? []
+        : [tolgeeSyntax(Boolean(nested))];
     editor.current?.dispatch({
       selection: editor.current.state.selection,
       effects: [
-        placeholders.current?.reconfigure(placholderPlugins),
+        placeholders.current?.reconfigure(placeholderPlugins),
         languageCompartment.current.reconfigure(syntaxPlugins),
       ],
     });

--- a/webapp/src/constants/docLinks.ts
+++ b/webapp/src/constants/docLinks.ts
@@ -5,4 +5,5 @@ export const DOCS_LINKS = {
   importingPlaceholders: `${DOCS_ROOT}/platform/projects_and_organizations/import#importing-placeholders`,
   qaChecksGrammar: `${DOCS_ROOT}/platform/translation_process/qa_checks#spelling-and-grammar-checks`,
   qaChecksSpelling: `${DOCS_ROOT}/platform/translation_process/qa_checks#spelling-and-grammar-checks`,
+  poMsgctxt: `${DOCS_ROOT}/platform/formats/po#message-context-msgctxt-and-key-names`,
 };

--- a/webapp/src/ee/branching/merge/components/changes/MergeKeyHeader.tsx
+++ b/webapp/src/ee/branching/merge/components/changes/MergeKeyHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, styled } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import clsx from 'clsx';
 import { MinusCircle, PlusCircle } from '@untitled-ui/icons-react';
 
@@ -80,7 +81,8 @@ export const MergeKeyHeader: React.FC<Props> = ({ data, variant }) => {
         <TextColumn strike={strike}>
           <StyledKey data-cy="translations-key-name">
             <LimitedHeightText maxLines={3} wrap="break-all">
-              {[data.namespace, data.keyName].filter(Boolean).join('.')}
+              {data.namespace && <>{data.namespace}.</>}
+              <KeyName name={data.keyName} />
             </LimitedHeightText>
           </StyledKey>
           {data.keyDescription && (

--- a/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntryRow.tsx
+++ b/webapp/src/ee/translationMemory/components/content/TranslationMemoryEntryRow.tsx
@@ -4,6 +4,7 @@ import { T } from '@tolgee/react';
 import { FlagImage } from '@tginternal/library/components/languages/FlagImage';
 import { languageInfo } from '@tginternal/language-util/lib/generated/languageInfo';
 import { LimitedHeightText } from 'tg.component/LimitedHeightText';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { components } from 'tg.service/apiSchema.generated';
 import { SelectionService } from 'tg.service/useSelectionService';
 import { ProjectLink } from 'tg.component/ProjectLink';
@@ -163,7 +164,7 @@ export const TranslationMemoryEntryRow: React.VFC<Props> = ({
             rows have no key of their own and stay unlabeled. */}
         {row.keyName && (
           <StyledKeyName data-cy="tm-entry-row-keys">
-            {row.keyName}
+            <KeyName name={row.keyName} />
           </StyledKeyName>
         )}
         <StyledSourceText>

--- a/webapp/src/fixtures/__tests__/keyName.test.ts
+++ b/webapp/src/fixtures/__tests__/keyName.test.ts
@@ -1,0 +1,33 @@
+import { PO_MSGCTXT_KEY_SEPARATOR, splitKeyName } from '../keyName';
+
+describe('splitKeyName', () => {
+  it('returns only msgid for name without separator', () => {
+    expect(splitKeyName('plain.key')).toEqual({ msgid: 'plain.key' });
+  });
+
+  it('splits name into msgctxt and msgid on first separator', () => {
+    expect(splitKeyName(`menu${PO_MSGCTXT_KEY_SEPARATOR}Open`)).toEqual({
+      msgctxt: 'menu',
+      msgid: 'Open',
+    });
+  });
+
+  it('treats only the first separator as boundary; later occurrences belong to msgid', () => {
+    const name = `ctx${PO_MSGCTXT_KEY_SEPARATOR}id${PO_MSGCTXT_KEY_SEPARATOR}rest`;
+    expect(splitKeyName(name)).toEqual({
+      msgctxt: 'ctx',
+      msgid: `id${PO_MSGCTXT_KEY_SEPARATOR}rest`,
+    });
+  });
+
+  it('returns empty msgctxt when separator is at start', () => {
+    expect(splitKeyName(`${PO_MSGCTXT_KEY_SEPARATOR}Cancel`)).toEqual({
+      msgctxt: '',
+      msgid: 'Cancel',
+    });
+  });
+
+  it('returns empty msgid for empty input', () => {
+    expect(splitKeyName('')).toEqual({ msgid: '' });
+  });
+});

--- a/webapp/src/fixtures/keyName.ts
+++ b/webapp/src/fixtures/keyName.ts
@@ -1,0 +1,14 @@
+import { PO_MSGCTXT_KEY_SEPARATOR } from '@tginternal/editor';
+
+export { PO_MSGCTXT_KEY_SEPARATOR };
+
+export type SplitKeyName = {
+  msgctxt?: string;
+  msgid: string;
+};
+
+export function splitKeyName(name: string): SplitKeyName {
+  const i = name.indexOf(PO_MSGCTXT_KEY_SEPARATOR);
+  if (i < 0) return { msgid: name };
+  return { msgctxt: name.slice(0, i), msgid: name.slice(i + 1) };
+}

--- a/webapp/src/views/projects/import/component/ImportConflictsData.tsx
+++ b/webapp/src/views/projects/import/component/ImportConflictsData.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { Box, Grid, Pagination, Typography } from '@mui/material';
 import { T } from '@tolgee/react';
 
@@ -57,7 +58,9 @@ export const ImportConflictsData: FunctionComponent<{
                       variant={'body2'}
                       data-cy="import-resolution-dialog-key-name"
                     >
-                      <b>{t.keyName}</b>
+                      <b>
+                        <KeyName name={t.keyName} />
+                      </b>
                     </Typography>
                   </Box>
                 </Grid>

--- a/webapp/src/views/projects/import/component/ImportTranslationsDialog.tsx
+++ b/webapp/src/views/projects/import/component/ImportTranslationsDialog.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useState } from 'react';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { Box, Grid, styled } from '@mui/material';
 import Dialog from '@mui/material/Dialog';
 import IconButton from '@mui/material/IconButton';
@@ -116,7 +117,9 @@ export const ImportTranslationsDialog: FunctionComponent<{
                 >
                   <Grid container spacing={2}>
                     <Grid item lg={4} md={3} sm xs>
-                      <Box>{i.keyName}</Box>
+                      <Box>
+                        <KeyName name={i.keyName} />
+                      </Box>
                       {i.keyDescription && (
                         <StyledDescription>
                           {i.keyDescription}

--- a/webapp/src/views/projects/translations/KeyCellContent.tsx
+++ b/webapp/src/views/projects/translations/KeyCellContent.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { LimitedHeightText } from 'tg.component/LimitedHeightText';
 import { MarkdownLink } from 'tg.component/common/MarkdownLink';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 
 export const StyledKey = styled('div')`
   grid-area: key;
@@ -37,7 +38,7 @@ export const KeyCellContent: React.FC<Props> = ({
     <>
       <StyledKey data-cy="translations-key-name">
         <LimitedHeightText width={width} maxLines={3} wrap="break-all">
-          {keyName}
+          <KeyName name={keyName} />
         </LimitedHeightText>
       </StyledKey>
       {description && (

--- a/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
+++ b/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
@@ -121,7 +121,7 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
                   <EditorWrapper>
                     <StyledEdtorWrapper data-cy="translation-create-key-input">
                       <Editor
-                        mode="plain"
+                        mode="keyName"
                         value={field.value}
                         onChange={(val) => {
                           form.setFieldValue(field.name, val);

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -71,7 +71,7 @@ export const KeyGeneral = () => {
                   run: () => (submitForm(), true),
                 },
               ]}
-              mode="plain"
+              mode="keyName"
               minHeight="unset"
             />
           </EditorWrapper>

--- a/webapp/src/views/projects/translations/KeySingle/KeySingle.tsx
+++ b/webapp/src/views/projects/translations/KeySingle/KeySingle.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { T, useTranslate } from '@tolgee/react';
 import { useQueryClient } from 'react-query';
 import { useHistory } from 'react-router-dom';
@@ -97,7 +98,7 @@ export const KeySingle: React.FC<Props> = ({ keyName, keyId }) => {
         ],
         [
           keyExists ? (
-            translation!.keyName
+            <KeyName name={translation!.keyName} />
           ) : (
             <T keyName="translation_single_create_title" />
           ),

--- a/webapp/src/views/projects/translations/SimpleCellKey.tsx
+++ b/webapp/src/views/projects/translations/SimpleCellKey.tsx
@@ -8,6 +8,7 @@ import { Screenshots } from './Screenshots/Screenshots';
 import ReactMarkdown from 'react-markdown';
 import { MarkdownLink } from 'tg.component/common/MarkdownLink';
 import clsx from 'clsx';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 
 type KeyWithTranslationsModel =
   components['schemas']['KeyWithTranslationsModel'];
@@ -52,7 +53,7 @@ export const SimpleCellKey: React.FC<Props> = ({ data }) => {
     >
       <StyledKey data-cy="translations-key-name">
         <LimitedHeightText maxLines={3} wrap="break-all">
-          {data.keyName}
+          <KeyName name={data.keyName} />
         </LimitedHeightText>
       </StyledKey>
       {data.keyDescription && (

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/TranslationMemory/TranslationMemoryItem.tsx
@@ -1,4 +1,5 @@
 import { styled, Tooltip } from '@mui/material';
+import { KeyName } from 'tg.component/KeyName/KeyName';
 import { components } from 'tg.service/apiSchema.generated';
 import { useTimeDistance } from 'tg.hooks/useTimeDistance';
 import { TranslationWithPlaceholders } from 'tg.views/projects/translations/translationVisual/TranslationWithPlaceholders';
@@ -279,7 +280,7 @@ export const TranslationMemoryItem = ({
               parts.push(
                 <Tooltip key="key" title={item.keyName}>
                   <StyledMetaKey data-cy="translation-tools-translation-memory-item-key-name">
-                    {item.keyName}
+                    <KeyName name={item.keyName} />
                   </StyledMetaKey>
                 </Tooltip>
               );

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -44,6 +44,9 @@ export default defineConfig(({ mode }) => {
     resolve: {
       preserveSymlinks: true,
       dedupe: [
+        '@codemirror/lint',
+        '@codemirror/state',
+        '@codemirror/view',
         '@emotion/react',
         '@emotion/styled',
         '@mui/material',


### PR DESCRIPTION
Supersedes #3459
Fixes #3053

## Summary
- **Import:** the PO parser now captures the optional `msgctxt` field. On import, Tolgee stores the pair `(msgctxt, msgid)` as a single key name using the U+0004 EOT separator — the same convention GNU Gettext uses internally in MO files — so two entries with the same `msgid` but different `msgctxt` remain distinct keys.
- **Export:** the PO exporter splits the key name on U+0004 and writes the `msgctxt` line back before `msgid`. Plural fallback now uses the split `msgid` instead of the raw key name.
- **Parser cleanup:** header detection now requires both `msgid` and `msgctxt` to be empty, so a malformed msgctxt-only entry can't be misread as the header block. The legacy `PO_MSGCTXT_NOT_SUPPORTED` file issue is no longer emitted (the enum value stays in place for back-compat with previously stored issues).
- **UI display:** a new `<KeyName>` component renders the `msgctxt` portion as a styled chip in front of the `msgid` across all key-name display sites (translations grid, simple/list view, single-key page breadcrumb, activity log, import dialogs, translation-memory rows and tooltips, branching/merge header, screenshot label tooltips). The window title intentionally still shows the raw key — the chip cannot render in a `document.title` string.
- **UI edit:** the `<Editor>` component gains a `keyName` mode that wires a new CodeMirror plugin (`KeyNamePlugin` from `@tginternal/editor`) decorating the U+0004 with an atomic widget. Display and edit are now visually identical — the previous substitution-based workaround (`keyNameForEditing`/`keyNameFromEdited` + `␄` visible-char) is removed.
- **Vite config:** added `@codemirror/state`, `@codemirror/view`, `@codemirror/lint` to `resolve.dedupe` to avoid the "multiple instances of @codemirror/state" runtime error introduced when `preserveSymlinks: true` is combined with the linked `@tginternal/editor` worktree.

## Notes
- Re-importing a `.po` file that was imported before this change (when msgctxt was silently dropped) will create new keys for the `(msgctxt, msgid)` pairs instead of updating the existing `msgid`-only keys. Accepted breakage — most users import once.
- An empty `msgctxt ""` collapses to a plain key without a chip, matching gettext semantics.

## Companion PRs
- editor: https://github.com/tolgee/editor/pull/8
- tolgee-js: https://github.com/tolgee/tolgee-js/pull/3523
- documentation: https://github.com/tolgee/documentation/pull/1111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full PO msgctxt support: import/export preserves and uses context to disambiguate identical strings.
  * Key display shows visual context indicators with a tooltip linking to docs via a new KeyName component.
  * Key editor gains a new "keyName" mode for viewing/editing keys with context.
  * Import ignores stray context-only entries to avoid header mis-parsing.

* **Tests**
  * Added unit and end-to-end tests for msgctxt parsing, escaping, import/export, fixtures and UI behavior.

* **Chores**
  * Editor package updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->