### PR TITLE
feat: include projectId in webhook payload

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookProcessor.kt
@@ -35,6 +35,7 @@ class WebhookProcessor(
     val data =
       WebhookRequest(
         webhookConfigId = config.id,
+        projectId = config.project.id,
         eventType = WebhookEventType.PROJECT_ACTIVITY,
         activityData = activityModel,
       )

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookRequest.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookRequest.kt
@@ -4,6 +4,7 @@ import io.tolgee.api.IProjectActivityModel
 
 data class WebhookRequest(
   val webhookConfigId: Long?,
+  val projectId: Long?,
   val eventType: WebhookEventType,
   val activityData: IProjectActivityModel?,
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/WebhookConfigService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/WebhookConfigService.kt
@@ -63,7 +63,7 @@ class WebhookConfigService(
     try {
       webhookExecutor.signAndExecute(
         config = webhookConfig,
-        data = WebhookRequest(webhookConfigId, WebhookEventType.TEST, null),
+        data = WebhookRequest(webhookConfigId, projectId, WebhookEventType.TEST, null),
       )
     } catch (e: WebhookException) {
       return false

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
@@ -152,6 +152,7 @@ class WebhookAutomationTest : ProjectAuthControllerTest("/v2/projects/") {
 
       assertThatJson(httpEntity.body!!) {
         node("webhookConfigId").isValidId
+        node("projectId").isEqualTo(testData.projectBuilder.self.id)
         node("eventType").isEqualTo("PROJECT_ACTIVITY")
         node("activityData") {
           node("revisionId").isNumber


### PR DESCRIPTION
## Summary

- Add `projectId` to the webhook envelope (`WebhookRequest`) alongside `webhookConfigId` and `eventType`
- Set from `WebhookConfig.project.id` in `WebhookProcessor` (PROJECT_ACTIVITY events) and from the `projectId` parameter in `WebhookConfigService.test` (TEST events)
- Extend `WebhookAutomationTest` to assert the field is present and equal to the test data's project id

## Why

A webhook recipient needs the project id to call any activity API endpoint — e.g. `/v2/projects/{projectId}/activity/revisions/{revisionId}/modified-entities`, which is the recommended way to enumerate translations changed by batch operations (`BATCH_MACHINE_TRANSLATE`, etc.). Currently the only project hint in the payload is `webhookConfigId`, which forces consumers to maintain their own config-to-project map. Surfacing `projectId` at the envelope level avoids that.

`projectId` is intentionally kept on the wrapper (next to `webhookConfigId`) rather than on `ProjectActivityModel`, so the activity model used by the activity REST API doesn't end up carrying a field that's already redundant with its URL path.

## Test plan

- [x] `WebhookAutomationTest` passes locally (all 4 tests)
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhooks now include project ID information in event payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->