### PR TITLE
fix: bump postgres base image 13.21 → 13.23

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13.21-alpine3.22
+FROM postgres:13.23-alpine3.22
 
 ENTRYPOINT []
 


### PR DESCRIPTION
## What

`FROM postgres:13.21-alpine3.22` → `FROM postgres:13.23-alpine3.22` in `docker/app/Dockerfile`.

## Why

The newer base pulls in `libxml2 2.13.9-r0` (was 2.13.8-r0) and a `busybox` bump. Verified by scanning both base images with `snyk container test`:

| | Critical | High | Medium | Low | Total |
|---|---|---|---|---|---|
| `postgres:13.21-alpine3.22` | 3 | 8 | 2 | 21 | 34 |
| `postgres:13.23-alpine3.22` | 1 | 6 | 2 | 17 | 26 |
| **Δ Cleared** | **−2** | −2 | 0 | −4 | **−8** |

Cleared CVEs:
- ✅ `libxml2` **CVE-2025-49794** (Critical, Expired Pointer Dereference)
- ✅ `libxml2` **CVE-2025-49796** (Critical, Out-of-bounds Read)
- `libxml2` CVE-2025-49795 (High), CVE-2025-6021 (High), CVE-2025-6170 (Low)
- `openssl` CVE-2025-9230, CVE-2025-9231, CVE-2025-9232 (Lows)

0 new vulnerabilities introduced.

For the `tolgee/tolgee:latest` Snyk dashboard, this should take the apk-package count from **33 → ~25**. Remaining issues are no-fix Alpine advisories — a separate concern.

## Risk

`13.21 → 13.23` is a patch-level Postgres bump within PG 13 — no data migration, no breaking change for embedded-Postgres users.