### PR TITLE
feat: hide QA recheck batch operation from non-privileged users

### DIFF
--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -17,7 +17,11 @@ import { useGlobalContext } from '../globalContext/GlobalContext';
 import { useUserTasks } from '../globalContext/useUserTasks';
 import { AdministrationEeLicenseView } from 'tg.ee.module/billing/administration/AdministrationEeLicenseView';
 import { SlackApp } from '../ee/organizationApps/SlackApp';
-import { useConfig, useEnabledFeatures } from '../globalContext/helpers';
+import {
+  useConfig,
+  useEnabledFeatures,
+  useIsAdminOrSupporter,
+} from '../globalContext/helpers';
 import { ProjectTasksView } from '../ee/task/views/projectTasks/ProjectTasksView';
 import { addOperations } from '../views/projects/translations/BatchOperations/operations';
 import { OperationTaskCreate } from '../ee/batchOperations/OperationTaskCreate';
@@ -197,6 +201,10 @@ export const useAddBatchOperations = () => {
   const labelFeature = isEnabled('TRANSLATION_LABELS');
   const qaChecksFeature = isEnabled('QA_CHECKS');
   const orderTranslationsFeature = isEnabled('ORDER_TRANSLATION');
+  const qaChecksProjectFeature = qaChecksFeature && project.useQaChecks;
+  const hasPrivilegedAccess =
+    useIsAdminOrSupporter() ||
+    useGlobalContext((c) => Boolean(c.auth.adminToken));
   const { t } = useTranslate();
 
   return addOperations([
@@ -207,7 +215,7 @@ export const useAddBatchOperations = () => {
           label: t('batch_operations_qa_recheck'),
           divider: true,
           enabled: canEditTranslations,
-          hidden: !qaChecksFeature || !project.useQaChecks,
+          hidden: !qaChecksProjectFeature || !hasPrivilegedAccess,
           component: OperationQaRecheck,
         },
       ],

--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -21,6 +21,7 @@ import {
   useConfig,
   useEnabledFeatures,
   useIsAdminOrSupporter,
+  useIsBeingImpersonated,
 } from '../globalContext/helpers';
 import { ProjectTasksView } from '../ee/task/views/projectTasks/ProjectTasksView';
 import { addOperations } from '../views/projects/translations/BatchOperations/operations';
@@ -202,9 +203,9 @@ export const useAddBatchOperations = () => {
   const qaChecksFeature = isEnabled('QA_CHECKS');
   const orderTranslationsFeature = isEnabled('ORDER_TRANSLATION');
   const qaChecksProjectFeature = qaChecksFeature && project.useQaChecks;
-  const hasPrivilegedAccess =
-    useIsAdminOrSupporter() ||
-    useGlobalContext((c) => Boolean(c.auth.adminToken));
+  const isAdminOrSupporter = useIsAdminOrSupporter();
+  const isBeingImpersonated = useIsBeingImpersonated();
+  const hasPrivilegedAccess = isAdminOrSupporter || isBeingImpersonated;
   const { t } = useTranslate();
 
   return addOperations([

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -27,6 +27,9 @@ export const useIsAdminOrSupporter = () =>
     return role === 'ADMIN' || role === 'SUPPORTER';
   });
 
+export const useIsBeingImpersonated = () =>
+  useGlobalContext((c) => Boolean(c.auth.adminToken));
+
 export const useIsSsoMigrationRequired = () =>
   useGlobalContext(
     (c) =>


### PR DESCRIPTION
## Summary

- Hide the "Rerun QA checks" batch operation for everyone except server admins and supporters.
- Admins and supporters keep seeing it while impersonating another user (detected via the impersonation/admin token, same signal the top bar uses).
- Backend `qa-check` batch job endpoint is unchanged and remains accessible to all users — this is a UI-only restriction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QA recheck batch operation now appears only when QA checks are enabled for the project and the user has privileged access (admins/supporters) or is in an impersonated session.
  * Visibility now respects impersonation state so delegated sessions see the same access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->