### PR TITLE
fix: ConcurrentModificationException when changing multiple tags via complex-update endpoint

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/TagServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/TagServiceTest.kt
@@ -6,6 +6,7 @@ package io.tolgee.service
 
 import io.tolgee.AbstractSpringTest
 import io.tolgee.development.testDataBuilder.data.TagsTestData
+import io.tolgee.model.key.Key
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -40,5 +41,25 @@ class TagServiceTest : AbstractSpringTest() {
     entityManager.flush()
     val time = System.currentTimeMillis() - start
     assertThat(time).isLessThan(20000)
+  }
+
+  @Test
+  fun `updates tags without concurrent modification`() {
+    val tagsTestData = TagsTestData()
+    testDataService.saveTestData(tagsTestData.root)
+    entityManager.flush()
+    entityManager.clear()
+
+    val key = entityManager.find(Key::class.java, tagsTestData.existingTagKey.id)
+    tagService.updateTags(key, listOf("existing tag 2"))
+    entityManager.flush()
+    entityManager.clear()
+
+    val updatedKey = entityManager.find(Key::class.java, tagsTestData.existingTagKey.id)
+    val tagNames = updatedKey.keyMeta?.tags?.map { it.name } ?: emptyList()
+
+    assertThat(tagNames).containsExactly("existing tag 2")
+    assertThat(tagService.find(tagsTestData.existingTag.id)).isNull()
+    assertThat(tagService.find(tagsTestData.existingTag2.id)).isNotNull()
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -200,17 +200,21 @@ class TagService(
 
   @Transactional
   fun updateTags(
-    key: Key,
-    newTags: List<String>,
+      key: Key,
+      newTags: List<String>,
   ) {
-    key.keyMeta?.tags?.forEach { oldTag ->
-      if (newTags.find { oldTag.name == it } == null) {
-        this.remove(key, oldTag)
+      val tagsToRemove =
+          key.keyMeta?.tags
+              ?.filter { it.name !in newTags }
+              ?: emptyList()
+
+      tagsToRemove.forEach {
+          this.remove(key, it)
       }
-    }
-    newTags.forEach { tagName ->
-      this.tagKey(key, tagName)
-    }
+
+      newTags.forEach {
+          tagKey(key, it)
+      }
   }
 
   fun getProjectTags(

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/TagService.kt
@@ -200,21 +200,18 @@ class TagService(
 
   @Transactional
   fun updateTags(
-      key: Key,
-      newTags: List<String>,
+    key: Key,
+    newTags: List<String>,
   ) {
-      val tagsToRemove =
-          key.keyMeta?.tags
-              ?.filter { it.name !in newTags }
-              ?: emptyList()
+    val tagsToRemove = key.keyMeta?.tags?.filter { it.name !in newTags } ?: emptyList()
 
-      tagsToRemove.forEach {
-          this.remove(key, it)
-      }
+    tagsToRemove.forEach {
+      this.remove(key, it)
+    }
 
-      newTags.forEach {
-          tagKey(key, it)
-      }
+    newTags.forEach {
+      tagKey(key, it)
+    }
   }
 
   fun getProjectTags(


### PR DESCRIPTION
**Fix ConcurrentModificationException in updateTags()**

**Root cause:**
`updateTags()` iterates over `keyMeta.tags` while `remove()` modifies the same collection.

**Solution:**
Create a separate collection of tags to remove and perform removals afterward.

**Added test covering the scenario.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved tag-update logic to make tag changes more reliable and resilient, reducing risk of incorrect tag removals during updates.

* **Tests**
  * Added automated test coverage for tag updates to confirm removed tags are cleared and existing tags remain intact, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->