### PR TITLE
feat: show distinct QA badge tooltip when checks are stale

### DIFF
--- a/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
+++ b/webapp/src/views/projects/translations/cell/ControlsTranslation.tsx
@@ -209,7 +209,11 @@ export const ControlsTranslation: React.FC<ControlsProps> = ({
             [CELL_SHOW_ON_HOVER]: !qaIssueCount,
             [CELL_HIGHLIGHT_ON_HOVER]: qaIssuesResolved || qaChecksStale,
           })}
-          tooltip={t('translation_cell_qa_issues')}
+          tooltip={
+            qaChecksStale
+              ? t('translation_cell_qa_checks_stale')
+              : t('translation_cell_qa_issues')
+          }
         >
           <QaBadge count={qaIssueCount} stale={qaChecksStale} />
         </ControlsButton>


### PR DESCRIPTION
## Summary
- QA badge tooltip in the translations view is now dynamic: when the badge shows the *stale* state, it reads `translation_cell_qa_checks_stale` ("QA checks are being evaluated") instead of the static `translation_cell_qa_issues` ("QA Issues").
- New translation key `translation_cell_qa_checks_stale` created in Tolgee.
- No backend or API schema changes — relies on the existing `qaChecksStale` field already plumbed into `ControlsTranslation`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QA tooltip messaging to display context-specific information based on check status. The tooltip now distinguishes between stale QA checks and active QA issues, providing clearer feedback to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tolgee/tolgee-platform/pull/3707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->