### PR TITLE
feat: add info tooltip to missing plural forms QA check

### DIFF
--- a/webapp/src/ee/qa/hooks/useQaCheckTypeTooltip.ts
+++ b/webapp/src/ee/qa/hooks/useQaCheckTypeTooltip.ts
@@ -12,6 +12,8 @@ export function useQaCheckTypeTooltip(type: QaCheckType): string | null {
       return t('qa_check_tooltip_character_case_mismatch');
     case 'MISSING_NUMBERS':
       return t('qa_check_tooltip_missing_numbers');
+    case 'MISSING_PLURAL_CATEGORIES':
+      return t('qa_check_tooltip_missing_plural_categories');
     case 'SPELLING':
       return t('qa_check_tooltip_spelling');
     case 'GRAMMAR':


### PR DESCRIPTION
## Summary

- Wire up the `(i)` info tooltip for the **Missing plural forms** QA check in QA settings (it was the notable check without one), via a new `MISSING_PLURAL_CATEGORIES` case in `useQaCheckTypeTooltip`.
- Tooltip copy (new Tolgee key `qa_check_tooltip_missing_plural_categories`): "Detects plural forms required by the target language that are missing from the translation."
- Part of standardizing user-facing terminology on "plural form" (the check label and QA issue messages were also updated from "plural categories"/"plural variant" in Tolgee).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QA check functionality with localized tooltip support for missing plural categories, providing users with helpful guidance during quality analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->