### PR TITLE
fix: stop leaking untranslated glossary terms into AI translations

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
@@ -45,24 +45,26 @@ class GlossaryAiTranslationTestData {
               assignProject(project)
 
               translatedTerm =
-                addTerm {}.build {
-                  addTranslation {
-                    languageTag = "en"
-                    text = "Apple"
-                  }
-                  addTranslation {
-                    languageTag = "fr"
-                    text = "Pomme"
-                  }
-                }.self
+                addTerm {}
+                  .build {
+                    addTranslation {
+                      languageTag = "en"
+                      text = "Apple"
+                    }
+                    addTranslation {
+                      languageTag = "fr"
+                      text = "Pomme"
+                    }
+                  }.self
 
               untranslatedTerm =
-                addTerm {}.build {
-                  addTranslation {
-                    languageTag = "en"
-                    text = "Banana"
-                  }
-                }.self
+                addTerm {}
+                  .build {
+                    addTranslation {
+                      languageTag = "en"
+                      text = "Banana"
+                    }
+                  }.self
 
               untranslatedWithDescriptionTerm =
                 addTerm {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
@@ -17,8 +17,9 @@ class GlossaryAiTranslationTestData {
   lateinit var nonTranslatableTerm: GlossaryTerm
   lateinit var forbiddenTerm: GlossaryTerm
   lateinit var caseSensitiveOnlyTerm: GlossaryTerm
+  lateinit var abbreviationOnlyTerm: GlossaryTerm
 
-  val sourceText = "Apple Banana Cherry Dragon Elder Fig are common words"
+  val sourceText = "Apple Banana Cherry Dragon Elder Fig Grape are common words"
 
   val root: TestDataBuilder =
     TestDataBuilder().apply {
@@ -103,6 +104,16 @@ class GlossaryAiTranslationTestData {
                   addTranslation {
                     languageTag = "en"
                     text = "Fig"
+                  }
+                }.self
+
+              abbreviationOnlyTerm =
+                addTerm {
+                  flagAbbreviation = true
+                }.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Grape"
                   }
                 }.self
             }.self

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryAiTranslationTestData.kt
@@ -1,0 +1,110 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
+import io.tolgee.model.glossary.Glossary
+import io.tolgee.model.glossary.GlossaryTerm
+
+class GlossaryAiTranslationTestData {
+  lateinit var userOwner: UserAccount
+  lateinit var project: Project
+  lateinit var glossary: Glossary
+
+  lateinit var translatedTerm: GlossaryTerm
+  lateinit var untranslatedTerm: GlossaryTerm
+  lateinit var untranslatedWithDescriptionTerm: GlossaryTerm
+  lateinit var nonTranslatableTerm: GlossaryTerm
+  lateinit var forbiddenTerm: GlossaryTerm
+  lateinit var caseSensitiveOnlyTerm: GlossaryTerm
+
+  val sourceText = "Apple Banana Cherry Dragon Elder Fig are common words"
+
+  val root: TestDataBuilder =
+    TestDataBuilder().apply {
+      addUserAccount {
+        username = "Owner"
+      }.build {
+        userOwner = self
+
+        project =
+          addProject(defaultOrganizationBuilder.self) {
+            name = "GlossaryAiProject"
+          }.build {
+            val english = addEnglish()
+            addFrench()
+            self.baseLanguage = english.self
+          }.self
+
+        defaultOrganizationBuilder.build {
+          glossary =
+            addGlossary {
+              name = "AI Glossary"
+              baseLanguageTag = "en"
+            }.build {
+              assignProject(project)
+
+              translatedTerm =
+                addTerm {}.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Apple"
+                  }
+                  addTranslation {
+                    languageTag = "fr"
+                    text = "Pomme"
+                  }
+                }.self
+
+              untranslatedTerm =
+                addTerm {}.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Banana"
+                  }
+                }.self
+
+              untranslatedWithDescriptionTerm =
+                addTerm {
+                  description = "Translate as the fruit, never as a name"
+                }.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Cherry"
+                  }
+                }.self
+
+              nonTranslatableTerm =
+                addTerm {
+                  flagNonTranslatable = true
+                }.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Dragon"
+                  }
+                }.self
+
+              forbiddenTerm =
+                addTerm {
+                  flagForbiddenTerm = true
+                }.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Elder"
+                  }
+                }.self
+
+              caseSensitiveOnlyTerm =
+                addTerm {
+                  flagCaseSensitive = true
+                }.build {
+                  addTranslation {
+                    languageTag = "en"
+                    text = "Fig"
+                  }
+                }.self
+            }.self
+        }
+      }
+    }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/glossary/GlossaryTerm.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/glossary/GlossaryTerm.kt
@@ -4,6 +4,7 @@ import io.tolgee.activity.annotation.ActivityEntityDescribingPaths
 import io.tolgee.activity.annotation.ActivityLoggedEntity
 import io.tolgee.activity.annotation.ActivityLoggedProp
 import io.tolgee.model.StandardAuditModel
+import io.tolgee.model.glossary.GlossaryTerm_.flagNonTranslatable
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -43,4 +44,9 @@ class GlossaryTerm(
 
   @ActivityLoggedProp
   var flagForbiddenTerm: Boolean = false
+
+  companion object {
+    val GlossaryTerm.hasNoFlags: Boolean
+      get() = !flagNonTranslatable && !flagCaseSensitive && !flagAbbreviation && !flagForbiddenTerm
+  }
 }

--- a/e2e/cypress/e2e/aiPlayground/basicPrompt.cy.ts
+++ b/e2e/cypress/e2e/aiPlayground/basicPrompt.cy.ts
@@ -41,7 +41,10 @@ describe('basic prompt', () => {
       'KEY_CONTEXT',
       'Here is list of translations used in the same context'
     );
-    testOption('GLOSSARY', 'These glossary terms should be strictly used');
+    testOption(
+      'GLOSSARY',
+      'Use these glossary terms when the source text contains them'
+    );
     testOption('SCREENSHOT', '[[screenshot_small_');
   });
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
@@ -14,6 +14,7 @@ import io.tolgee.ee.repository.glossary.GlossaryTermRepository
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.model.glossary.Glossary
 import io.tolgee.model.glossary.GlossaryTerm
+import io.tolgee.model.glossary.GlossaryTerm.Companion.hasNoFlags
 import io.tolgee.model.glossary.GlossaryTermTranslation
 import io.tolgee.model.glossary.GlossaryTermTranslation.Companion.WORD_REGEX
 import io.tolgee.service.machineTranslation.MtGlossaryTermsProvider
@@ -300,10 +301,7 @@ class GlossaryTermService(
         if (
           target.isNullOrBlank() &&
           description.isBlank() &&
-          !term.flagNonTranslatable &&
-          !term.flagForbiddenTerm &&
-          !term.flagCaseSensitive &&
-          !term.flagAbbreviation
+          term.hasNoFlags
         ) {
           // Term doesn't bring anything of value - passing it could confuse (AI) translators
           return@mapNotNull null

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
@@ -292,13 +292,27 @@ class GlossaryTermService(
   ): Set<TranslationGlossaryItem> =
     getHighlights(project.organizationOwnerId, project.id, text, sourceLanguageTag)
       .filter { it.value.text.isNotEmpty() }
-      .map { highlight ->
+      .mapNotNull { highlight ->
         val term = highlight.value.term
-        val targetTranslation = term.translations.find { it.languageTag == targetLanguageTag }
+        val target = term.translations.find { it.languageTag == targetLanguageTag }?.text
+        val description = term.description
+
+        if (
+          target.isNullOrBlank() &&
+          description.isBlank() &&
+          !term.flagNonTranslatable &&
+          !term.flagForbiddenTerm &&
+          !term.flagCaseSensitive &&
+          !term.flagAbbreviation
+        ) {
+          // Term doesn't bring anything of value - passing it could confuse (AI) translators
+          return@mapNotNull null
+        }
+
         TranslationGlossaryItem(
           source = highlight.value.text,
-          target = targetTranslation?.text,
-          description = term.description,
+          target = target,
+          description = description,
           isNonTranslatable = term.flagNonTranslatable,
           isCaseSensitive = term.flagCaseSensitive,
           isAbbreviation = term.flagAbbreviation,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptFragmentsHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptFragmentsHelper.kt
@@ -90,10 +90,17 @@ class PromptFragmentsHelper {
         "glossary",
         """
         {{#if glossary.json}}
-        These glossary terms should be strictly used, adjust form to fit into the context:
+        Use these glossary terms when the source text contains them, adapting the form to fit the context:
         {{glossary.json}}
         
+        Field descriptions:
+        source: the term as it appears in the source text.
+        target: how the term should be translated in {{target.languageName}}. When present, use it and adapt its form to the context. When absent, translate the term naturally like any other word.
+        description: extra guidance on how to handle this term; follow it.
         isCaseSensitive: If true, strictly follow the term casing, otherwise adjust casing to fit the context
+        {{#if glossary.hasAbbreviation}}
+        isAbbreviation: the term is an abbreviation.
+        {{/if}}
         {{#if glossary.hasForbiddenTerm}}
         isForbidden = Do not use it in the resulting translation.
         {{/if}}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/glossary/GlossaryTermsForAiTranslationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/glossary/GlossaryTermsForAiTranslationTest.kt
@@ -1,0 +1,90 @@
+package io.tolgee.ee.service.glossary
+
+import io.tolgee.component.machineTranslation.metadata.TranslationGlossaryItem
+import io.tolgee.constants.Feature
+import io.tolgee.development.testDataBuilder.data.GlossaryAiTranslationTestData
+import io.tolgee.dtos.cacheable.ProjectDto
+import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class GlossaryTermsForAiTranslationTest : AuthorizedControllerTest() {
+  @Autowired
+  private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  @Autowired
+  private lateinit var glossaryTermService: GlossaryTermService
+
+  lateinit var testData: GlossaryAiTranslationTestData
+
+  @BeforeEach
+  fun setup() {
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.GLOSSARY)
+    testData = GlossaryAiTranslationTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.userOwner
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+    userAccount = null
+    enabledFeaturesProvider.forceEnabled = null
+  }
+
+  private fun getTerms(): Map<String, TranslationGlossaryItem> {
+    val projectDto: ProjectDto = projectService.getDto(testData.project.id)
+    return glossaryTermService
+      .getGlossaryTerms(projectDto, "en", "fr", testData.sourceText)
+      .associateBy { it.source }
+  }
+
+  @Test
+  fun `includes a term that has a translation in the target language`() {
+    val term = getTerms()["Apple"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isEqualTo("Pomme")
+  }
+
+  @Test
+  fun `excludes an untranslated term with no description and no flags`() {
+    assertThat(getTerms()).doesNotContainKey("Banana")
+  }
+
+  @Test
+  fun `includes an untranslated term that has a description`() {
+    val term = getTerms()["Cherry"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isNull()
+    assertThat(term.description).isEqualTo("Translate as the fruit, never as a name")
+  }
+
+  @Test
+  fun `includes an untranslated non-translatable term`() {
+    val term = getTerms()["Dragon"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isNull()
+    assertThat(term.isNonTranslatable).isTrue()
+  }
+
+  @Test
+  fun `includes an untranslated forbidden term`() {
+    val term = getTerms()["Elder"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isNull()
+    assertThat(term.isForbiddenTerm).isTrue()
+  }
+
+  @Test
+  fun `excludes an untranslated case-sensitive-only term`() {
+    assertThat(getTerms()).doesNotContainKey("Fig")
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/glossary/GlossaryTermsForAiTranslationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/glossary/GlossaryTermsForAiTranslationTest.kt
@@ -84,7 +84,18 @@ class GlossaryTermsForAiTranslationTest : AuthorizedControllerTest() {
   }
 
   @Test
-  fun `excludes an untranslated case-sensitive-only term`() {
-    assertThat(getTerms()).doesNotContainKey("Fig")
+  fun `includes an untranslated case-sensitive-only term`() {
+    val term = getTerms()["Fig"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isNull()
+    assertThat(term.isCaseSensitive).isTrue()
+  }
+
+  @Test
+  fun `includes an untranslated abbreviation-only term`() {
+    val term = getTerms()["Grape"]
+    assertThat(term).isNotNull
+    assertThat(term!!.target).isNull()
+    assertThat(term.isAbbreviation).isTrue()
   }
 }


### PR DESCRIPTION
## Summary

Closes #3288.

- Glossary terms matched in the source text were always sent to the AI translation prompt, even with no translation in the target language. The prompt told the model to use them, so the source-language form leaked into the output untranslated.
- `GlossaryTermService.getGlossaryTerms` now includes a matched term only when it carries a usable signal for the target language: a target translation, a description, or the non-translatable / forbidden flags. Bare untranslated terms are dropped.
- The glossary prompt fragment gains a per-field legend (`source` / `target` / `description` / `isAbbreviation`) and clarifies that an absent `target` means the term should be translated naturally rather than copied verbatim.
- Adds `GlossaryTermsForAiTranslationTest` covering all include/exclude cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI translation glossary now omits entries that would yield empty/meaningless target translations while still including terms with descriptions or special flags (non‑translatable, forbidden, case‑sensitive, abbreviation).
  * Glossary prompt fragment expanded with clearer instructions and explicit fields for source, target, description, case sensitivity and abbreviation handling.
  * Added helper to detect glossary terms with no flags.

* **Tests**
  * Added integration tests and seed data validating glossary term selection for AI-assisted en→fr translations.
  * Updated E2E assertion text for glossary option in AI Playground tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->