### PR TITLE
fix: allow API key access to get-modified-entities-by-revision endpoint

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectActivityController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectActivityController.kt
@@ -99,6 +99,7 @@ class ProjectActivityController(
   @Operation(summary = "Get modified entities in revision")
   @GetMapping("/revisions/{revisionId}/modified-entities")
   @RequiresProjectPermissions([Scope.ACTIVITY_VIEW])
+  @AllowApiAccess
   fun getModifiedEntitiesByRevision(
     @ParameterObject pageable: Pageable,
     @PathVariable revisionId: Long,

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectActivityControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectActivityControllerTest.kt
@@ -9,6 +9,8 @@ import io.tolgee.fixtures.isValidId
 import io.tolgee.fixtures.node
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.model.activity.ActivityRevision
+import io.tolgee.model.enums.Scope
+import io.tolgee.testing.annotations.ProjectApiKeyAuthTestMethod
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import net.javacrumbs.jsonunit.assertj.JsonAssert
 import org.junit.jupiter.api.BeforeEach
@@ -147,6 +149,17 @@ class ProjectActivityControllerTest : ProjectAuthControllerTest("/v2/projects/")
       .andIsOk
       .andAssertThatJson {
         node("page.totalElements").isEqualTo(1)
+      }
+  }
+
+  @ProjectApiKeyAuthTestMethod(scopes = [Scope.ADMIN])
+  fun `returns modified entities with API key`() {
+    performProjectAuthPut("/import/apply").andIsOk
+    val revision = activityUtil.getLastRevision()
+    performProjectAuthGet("activity/revisions/${revision?.id}/modified-entities")
+      .andIsOk
+      .andAssertThatJson {
+        node("_embedded.modifiedEntities").isArray
       }
   }
 }


### PR DESCRIPTION
## Summary

- Add `@AllowApiAccess` to `ProjectActivityController.getModifiedEntitiesByRevision`
- Add a regression test that hits the endpoint with an API key (`@ProjectApiKeyAuthTestMethod`)

## Why

The other two endpoints in `ProjectActivityController` (`getActivity`, `getSingleRevision`) already permit API-key auth. `getModifiedEntitiesByRevision` was introduced in #2284 without the annotation — apparently an oversight, not a deliberate restriction (same `Scope.ACTIVITY_VIEW`, same controller, same `/v2/projects/activity` alias route). Webhook consumers that want to enumerate translations changed by a batch operation (the recommended pattern for `BATCH_MACHINE_TRANSLATE` etc.) currently have to fall back to JWT auth, which is awkward for headless integrations.

## Test plan

- [x] New `returns modified entities with API key` test passes locally
- [x] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The project activity endpoint for retrieving modified entities is now accessible via API key authentication, enabling programmatic access to entity modification history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->