### PR TITLE
fix: sanitize XML 1.0-invalid characters in TMX and translation exports

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/resx/out/ResxWriter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/resx/out/ResxWriter.kt
@@ -4,6 +4,7 @@ import io.tolgee.formats.resx.ResxEntry
 import io.tolgee.util.attr
 import io.tolgee.util.buildDom
 import io.tolgee.util.element
+import io.tolgee.util.sanitizeXmlText
 import org.w3c.dom.Element
 import java.io.InputStream
 
@@ -52,12 +53,12 @@ class ResxWriter(
       attr("xml:space", "preserve")
       entry.data?.let {
         element("value") {
-          textContent = it
+          textContent = sanitizeXmlText(it)
         }
       }
       entry.comment?.let {
         element("comment") {
-          textContent = it
+          textContent = sanitizeXmlText(it)
         }
       }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/xliff/out/XliffFileWriter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xliff/out/XliffFileWriter.kt
@@ -8,6 +8,7 @@ import io.tolgee.util.appendXmlOrText
 import io.tolgee.util.attr
 import io.tolgee.util.buildDom
 import io.tolgee.util.element
+import io.tolgee.util.sanitizeXmlText
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.InputStream
@@ -93,7 +94,7 @@ class XliffFileWriter(
 
   private fun Element.appendXmlIfEnabledOrText(content: String?) {
     if (!enableXmlContent) {
-      textContent = content
+      textContent = sanitizeXmlText(content ?: "")
       return
     }
     this.appendXmlOrText(content)

--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -8,6 +8,7 @@ import io.tolgee.formats.xmlResources.XmlResourcesStringValue
 import io.tolgee.util.Logging
 import io.tolgee.util.XmlSecurity
 import io.tolgee.util.logger
+import io.tolgee.util.sanitizeXmlText
 import org.w3c.dom.Document
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
@@ -26,7 +27,10 @@ class TextToXmlResourcesConvertor(
   private val value: XmlResourcesStringValue,
   private val format: ExportFormat,
 ) : Logging {
-  val string = value.string
+  // Sanitised once at the boundary so every downstream path (parse, CDATA escape, text-node
+  // rewrite) stays free of XML 1.0-invalid codepoints. Otherwise a user-pasted 0x0B sinks the
+  // whole Android/Compose XML export at Transformer.transform time.
+  val string = sanitizeXmlText(value.string)
 
   fun convert(): ContentToAppend {
     if (value.isWrappedCdata || containsXmlAndPlaceholders) {

--- a/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/xmlResources/out/TextToXmlResourcesConvertor.kt
@@ -27,9 +27,6 @@ class TextToXmlResourcesConvertor(
   private val value: XmlResourcesStringValue,
   private val format: ExportFormat,
 ) : Logging {
-  // Sanitised once at the boundary so every downstream path (parse, CDATA escape, text-node
-  // rewrite) stays free of XML 1.0-invalid codepoints. Otherwise a user-pasted 0x0B sinks the
-  // whole Android/Compose XML export at Transformer.transform time.
   val string = sanitizeXmlText(value.string)
 
   fun convert(): ContentToAppend {

--- a/backend/data/src/main/kotlin/io/tolgee/util/domBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/domBuilder.kt
@@ -76,12 +76,15 @@ fun Element.attr(
   value: String?,
 ) {
   val attr = this.ownerDocument.createAttribute(name)
-  attr.value = value ?: ""
+  attr.value = sanitizeXmlText(value ?: "")
   this.setAttributeNode(attr)
 }
 
 fun Element.appendXmlOrText(content: String?) {
-  val contentNotNull = content ?: ""
+  // User-pasted control chars (e.g. 0x0B from Word/Excel) sink the whole export at write time
+  // because JDK's default Transformer rejects them with TransformerException — strip codepoints
+  // outside the XML 1.0 Char production up front so both branches stay safe.
+  val contentNotNull = sanitizeXmlText(content ?: "")
   try {
     val documentBuilder = XmlSecurity.newSecureDocumentBuilderFactory().newDocumentBuilder()
     val doc: Document = documentBuilder.parse(InputSource(StringReader("<root>$contentNotNull</root>")))

--- a/backend/data/src/main/kotlin/io/tolgee/util/domBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/domBuilder.kt
@@ -81,9 +81,6 @@ fun Element.attr(
 }
 
 fun Element.appendXmlOrText(content: String?) {
-  // User-pasted control chars (e.g. 0x0B from Word/Excel) sink the whole export at write time
-  // because JDK's default Transformer rejects them with TransformerException — strip codepoints
-  // outside the XML 1.0 Char production up front so both branches stay safe.
   val contentNotNull = sanitizeXmlText(content ?: "")
   try {
     val documentBuilder = XmlSecurity.newSecureDocumentBuilderFactory().newDocumentBuilder()

--- a/backend/data/src/main/kotlin/io/tolgee/util/xmlSanitization.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/xmlSanitization.kt
@@ -1,15 +1,11 @@
 package io.tolgee.util
 
 /**
- * Strips every codepoint outside the XML 1.0 `Char` production
- * (`#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`).
+ * Strips every codepoint outside the XML 1.0 `Char` production. Apply at every user-content
+ * boundary that lands in an XML document — both DOM and StAX writers throw on illegal codepoints
+ * and a single bad one (e.g. a Word-pasted vertical tab) can sink the whole file.
  *
- * We walk codepoints rather than UTF-16 chars so valid surrogate pairs (emoji etc.) survive
- * intact while lone surrogates, illegal C0 controls (everything but tab/LF/CR), and BMP
- * noncharacters get dropped. Apply this to any user-controlled string that lands in an XML
- * document — both DOM (`textContent`, attribute values) and StAX (`writeCharacters`) writers
- * reject illegal codepoints with hard exceptions (`TransformerException` and
- * `WstxIOException` respectively), so a single bad codepoint can sink the whole export.
+ * Walks codepoints rather than UTF-16 chars so valid surrogate pairs (emoji etc.) survive intact.
  */
 fun sanitizeXmlText(text: String): String {
   if (text.isEmpty()) return text

--- a/backend/data/src/main/kotlin/io/tolgee/util/xmlSanitization.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/xmlSanitization.kt
@@ -1,0 +1,32 @@
+package io.tolgee.util
+
+/**
+ * Strips every codepoint outside the XML 1.0 `Char` production
+ * (`#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`).
+ *
+ * We walk codepoints rather than UTF-16 chars so valid surrogate pairs (emoji etc.) survive
+ * intact while lone surrogates, illegal C0 controls (everything but tab/LF/CR), and BMP
+ * noncharacters get dropped. Apply this to any user-controlled string that lands in an XML
+ * document — both DOM (`textContent`, attribute values) and StAX (`writeCharacters`) writers
+ * reject illegal codepoints with hard exceptions (`TransformerException` and
+ * `WstxIOException` respectively), so a single bad codepoint can sink the whole export.
+ */
+fun sanitizeXmlText(text: String): String {
+  if (text.isEmpty()) return text
+  val out = StringBuilder(text.length)
+  var i = 0
+  while (i < text.length) {
+    val cp = text.codePointAt(i)
+    if (isValidXmlChar(cp)) out.appendCodePoint(cp)
+    i += Character.charCount(cp)
+  }
+  return out.toString()
+}
+
+private fun isValidXmlChar(cp: Int): Boolean {
+  if (cp == 0x9 || cp == 0xA || cp == 0xD) return true
+  if (cp in 0x20..0xD7FF) return true
+  if (cp in 0xE000..0xFFFD) return true
+  if (cp in 0x10000..0x10FFFF) return true
+  return false
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
@@ -350,7 +350,7 @@ class AndroidXmlFileExporterTest {
         add(
           languageTag = "cs",
           keyName = "poisoned",
-          text = "Helloworld",
+          text = "Hello\u000Bworld",
         )
       }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.service.export.ExportFileStructureTemplateProvider
 import io.tolgee.service.export.dataProvider.ExportTranslationView
 import io.tolgee.testing.assert
 import io.tolgee.util.buildExportTranslationList
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class AndroidXmlFileExporterTest {
@@ -340,5 +341,25 @@ class AndroidXmlFileExporterTest {
 
   private fun getExportParams(): ExportParams {
     return ExportParams().also { it.format = ExportFormat.ANDROID_XML }
+  }
+
+  @Test
+  fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
+    // Production Sentry TOLGEE-BACKEND-3E3 (XLIFF) — Android XML resources export shares the same
+    // DOM-based write path via TextToXmlResourcesConvertor, so a user-pasted 0x0B kills it
+    // identically. The exporter must drop the bad codepoint instead of crashing the whole export.
+    val built =
+      buildExportTranslationList {
+        add(
+          languageTag = "cs",
+          keyName = "poisoned",
+          text = "Helloworld",
+        )
+      }
+
+    val xml = getExported(getExporter(built.translations))["values-cs/strings.xml"]!!
+
+    assertThat(xml).contains("Helloworld")
+    assertThat(xml).doesNotContain(Char(0x0B).toString())
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/android/out/AndroidXmlFileExporterTest.kt
@@ -345,9 +345,6 @@ class AndroidXmlFileExporterTest {
 
   @Test
   fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
-    // Production Sentry TOLGEE-BACKEND-3E3 (XLIFF) — Android XML resources export shares the same
-    // DOM-based write path via TextToXmlResourcesConvertor, so a user-pasted 0x0B kills it
-    // identically. The exporter must drop the bad codepoint instead of crashing the whole export.
     val built =
       buildExportTranslationList {
         add(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
@@ -293,7 +293,7 @@ class ResxExporterTest {
         add(
           languageTag = "cs",
           keyName = "poisoned",
-          text = "Helloworld",
+          text = "Hello\u000Bworld",
         )
       }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
@@ -8,6 +8,7 @@ import io.tolgee.service.export.ExportFileStructureTemplateProvider
 import io.tolgee.service.export.dataProvider.ExportTranslationView
 import io.tolgee.testing.assert
 import io.tolgee.util.buildExportTranslationList
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class ResxExporterTest {
@@ -283,5 +284,25 @@ class ResxExporterTest {
 
   private fun getExportParams(): ExportParams {
     return ExportParams().also { it.format = ExportFormat.RESX_ICU }
+  }
+
+  @Test
+  fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
+    // Production Sentry TOLGEE-BACKEND-3E3 (XLIFF) — ResX shares the same DOM-based write path via
+    // `textContent`, so a user-pasted 0x0B kills it identically. The exporter must drop the bad
+    // codepoint instead of crashing the whole export.
+    val built =
+      buildExportTranslationList {
+        add(
+          languageTag = "cs",
+          keyName = "poisoned",
+          text = "Helloworld",
+        )
+      }
+
+    val xml = getExported(getExporter(built.translations))["cs.resx"]!!
+
+    assertThat(xml).contains("Helloworld")
+    assertThat(xml).doesNotContain(Char(0x0B).toString())
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
@@ -288,9 +288,6 @@ class ResxExporterTest {
 
   @Test
   fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
-    // Production Sentry TOLGEE-BACKEND-3E3 (XLIFF) — ResX shares the same DOM-based write path via
-    // `textContent`, so a user-pasted 0x0B kills it identically. The exporter must drop the bad
-    // codepoint instead of crashing the whole export.
     val built =
       buildExportTranslationList {
         add(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
@@ -532,10 +532,6 @@ class XliffFileExporterTest {
 
   @Test
   fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
-    // Production Sentry TOLGEE-BACKEND-3E3: a user-pasted 0x0B (vertical tab from Word/Excel)
-    // crashed the whole project export with TransformerException because JDK's default Transformer
-    // refuses to emit codepoints outside the XML 1.0 Char production. The exporter must silently
-    // drop the bad codepoint so a single poisoned translation can't sink the file.
     val built =
       buildExportTranslationList {
         add(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
@@ -537,7 +537,7 @@ class XliffFileExporterTest {
         add(
           languageTag = "de",
           keyName = "poisoned",
-          text = "Helloworld",
+          text = "Hello\u000Bworld",
         )
       }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
@@ -529,4 +529,26 @@ class XliffFileExporterTest {
   }
 
   private fun getExportParams() = ExportParams().apply { format = ExportFormat.XLIFF }
+
+  @Test
+  fun `exports cleanly when translation text contains XML 1_0-invalid characters`() {
+    // Production Sentry TOLGEE-BACKEND-3E3: a user-pasted 0x0B (vertical tab from Word/Excel)
+    // crashed the whole project export with TransformerException because JDK's default Transformer
+    // refuses to emit codepoints outside the XML 1.0 Char production. The exporter must silently
+    // drop the bad codepoint so a single poisoned translation can't sink the file.
+    val built =
+      buildExportTranslationList {
+        add(
+          languageTag = "de",
+          keyName = "poisoned",
+          text = "Helloworld",
+        )
+      }
+
+    val files = getExporter(built.translations).produceFiles()
+
+    val xml = files["de.xliff"]!!.bufferedReader().readText()
+    assertThat(xml).contains("Helloworld")
+    assertThat(xml).doesNotContain("")
+  }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/util/XmlSanitizationTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/util/XmlSanitizationTest.kt
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.Test
 class XmlSanitizationTest {
   @Test
   fun `strips every illegal C0 control character except tab, LF, and CR`() {
-    // The Sentry-reported crash was specifically 0x0B (vertical tab); cover the whole illegal C0
-    // range in one assertion so this contract is locked even if Woodstox/Xalan loosens later.
     val invalidControls = (0x00..0x1F).filter { it != 0x09 && it != 0x0A && it != 0x0D }
     val poisoned = invalidControls.joinToString(separator = "") { "x${it.toChar()}" }
 
@@ -18,9 +16,6 @@ class XmlSanitizationTest {
 
   @Test
   fun `strips lone UTF-16 surrogates while keeping valid surrogate pairs intact`() {
-    // Lone surrogates aren't legal codepoints in any XML version. A naive char-by-char strip
-    // would also tear valid surrogate pairs (e.g. 😀 = U+D83D U+DE00) apart and produce two
-    // lone surrogates — the codepoint-aware walker has to preserve those.
     val cleaned = sanitizeXmlText("a\uD800b😀c\uDFFFd")
 
     assertThat(cleaned).isEqualTo("ab😀cd")
@@ -35,15 +30,13 @@ class XmlSanitizationTest {
 
   @Test
   fun `preserves legal whitespace and supplementary plane codepoints`() {
-    // Tab/LF/CR are inside the XML 1.0 Char production and must survive — stripping them would
-    // silently mangle formatted segment text. Supplementary plane (emoji etc.) likewise.
     val input = "line1\nline2\tcol\rend 😀"
 
     assertThat(sanitizeXmlText(input)).isEqualTo(input)
   }
 
   @Test
-  fun `returns empty string unchanged without allocating`() {
+  fun `returns empty string unchanged`() {
     assertThat(sanitizeXmlText("")).isEqualTo("")
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/util/XmlSanitizationTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/util/XmlSanitizationTest.kt
@@ -1,0 +1,49 @@
+package io.tolgee.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class XmlSanitizationTest {
+  @Test
+  fun `strips every illegal C0 control character except tab, LF, and CR`() {
+    // The Sentry-reported crash was specifically 0x0B (vertical tab); cover the whole illegal C0
+    // range in one assertion so this contract is locked even if Woodstox/Xalan loosens later.
+    val invalidControls = (0x00..0x1F).filter { it != 0x09 && it != 0x0A && it != 0x0D }
+    val poisoned = invalidControls.joinToString(separator = "") { "x${it.toChar()}" }
+
+    val cleaned = sanitizeXmlText(poisoned)
+
+    assertThat(cleaned).isEqualTo("x".repeat(invalidControls.size))
+  }
+
+  @Test
+  fun `strips lone UTF-16 surrogates while keeping valid surrogate pairs intact`() {
+    // Lone surrogates aren't legal codepoints in any XML version. A naive char-by-char strip
+    // would also tear valid surrogate pairs (e.g. 😀 = U+D83D U+DE00) apart and produce two
+    // lone surrogates — the codepoint-aware walker has to preserve those.
+    val cleaned = sanitizeXmlText("a\uD800b😀c\uDFFFd")
+
+    assertThat(cleaned).isEqualTo("ab😀cd")
+  }
+
+  @Test
+  fun `strips BMP noncharacters U+FFFE and U+FFFF`() {
+    val cleaned = sanitizeXmlText("a${Char(0xFFFE)}b${Char(0xFFFF)}c")
+
+    assertThat(cleaned).isEqualTo("abc")
+  }
+
+  @Test
+  fun `preserves legal whitespace and supplementary plane codepoints`() {
+    // Tab/LF/CR are inside the XML 1.0 Char production and must survive — stripping them would
+    // silently mangle formatted segment text. Supplementary plane (emoji etc.) likewise.
+    val input = "line1\nline2\tcol\rend 😀"
+
+    assertThat(sanitizeXmlText(input)).isEqualTo(input)
+  }
+
+  @Test
+  fun `returns empty string unchanged without allocating`() {
+    assertThat(sanitizeXmlText("")).isEqualTo("")
+  }
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporter.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporter.kt
@@ -1,34 +1,9 @@
 package io.tolgee.ee.service.translationMemory.tmx
 
+import io.tolgee.util.sanitizeXmlText
 import java.io.ByteArrayOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
-
-// XML 1.0 §2.2 Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
-// TMX 1.4 mandates XML 1.0, so the underlying stream writer rejects every other codepoint — a
-// single user-pasted #x0B vertical tab (Word/Excel copy-paste) blew up the whole export with
-// WstxIOException. We walk codepoints rather than UTF-16 chars so valid surrogate pairs (emoji
-// etc.) survive intact; lone surrogates and BMP noncharacters are dropped along with the C0
-// controls so no other illegal codepoint can sink the file either.
-private fun sanitizeXmlText(text: String): String {
-  if (text.isEmpty()) return text
-  val out = StringBuilder(text.length)
-  var i = 0
-  while (i < text.length) {
-    val cp = text.codePointAt(i)
-    if (isValidXmlChar(cp)) out.appendCodePoint(cp)
-    i += Character.charCount(cp)
-  }
-  return out.toString()
-}
-
-private fun isValidXmlChar(cp: Int): Boolean {
-  if (cp == 0x9 || cp == 0xA || cp == 0xD) return true
-  if (cp in 0x20..0xD7FF) return true
-  if (cp in 0xE000..0xFFFD) return true
-  if (cp in 0x10000..0x10FFFF) return true
-  return false
-}
 
 class TmxExporter(
   private val sourceLanguageTag: String,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporter.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporter.kt
@@ -4,6 +4,32 @@ import java.io.ByteArrayOutputStream
 import javax.xml.stream.XMLOutputFactory
 import javax.xml.stream.XMLStreamWriter
 
+// XML 1.0 §2.2 Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF].
+// TMX 1.4 mandates XML 1.0, so the underlying stream writer rejects every other codepoint — a
+// single user-pasted #x0B vertical tab (Word/Excel copy-paste) blew up the whole export with
+// WstxIOException. We walk codepoints rather than UTF-16 chars so valid surrogate pairs (emoji
+// etc.) survive intact; lone surrogates and BMP noncharacters are dropped along with the C0
+// controls so no other illegal codepoint can sink the file either.
+private fun sanitizeXmlText(text: String): String {
+  if (text.isEmpty()) return text
+  val out = StringBuilder(text.length)
+  var i = 0
+  while (i < text.length) {
+    val cp = text.codePointAt(i)
+    if (isValidXmlChar(cp)) out.appendCodePoint(cp)
+    i += Character.charCount(cp)
+  }
+  return out.toString()
+}
+
+private fun isValidXmlChar(cp: Int): Boolean {
+  if (cp == 0x9 || cp == 0xA || cp == 0xD) return true
+  if (cp in 0x20..0xD7FF) return true
+  if (cp in 0xE000..0xFFFD) return true
+  if (cp in 0x10000..0x10FFFF) return true
+  return false
+}
+
 class TmxExporter(
   private val sourceLanguageTag: String,
   private val units: List<TmxExportUnit>,
@@ -65,7 +91,7 @@ class TmxExporter(
     // forbids prefixes in the name and throws XMLStreamException on strict implementations.
     writer.writeAttribute("xml", "http://www.w3.org/XML/1998/namespace", "lang", lang)
     writer.writeStartElement("seg")
-    writer.writeCharacters(text)
+    writer.writeCharacters(sanitizeXmlText(text))
     writer.writeEndElement() // seg
     writer.writeEndElement() // tuv
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporterTest.kt
@@ -1,0 +1,81 @@
+package io.tolgee.ee.service.translationMemory.tmx
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TmxExporterTest {
+  @Test
+  fun `strips C0 control characters so a bad codepoint can't sink the export`() {
+    // Production Sentry TOLGEE-BACKEND-2VE: a 0x0B (vertical tab) — commonly pasted from Word/Excel —
+    // killed every TMX export for the affected TM because Woodstox refuses anything outside the
+    // XML 1.0 Char range. The exporter must silently drop the illegal codepoint instead. Cover the
+    // whole illegal C0 range (everything except tab/LF/CR) in one go to lock the contract.
+    val invalidControls = (0x00..0x1F).filter { it != 0x09 && it != 0x0A && it != 0x0D }
+    val poisoned = invalidControls.joinToString(separator = "") { "x${it.toChar()}" }
+    val unit =
+      TmxExportUnit(
+        tuid = "1",
+        sourceText = poisoned,
+        translations = listOf("de" to poisoned),
+      )
+
+    val xml = TmxExporter(sourceLanguageTag = "en", units = listOf(unit)).export().toString(Charsets.UTF_8)
+
+    val clean = "x".repeat(invalidControls.size)
+    assertThat(xml).contains("<seg>$clean</seg>")
+    assertThat(xml.toCharArray().none { it.code in invalidControls }).isTrue()
+  }
+
+  @Test
+  fun `strips lone UTF-16 surrogates while preserving valid supplementary codepoints`() {
+    // Lone surrogates are not legal codepoints in any XML version and a stray one — easy to
+    // produce via a JSON paste with broken UTF-16 — would otherwise crash export. The sanitiser
+    // must walk codepoints so a valid surrogate pair (😀 = U+1F600) survives intact.
+    val unit =
+      TmxExportUnit(
+        tuid = "1",
+        sourceText = "a\uD800b😀c\uDFFFd",
+        translations = emptyList(),
+      )
+
+    val xml = TmxExporter(sourceLanguageTag = "en", units = listOf(unit)).export().toString(Charsets.UTF_8)
+
+    assertThat(xml).contains("<seg>ab😀cd</seg>")
+  }
+
+  @Test
+  fun `strips BMP noncharacters U+FFFE and U+FFFF`() {
+    // The two BMP noncharacters sit outside the XML 1.0 Char production and would otherwise be
+    // rejected by Woodstox. They're rare in real content but trivial to leak through a broken
+    // import — the sanitiser drops them. Built via Char(int) to dodge any source-encoding
+    // round-trip mishaps on these edge codepoints.
+    val unit =
+      TmxExportUnit(
+        tuid = "1",
+        sourceText = "a${Char(0xFFFE)}b${Char(0xFFFF)}c",
+        translations = emptyList(),
+      )
+
+    val xml = TmxExporter(sourceLanguageTag = "en", units = listOf(unit)).export().toString(Charsets.UTF_8)
+
+    assertThat(xml).contains("<seg>abc</seg>")
+  }
+
+  @Test
+  fun `preserves legal whitespace and astral characters during sanitisation`() {
+    // Tab/LF/CR are legal in XML 1.0 and must survive sanitisation, otherwise segment text would
+    // get its formatting silently mangled. Supplementary-plane codepoints (emoji etc.) also need
+    // to pass through unchanged.
+    val unit =
+      TmxExportUnit(
+        tuid = "1",
+        sourceText = "line1\nline2\tcol\rend 😀",
+        translations = emptyList(),
+      )
+
+    val xml = TmxExporter(sourceLanguageTag = "en", units = listOf(unit)).export().toString(Charsets.UTF_8)
+
+    assertThat(xml).contains("line1\nline2\tcol")
+    assertThat(xml).contains("😀")
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/translationMemory/tmx/TmxExporterTest.kt
@@ -5,11 +5,7 @@ import org.junit.jupiter.api.Test
 
 class TmxExporterTest {
   @Test
-  fun `strips C0 control characters so a bad codepoint can't sink the export`() {
-    // Production Sentry TOLGEE-BACKEND-2VE: a 0x0B (vertical tab) — commonly pasted from Word/Excel —
-    // killed every TMX export for the affected TM because Woodstox refuses anything outside the
-    // XML 1.0 Char range. The exporter must silently drop the illegal codepoint instead. Cover the
-    // whole illegal C0 range (everything except tab/LF/CR) in one go to lock the contract.
+  fun `strips C0 control characters from segment text`() {
     val invalidControls = (0x00..0x1F).filter { it != 0x09 && it != 0x0A && it != 0x0D }
     val poisoned = invalidControls.joinToString(separator = "") { "x${it.toChar()}" }
     val unit =
@@ -28,9 +24,6 @@ class TmxExporterTest {
 
   @Test
   fun `strips lone UTF-16 surrogates while preserving valid supplementary codepoints`() {
-    // Lone surrogates are not legal codepoints in any XML version and a stray one — easy to
-    // produce via a JSON paste with broken UTF-16 — would otherwise crash export. The sanitiser
-    // must walk codepoints so a valid surrogate pair (😀 = U+1F600) survives intact.
     val unit =
       TmxExportUnit(
         tuid = "1",
@@ -45,10 +38,6 @@ class TmxExporterTest {
 
   @Test
   fun `strips BMP noncharacters U+FFFE and U+FFFF`() {
-    // The two BMP noncharacters sit outside the XML 1.0 Char production and would otherwise be
-    // rejected by Woodstox. They're rare in real content but trivial to leak through a broken
-    // import — the sanitiser drops them. Built via Char(int) to dodge any source-encoding
-    // round-trip mishaps on these edge codepoints.
     val unit =
       TmxExportUnit(
         tuid = "1",
@@ -62,10 +51,7 @@ class TmxExporterTest {
   }
 
   @Test
-  fun `preserves legal whitespace and astral characters during sanitisation`() {
-    // Tab/LF/CR are legal in XML 1.0 and must survive sanitisation, otherwise segment text would
-    // get its formatting silently mangled. Supplementary-plane codepoints (emoji etc.) also need
-    // to pass through unchanged.
+  fun `preserves legal whitespace and astral characters`() {
     val unit =
       TmxExportUnit(
         tuid = "1",


### PR DESCRIPTION
## Summary

A user-pasted `0x0B` (vertical tab — common from Word/Excel paste) anywhere in a TM entry or translation crashes the whole XML export. Same root cause across exporters: XML 1.0 forbids most C0 controls and the underlying writers refuse to emit them (`WstxIOException` on the StAX side, `TransformerException` on the DOM side).

**Fix:** extract a shared `io.tolgee.util.sanitizeXmlText` that drops every codepoint outside the XML 1.0 `Char` production (`#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`). Walks codepoints rather than UTF-16 chars so valid surrogate pairs (emoji etc.) stay intact while lone surrogates, illegal C0 controls, and BMP noncharacters get dropped.

Applied at every user-content boundary that lands in an XML document:
- `TmxExporter` (StAX `writeCharacters`)
- `Element.attr` and `Element.appendXmlOrText` in `domBuilder` (covers all attribute writes and the XLIFF / Android XML DOM paths)
- `XliffFileWriter.appendXmlIfEnabledOrText` (the xml-content-disabled branch bypasses `appendXmlOrText`)
- `TextToXmlResourcesConvertor.string` (Android / Compose XML — sanitised once at construction so every downstream path stays safe)
- `ResxWriter` `textContent` assignments for value + comment

## Test plan

- [x] `XmlSanitizationTest` — 5 cases: every illegal C0 char stripped, lone surrogates stripped, BMP noncharacters stripped, legal whitespace + emoji + supplementary chars preserved, empty string short-circuit
- [x] `TmxExporterTest` — TMX-specific regression tests (still pass)
- [x] `XliffFileExporterTest`, `ResxExporterTest`, `AndroidXmlFileExporterTest` — added a `0x0B`-poisoned-input regression test in each; the file exports cleanly and the bad char is gone from the output
- [x] Full `:data:test` formats + util suites pass
- [x] CI green on this PR
- [ ] Manual smoke: re-trigger the broken endpoints for the affected projects — should produce valid output with the bad char dropped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * XML exports (RESX, XLIFF, Android XML, TMX, XML Resources) now automatically sanitize translated content by removing invalid XML characters. This includes problematic control characters and Unicode sequences that could corrupt export files, ensuring cleaner and more reliable exports while preserving translation meaning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->