### PR TITLE
feat: support Python brace-format placeholders in PO

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/ExportMessageFormat.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/ExportMessageFormat.kt
@@ -5,6 +5,7 @@ import io.tolgee.formats.paramConvertors.out.IcuToCPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.out.IcuToI18nextPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.out.IcuToJavaPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.out.IcuToPhpPlaceholderConvertor
+import io.tolgee.formats.paramConvertors.out.IcuToPythonBracePlaceholderConvertor
 import io.tolgee.formats.paramConvertors.out.IcuToPythonPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.out.IcuToRubyPlaceholderConvertor
 
@@ -20,4 +21,5 @@ enum class ExportMessageFormat(
   I18NEXT(paramConvertorFactory = { IcuToI18nextPlaceholderConvertor() }),
   ICU(paramConvertorFactory = { IcuToIcuPlaceholderConvertor() }),
   PYTHON_PERCENT(paramConvertorFactory = { IcuToPythonPlaceholderConvertor() }),
+  PYTHON_BRACE(paramConvertorFactory = { IcuToPythonBracePlaceholderConvertor() }),
 }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/escapePythonBraces.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/escapePythonBraces.kt
@@ -1,0 +1,5 @@
+package io.tolgee.formats
+
+fun escapePythonBraces(string: String): String {
+  return string.replace("{", "{{").replace("}", "}}")
+}

--- a/backend/data/src/main/kotlin/io/tolgee/formats/importCommon/ImportFormat.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/importCommon/ImportFormat.kt
@@ -5,6 +5,7 @@ import io.tolgee.formats.paramConvertors.`in`.CToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.I18nextToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.JavaToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.PhpToIcuPlaceholderConvertor
+import io.tolgee.formats.paramConvertors.`in`.PythonBraceToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.PythonToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.RubyToIcuPlaceholderConvertor
 import io.tolgee.formats.po.`in`.PoToIcuMessageConvertor
@@ -110,6 +111,10 @@ enum class ImportFormat(
   PO_PYTHON(
     ImportFileFormat.PO,
     messageConvertorOrNull = PoToIcuMessageConvertor { PythonToIcuPlaceholderConvertor() },
+  ),
+  PO_PYTHON_BRACE(
+    ImportFileFormat.PO,
+    messageConvertorOrNull = PoToIcuMessageConvertor { PythonBraceToIcuPlaceholderConvertor() },
   ),
 
   STRINGS(

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/PythonBraceToIcuPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/PythonBraceToIcuPlaceholderConvertor.kt
@@ -1,0 +1,104 @@
+package io.tolgee.formats.paramConvertors.`in`
+
+import io.tolgee.formats.ToIcuPlaceholderConvertor
+import io.tolgee.formats.escapeIcu
+
+class PythonBraceToIcuPlaceholderConvertor : ToIcuPlaceholderConvertor {
+  private var autoIndex = 0
+  private var placeholderCount = 0
+
+  override val pluralArgName: String = "0"
+
+  override val regex: Regex
+    get() = PYTHON_BRACE_PLACEHOLDER_REGEX
+
+  override fun convert(
+    matchResult: MatchResult,
+    isInPlural: Boolean,
+  ): String {
+    val value = matchResult.value
+    if (value == "{{") return "{".escapeIcu(isInPlural)
+    if (value == "}}") return "}".escapeIcu(isInPlural)
+
+    val field = matchResult.groups[GROUP_FIELD]?.value ?: ""
+    val name = resolveName(field) ?: return value.escapeIcu(isInPlural)
+    placeholderCount++
+
+    val conversion = matchResult.groups[GROUP_CONVERSION]?.value
+    if (conversion != null) {
+      // not supported
+      return value.escapeIcu(isInPlural)
+    }
+
+    val formatSpec = matchResult.groups[GROUP_FORMAT_SPEC]?.value
+    if (formatSpec == null) {
+      return "{$name}"
+    }
+
+    val numberSpec = NUMBER_SPEC_REGEX.matchEntire(formatSpec) ?: return value.escapeIcu(isInPlural)
+    val type = numberSpec.groups[GROUP_TYPE]!!.value
+    val precision = numberSpec.groups[GROUP_PRECISION]?.value?.toInt()
+
+    if (type == "e") return "{$name, number, scientific}"
+
+    if (type == "f" || type == "F") {
+      val fractionDigits = precision ?: DEFAULT_FLOAT_PRECISION
+      if (fractionDigits > MAX_FLOAT_PRECISION) return value.escapeIcu(isInPlural)
+      if (fractionDigits == 0) return "{$name, number}"
+      return "{$name, number, .${"0".repeat(fractionDigits)}}"
+    }
+
+    val isFirstParam = name == "0" || placeholderCount == 1
+    if (isInPlural && isFirstParam) return "#"
+    return "{$name, number}"
+  }
+
+  private fun resolveName(field: String): String? {
+    if (field.isEmpty()) return (autoIndex++).toString()
+    if (field.all { it.isDigit() }) return field
+    if (IDENTIFIER_REGEX.matches(field)) return field
+    return null
+  }
+
+  companion object {
+    private const val GROUP_FIELD = "field"
+    private const val GROUP_CONVERSION = "conversion"
+    private const val GROUP_FORMAT_SPEC = "formatspec"
+    private const val GROUP_TYPE = "type"
+    private const val GROUP_PRECISION = "precision"
+
+    private const val DEFAULT_FLOAT_PRECISION = 6
+    private const val MAX_FLOAT_PRECISION = 50
+
+    private val IDENTIFIER_REGEX = """[A-Za-z_][A-Za-z0-9_]*""".toRegex()
+
+    private val NUMBER_SPEC_REGEX = """(?:\.(?<precision>\d+))?(?<type>[dnefF])""".toRegex()
+
+    val PYTHON_BRACE_PLACEHOLDER_REGEX =
+      """
+      (?x)(
+      \{\{
+      |
+      }}
+      |
+      \{
+      (?<field>[^{}!:]*)
+      (?<conversion>![rsa])?
+      (?::(?<formatspec>[^{}]*))?
+      }
+      )
+      """.trimIndent().toRegex()
+
+    val PYTHON_BRACE_DETECTION_REGEX =
+      """
+      (?x)(
+      (^|\W+)
+      \{
+      (?<field>[^{}!:]*)
+      (?<conversion>![rsa])?
+      (?::(?<formatspec>[^{}]*))?
+      }
+      )
+      """.trimIndent().toRegex()
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPythonBracePlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPythonBracePlaceholderConvertor.kt
@@ -1,0 +1,58 @@
+package io.tolgee.formats.paramConvertors.out
+
+import com.ibm.icu.text.MessagePattern
+import io.tolgee.formats.FromIcuPlaceholderConvertor
+import io.tolgee.formats.MessagePatternUtil
+import io.tolgee.formats.escapePythonBraces
+
+class IcuToPythonBracePlaceholderConvertor : FromIcuPlaceholderConvertor {
+  override fun convert(node: MessagePatternUtil.ArgNode): String {
+    if (node.argType == MessagePattern.ArgType.SIMPLE && node.typeName == "number") {
+      return convertNumber(node)
+    }
+
+    return "{${node.name}}"
+  }
+
+  override fun convertText(
+    node: MessagePatternUtil.TextNode,
+    keepEscaping: Boolean,
+  ): String {
+    return escapePythonBraces(node.getText(keepEscaping))
+  }
+
+  override fun convertReplaceNumber(
+    node: MessagePatternUtil.MessageContentsNode,
+    argName: String?,
+  ): String {
+    if (argName != null) return "{$argName:d}"
+    return "{:d}"
+  }
+
+  private fun convertNumber(node: MessagePatternUtil.ArgNode): String {
+    if (node.simpleStyle.trim() == "scientific") {
+      return "{${node.name}:e}"
+    }
+
+    val precision = node.getPrecision()
+    if (precision == DEFAULT_FLOAT_PRECISION) {
+      return "{${node.name}:f}"
+    }
+    if (precision != null) {
+      return "{${node.name}:.${precision}f}"
+    }
+
+    return "{${node.name}:d}"
+  }
+
+  private fun MessagePatternUtil.ArgNode.getPrecision(): Int? {
+    val precisionMatch = ICU_PRECISION_REGEX.matchEntire(this.simpleStyle ?: "") ?: return null
+    return precisionMatch.groups["precision"]?.value?.length
+  }
+
+  companion object {
+    private const val DEFAULT_FLOAT_PRECISION = 6
+
+    val ICU_PRECISION_REGEX = """.*\.(?<precision>0+)""".toRegex()
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoFormatDetector.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/po/in/PoFormatDetector.kt
@@ -5,6 +5,7 @@ import io.tolgee.formats.importCommon.ImportFormat
 import io.tolgee.formats.paramConvertors.`in`.CToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.JavaToIcuPlaceholderConvertor.Companion.JAVA_DETECTION_REGEX
 import io.tolgee.formats.paramConvertors.`in`.PhpToIcuPlaceholderConvertor
+import io.tolgee.formats.paramConvertors.`in`.PythonBraceToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.PythonToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.RubyToIcuPlaceholderConvertor
 
@@ -55,16 +56,27 @@ class PoFormatDetector {
               1.0,
             ),
           ),
+        ImportFormat.PO_PYTHON_BRACE to
+          arrayOf(
+            FormatDetectionUtil.regexFactor(
+              PythonBraceToIcuPlaceholderConvertor.PYTHON_BRACE_DETECTION_REGEX,
+              // A plain "{name}" matches both ICU and PYTHON_BRACE.
+              // Weight below ICU, since ICU is preferred.
+              0.9,
+            ),
+          ),
       )
   }
 
   fun detectByFlag(flag: String): ImportFormat? {
     return when (flag) {
-      "php-format" -> return ImportFormat.PO_PHP
-      "c-format" -> return ImportFormat.PO_C
-      "java-format" -> return ImportFormat.PO_JAVA
-      "icu-format" -> return ImportFormat.PO_ICU
-      "python-format" -> return ImportFormat.PO_PYTHON
+      "php-format" -> ImportFormat.PO_PHP
+      "c-format" -> ImportFormat.PO_C
+      "java-format" -> ImportFormat.PO_JAVA
+      "icu-format" -> ImportFormat.PO_ICU
+      "ruby-format" -> ImportFormat.PO_RUBY
+      "python-format" -> ImportFormat.PO_PYTHON
+      "python-brace-format" -> ImportFormat.PO_PYTHON_BRACE
       else -> null
     }
   }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFormatDetectorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoFormatDetectorTest.kt
@@ -27,4 +27,24 @@ class PoFormatDetectorTest {
     val detected = PoFormatDetector().detectFormat(listOf("%b %d", "%d %s", "d %s"))
     assertThat(detected).isEqualTo(ImportFormat.PO_PHP)
   }
+
+  @Test
+  fun `detects python-brace-format flag`() {
+    assertThat(PoFormatDetector().detectByFlag("python-brace-format"))
+      .isEqualTo(ImportFormat.PO_PYTHON_BRACE)
+  }
+
+  @Test
+  fun `returns Python brace format for distinctive brace placeholders`() {
+    val detected = PoFormatDetector().detectFormat(listOf("{name:.2f}", "{count!r}", "{} items"))
+    assertThat(detected).isEqualTo(ImportFormat.PO_PYTHON_BRACE)
+  }
+
+  @Test
+  fun `prefers ICU over Python brace for plain placeholders`() {
+    // a plain "{name}" matches both ICU and brace detection; ICU must win so brace detection
+    // doesn't steal ICU files that lack a python-brace-format flag
+    val detected = PoFormatDetector().detectFormat(listOf("{name}", "{count} items"))
+    assertThat(detected).isEqualTo(ImportFormat.PO_ICU)
+  }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoToICUConverterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/in/PoToICUConverterTest.kt
@@ -1,8 +1,12 @@
 package io.tolgee.unit.formats.po.`in`
 
+import io.tolgee.formats.MessageConvertorFactory
 import io.tolgee.formats.paramConvertors.`in`.PhpToIcuPlaceholderConvertor
+import io.tolgee.formats.paramConvertors.`in`.PythonBraceToIcuPlaceholderConvertor
 import io.tolgee.formats.paramConvertors.`in`.PythonToIcuPlaceholderConvertor
+import io.tolgee.formats.paramConvertors.out.IcuToPythonBracePlaceholderConvertor
 import io.tolgee.formats.po.`in`.PoToIcuMessageConvertor
+import io.tolgee.formats.po.out.IcuToPoMessageConvertor
 import io.tolgee.util.FileProcessorContextMockUtil
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -152,6 +156,176 @@ class PoToICUConverterTest {
   }
 
   private fun getPythonConvertor() = PoToIcuMessageConvertor { PythonToIcuPlaceholderConvertor() }
+
+  @Test
+  fun testPythonBraceMessage() {
+    val result =
+      getPythonBraceConvertor()
+        .convert("{one} {two:d} {three:.2f} {four!r} {five:>10}", "cs", true)
+        .message
+    assertThat(result).isEqualTo(
+      "{one} {two, number} {three, number, .00} '{'four!r'}' '{'five:>10'}'",
+    )
+  }
+
+  @Test
+  fun testPythonBraceNumberSpecs() {
+    val result =
+      getPythonBraceConvertor()
+        .convert("{a:f} {b:e} {c:.0f} {d:n} {e:.3f}", "cs", true)
+        .message
+    assertThat(result).isEqualTo(
+      "{a, number, .000000} {b, number, scientific} {c, number} {d, number} {e, number, .000}",
+    )
+  }
+
+  @Test
+  fun testPythonBraceAutoIndexingAndPositional() {
+    val result =
+      getPythonBraceConvertor()
+        .convert("{} {} {0} {1}", "cs", true)
+        .message
+    assertThat(result).isEqualTo("{0} {1} {0} {1}")
+  }
+
+  @Test
+  fun testPythonBraceLiteralBraces() {
+    val result =
+      getPythonBraceConvertor()
+        .convert("{{ {name} }}", "cs", true)
+        .message
+    assertThat(result).isEqualTo("'{' {name} '}'")
+  }
+
+  @Test
+  fun testPythonBracePlurals() {
+    val result =
+      getPythonBraceConvertor()
+        .convert(
+          rawData =
+            mapOf(
+              0 to "Petr má jednoho psa.",
+              1 to "Petr má {count:d} psi.",
+              2 to "Petr má {count:d} psů.",
+            ),
+          languageTag = "cs",
+          convertPlaceholders = true,
+        ).message
+    assertThat(result).isEqualTo(
+      "{0, plural,\n" +
+        "one {Petr má jednoho psa.}\n" +
+        "few {Petr má # psi.}\n" +
+        "other {Petr má # psů.}\n" +
+        "}",
+    )
+  }
+
+  @Test
+  fun `python brace round-trips supported placeholders symmetrically`() {
+    val source = "{name} {count:d} {price:.2f} {ratio:e} {avg:f}"
+    val exportedOnce = exportPythonBrace(importPythonBrace(source))
+    // every supported placeholder maps back to its exact source form
+    assertThat(exportedOnce).isEqualTo(source)
+  }
+
+  @Test
+  fun `python brace round-trips unsupported placeholders and literal braces without corruption`() {
+    val source = "{name} {count:d} {x!r} {y:>10} {{lit}}"
+    val exportedOnce = exportPythonBrace(importPythonBrace(source))
+    val exportedTwice = exportPythonBrace(importPythonBrace(exportedOnce))
+
+    assertThat(exportedOnce).isEqualTo("{name} {count:d} {{x!r}} {{y:>10}} {{lit}}")
+    // unsupported placeholders / literal braces are neutralized to escaped literals on the first
+    // pass, then stay byte-stable on every subsequent Tolgee import -> export round-trip.
+    assertThat(exportedTwice).isEqualTo(exportedOnce)
+  }
+
+  @Test
+  fun `python brace plural round-trips the ICU hash placeholder`() {
+    val expectedIcu =
+      "{0, plural,\n" +
+        "one {# dog}\n" +
+        "few {# dogs}\n" +
+        "other {# dogs}\n" +
+        "}"
+
+    val icu =
+      getPythonBraceConvertor()
+        .convert(
+          rawData = mapOf(0 to "{count:d} dog", 1 to "{count:d} dogs", 2 to "{count:d} dogs"),
+          languageTag = "cs",
+          convertPlaceholders = true,
+        ).message
+    assertThat(icu).isEqualTo(expectedIcu)
+
+    val exportedForms =
+      IcuToPoMessageConvertor(
+        message = icu ?: "",
+        placeholderConvertorFactory = { IcuToPythonBracePlaceholderConvertor() },
+        languageTag = "cs",
+        forceIsPlural = true,
+      ).convert().formsResult ?: emptyList()
+    // the ICU "#" exports to a positional integer placeholder, never leaking raw "#"
+    assertThat(exportedForms).isNotEmpty
+    assertThat(exportedForms).allSatisfy {
+      assertThat(it).contains("{0:d}")
+      assertThat(it).doesNotContain("#")
+    }
+
+    // and "{0:d}" as the first plural param re-imports back to the same ICU "#" form
+    val reimported =
+      getPythonBraceConvertor()
+        .convert(
+          rawData = mapOf(0 to "{0:d} dog", 1 to "{0:d} dogs", 2 to "{0:d} dogs"),
+          languageTag = "cs",
+          convertPlaceholders = true,
+        ).message
+    assertThat(reimported).isEqualTo(expectedIcu)
+  }
+
+  @Test
+  fun `python brace keeps a literal hash distinct from the plural number in plurals`() {
+    val icu =
+      getPythonBraceConvertor()
+        .convert(
+          rawData = mapOf(0 to "{count:d} comment #", 1 to "{count:d} comments #", 2 to "{count:d} comments #"),
+          languageTag = "cs",
+          convertPlaceholders = true,
+        ).message
+    // the count becomes the ICU plural "#"; the literal "#" is ICU-escaped so it is not a second number
+    assertThat(icu).isEqualTo(
+      "{0, plural,\n" +
+        "one {# comment '#'}\n" +
+        "few {# comments '#'}\n" +
+        "other {# comments '#'}\n" +
+        "}",
+    )
+
+    val exportedForms =
+      IcuToPoMessageConvertor(
+        message = icu ?: "",
+        placeholderConvertorFactory = { IcuToPythonBracePlaceholderConvertor() },
+        languageTag = "cs",
+        forceIsPlural = true,
+      ).convert().formsResult ?: emptyList()
+    // export restores both: the count as "{0:d}" and the literal "#" verbatim
+    assertThat(exportedForms).isNotEmpty
+    assertThat(exportedForms).allSatisfy {
+      assertThat(it).contains("{0:d}")
+      assertThat(it).endsWith(" #")
+    }
+  }
+
+  private fun getPythonBraceConvertor() = PoToIcuMessageConvertor { PythonBraceToIcuPlaceholderConvertor() }
+
+  private fun importPythonBrace(message: String) = getPythonBraceConvertor().convert(message, "en", true).message ?: ""
+
+  private fun exportPythonBrace(icuMessage: String) =
+    MessageConvertorFactory(
+      message = icuMessage,
+      forceIsPlural = false,
+      isProjectIcuPlaceholdersEnabled = true,
+    ) { IcuToPythonBracePlaceholderConvertor() }.create().convert().singleResult ?: ""
 
   @Test
   fun testPhpMessageKey() {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoMessageFormatsExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/po/out/PoMessageFormatsExporterTest.kt
@@ -60,6 +60,29 @@ class PoMessageFormatsExporterTest {
   }
 
   @Test
+  fun pythonBrace() {
+    val exporter = getExporter(ExportMessageFormat.PYTHON_BRACE)
+    val data = getExported(exporter)
+    data.assertFile(
+      "cs.po",
+      """
+    |msgid ""
+    |msgstr ""
+    |"Language: cs\n"
+    |"MIME-Version: 1.0\n"
+    |"Content-Type: text/plain; charset=UTF-8\n"
+    |"Content-Transfer-Encoding: 8bit\n"
+    |"Plural-Forms: nplurals=3; plural=(n == 1 ? 0 : (n >= 2 && n <= 4) ? 1 : 2)\n"
+    |"X-Generator: Tolgee\n"
+    |
+    |msgid "key3"
+    |msgstr "{2:d} {1} {0}"
+    |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
   fun c() {
     val exporter = getExporter(ExportMessageFormat.C_SPRINTF)
     val data = getExported(exporter)

--- a/e2e/cypress/common/export.ts
+++ b/e2e/cypress/common/export.ts
@@ -317,6 +317,7 @@ const messageFormatParamMap = {
   'Java String.format': 'JAVA_STRING_FORMAT' as MessageFormat,
   'Ruby Sprintf': 'RUBY_SPRINTF' as MessageFormat,
   'Python Percent': 'PYTHON_PERCENT' as MessageFormat,
+  'Python Brace Format': 'PYTHON_BRACE' as MessageFormat,
 };
 
 type MessageFormat = components['schemas']['ExportParams']['messageFormat'];

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -2286,7 +2286,8 @@ export interface components {
         | "RUBY_SPRINTF"
         | "I18NEXT"
         | "ICU"
-        | "PYTHON_PERCENT";
+        | "PYTHON_PERCENT"
+        | "PYTHON_BRACE";
       name: string;
       pruneBeforePublish: boolean;
       publicUrl?: string;
@@ -2412,7 +2413,8 @@ export interface components {
         | "RUBY_SPRINTF"
         | "I18NEXT"
         | "ICU"
-        | "PYTHON_PERCENT";
+        | "PYTHON_PERCENT"
+        | "PYTHON_BRACE";
       name: string;
       /**
        * @description Whether the data in the CDN should be pruned before publishing new data.
@@ -3275,7 +3277,8 @@ export interface components {
         | "RUBY_SPRINTF"
         | "I18NEXT"
         | "ICU"
-        | "PYTHON_PERCENT";
+        | "PYTHON_PERCENT"
+        | "PYTHON_BRACE";
       /**
        * @description Delimiter to structure file content.
        *
@@ -3479,6 +3482,7 @@ export interface components {
         | "PO_ICU"
         | "PO_RUBY"
         | "PO_PYTHON"
+        | "PO_PYTHON_BRACE"
         | "STRINGS"
         | "STRINGSDICT"
         | "APPLE_XLIFF"
@@ -15677,7 +15681,8 @@ export interface operations {
           | "RUBY_SPRINTF"
           | "I18NEXT"
           | "ICU"
-          | "PYTHON_PERCENT";
+          | "PYTHON_PERCENT"
+          | "PYTHON_BRACE";
         /**
          * This is a template that defines the structure of the resulting .zip file content.
          *

--- a/webapp/src/views/projects/export/components/formatGroups.tsx
+++ b/webapp/src/views/projects/export/components/formatGroups.tsx
@@ -95,6 +95,7 @@ export const formatGroups: FormatGroup[] = [
           'ICU',
           'RUBY_SPRINTF',
           'PYTHON_PERCENT',
+          'PYTHON_BRACE',
         ],
       },
       {

--- a/webapp/src/views/projects/export/components/messageFormatTranslation.tsx
+++ b/webapp/src/views/projects/export/components/messageFormatTranslation.tsx
@@ -13,4 +13,5 @@ export const messageFormatTranslation: Record<MessageFormat, ReactNode> = {
   ICU: <T keyName="export_form_message_format_icu" />,
   APPLE_SPRINTF: <T keyName="export_form_message_format_apple-sprintf" />,
   PYTHON_PERCENT: <T keyName="export_form_message_format_python-percent" />,
+  PYTHON_BRACE: <T keyName="export_form_message_format_python-brace" />,
 };


### PR DESCRIPTION
Closes #3589

## Summary
- Add `PO_PYTHON_BRACE` import format (gettext `python-brace-format` flag) and `PYTHON_BRACE` export message format for Python `str.format` style placeholders (`{name}`, `{0}`, `{x:.2f}`, …), mirroring the existing `PO_PYTHON` / `PYTHON_PERCENT` pair.
- Import↔export are symmetric for every supported placeholder: `{x:d}` ↔ `{x, number}`, `{x:.Nf}` ↔ `{x, number, .0..0}`, `{x:f}` ↔ precision 6, `{x:e}` ↔ scientific, and the plural `{count:d}` count ↔ ICU `#` ↔ `{0:d}`.
- Unsupported specs (`{x!r}`, `{x:>10}`, attribute/index access) and literal braces (`{{`, `}}`) degrade to escaped ICU literals and remain byte-stable on every subsequent import → export. Literal `#` inside plurals is ICU-escaped so it survives export verbatim.
- Brace heuristic detection weighted below ICU so plain `{name}` files without the flag still resolve to `PO_ICU` (no regression to existing detection).
- Frontend: new option in the PO export-format group, dropdown label, and e2e map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Python Brace Format support for exporting translations
  * Added Python Brace Format support for importing PO files containing brace placeholders
  * Extended available message format options for export configuration

* **Tests**
  * Added test coverage for Python Brace Format detection, conversion, and round-trip operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->