### PR TITLE
fix: make email case-insensitive for login and signup

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/repository/UserAccountRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/UserAccountRepository.kt
@@ -104,7 +104,7 @@ private const val PROJECT_PERMISSIONS_MAIN = """
 interface UserAccountRepository : JpaRepository<UserAccount, Long> {
   fun findByUsername(username: String?): Optional<UserAccount>
 
-  @Query("from UserAccount ua where ua.username = :username and ua.deletedAt is null and ua.disabledAt is null")
+  @Query("from UserAccount ua where lower(ua.username) = lower(:username) and ua.deletedAt is null and ua.disabledAt is null")
   fun findActive(username: String): UserAccount?
 
   @Query("from UserAccount ua where ua.id = :id and ua.deletedAt is null and ua.disabledAt is null")

--- a/backend/data/src/main/kotlin/io/tolgee/security/thirdParty/ThirdPartyUserHandler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/security/thirdParty/ThirdPartyUserHandler.kt
@@ -98,7 +98,7 @@ class ThirdPartyUserHandler(
 
   private fun createUserEntity(data: ThirdPartyUserDetails): UserAccount {
     val user = UserAccount()
-    user.username = data.username
+    user.username = data.username.lowercase()
     user.name = data.name
     user.thirdPartyAuthId = data.authId
     user.thirdPartyAuthType = data.thirdPartyAuthType

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SignUpService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SignUpService.kt
@@ -27,7 +27,7 @@ class SignUpService(
 ) {
   @Transactional
   fun signUp(dto: SignUpDto): JwtAuthenticationResponse? {
-    userAccountService.findActive(dto.email)?.let {
+    userAccountService.findActive(dto.email.lowercase())?.let {
       throw BadRequestException(Message.USERNAME_ALREADY_EXISTS)
     }
 
@@ -61,6 +61,6 @@ class SignUpService(
 
   fun dtoToEntity(request: SignUpDto): UserAccount {
     val encodedPassword = passwordEncoder.encode(request.password!!)
-    return UserAccount(name = request.name, username = request.email, password = encodedPassword)
+    return UserAccount(name = request.name, username = request.email.lowercase(), password = encodedPassword)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/UserAccountService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/UserAccountService.kt
@@ -574,11 +574,11 @@ class UserAccountService(
         throw ValidationException(Message.VALIDATION_EMAIL_IS_NOT_VALID)
       }
 
-      this.findActive(dto.email)?.let { throw ValidationException(Message.USERNAME_ALREADY_EXISTS) }
+      this.findActive(dto.email.lowercase())?.let { throw ValidationException(Message.USERNAME_ALREADY_EXISTS) }
       if (tolgeeProperties.authentication.needsEmailVerification) {
         emailVerificationService.resendEmailVerification(userAccount, request, dto.callbackUrl, dto.email)
       } else {
-        userAccount.username = dto.email
+        userAccount.username = dto.email.lowercase()
       }
     }
   }


### PR DESCRIPTION
## Summary

Emails are currently case-sensitive in Tolgee. A user who registered as \JDimeo@email.org\ cannot log in with \jdimeo@email.org\. This is unexpected since virtually all major email providers treat the local part as case-insensitive.

Closes #1382

## Root Cause

- \UserAccountRepository.findActive()\ used exact username matching (\ua.username = :username\)
- \SignUpService.dtoToEntity()\ stored email as-is without normalization
- \UserAccountService.updateUserEmail()\ stored new email as-is
- \ThirdPartyUserHandler.createUserEntity()\ stored OAuth email as-is

## Changes

| File | Change |
|------|--------|
| \UserAccountRepository.kt\ | \indActive\ JPQL: \lower(ua.username) = lower(:username)\ |
| \SignUpService.kt\ | Normalize email to lowercase on signup |
| \UserAccountService.kt\ | Normalize email to lowercase on email change |
| \ThirdPartyUserHandler.kt\ | Normalize OAuth email to lowercase |

## Design

- **Write path**: lowercased at all entry points (signup, OAuth login, email change)
- **Read path**: case-insensitive repository query covers login, password reset, and all other lookups — including existing mixed-case user accounts

4 files changed, 6 insertions, 6 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Usernames and emails are now handled case-insensitively throughout the system.
  * Sign-up, login, and email update processes now normalize usernames and emails to lowercase for consistent user identification and matching.
  * Username lookups in the database now perform case-insensitive comparisons.
  * Third-party authentication now normalizes usernames during account creation to ensure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->