### PR TITLE
refactor: move billing admin link definitions to billing repo

### DIFF
--- a/webapp/src/constants/links.tsx
+++ b/webapp/src/constants/links.tsx
@@ -198,61 +198,6 @@ export class LINKS {
     'ee-license'
   );
 
-  static ADMINISTRATION_EE_TA = Link.ofParent(
-    LINKS.ADMINISTRATION,
-    'ee-translation-agencies'
-  );
-
-  static ADMINISTRATION_EE_TA_CREATE = Link.ofParent(
-    LINKS.ADMINISTRATION_EE_TA,
-    'create'
-  );
-
-  static ADMINISTRATION_EE_TA_EDIT = Link.ofParent(
-    LINKS.ADMINISTRATION_EE_TA,
-    p(PARAMS.TA_ID) + '/edit'
-  );
-
-  static ADMINISTRATION_BILLING_CLOUD_PLANS = Link.ofParent(
-    LINKS.ADMINISTRATION,
-    'cloud-plans'
-  );
-
-  static ADMINISTRATION_BILLING_CLOUD_PLAN_EDIT = Link.ofParent(
-    LINKS.ADMINISTRATION_BILLING_CLOUD_PLANS,
-    p(PARAMS.PLAN_ID)
-  );
-
-  static ADMINISTRATION_BILLING_CLOUD_PLAN_CREATE = Link.ofParent(
-    LINKS.ADMINISTRATION_BILLING_CLOUD_PLANS,
-    'create'
-  );
-
-  static ADMINISTRATION_BILLING_EE_PLANS = Link.ofParent(
-    LINKS.ADMINISTRATION,
-    'ee-plans'
-  );
-
-  static ADMINISTRATION_BILLING_SUBSCRIPTIONS = Link.ofParent(
-    LINKS.ADMINISTRATION,
-    'subscriptions'
-  );
-
-  static ADMINISTRATION_BILLING_INVOICES = Link.ofParent(
-    LINKS.ADMINISTRATION,
-    'invoices'
-  );
-
-  static ADMINISTRATION_BILLING_EE_PLAN_EDIT = Link.ofParent(
-    LINKS.ADMINISTRATION_BILLING_EE_PLANS,
-    p(PARAMS.PLAN_ID)
-  );
-
-  static ADMINISTRATION_BILLING_EE_PLAN_CREATE = Link.ofParent(
-    LINKS.ADMINISTRATION_BILLING_EE_PLANS,
-    'create'
-  );
-
   /**
    * Organizations
    */
@@ -293,11 +238,6 @@ export class LINKS {
   static ORGANIZATION_BILLING_TEST_CLOCK_HELPER = Link.ofParent(
     LINKS.ORGANIZATION,
     'billing-test-clock-helper'
-  );
-
-  static ORGANIZATION_BILLING_PLANS_EDIT = Link.ofParent(
-    LINKS.ORGANIZATION,
-    'billing-plans-edit'
   );
 
   static ORGANIZATION_SUBSCRIPTIONS_SELF_HOSTED_EE = Link.ofParent(


### PR DESCRIPTION
## Summary

Follow-up to #3577 (billing frontend split). The billing **route/link definitions** were left behind in the platform `links.tsx`; this moves the Cloud-only ones into the billing repo so billing links live with billing code.

Moved out of `webapp/src/constants/links.tsx` into `billing/frontend/src/billingLinks.ts` (`BILLING_LINKS`):
- `ADMINISTRATION_BILLING_*` — cloud plans, EE plans, subscriptions, invoices (+ their create/edit variants)
- `ADMINISTRATION_EE_TA*` — translation-agency admin (views already live in billing)

Also:
- Dropped the unused `ORGANIZATION_BILLING_PLANS_EDIT` link (referenced nowhere).
- `PARAMS.PLAN_ID` / `PARAMS.TA_ID` **stay** in the platform — shared param identifiers still imported by billing.

URL templates are byte-identical, so no route changes.

### What stays in the platform (intentionally)
The shared billing *interface* links remain in `links.tsx` because platform/OSS shell code references them directly (redirects, settings nav, "go to billing" CTAs) and the self-hosted build must resolve them without the billing repo: `GO_TO_CLOUD_BILLING`, `GO_TO_SELF_HOSTED_BILLING`, `ORGANIZATION_BILLING`, `ORGANIZATION_SUBSCRIPTIONS`, `ORGANIZATION_INVOICES`, `ORGANIZATION_BILLING_TEST_CLOCK_HELPER`, `ORGANIZATION_SUBSCRIPTIONS_SELF_HOSTED_EE`.

## Paired PR
- tolgee/billing#269 (must merge together — billing CI checks out the matching platform branch)

## Test plan
- [x] `npm run tsc` (platform + billing/frontend)
- [x] `npm run eslint` (platform + billing/frontend)
- [x] `npm run build` — EE bundle (billing present)
- [x] `npm run build` — standalone/self-hosted bundle (billing repo **absent**)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated billing administration features into a dedicated service for improved organization and maintainability
  * Removed several billing and enterprise administration pages and related plan create/edit flows from the public navigation and routes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->