### PR TITLE
fix: PO_ICU plural import should not escape ICU placeholders

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoToIcuMessageConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoToIcuMessageConvertor.kt
@@ -6,7 +6,6 @@ import io.tolgee.formats.DEFAULT_PLURAL_ARGUMENT_NAME
 import io.tolgee.formats.FormsToIcuPluralConvertor
 import io.tolgee.formats.MessageConvertorResult
 import io.tolgee.formats.ToIcuPlaceholderConvertor
-import io.tolgee.formats.convertMessage
 import io.tolgee.formats.getULocaleFromTag
 import io.tolgee.formats.importCommon.BaseImportRawDataConverter
 import io.tolgee.formats.importCommon.ImportMessageConvertor
@@ -35,8 +34,7 @@ class PoToIcuMessageConvertor(
     }
 
     if (rawData is Map<*, *>) {
-      val converted = convertPoPlural(rawData, languageTag, convertPlaceholders, isProjectIcuEnabled)
-      return converted
+      return convertPoPlural(rawData, languageTag, baseImportRawDataConverter)
     }
 
     throw IllegalArgumentException("Unsupported type of message")
@@ -45,8 +43,7 @@ class PoToIcuMessageConvertor(
   private fun convertPoPlural(
     possiblePluralForms: Map<*, *>,
     languageTag: String,
-    convertPlaceholders: Boolean,
-    isProjectIcuEnabled: Boolean,
+    baseImportRawDataConverter: BaseImportRawDataConverter,
   ): MessageConvertorResult {
     val formsConverted =
       possiblePluralForms.entries.associate { (formNumPossibleString, value) ->
@@ -57,7 +54,7 @@ class PoToIcuMessageConvertor(
         val locale = getULocaleFromTag(languageTag)
         val example = findSuitableExample(formNumber, locale)
         val keyword = PluralRules.forLocale(locale).select(example.toDouble())
-        keyword to (convert(value, true, convertPlaceholders, isProjectIcuEnabled))
+        keyword to baseImportRawDataConverter.convertMessage(value, isInPlural = true)
       }
     val argName =
       formsConverted.values.firstNotNullOfOrNull { it.pluralArgName }
@@ -78,20 +75,5 @@ class PoToIcuMessageConvertor(
   ): Int {
     val examples = PluralData.DATA[locale.language]?.examples ?: PluralData.DATA["en"]!!.examples
     return examples.find { it.plural == key }?.sample ?: examples[0].sample
-  }
-
-  private fun convert(
-    message: String,
-    isInPlural: Boolean = false,
-    convertPlaceholders: Boolean,
-    isProjectIcuEnabled: Boolean,
-  ): MessageConvertorResult {
-    return convertMessage(
-      message,
-      isInPlural,
-      convertPlaceholders,
-      isProjectIcuEnabled,
-      convertorFactory = paramConvertorFactory,
-    )
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFileProcessorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFileProcessorTest.kt
@@ -156,6 +156,30 @@ class PoFileProcessorTest {
   }
 
   @Test
+  fun `PO_ICU preserves ICU placeholders in plural forms`() {
+    mockUtil.mockIt("en.po", "src/test/resources/import/po/example_icu_plural.po")
+    processFile()
+    mockUtil.fileProcessorContext.assertLanguagesCount(1)
+    mockUtil.fileProcessorContext
+      .assertTranslations("en", "Welcome, {name}")
+      .assertSingle {
+        hasText("Welcome, {name}")
+      }
+    mockUtil.fileProcessorContext
+      .assertTranslations("en", "1 item")
+      .assertSinglePlural {
+        hasText(
+          """
+          {value, plural,
+          one {1 item}
+          other {{count} items}
+          }
+          """.trimIndent(),
+        )
+      }
+  }
+
+  @Test
   fun `respects provided format`() {
     mockUtil.mockIt("en.json", "src/test/resources/import/po/example.po")
     mockUtil.fileProcessorContext.params =

--- a/backend/data/src/test/resources/import/po/example_icu_plural.po
+++ b/backend/data/src/test/resources/import/po/example_icu_plural.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#, icu-format
+msgid "Welcome, {name}"
+msgstr "Welcome, {name}"
+
+#, icu-format
+msgid "1 item"
+msgid_plural "{count} items"
+msgstr[0] "1 item"
+msgstr[1] "{count} items"


### PR DESCRIPTION
Related issue #3589

## Summary

- Plural form conversion in `PoToIcuMessageConvertor.convertPoPlural` previously called the free `convertMessage(...)` with the default `escapeUnmatched=true`, which forced `ForceIcuEscaper` to wrap `{` / `}` in single quotes even for source formats whose placeholders are already valid ICU (PO_ICU). The `canContainIcu` flag added by the #2375 fix was only honored on the singular path via `BaseImportRawDataConverter`.
- Route the plural branch through `BaseImportRawDataConverter.convertMessage(value, isInPlural = true)` so `canContainIcu` propagates as `escapeUnmatched = !canContainIcu`. This matches the pattern already used by `GenericMapPluralImportRawDataConvertor` for JSON_ICU / CSV_ICU.
- Non-ICU PO formats (PO_PHP / PO_C / PO_JAVA / PO_RUBY / PO_PYTHON) keep `canContainIcu = false` → `escapeUnmatched = true`, so their behavior is unchanged.
- Adds a new fixture `example_icu_plural.po` plus a `PoFileProcessorTest` case covering both singular and plural placeholder preservation for PO_ICU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ICU-style placeholders are now properly preserved in plural forms when importing translation files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->