### PR TITLE
fix: ignore tags, placeholders and URLs in case and special-char QA checks

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheck.kt
@@ -24,6 +24,14 @@ class CharacterCaseMismatchCheck : QaCheck {
     baseText: String?,
     languageTag: String,
   ): List<QaCheckResult> {
+    return filterResultsInBlockedRanges(detectCaseMismatch(text, baseText, languageTag), text)
+  }
+
+  private fun detectCaseMismatch(
+    text: String,
+    baseText: String?,
+    languageTag: String,
+  ): List<QaCheckResult> {
     val base = baseText ?: return emptyList()
     if (base.isBlank()) return emptyList()
     if (text.isBlank()) return emptyList()

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheck.kt
@@ -68,7 +68,7 @@ class SpecialCharacterMismatchCheck : QaCheck {
       }
     }
 
-    return results
+    return filterResultsInBlockedRanges(results, text)
   }
 
   companion object {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/CharacterCaseMismatchCheckTest.kt
@@ -104,4 +104,30 @@ class CharacterCaseMismatchCheckTest {
   fun `all types are CHARACTER_CASE_MISMATCH`() {
     check.check(params("bonjour", "Hello")).assertAllHaveType(QaCheckType.CHARACTER_CASE_MISMATCH)
   }
+
+  @Test
+  fun `does not flag first letter inside an HTML tag`() {
+    // First letter is the `b` of the <b> tag — intentionally not re-checked against
+    // the real first word; we only filter, we don't advance to the next letter.
+    check.check(params("<b>hello</b>", "Hello")).assertNoIssues()
+  }
+
+  @Test
+  fun `does not flag first letter inside an ICU placeholder`() {
+    check.check(params("{name} world", "Hello")).assertNoIssues()
+  }
+
+  @Test
+  fun `does not flag first letter inside a URL`() {
+    check.check(params("https://example.com is here", "Hello")).assertNoIssues()
+  }
+
+  @Test
+  fun `flags genuine mismatch when first letter is outside blocked ranges`() {
+    check.check(params("bonjour <b>x</b>", "Hello world")).assertSingleIssue {
+      message(QaIssueMessage.QA_CASE_CAPITALIZE)
+      replacement("B")
+      position(0, 1)
+    }
+  }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/SpecialCharacterMismatchCheckTest.kt
@@ -171,4 +171,33 @@ class SpecialCharacterMismatchCheckTest {
   fun `does not flag non-special characters`() {
     check.check(params("Hello world", "Hello world!?.:;")).assertNoIssues()
   }
+
+  @Test
+  fun `does not flag extra special char inside a URL`() {
+    // The `&` lives inside the URL query string, not in the translated content.
+    check.check(params("Visit https://x.com?a=1&b=2", "Visit page")).assertNoIssues()
+  }
+
+  @Test
+  fun `does not flag extra special char inside an HTML tag`() {
+    check.check(params("""Click <a href="mailto:x@y.com">here</a>""", "Click here")).assertNoIssues()
+  }
+
+  @Test
+  fun `flags genuine extra special char outside blocked ranges`() {
+    check.check(params("Price \$5 https://x.com", "Price 5")).assertSingleIssue {
+      message(QaIssueMessage.QA_SPECIAL_CHAR_ADDED)
+      param("character", "\$")
+    }
+  }
+
+  @Test
+  fun `still reports missing special char when a URL is present`() {
+    // The missing-char issue carries no position, so range filtering never drops it.
+    check.check(params("Cena: 10 https://x.com", "Price: \$10 https://x.com")).assertSingleIssue {
+      message(QaIssueMessage.QA_SPECIAL_CHAR_MISSING)
+      param("characters", "\$")
+      param("count", "1")
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- `CharacterCaseMismatchCheck` no longer flags a first-character case mismatch when the first letter lives inside an HTML tag, ICU placeholder, or URL (the original false-positive: a leading `<tag>` made the tag name's first letter look like the sentence start).
- `SpecialCharacterMismatchCheck` no longer reports "extra" special characters that only occur inside URLs, HTML tags, or placeholders (e.g. `&`/`#` in a URL query string).
- Both route their positioned findings through the existing `filterResultsInBlockedRanges`, reusing the same blocked-range logic already used by the spelling, grammar, and repeated-words checks. Missing-character findings carry no position and are intentionally left untouched.
- We filter, not advance: a translation whose first visible letter is preceded by a tag is simply not flagged, rather than re-checking the next letter.
- Added unit tests covering tag/placeholder/URL suppression plus regressions confirming genuine out-of-range mismatches are still reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QA character case and special character mismatch checks now correctly ignore mismatches detected within protected syntax regions such as HTML tags, ICU placeholders, and URLs.

* **Tests**
  * Added test coverage validating mismatch detection behavior around protected syntax areas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->