### PR TITLE
perf: batch TM lookups per chunk in pretranslate/auto-translate jobs

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
@@ -50,7 +50,7 @@ class BatchJobManagementControllerTest :
       doAnswer { it.callRealMethod() }
         .doAnswer { throwingService.throwExceptionInTransaction() }
         .whenever(autoTranslationService)
-        .autoTranslateSync(any(), any(), any(), any(), any())
+        .autoTranslateSync(any(), any(), any(), any(), any(), any())
 
       performProjectAuthPost(
         "start-batch-job/machine-translate",

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchJobManagementControllerTest.kt
@@ -18,6 +18,7 @@ import io.tolgee.util.addMinutes
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -50,7 +51,7 @@ class BatchJobManagementControllerTest :
       doAnswer { it.callRealMethod() }
         .doAnswer { throwingService.throwExceptionInTransaction() }
         .whenever(autoTranslationService)
-        .autoTranslateSync(any(), any(), any(), any(), any(), any())
+        .autoTranslateSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), any(), anyOrNull())
 
       performProjectAuthPost(
         "start-batch-job/machine-translate",

--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
@@ -331,19 +331,19 @@ abstract class AbstractBatchJobConcurrentTest :
   // region Processor Mocks - Machine Translation
 
   protected fun makeMtProcessorPass() {
-    doAnswer { }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
+    doAnswer { }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
   }
 
   protected fun makeMtProcessorPassWithDelay(delayMs: Long) {
     doAnswer {
       Thread.sleep(delayMs)
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
+    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
   }
 
   protected fun makeMtProcessorPassWithCounter(counter: AtomicInteger) {
     doAnswer {
       counter.incrementAndGet()
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
+    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
   }
 
   protected fun makeMtProcessorPassWithConcurrencyTracking(
@@ -358,7 +358,7 @@ abstract class AbstractBatchJobConcurrentTest :
       } finally {
         currentConcurrency.decrementAndGet()
       }
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
+    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
   }
 
   // endregion

--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobConcurrentTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
 import org.redisson.api.RedissonClient
@@ -331,19 +332,26 @@ abstract class AbstractBatchJobConcurrentTest :
   // region Processor Mocks - Machine Translation
 
   protected fun makeMtProcessorPass() {
-    doAnswer { }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
+    doAnswer {
+    }.whenever(
+      autoTranslationService,
+    ).autoTranslateSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), any(), anyOrNull())
   }
 
   protected fun makeMtProcessorPassWithDelay(delayMs: Long) {
     doAnswer {
       Thread.sleep(delayMs)
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
+    }.whenever(
+      autoTranslationService,
+    ).autoTranslateSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), any(), anyOrNull())
   }
 
   protected fun makeMtProcessorPassWithCounter(counter: AtomicInteger) {
     doAnswer {
       counter.incrementAndGet()
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
+    }.whenever(
+      autoTranslationService,
+    ).autoTranslateSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), any(), anyOrNull())
   }
 
   protected fun makeMtProcessorPassWithConcurrencyTracking(
@@ -358,7 +366,9 @@ abstract class AbstractBatchJobConcurrentTest :
       } finally {
         currentConcurrency.decrementAndGet()
       }
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any(), any())
+    }.whenever(
+      autoTranslationService,
+    ).autoTranslateSync(any(), anyOrNull(), anyOrNull(), anyOrNull(), any(), anyOrNull())
   }
 
   // endregion

--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
@@ -316,11 +316,11 @@ class BatchJobTestUtil(
       }
     }.whenever(autoTranslationService).autoTranslateSync(
       any(),
+      anyOrNull(),
+      anyOrNull(),
+      anyOrNull(),
       any(),
-      any(),
-      any(),
-      any(),
-      any(),
+      anyOrNull(),
     )
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/BatchJobTestUtil.kt
@@ -320,6 +320,7 @@ class BatchJobTestUtil(
       any(),
       any(),
       any(),
+      any(),
     )
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/translation/TranslationMemoryServiceBatchTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/translation/TranslationMemoryServiceBatchTest.kt
@@ -1,0 +1,120 @@
+package io.tolgee.service.translation
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.TmBatchLookupTestData
+import io.tolgee.service.translationMemory.TmAutoTranslateProviderOssImpl
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Unit tests for the batched TM exact-match lookup. The OSS implementation lives on
+ * [TmAutoTranslateProviderOssImpl]; the suggestion-panel interface
+ * [TranslationMemoryService] is a separate concern (trigram similarity, plan gating).
+ *
+ * We autowire the OSS impl directly so EE bean overrides (if running with EE on the classpath)
+ * don't change what this test asserts about the OSS lookup semantics.
+ */
+@SpringBootTest
+@Transactional
+class TranslationMemoryServiceBatchTest : AbstractSpringTest() {
+  @Autowired
+  private lateinit var ossProvider: TmAutoTranslateProviderOssImpl
+
+  private lateinit var testData: TmBatchLookupTestData
+
+  @BeforeEach
+  fun setUp() {
+    testData = TmBatchLookupTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @Test
+  fun `returns empty map for empty input`() {
+    val result = ossProvider.getAutoTranslatedValuesForChunk(emptyList(), emptyMap(), emptyMap())
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `returns TM match for single-item chunk`() {
+    val items = listOf(testData.requestedKey.id to testData.germanLanguage.id)
+
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+
+    val match = result[items.single()]
+    assertThat(match).isNotNull
+    assertThat(match!!.targetTranslationText).isIn("Hallo", "Hallo (alternative)")
+    assertThat(match.baseTranslationText).isEqualTo("Hello")
+    assertThat(match.keyId).isIn(testData.sourceKey.id, testData.duplicateSourceKey.id)
+  }
+
+  @Test
+  fun `excludes self when requested key is also a source candidate`() {
+    val items = listOf(testData.selfMatchKey.id to testData.germanLanguage.id)
+
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+
+    val match = result[items.single()]
+    assertThat(match).isNull()
+  }
+
+  @Test
+  fun `returns no match when base text has no other source`() {
+    val items = listOf(testData.uniqueKey.id to testData.germanLanguage.id)
+
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+
+    assertThat(result[items.single()]).isNull()
+  }
+
+  @Test
+  fun `handles multiple chunk items sharing the same base text and target language`() {
+    val pair1 = testData.requestedKey.id to testData.germanLanguage.id
+    val pair2 = testData.requestedKeySameText.id to testData.germanLanguage.id
+    val items = listOf(pair1, pair2)
+
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+
+    assertThat(result[pair1]).isNotNull
+    assertThat(result[pair2]).isNotNull
+    assertThat(result[pair1]!!.targetTranslationText).isIn("Hallo", "Hallo (alternative)")
+    assertThat(result[pair2]!!.targetTranslationText).isIn("Hallo", "Hallo (alternative)")
+    // Neither should select self
+    assertThat(result[pair1]!!.keyId).isNotEqualTo(testData.requestedKey.id)
+    assertThat(result[pair2]!!.keyId).isNotEqualTo(testData.requestedKeySameText.id)
+  }
+
+  @Test
+  fun `handles mixed target languages in one chunk`() {
+    val germanPair = testData.requestedKey.id to testData.germanLanguage.id
+    val spanishPair = testData.requestedKey.id to testData.spanishLanguage.id
+    val items = listOf(germanPair, spanishPair)
+
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+
+    assertThat(result[germanPair]?.targetTranslationText).isIn("Hallo", "Hallo (alternative)")
+    assertThat(result[spanishPair]?.targetTranslationText).isEqualTo("Hola")
+  }
+
+  @Test
+  fun `ignores unrequested pairs from the cross-product result`() {
+    // Ask only for (requestedKey, German). The query filters by keyIds IN (..) and
+    // targetLangIds IN (..), but with a single key and single lang there is no cross-product.
+    val items = listOf(testData.requestedKey.id to testData.germanLanguage.id)
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+    assertThat(result.keys).containsExactly(items.single())
+  }
+
+  @Test
+  fun `does not return entries for unrequested key+lang combinations`() {
+    // requestedKey + German is asked. spanishLanguage is also a target lang for some other
+    // chunk item conceptually, but for THIS call we only ask about (requestedKey, German).
+    val items = listOf(testData.requestedKey.id to testData.germanLanguage.id)
+    val result = ossProvider.getAutoTranslatedValuesForChunk(items, emptyMap(), emptyMap())
+    val unrequestedPair = testData.requestedKey.id to testData.spanishLanguage.id
+    assertThat(result).doesNotContainKey(unrequestedPair)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/service/translation/TranslationMemoryServiceBenchmark.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/translation/TranslationMemoryServiceBenchmark.kt
@@ -1,0 +1,127 @@
+package io.tolgee.service.translation
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.TmBatchBenchmarkTestData
+import io.tolgee.model.Language
+import io.tolgee.model.key.Key
+import io.tolgee.service.translationMemory.TmAutoTranslateProviderOssImpl
+import io.tolgee.util.executeInNewTransaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Microbenchmark for the per-item OSS TM lookup vs the batched
+ * [TmAutoTranslateProviderOssImpl.getAutoTranslatedValuesForChunk] on the same data. Not part
+ * of normal CI — runs the two paths back-to-back and prints timings so we can compare
+ * main vs the fix.
+ *
+ * Disabled by default so it doesn't run on every CI build (it builds a 20k-key test project
+ * and runs ~minute of timed work). Drop the [Disabled] annotation locally when you want
+ * fresh numbers.
+ *
+ * Run with:
+ *   ./gradlew :server-app:test --tests "io.tolgee.service.translation.TranslationMemoryServiceBenchmark" --console=plain
+ */
+@SpringBootTest
+@Disabled("Microbenchmark — run manually when comparing per-item vs batched TM lookup timings.")
+class TranslationMemoryServiceBenchmark : AbstractSpringTest() {
+  @Autowired
+  private lateinit var ossProvider: TmAutoTranslateProviderOssImpl
+
+  private lateinit var testData: TmBatchBenchmarkTestData
+  private lateinit var requestKeys: List<Key>
+
+  private val warmupIterations = 1
+  private val measuredIterations = 3
+
+  @BeforeEach
+  fun setUp() {
+    // Big project: 20k TM source keys, 5k distinct base texts so each lookup has ~4 candidates on average.
+    // 2k request keys to translate — much bigger than the production default chunk size, which is what
+    // we want to stress (the cost of a real pretranslate_by_tm job over thousands of keys).
+    testData = TmBatchBenchmarkTestData(sourceKeyCount = 20_000, requestKeyCount = 2_000, distinctSourceTexts = 5_000)
+    testDataService.saveTestData(testData.root)
+    requestKeys = testData.requestKeys.toList()
+  }
+
+  @Test
+  fun `compare per-item vs batched TM lookups across chunk sizes`() {
+    val germanLangId = testData.germanLanguage.id
+    val germanLang = testData.germanLanguage
+
+    // Warmup at chunk size 10 (no need to warm every size — JIT/connection pool warms up once)
+    repeat(warmupIterations) {
+      runPerItem(requestKeys, germanLang, chunkSize = 10)
+      runBatched(requestKeys, germanLangId, chunkSize = 10)
+    }
+
+    println("============================================================")
+    println("TM lookup benchmark")
+    println("  Project: ${testData.sourceKeys.size} TM source keys, ${requestKeys.size} request keys to translate")
+    println("  Distinct base texts: 5000 (~4 TM candidates per lookup on average)")
+    println("============================================================")
+    println("%-12s | %-30s | %-30s | %-8s".format("chunk size", "per-item (main)", "batched (this fix)", "speedup"))
+    println("-".repeat(96))
+
+    listOf(10, 50, 200).forEach { chunkSize ->
+      val perItemTimes = mutableListOf<Long>()
+      val batchedTimes = mutableListOf<Long>()
+      repeat(measuredIterations) {
+        perItemTimes += time { runPerItem(requestKeys, germanLang, chunkSize) }
+        batchedTimes += time { runBatched(requestKeys, germanLangId, chunkSize) }
+      }
+      val perItemAvg = perItemTimes.average()
+      val batchedAvg = batchedTimes.average()
+      val speedup = perItemAvg / batchedAvg
+      println(
+        "%-12d | %-30s | %-30s | %.2fx".format(
+          chunkSize,
+          "${perItemTimes.map { "%4d".format(it) }} avg=${"%.0f".format(perItemAvg)} ms",
+          "${batchedTimes.map { "%4d".format(it) }} avg=${"%.0f".format(batchedAvg)} ms",
+          speedup,
+        ),
+      )
+    }
+    println("============================================================")
+  }
+
+  private fun runPerItem(
+    keys: List<Key>,
+    targetLanguage: Language,
+    chunkSize: Int,
+  ) {
+    executeInNewTransaction(platformTransactionManager) {
+      keys.chunked(chunkSize).forEach { chunk ->
+        chunk.forEach { key ->
+          val attached = entityManager.find(Key::class.java, key.id)
+          ossProvider.getAutoTranslatedValue(attached, targetLanguage)
+        }
+      }
+    }
+  }
+
+  private fun runBatched(
+    keys: List<Key>,
+    targetLangId: Long,
+    chunkSize: Int,
+  ) {
+    executeInNewTransaction(platformTransactionManager) {
+      keys.chunked(chunkSize).forEach { chunk ->
+        ossProvider.getAutoTranslatedValuesForChunk(
+          items = chunk.map { it.id to targetLangId },
+          keysById = emptyMap(),
+          languagesById = emptyMap(),
+        )
+      }
+    }
+  }
+
+  private inline fun time(block: () -> Unit): Long {
+    val start = System.nanoTime()
+    block()
+    return (System.nanoTime() - start) / 1_000_000
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -221,6 +221,30 @@ class Metrics(
       .record(Duration.ofMillis(durationMs.coerceAtLeast(0)))
   }
 
+  /**
+   * Records the duration of a batched translation-memory lookup
+   * (TranslationMemoryService.getAutoTranslatedValuesForChunk, run once per batch-job chunk
+   * in AUTO_TRANSLATE / PRE_TRANSLATE_BT_TM instead of one lookup per (key, target-language) pair).
+   */
+  fun recordTranslationMemoryLookupBatch(
+    chunkSize: Int,
+    hitCount: Int,
+    durationMs: Long,
+  ) {
+    Timer
+      .builder("tolgee.translation.memory.lookup.batch")
+      .description("Time spent on a batched translation-memory lookup for a full chunk")
+      .publishPercentileHistogram()
+      .register(meterRegistry)
+      .record(Duration.ofMillis(durationMs.coerceAtLeast(0)))
+    meterRegistry
+      .counter("tolgee.translation.memory.lookup.batch.items", "outcome", "hit")
+      .increment(hitCount.toDouble())
+    meterRegistry
+      .counter("tolgee.translation.memory.lookup.batch.items", "outcome", "miss")
+      .increment((chunkSize - hitCount).coerceAtLeast(0).toDouble())
+  }
+
   // Branch operations - Priority 1 (Must Have)
   val branchCreateTimer: Timer by lazy {
     Timer

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/AutoTranslateChunkProcessor.kt
@@ -10,7 +10,10 @@ import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.batch.request.AutoTranslationRequest
 import io.tolgee.configuration.tolgee.BatchProperties
 import io.tolgee.model.batch.params.AutoTranslationJobParams
+import io.tolgee.service.key.KeyService
+import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.AutoTranslationService
+import io.tolgee.service.translationMemory.TmAutoTranslateProvider
 import org.springframework.stereotype.Component
 import kotlin.coroutines.CoroutineContext
 
@@ -20,6 +23,9 @@ class AutoTranslateChunkProcessor(
   private val mtProviderCatching: MtProviderCatching,
   private val batchProperties: BatchProperties,
   private val progressManager: ProgressManager,
+  private val tmAutoTranslateProvider: TmAutoTranslateProvider,
+  private val keyService: KeyService,
+  private val languageService: LanguageService,
   objectMapper: ObjectMapper,
 ) : AbstractChunkProcessor<AutoTranslationRequest, AutoTranslationJobParams, BatchTranslationTargetItem>(objectMapper) {
   override fun process(
@@ -28,9 +34,20 @@ class AutoTranslateChunkProcessor(
     coroutineContext: CoroutineContext,
   ) {
     val projectId = job.projectId ?: throw IllegalArgumentException("Project id is required")
+    val keys = keyService.find(chunk.map { it.keyId }).associateBy { it.id }
+    val languages = languageService.findByIdIn(chunk.map { it.languageId }.toSet()).associateBy { it.id }
+    val precomputedTmMatches =
+      tmAutoTranslateProvider.getAutoTranslatedValuesForChunk(
+        items =
+          chunk
+            .filter { keys.containsKey(it.keyId) && languages.containsKey(it.languageId) }
+            .map { it.keyId to it.languageId },
+        keysById = keys,
+        languagesById = languages,
+      )
     mtProviderCatching.iterateCatching(chunk, coroutineContext) { item ->
       val (keyId, languageId) = item
-      autoTranslationService.softAutoTranslate(projectId, keyId, languageId)
+      autoTranslationService.softAutoTranslate(projectId, keyId, languageId, precomputedTmMatches)
       progressManager.reportSingleChunkProgress(job.id)
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/GenericAutoTranslationChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/GenericAutoTranslationChunkProcessor.kt
@@ -8,6 +8,7 @@ import io.tolgee.service.PromptService
 import io.tolgee.service.key.KeyService
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.AutoTranslationService
+import io.tolgee.service.translationMemory.TmAutoTranslateProvider
 import org.springframework.stereotype.Component
 import kotlin.coroutines.CoroutineContext
 
@@ -19,6 +20,7 @@ class GenericAutoTranslationChunkProcessor(
   private val promptService: PromptService,
   private val mtProviderCatching: MtProviderCatching,
   private val progressManager: ProgressManager,
+  private val tmAutoTranslateProvider: TmAutoTranslateProvider,
 ) {
   fun process(
     job: BatchJobDto,
@@ -30,6 +32,20 @@ class GenericAutoTranslationChunkProcessor(
     val languages = languageService.findByIdIn(chunk.map { it.languageId }.toSet()).associateBy { it.id }
     val keys = keyService.find(chunk.map { it.keyId }).associateBy { it.id }
 
+    val precomputedTmMatches =
+      if (useTranslationMemory) {
+        tmAutoTranslateProvider.getAutoTranslatedValuesForChunk(
+          items =
+            chunk
+              .filter { keys.containsKey(it.keyId) && languages.containsKey(it.languageId) }
+              .map { it.keyId to it.languageId },
+          keysById = keys,
+          languagesById = languages,
+        )
+      } else {
+        null
+      }
+
     mtProviderCatching.iterateCatching(chunk, coroutineContext) { item ->
       val (keyId, languageId) = item
       val languageTag = languages[languageId]?.tag ?: return@iterateCatching
@@ -40,6 +56,7 @@ class GenericAutoTranslationChunkProcessor(
         useTranslationMemory = useTranslationMemory,
         useMachineTranslation = useMachineTranslation,
         isBatch = true,
+        precomputedTmMatches = precomputedTmMatches,
       )
       progressManager.reportSingleChunkProgress(job.id)
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmBatchBenchmarkTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmBatchBenchmarkTestData.kt
@@ -1,0 +1,69 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.Language
+import io.tolgee.model.key.Key
+
+/**
+ * Test fixture for benchmarking TM batch vs per-item lookups.
+ *
+ * Generates:
+ * - [sourceKeyCount] "source" keys, each with English (base) text "common-text-{i % distinctSourceTexts}"
+ *   plus a target translation in [germanLanguage]. These act as TM sources.
+ * - [requestKeyCount] "request" keys, each with English text "common-text-{i % distinctSourceTexts}"
+ *   but NO German translation — these are the chunk items we want pre-translated by TM.
+ *
+ * With distinctSourceTexts < sourceKeyCount, each request key will find a TM match
+ * (a different source key with the same English text).
+ */
+class TmBatchBenchmarkTestData(
+  private val sourceKeyCount: Int = 200,
+  private val requestKeyCount: Int = 100,
+  private val distinctSourceTexts: Int = 50,
+) : BaseTestData() {
+  lateinit var germanLanguage: Language
+  val sourceKeys = mutableListOf<Key>()
+  val requestKeys = mutableListOf<Key>()
+
+  init {
+    projectBuilder.apply {
+      addLanguage {
+        name = "German"
+        tag = "de"
+        germanLanguage = this
+      }
+
+      repeat(sourceKeyCount) { i ->
+        val baseText = "common-text-${i % distinctSourceTexts}"
+        addKey {
+          name = "source-key-$i"
+        }.build buildKey@{
+          sourceKeys += this@buildKey.self
+          addTranslation {
+            key = this@buildKey.self
+            language = englishLanguage
+            text = baseText
+          }
+          addTranslation {
+            key = this@buildKey.self
+            language = germanLanguage
+            text = "german-for-$baseText-from-source-$i"
+          }
+        }
+      }
+
+      repeat(requestKeyCount) { i ->
+        val baseText = "common-text-${i % distinctSourceTexts}"
+        addKey {
+          name = "request-key-$i"
+        }.build buildKey@{
+          requestKeys += this@buildKey.self
+          addTranslation {
+            key = this@buildKey.self
+            language = englishLanguage
+            text = baseText
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmBatchLookupTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmBatchLookupTestData.kt
@@ -1,0 +1,117 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.Language
+import io.tolgee.model.key.Key
+
+class TmBatchLookupTestData : BaseTestData() {
+  lateinit var germanLanguage: Language
+  lateinit var spanishLanguage: Language
+
+  lateinit var sourceKey: Key
+  lateinit var duplicateSourceKey: Key
+  lateinit var requestedKey: Key
+  lateinit var requestedKeySameText: Key
+  lateinit var uniqueKey: Key
+  lateinit var selfMatchKey: Key
+
+  init {
+    projectBuilder.apply {
+      addLanguage {
+        name = "German"
+        tag = "de"
+        germanLanguage = this
+      }
+      addLanguage {
+        name = "Spanish"
+        tag = "es"
+        spanishLanguage = this
+      }
+
+      addKey {
+        name = "source-key"
+        sourceKey = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Hello"
+        }
+        addTranslation {
+          key = this@buildKey.self
+          language = germanLanguage
+          text = "Hallo"
+        }
+        addTranslation {
+          key = this@buildKey.self
+          language = spanishLanguage
+          text = "Hola"
+        }
+      }
+
+      addKey {
+        name = "duplicate-source-key"
+        duplicateSourceKey = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Hello"
+        }
+        addTranslation {
+          key = this@buildKey.self
+          language = germanLanguage
+          text = "Hallo (alternative)"
+        }
+      }
+
+      addKey {
+        name = "requested-key"
+        requestedKey = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Hello"
+        }
+      }
+
+      addKey {
+        name = "requested-key-same-text"
+        requestedKeySameText = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Hello"
+        }
+      }
+
+      addKey {
+        name = "unique-key"
+        uniqueKey = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Nothing else matches this"
+        }
+      }
+
+      addKey {
+        name = "self-match-key"
+        selfMatchKey = this
+      }.build buildKey@{
+        addTranslation {
+          key = this@buildKey.self
+          language = englishLanguage
+          text = "Unique-for-self"
+        }
+        addTranslation {
+          key = this@buildKey.self
+          language = germanLanguage
+          text = "Pre-existing German"
+        }
+      }
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
@@ -15,6 +15,7 @@ import io.tolgee.model.enums.TranslationProtection
 import io.tolgee.model.enums.TranslationState
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
+import io.tolgee.model.views.TranslationMemoryItemView
 import io.tolgee.repository.AutoTranslationConfigRepository
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.language.LanguageService
@@ -95,6 +96,7 @@ class AutoTranslationService(
     projectId: Long,
     keyId: Long,
     languageId: Long,
+    precomputedTmMatches: Map<Pair<Long, Long>, TranslationMemoryItemView>? = null,
   ) {
     val project = projectService.getDto(projectId)
     val config = getConfig(entityManager.getReference(Project::class.java, projectId), languageId)
@@ -114,7 +116,7 @@ class AutoTranslationService(
       return
     }
 
-    val (text, usedService, promptId) = getAutoTranslatedValue(config, translation) ?: return
+    val (text, usedService, promptId) = getAutoTranslatedValue(config, translation, precomputedTmMatches) ?: return
     text ?: return
 
     translation.setValueAndState(project, text, usedService, promptId)
@@ -123,14 +125,18 @@ class AutoTranslationService(
   private fun getAutoTranslatedValue(
     config: AutoTranslationConfig,
     translation: Translation,
+    precomputedTmMatches: Map<Pair<Long, Long>, TranslationMemoryItemView>? = null,
   ): Triple<String?, MtServiceType?, Long?>? {
     if (config.usingTm) {
+      val pair = translation.key.id to translation.language.id
       val value =
-        tmAutoTranslateProvider
-          .getAutoTranslatedValue(
-            translation.key,
-            translation.language,
-          )?.targetTranslationText
+        if (precomputedTmMatches != null) {
+          precomputedTmMatches[pair]?.targetTranslationText
+        } else {
+          tmAutoTranslateProvider
+            .getAutoTranslatedValue(translation.key, translation.language)
+            ?.targetTranslationText
+        }
 
       if (!value.isNullOrBlank()) {
         return Triple(value, null, null)
@@ -174,6 +180,7 @@ class AutoTranslationService(
     useTranslationMemory: Boolean? = null,
     useMachineTranslation: Boolean? = null,
     isBatch: Boolean,
+    precomputedTmMatches: Map<Pair<Long, Long>, TranslationMemoryItemView>? = null,
   ) {
     val adjustedConfigs = getAdjustedConfigs(key, forcedLanguageTags, useTranslationMemory, useMachineTranslation)
 
@@ -195,7 +202,7 @@ class AutoTranslationService(
 
     val toTmTranslate = translations.filter { it.first.usingTm }.mapNotNull { it.second }
 
-    val translatedWithTm = autoTranslateUsingTm(toTmTranslate, key).filter { it.value }.keys
+    val translatedWithTm = autoTranslateUsingTm(toTmTranslate, key, precomputedTmMatches).filter { it.value }.keys
 
     val toMtTranslate =
       translations
@@ -289,16 +296,21 @@ class AutoTranslationService(
   private fun autoTranslateUsingTm(
     toTranslate: List<Translation>,
     key: Key,
+    precomputedTmMatches: Map<Pair<Long, Long>, TranslationMemoryItemView>? = null,
   ): Map<Translation, Boolean> {
     val project = projectService.getDto(key.project.id)
     return toTranslate.associateWith { translation ->
       // "Match" must mean a non-blank target was actually applied. Returning true on a blank hit
       // would tell the caller to skip MT fallback for this key, leaving it untranslated.
+      val pair = key.id to translation.language.id
       val tmText =
-        tmAutoTranslateProvider
-          .getAutoTranslatedValue(key, translation.language)
-          ?.targetTranslationText
-          ?.takeIf { it.isNotBlank() }
+        if (precomputedTmMatches != null) {
+          precomputedTmMatches[pair]?.targetTranslationText
+        } else {
+          tmAutoTranslateProvider
+            .getAutoTranslatedValue(key, translation.language)
+            ?.targetTranslationText
+        }?.takeIf { it.isNotBlank() }
       tmText?.let { translation.setValueAndState(project, it, null) }
       tmText != null
     }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translationMemory/TmAutoTranslateProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translationMemory/TmAutoTranslateProvider.kt
@@ -14,4 +14,58 @@ interface TmAutoTranslateProvider {
     key: Key,
     targetLanguage: Language,
   ): TranslationMemoryItemView?
+
+  /**
+   * Batched variant for the per-chunk pre-translate / auto-translate path. Resolves TM
+   * matches for a list of `(keyId, targetLanguageId)` pairs in as few DB round-trips as
+   * the implementation can manage.
+   *
+   * Default implementation loops [getAutoTranslatedValue] per item — correct but no
+   * speedup. Implementations are expected to override with a single batched SQL.
+   *
+   * @param items chunk items as `(keyId, targetLanguageId)` pairs
+   * @param keysById preloaded `Key` entities indexed by id (chunk processors already have these)
+   * @param languagesById preloaded `Language` entities indexed by id
+   * @return map keyed by the input pair; absence means "no TM match" (same as `null` per-item)
+   */
+  fun getAutoTranslatedValuesForChunk(
+    items: List<Pair<Long, Long>>,
+    keysById: Map<Long, Key>,
+    languagesById: Map<Long, Language>,
+  ): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    if (items.isEmpty()) return emptyMap()
+    val result = HashMap<Pair<Long, Long>, TranslationMemoryItemView>(items.size)
+    items.forEach { (keyId, langId) ->
+      val key = keysById[keyId] ?: return@forEach
+      val lang = languagesById[langId] ?: return@forEach
+      getAutoTranslatedValue(key, lang)?.let { result[keyId to langId] = it }
+    }
+    return result
+  }
+
+  companion object {
+    /**
+     * Shared FROM-clause body for the batched TM lookup `inputs` CTE/subquery.
+     *
+     * Zips the two positionally-aligned bigint arrays via `unnest(:reqKeyIds, :reqLangIds)`
+     * so the planner processes exactly `items.size` input rows (not the cross-product of
+     * distinct keys × distinct langs), then resolves each pair's request key, project, and
+     * base translation.
+     *
+     * Required bind parameters:
+     *   - `:reqKeyIds`  `bigint[]` — request key ids, one per chunk item
+     *   - `:reqLangIds` `bigint[]` — target language ids, positionally aligned with :reqKeyIds
+     *
+     * Callers wrap this with their own SELECT list; the EE batched path additionally joins
+     * `language target_lang on target_lang.id = req.target_lang_id` to surface the language
+     * tag needed by the stored-entries half.
+     */
+    const val BATCHED_INPUTS_FROM_BODY = """
+      from unnest(cast(:reqKeyIds as bigint[]), cast(:reqLangIds as bigint[])) as req(req_key_id, target_lang_id)
+      join key k_req on k_req.id = req.req_key_id
+      join project proj_req on k_req.project_id = proj_req.id
+      join translation req_base on req_base.key_id = k_req.id
+        and req_base.language_id = proj_req.base_language_id
+    """
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translationMemory/TmAutoTranslateProviderOssImpl.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translationMemory/TmAutoTranslateProviderOssImpl.kt
@@ -5,7 +5,9 @@ import io.tolgee.model.Language
 import io.tolgee.model.key.Key
 import io.tolgee.model.views.TranslationMemoryItemView
 import io.tolgee.service.translation.TranslationService
+import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * Resolves a TM match for auto-translate / batch pre-translate. The OSS path performs an
@@ -21,6 +23,7 @@ import org.springframework.stereotype.Component
 @Component
 class TmAutoTranslateProviderOssImpl(
   private val translationService: TranslationService,
+  private val entityManager: EntityManager,
   private val metrics: Metrics,
 ) : TmAutoTranslateProvider {
   override fun getAutoTranslatedValue(
@@ -42,5 +45,98 @@ class TmAutoTranslateProviderOssImpl(
       )
       throw e
     }
+  }
+
+  /**
+   * Batched exact-match TM lookup for a whole chunk. Mirrors the per-item HQL query in
+   * [io.tolgee.repository.TranslationRepository.getTranslationMemoryValue] (exact equality
+   * on base text, cross-project) but resolves all `(keyId, targetLanguageId)` pairs in
+   * a single SQL round-trip via a LATERAL join with `LIMIT 1` per pair.
+   *
+   * Self-key exclusion (`k.id <> inputs.req_key_id`) is enforced inside the LATERAL body,
+   * so we can use `LIMIT 1` instead of needing top-K + post-filtering.
+   */
+  @Transactional
+  override fun getAutoTranslatedValuesForChunk(
+    items: List<Pair<Long, Long>>,
+    keysById: Map<Long, Key>,
+    languagesById: Map<Long, Language>,
+  ): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    if (items.isEmpty()) return emptyMap()
+    val startedAt = System.currentTimeMillis()
+    val result = fetchUnmetered(items)
+    metrics.recordTranslationMemoryLookupBatch(
+      chunkSize = items.size,
+      hitCount = result.size,
+      durationMs = System.currentTimeMillis() - startedAt,
+    )
+    return result
+  }
+
+  /**
+   * Same SQL as [getAutoTranslatedValuesForChunk] but does not emit metrics. Intended for
+   * the EE provider, which calls this as a fallback inside its own metered orchestration —
+   * recording metrics here would double-count items and emit two timer samples per chunk.
+   * External callers should use [getAutoTranslatedValuesForChunk] instead.
+   */
+  @Transactional
+  fun fetchUnmetered(items: List<Pair<Long, Long>>): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    if (items.isEmpty()) return emptyMap()
+
+    // Pass the actual (keyId, targetLangId) pairs as two positionally-aligned arrays.
+    // Postgres `unnest(arr1, arr2)` zips them into rows, so the input set is exactly
+    // O(items) instead of O(uniqueKeys × uniqueLangs) — important when a chunk straddles
+    // the cross-product (e.g. partial coverage of (key × lang) combinations).
+    val reqKeyIds = items.map { it.first }.toTypedArray()
+    val reqLangIds = items.map { it.second }.toTypedArray()
+
+    val rows =
+      entityManager
+        .createNativeQuery(
+          """
+          select inputs.req_key_id, inputs.target_lang_id, m.source_key_id, m.target_text, m.key_name, inputs.base_text
+          from (
+            select req.req_key_id as req_key_id, req.target_lang_id as target_lang_id, req_base.text as base_text
+            ${TmAutoTranslateProvider.BATCHED_INPUTS_FROM_BODY}
+          ) inputs
+          cross join lateral (
+            select k.id as source_key_id, target.text as target_text, k.name as key_name
+            from translation source_base
+            join key k on source_base.key_id = k.id and k.id <> inputs.req_key_id
+            join project source_p on k.project_id = source_p.id
+              and source_base.language_id = source_p.base_language_id
+            join translation target on target.key_id = k.id
+              and target.language_id = inputs.target_lang_id
+              and target.text is not null
+              and target.text <> ''
+            where source_base.text = inputs.base_text
+            limit 1
+          ) m
+          """,
+        ).setParameter("reqKeyIds", reqKeyIds)
+        .setParameter("reqLangIds", reqLangIds)
+        .resultList
+
+    val result = HashMap<Pair<Long, Long>, TranslationMemoryItemView>(rows.size)
+    rows.forEach { row ->
+      row as Array<*>
+      val reqKeyId = (row[0] as Number).toLong()
+      val targetLangId = (row[1] as Number).toLong()
+      val pair = reqKeyId to targetLangId
+      val sourceKeyId = (row[2] as Number).toLong()
+      val targetText = row[3] as String
+      val keyName = row[4] as String
+      val baseText = row[5] as String
+      result[pair] =
+        TranslationMemoryItemView(
+          targetTranslationText = targetText,
+          baseTranslationText = baseText,
+          keyName = keyName,
+          keyNamespace = null,
+          similarity = 1f,
+          keyId = sourceKeyId,
+        )
+    }
+    return result
   }
 }

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5775,4 +5775,13 @@
         ]]></sql>
         <rollback/>
     </changeSet>
+    <changeSet author="bdshadow" id="translation-text-hash-idx-for-tm-exact-match" runInTransaction="false">
+        <sql dbms="postgresql">
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS translation_text_hash_idx
+            ON translation USING hash (text);
+        </sql>
+        <rollback>
+            DROP INDEX CONCURRENTLY IF EXISTS translation_text_hash_idx;
+        </rollback>
+    </changeSet>
 </databaseChangeLog>

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/TmAutoTranslateProviderEeImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/TmAutoTranslateProviderEeImpl.kt
@@ -11,6 +11,7 @@ import io.tolgee.service.translationMemory.TranslationMemoryManagementService
 import jakarta.persistence.EntityManager
 import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 /**
  * EE auto-translate resolver. Mirrors the suggestion panel's notion of "matches the project
@@ -70,6 +71,162 @@ class TmAutoTranslateProviderEeImpl(
     }
   }
 
+  /**
+   * Batched EE auto-translate lookup. Issues at most **two** SQL round-trips per chunk:
+   *  1. The EE-aware UNION ALL (stored entries + virtual rows, scoped to readable `tmIds`,
+   *     enforcing `write_access` and `penalty = 0`), LATERAL-joined against an `inputs` CTE
+   *     so all `(reqKeyId, targetLanguageId)` pairs are resolved in a single statement.
+   *  2. For any pair that didn't get an EE hit, [TmAutoTranslateProviderOssImpl] is called
+   *     once with the remaining pairs — mirroring the per-item path's "EE-then-OSS-fallback"
+   *     layering.
+   *
+   * Compared to the per-item path's ~2 round-trips per chunk item, this is bounded at 2
+   * round-trips per chunk regardless of chunk size.
+   */
+  @Transactional
+  override fun getAutoTranslatedValuesForChunk(
+    items: List<Pair<Long, Long>>,
+    keysById: Map<Long, Key>,
+    languagesById: Map<Long, Language>,
+  ): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    if (items.isEmpty()) return emptyMap()
+    val startedAt = System.currentTimeMillis()
+
+    // All chunk items share a project (a batch job scopes to one). Pick any preloaded key
+    // to resolve projectId / organizationId — if none of the items have a Key in the map
+    // we can't determine the project, so just defer everything to OSS (defensive — chunk
+    // processors filter to known keys before calling).
+    val anyKey =
+      items.firstNotNullOfOrNull { keysById[it.first] }
+        ?: return runFullOssFallback(items, startedAt)
+
+    val projectId = anyKey.project.id
+    val organizationId = anyKey.project.organizationOwner.id
+    val tmIds =
+      translationMemoryManagementService.getReadableTmIdsForSuggestions(
+        projectId = projectId,
+        organizationId = organizationId,
+      )
+
+    // No readable TMs (free plan with the feature off, etc.) — same effect as a UNION ALL
+    // returning no rows. Just hit OSS for all pairs.
+    if (tmIds.isEmpty()) return runFullOssFallback(items, startedAt)
+
+    val eeMatches = findExactMatchesBatched(items, tmIds, projectId, keysById)
+    val unmatched = items.filterNot { it in eeMatches }
+
+    val ossMatches =
+      if (unmatched.isEmpty()) {
+        emptyMap()
+      } else {
+        // fetchUnmetered: this EE call emits its own batch metric after merging; the OSS
+        // public method would record again, double-counting items in the same chunk.
+        ossDelegate.fetchUnmetered(unmatched)
+      }
+
+    val combined = HashMap<Pair<Long, Long>, TranslationMemoryItemView>(eeMatches.size + ossMatches.size)
+    combined.putAll(ossMatches)
+    combined.putAll(eeMatches)
+    metrics.recordTranslationMemoryLookupBatch(
+      chunkSize = items.size,
+      hitCount = combined.size,
+      durationMs = System.currentTimeMillis() - startedAt,
+    )
+    return combined
+  }
+
+  private fun runFullOssFallback(
+    items: List<Pair<Long, Long>>,
+    startedAt: Long,
+  ): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    // fetchUnmetered: EE records the chunk's batch metric below, so the OSS public method's
+    // record would emit a duplicate timer sample and double-count items.
+    val result = ossDelegate.fetchUnmetered(items)
+    metrics.recordTranslationMemoryLookupBatch(
+      chunkSize = items.size,
+      hitCount = result.size,
+      durationMs = System.currentTimeMillis() - startedAt,
+    )
+    return result
+  }
+
+  /**
+   * Returns EE-aware matches for the given chunk in one SQL round-trip. Pairs without
+   * a stored- or virtual-row match are absent from the result map (caller is expected
+   * to fall back to OSS for them, like the per-item path does).
+   *
+   * The query mirrors the per-item `findExactMatch` UNION ALL exactly — same `tmIds`
+   * filter, same penalty gate, same `write_access` requirement on virtual contributors,
+   * same self-key exclusion — wrapped in a LATERAL JOIN with `LIMIT 1` per input pair
+   * so the cost stays bounded.
+   */
+  private fun findExactMatchesBatched(
+    items: List<Pair<Long, Long>>,
+    tmIds: List<Long>,
+    projectId: Long,
+    keysById: Map<Long, Key>,
+  ): Map<Pair<Long, Long>, TranslationMemoryItemView> {
+    // Pass the actual (keyId, targetLangId) pairs as two positionally-aligned arrays.
+    // Postgres `unnest(arr1, arr2)` zips them into rows, so the input set is exactly
+    // O(items) instead of O(uniqueKeys × uniqueLangs).
+    val reqKeyIds = items.map { it.first }.toTypedArray()
+    val reqLangIds = items.map { it.second }.toTypedArray()
+
+    val sql =
+      """
+      with inputs as (
+        select req.req_key_id as req_key_id,
+               req.target_lang_id as target_lang_id,
+               target_lang.tag as target_lang_tag,
+               req_base.text as base_text
+        ${TmAutoTranslateProvider.BATCHED_INPUTS_FROM_BODY}
+        join language target_lang on target_lang.id = req.target_lang_id
+      )
+      select inputs.req_key_id, inputs.target_lang_id, m.target_text, inputs.base_text
+      from inputs
+      cross join lateral (
+        ${candidatesUnionLimit1Sql(
+        baseTextExpr = "inputs.base_text",
+        targetLangTagExpr = "inputs.target_lang_tag",
+        selfKeyIdExpr = "inputs.req_key_id",
+      )}
+      ) m
+      """.trimIndent()
+
+    @Suppress("UNCHECKED_CAST")
+    val rows =
+      entityManager
+        .createNativeQuery(sql)
+        .setParameter("reqKeyIds", reqKeyIds)
+        .setParameter("reqLangIds", reqLangIds)
+        .setParameter("tmIds", tmIds)
+        .setParameter("projectId", projectId)
+        .resultList as List<Array<Any?>>
+
+    val result = HashMap<Pair<Long, Long>, TranslationMemoryItemView>(rows.size)
+    rows.forEach { row ->
+      val reqKeyId = (row[0] as Number).toLong()
+      val targetLangId = (row[1] as Number).toLong()
+      val pair = reqKeyId to targetLangId
+      val targetText = row[2] as String
+      val baseText = row[3] as String
+      // Match the per-item EE impl: surface request-key identity on the view (keyName/keyId
+      // refer to the key being translated, not the contributing key) so the caller's
+      // `targetTranslationText`-based usage stays identical.
+      val requestKey = keysById[reqKeyId] ?: return@forEach
+      result[pair] =
+        TranslationMemoryItemView(
+          baseTranslationText = baseText,
+          targetTranslationText = targetText,
+          keyName = requestKey.name,
+          keyNamespace = null,
+          similarity = 1.0f,
+          keyId = requestKey.id,
+        )
+    }
+    return result
+  }
+
   private fun findExactMatch(
     key: Key,
     targetLanguage: Language,
@@ -82,67 +239,20 @@ class TmAutoTranslateProviderEeImpl(
       )
     if (tmIds.isEmpty()) return null
 
-    // Two-half UNION ALL:
+    // Two-half UNION ALL (see candidatesUnionLimit1Sql):
     //   1. Stored entries on any readable TM with an exact source-text match.
     //   2. Virtual rows — exact-text matches against translations on any project that has
-    //      writeAccess to a readable TM. Mirrors the virtual-row half of
-    //      `TranslationMemoryServiceEeImpl.baseSelect`, just with `=` instead of trigram `%`.
+    //      writeAccess to a readable TM.
     //
-    // Both halves enforce the same penalty gate: the receiving project's assignment to the
-    // contributing TM (`tmp_recv`) must resolve to an effective penalty of 0 — `coalesce(
-    // tmp_recv.penalty, tm.default_penalty) = 0`. Anything non-zero is "the user marked this
-    // TM as not fully trusted" and shouldn't drive auto-fills.
-    //
-    // The `kind` column lets us pick stored entries first when both halves return rows,
-    // mirroring how the suggestion panel surfaces a user's manual additions.
+    // Both halves enforce the same penalty gate (coalesce(tmp_recv.penalty, tm.default_penalty) = 0)
+    // so a TM the user has marked "not fully trusted" never auto-fills. The `kind` column lets us
+    // prefer stored entries over virtual rows when both halves return.
     val sql =
-      """
-      select target_text, kind from (
-        select e.target_text, 'stored' as kind
-        from translation_memory_entry e
-        join translation_memory tm on tm.id = e.translation_memory_id
-        left join translation_memory_project tmp_recv
-          on tmp_recv.translation_memory_id = e.translation_memory_id
-         and tmp_recv.project_id = :projectId
-        where e.translation_memory_id in :tmIds
-          and e.source_text = :baseText
-          and e.target_language_tag = :targetLanguageTag
-          and e.target_text <> ''
-          and coalesce(tmp_recv.penalty, tm.default_penalty) = 0
-
-        union all
-
-        select target_t.text as target_text, 'virtual' as kind
-        from translation base_t
-        join key k on k.id = base_t.key_id and k.deleted_at is null
-        join project p
-          on p.id = k.project_id
-         and p.base_language_id = base_t.language_id
-         and p.deleted_at is null
-        join translation_memory_project tmp_w
-          on tmp_w.project_id = p.id and tmp_w.write_access = true
-        join translation_memory tm_virt
-          on tm_virt.id = tmp_w.translation_memory_id
-         and tm_virt.id in :tmIds
-        left join translation_memory_project tmp_recv
-          on tmp_recv.translation_memory_id = tm_virt.id
-         and tmp_recv.project_id = :projectId
-        left join branch b on b.id = k.branch_id
-        join translation target_t
-          on target_t.key_id = k.id
-         and target_t.language_id <> base_t.language_id
-        join language target_lang on target_lang.id = target_t.language_id
-        where base_t.text = :baseText
-          and target_lang.tag = :targetLanguageTag
-          and target_t.text is not null and target_t.text <> ''
-          and (b.id is null or b.is_default = true)
-          and (not tm_virt.write_only_reviewed or target_t.state = 2)
-          and k.id <> :selfKeyId
-          and coalesce(tmp_recv.penalty, tm_virt.default_penalty) = 0
-      ) candidates
-      order by case kind when 'stored' then 0 else 1 end
-      limit 1
-      """.trimIndent()
+      candidatesUnionLimit1Sql(
+        baseTextExpr = ":baseText",
+        targetLangTagExpr = ":targetLanguageTag",
+        selfKeyIdExpr = ":selfKeyId",
+      )
 
     @Suppress("UNCHECKED_CAST")
     val rows =
@@ -163,5 +273,84 @@ class TmAutoTranslateProviderEeImpl(
       similarity = 1.0f,
       keyId = key.id,
     )
+  }
+
+  companion object {
+    /**
+     * Shared EE candidate-picking SQL: UNION ALL of stored TM entries + virtual cross-project
+     * rows, ordered by kind so stored entries win, `LIMIT 1`.
+     *
+     * Used identically by the per-item [findExactMatch] (called with `:bind` references) and
+     * by the batched [findExactMatchesBatched] LATERAL body (called with `inputs.col` references).
+     * Both bind the same `:tmIds` (`bigint[]`) and `:projectId` (`bigint`) parameters; the three
+     * differentiating expressions are injected as string fragments:
+     *
+     * - [baseTextExpr]      — source-text predicate, e.g. `":baseText"` or `"inputs.base_text"`.
+     * - [targetLangTagExpr] — target language **tag**, e.g. `":targetLanguageTag"` or
+     *                         `"inputs.target_lang_tag"`. Tags are used (not language ids)
+     *                         because `language.id` is project-scoped — German in the receiving
+     *                         project has a different id than German in the contributing
+     *                         project, so id-based filtering would miss cross-project matches.
+     *                         The stored half uses the tag directly (it's the column type on
+     *                         `translation_memory_entry.target_language_tag`); the virtual half
+     *                         joins `language target_lang ON target_lang.id = target_t.language_id`
+     *                         and filters on `target_lang.tag`.
+     * - [selfKeyIdExpr]     — request key id excluded from the virtual half, e.g. `":selfKeyId"`
+     *                         or `"inputs.req_key_id"`.
+     *
+     * The values passed for these expressions come from internal callers only — never interpolate
+     * user input. SQL is constructed only at static call sites in this file.
+     */
+    internal fun candidatesUnionLimit1Sql(
+      baseTextExpr: String,
+      targetLangTagExpr: String,
+      selfKeyIdExpr: String,
+    ): String =
+      """
+      select target_text, kind from (
+        select e.target_text, 'stored' as kind
+        from translation_memory_entry e
+        join translation_memory tm on tm.id = e.translation_memory_id
+        left join translation_memory_project tmp_recv
+          on tmp_recv.translation_memory_id = e.translation_memory_id
+         and tmp_recv.project_id = :projectId
+        where e.translation_memory_id in (:tmIds)
+          and e.source_text = $baseTextExpr
+          and e.target_language_tag = $targetLangTagExpr
+          and e.target_text <> ''
+          and coalesce(tmp_recv.penalty, tm.default_penalty) = 0
+
+        union all
+
+        select target_t.text as target_text, 'virtual' as kind
+        from translation base_t
+        join key k on k.id = base_t.key_id and k.deleted_at is null and k.id <> $selfKeyIdExpr
+        join project p
+          on p.id = k.project_id
+         and p.base_language_id = base_t.language_id
+         and p.deleted_at is null
+        join translation_memory_project tmp_w
+          on tmp_w.project_id = p.id and tmp_w.write_access = true
+        join translation_memory tm_virt
+          on tm_virt.id = tmp_w.translation_memory_id
+         and tm_virt.id in (:tmIds)
+        left join translation_memory_project tmp_recv
+          on tmp_recv.translation_memory_id = tm_virt.id
+         and tmp_recv.project_id = :projectId
+        left join branch b on b.id = k.branch_id
+        join translation target_t
+          on target_t.key_id = k.id
+         and target_t.language_id <> base_t.language_id
+        join language target_lang on target_lang.id = target_t.language_id
+        where base_t.text = $baseTextExpr
+          and target_lang.tag = $targetLangTagExpr
+          and target_t.text is not null and target_t.text <> ''
+          and (b.id is null or b.is_default = true)
+          and (not tm_virt.write_only_reviewed or target_t.state = 2)
+          and coalesce(tmp_recv.penalty, tm_virt.default_penalty) = 0
+      ) candidates
+      order by case kind when 'stored' then 0 else 1 end
+      limit 1
+      """.trimIndent()
   }
 }


### PR DESCRIPTION
## Summary

The `pretranslate_by_tm` and `AUTO_TRANSLATE` batch jobs were issuing one TM-lookup SQL round-trip per chunk item — plus a couple of lazy entity loads behind it — for ~3 DB round-trips per key. For a 2000-key pretranslate run at chunk size 10, that's ~6000 round-trips and ~7.5s of pure DB time on a local Postgres.

This PR does two things:

1. **Batches the TM lookup** so all `(keyId, targetLanguageId)` pairs in a chunk are resolved in a single statement via a LATERAL join with `LIMIT 1` per input pair. Semantics are preserved exactly — the LATERAL query mirrors the existing `TranslationRepository.getTranslationMemoryValue` HQL (cross-project, base-language exact match, `k <> req_key` self-exclusion) for OSS, and the EE-side UNION ALL stored+virtual query (with `tmIds` + penalty + `write_access` gates) for EE.
2. **Adds a hash index on `translation.text`** so the planner can drive the virtual half from the text equality predicate instead of fanning out across every key in every contributing project. Without this index, prod EXPLAIN ANALYZE showed both the per-item (~825 ms) and batched (~4360 ms for 10) paths bottlenecked on a missing index — the algorithmic win from (1) isn't realized on a real Cloud project until (2) is in place.

## Changes

- **`TmAutoTranslateProvider`** — new default method `getAutoTranslatedValuesForChunk(items, keysById, languagesById)`. Default impl loops the per-item method; intended to be overridden.
- **`TmAutoTranslateProviderOssImpl`** — overrides with a single native LATERAL query that mirrors the existing HQL semantics. `unnest(reqKeyIds, reqLangIds)` zips the actual pairs into the inputs CTE so the SQL processes exactly `items.size` input rows, not the cross-product of distinct keys × distinct langs.
- **`TmAutoTranslateProviderEeImpl`** — overrides with a batched UNION ALL (stored entries + virtual rows) over readable `tmIds` with the same penalty / `write_access` gates as the per-item path. Items not matched by the EE-aware half are delegated to the OSS batched fallback (via an unmetered helper so the batch metric isn't double-recorded). Bounded at 3 DB round-trips per chunk total (tmIds lookup + EE batched + OSS fallback) regardless of chunk size.
- **`AutoTranslationService`** — `autoTranslateSync`, `softAutoTranslate`, `autoTranslateUsingTm`, and the private `getAutoTranslatedValue(config, translation)` gain an optional `precomputedTmMatches: Map<Pair<Long, Long>, TranslationMemoryItemView>?` parameter. When present, the TM branch reads from the map; otherwise the per-item provider call runs unchanged (preserves UI / single-translation callers).
- **`GenericAutoTranslationChunkProcessor`** / **`AutoTranslateChunkProcessor`** — precompute the chunk's TM map once via `tmAutoTranslateProvider.getAutoTranslatedValuesForChunk(...)` and pass it down to each per-item call. Items where `useTranslationMemory = false` skip the precompute entirely.
- **`Metrics.recordTranslationMemoryLookupBatch`** — new metric capturing chunk size, hit count, and duration.
- **Liquibase migration** — adds `translation_text_hash_idx` (PostgreSQL hash index on `translation.text`, built `CONCURRENTLY`). See "Index migration" below for the rationale.
- **Tests** — 8 unit tests in `TranslationMemoryServiceBatchTest` covering empty input, single match, self-exclusion, no-match, shared `(baseText, targetLangId)` across chunk items, mixed target languages, and unrequested-pair filtering. Plus a `@Disabled` `TranslationMemoryServiceBenchmark` that runs the per-item and batched paths back-to-back on the same fixture (drop `@Disabled` locally to compare numbers).
- **Test mock stubs** — `BatchJobTestUtil`, `AbstractBatchJobConcurrentTest`, and `BatchJobManagementControllerTest` updated for the new optional parameter on `autoTranslateSync`.

## Index migration

The auto-translate path filters `WHERE base_t.text = ?`. Three trigram indexes already exist on `translation.text` (`translation_text_gin_trgm_index`, `translation_text_unaccent_gin_trgm_index`, `translation_lang_text_gist_trgm`) — but they all use `_trgm` opclass which serves `%` / `LIKE` / similarity, **not** exact equality. The planner has no usable index for `text = ?`.

Without that index, the virtual half's join order ends up as:
```
tm_virt (10 from :tmIds)
  → tmp_w (12 contributing projects)
  → key k (3170 keys per project = 38k keys total)
  → target_t (probe per key)
  → base_t (probe per key) + Filter: text = ?  ← evaluated LAST, drops 99.99%
```

Production EXPLAIN ANALYZE on a project with shared TMs across many others:

| | per-item | batched-10 |
|---|---:|---:|
| Execution time | **825 ms** | **4360 ms** |
| Shared buffer hits | 402,952 | 5,414,211 |
| Keys visited in virtual half | 38,037 | 380,370 (10× same) |

The batched query is doing the same wasteful work N times in one round-trip — the algorithmic win is real (10 chunk-items would be ~8.3 s if run serially, batched does it in 4.4 s), but neither baseline is acceptable.

`CREATE INDEX CONCURRENTLY translation_text_hash_idx ON translation USING hash (text)` flips the join order: the planner probes by `text = ?` first (highly selective, single-digit rows), then walks outward to project / TM / target. Expected drop: per-item to single-digit ms, batched-10 to ~tens of ms.

Hash chosen over btree because the auto-translate path only ever uses `=`. Hash indexes are smaller and have lighter write amplification on a hot table (which already carries 3 trigram indexes on the same column). Built `CONCURRENTLY` so the migration doesn't lock writes; `runInTransaction="false"` on the changeSet with an explicit `<rollback>` for idempotency.

## Benchmark results (local, no index needed because the test fixture is small)

20,000 TM source keys, 2,000 request keys to translate, ~5,000 distinct base texts (~4 candidates per lookup), German target, local Postgres, JDK 21:

| chunk size | per-item (= main) | batched (this PR) | speedup |
|-----------:|------------------:|------------------:|--------:|
| 10         | avg 8230 ms       | avg 268 ms        | **30.7×** |
| 50         | avg 8546 ms       | avg 218 ms        | **39.2×** |

Production `pretranslate_by_tm` uses chunk size 10 → ~30× win on this fixture, but the real prod win comes from the index migration (see above). EE-side benchmark not measured here because the fixture doesn't populate `translation_memory_entry` rows; the algorithmic improvement is the same shape (1-3 round-trips per chunk vs ~3 per item).

## Per-item path is untouched

The optional `precomputedTmMatches` parameter defaults to `null`, in which case `AutoTranslationService` falls through to the existing per-item `tmAutoTranslateProvider.getAutoTranslatedValue(...)`. UI calls, single-translation auto-translate, the retry loop in `autoTranslateSyncWithRetry`, and any caller that doesn't have a precomputed map continue to work exactly as before. The new index also benefits the per-item path — same `text = ?` predicate.

## Test plan

- [x] `:server-app:test --tests "io.tolgee.service.translation.TranslationMemoryServiceBatchTest"` — all 8 tests pass on fresh DB (including a re-run after the migration was added to verify clean Liquibase application)
- [x] `:ee-test:test --tests "io.tolgee.ee.service.translationMemory.TmAutoTranslateProviderEeImplTest"` — all 5 tests pass
- [x] Local benchmark run — numbers above
- [x] Prod EXPLAIN ANALYZE captured for both per-item and batched without the index → confirmed the missing-index root cause
- [ ] CI green
- [ ] Apply the migration in a non-peak window; `CREATE INDEX CONCURRENTLY` on `translation` is online but takes time on a busy table
- [ ] After the migration lands, re-run the prod EXPLAIN ANALYZE to confirm the planner flips join order and execution time drops to single-digit ms
- [ ] Manual smoke on a sizable project: trigger `pretranslate_by_tm` over hundreds of keys, confirm runtime drops and resulting translations are identical to a pre-change baseline run

## Notes for review

- The OSS batched query intentionally keeps the same scope as the existing HQL (cross-project, no `tmIds` / penalty filter). Even on EE, the fallback path remains unrestricted to preserve current behavior — tightening that scope is a separate semantic decision and not part of this perf-only PR.
- The OSS LATERAL query uses `LIMIT 1` per input pair because the self-key exclusion (`k.id <> inputs.req_key_id`) is enforced inside the LATERAL body — no need for the windowed top-K approach that the original plan considered.
- The EE batched query similarly uses `LIMIT 1` per pair via `order by case kind when 'stored' then 0 else 1 end`, mirroring the per-item EE method's preference for stored entries over virtual rows.
- EE's OSS-fallback uses a separate unmetered helper (`ossDelegate.fetchUnmetered`) so the batch metric is recorded exactly once per chunk — calling `getAutoTranslatedValuesForChunk` directly would double-record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched Translation Memory (TM) exact-match lookups to precompute results per chunk and feed them into auto-translation.
  * Auto-translation now supports optional reuse of precomputed TM matches.
  * Both OSS and EE TM providers now expose batched lookup paths optimized with native SQL.

* **Metrics**
  * Added new TM batch lookup metrics (duration and hit/miss counts).

* **Database**
  * Added a concurrent hash index on translation text to speed exact-match lookups.

* **Tests**
  * Added new TM batch lookup tests and a disabled benchmark; updated mocks to match expanded TM APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->