### PR TITLE
Don't encode URLs that already contain "%" or else they will be double escaped

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -31,13 +31,13 @@ class WebhookExecutor(
     headers.contentType = MediaType.APPLICATION_JSON
 
     val request = HttpEntity(stringData, headers)
-    
+
     // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
     val fullyEncoded =
       config.url.contains("%") &&
         Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
     val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
-    
+
     try {
       val responseEntity: ResponseEntity<String> =
         restTemplate.exchange(uri, HttpMethod.POST, request, String::class.java)

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class WebhookExecutor(
@@ -30,10 +31,13 @@ class WebhookExecutor(
     headers.contentType = MediaType.APPLICATION_JSON
 
     val request = HttpEntity(stringData, headers)
-
+    
+    // If the webhook URL already contains a % it likely already properly escaped its parameters
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(config.url.contains("%"))
+    
     try {
       val responseEntity: ResponseEntity<String> =
-        restTemplate.exchange(config.url, HttpMethod.POST, request, String::class.java)
+        restTemplate.exchange(uri, HttpMethod.POST, request, String::class.java)
       if (!responseEntity.statusCode.is2xxSuccessful) {
         throw WebhookRespondedWithNon200Status(responseEntity.statusCode, responseEntity.body)
       }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -32,8 +32,11 @@ class WebhookExecutor(
 
     val request = HttpEntity(stringData, headers)
     
-    // If the webhook URL already contains a % it likely already properly escaped its parameters
-    val uri = UriComponentsBuilder.fromUriString(config.url).build(config.url.contains("%"))
+    // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
+    val fullyEncoded =
+      config.url.contains("%") &&
+        Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded)
     
     try {
       val responseEntity: ResponseEntity<String> =

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -36,7 +36,7 @@ class WebhookExecutor(
     val fullyEncoded =
       config.url.contains("%") &&
         Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
-    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded)
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
     
     try {
       val responseEntity: ResponseEntity<String> =


### PR DESCRIPTION
I have configured my project webhook to be:
`https://host/translation/webhook/21469?promptToModel=576%3Acompassion-translation-v1&promptToModel=577%3Apseudo`

I build this URL using a Jersey UriBuilder class and it nicely handled all encoding for me. When my webhook was invoked by Tolgee, it actually called
`https://host/translation/webhook/21469?promptToModel=576%253Acompassion-translation-v1&promptToModel=577%253Apseudo` (note the double encoding/escaping)

A similar issue was raised here:
https://stackoverflow.com/questions/28182836/resttemplate-to-not-escape-url

This PR should "detect" escaping in the configured URL and not double escape it. It would be an anti-pattern for me to build a non-valid URI with `:` just to allow Tolgee to encode it for me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook URL handling by properly constructing the destination URI from the configured URL.
  * Added validation for pre-encoded URLs by detecting percent-encoding and ensuring percent markers use valid two-digit hex sequences, reducing failed webhook deliveries for special-character URLs.
  * Preserves the existing signed payload and error/response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->