### PR TITLE
feat: pass key context to DeepL machine translation

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
@@ -150,6 +151,7 @@ class TranslationSuggestionControllerMtTest : ProjectAuthControllerTest("/v2/pro
         any(),
         any(),
         any(),
+        anyOrNull(),
       ),
     ).thenReturn("Translated with DeepL")
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
@@ -91,6 +91,7 @@ class MtServiceManager(
         sourceLanguageTag = params.sourceLanguageTag,
         targetLanguageTag = params.targetLanguageTag,
         metadata = params.metadata,
+        context = params.context,
         formality = if (supportsFormality) params.serviceInfo.formality else null,
         isBatch = params.isBatch,
         pluralFormExamples = params.pluralFormExamples,

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtValueProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtValueProvider.kt
@@ -41,6 +41,9 @@ interface MtValueProvider {
 
   val formalitySupportingLanguages: Array<String>?
 
+  val supportsContext: Boolean
+    get() = false
+
   fun getSuitableTag(tag: String): String? {
     if (supportedLanguages.isNullOrEmpty()) {
       return tag

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/TranslationParams.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/TranslationParams.kt
@@ -10,6 +10,7 @@ data class TranslationParams(
   val sourceLanguageTag: String,
   val targetLanguageTag: String,
   val metadata: MtMetadata? = null,
+  val context: String? = null,
   val serviceInfo: MtServiceInfo,
   val isBatch: Boolean,
   var pluralForms: Map<String, String>? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplApiService.kt
@@ -25,6 +25,7 @@ class DeeplApiService(
     sourceTag: String,
     targetTag: String,
     formality: Formality,
+    context: String? = null,
   ): String? {
     val headers = HttpHeaders()
     headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
@@ -39,6 +40,7 @@ class DeeplApiService(
       requestBody.add(it.key, it.value)
     }
     addFormality(requestBody, formality)
+    context?.takeIf { it.isNotBlank() }?.let { requestBody.add("context", it) }
 
     val request = HttpEntity(requestBody, headers)
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplTranslationProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/DeeplTranslationProvider.kt
@@ -16,6 +16,8 @@ class DeeplTranslationProvider(
   override val isEnabled: Boolean
     get() = !deeplMachineTranslationProperties.authKey.isNullOrEmpty()
 
+  override val supportsContext = true
+
   override fun translateViaProvider(params: ProviderTranslateParams): MtValueProvider.MtResult {
     val result =
       deeplApiService.translate(
@@ -23,6 +25,7 @@ class DeeplTranslationProvider(
         params.sourceLanguageTag.uppercase(),
         params.targetLanguageTag.uppercase(),
         getFormality(params),
+        params.context,
       )
 
     return MtValueProvider.MtResult(

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/ProviderTranslateParams.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/ProviderTranslateParams.kt
@@ -11,6 +11,7 @@ data class ProviderTranslateParams(
   var sourceLanguageTag: String,
   var targetLanguageTag: String,
   var metadata: MtMetadata? = null,
+  val context: String? = null,
   val formality: Formality? = null,
   /**
    * Whether translation is executed as a part of batch translation task
@@ -35,6 +36,7 @@ data class ProviderTranslateParams(
           sourceLanguageTag,
           targetLanguageTag,
           metadata,
+          context,
           formality,
           pluralForms,
           pluralFormExamples,

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MetadataProvider.kt
@@ -5,10 +5,14 @@ import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.service.translation.TranslationMemoryService
 import jakarta.persistence.EntityManager
+import org.slf4j.LoggerFactory
+import org.springframework.dao.DataAccessException
 
 class MetadataProvider(
   private val context: MtTranslatorContext,
 ) {
+  private val log = LoggerFactory.getLogger(MetadataProvider::class.java)
+
   fun getCloseItems(
     sourceLanguage: LanguageDto,
     targetLanguage: LanguageDto,
@@ -37,6 +41,31 @@ class MetadataProvider(
       .setParameter("sourceLanguageId", sourceLanguage.id)
       .setParameter("closeKeyIds", closeKeyIds)
       .resultList
+  }
+
+  /**
+   * Builds a plain-text context payload for providers that accept one
+   * Best-effort: context only improves the result, so a database failure while fetching the
+   * neighbouring keys yields no context rather than failing the translation itself.
+   */
+  fun getContext(
+    sourceLanguage: LanguageDto,
+    targetLanguage: LanguageDto,
+    metadataKey: MetadataKey,
+    keyDescription: String?,
+  ): String? {
+    try {
+      val parts = mutableListOf<String>()
+      keyDescription?.takeIf { it.isNotBlank() }?.let { parts.add(it) }
+      getCloseItems(sourceLanguage, targetLanguage, metadataKey)
+        .map { it.source }
+        .filter { it.isNotBlank() }
+        .forEach { parts.add(it) }
+      return parts.joinToString("\n").ifBlank { null }
+    } catch (e: DataAccessException) {
+      log.warn("Failed to build MT context for key ${metadataKey.keyId}", e)
+      return null
+    }
   }
 
   /**

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
@@ -176,7 +176,8 @@ class MtBatchTranslator(
         item.promptId,
       )
 
-    val providerContext = buildContext(item, baseTranslationText, provider.supportsContext)
+    val providerContext =
+      if (provider.supportsContext) buildContext(item, baseTranslationText) else null
 
     return TranslationParams(
       text = withReplacedParams,
@@ -200,17 +201,10 @@ class MtBatchTranslator(
     )
   }
 
-  /**
-   * Builds the context passed to providers supporting it (e.g. DeepL), delegating the actual
-   * assembly to [MetadataProvider]. Returns null when the provider ignores context or there is
-   * no key to derive context from.
-   */
   private fun buildContext(
     item: MtBatchItemParams,
     baseTranslationText: String,
-    supportsContext: Boolean,
   ): String? {
-    if (!supportsContext) return null
     val keyId = item.keyId ?: return null
     return MetadataProvider(context).getContext(
       context.baseLanguage,

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
@@ -176,6 +176,8 @@ class MtBatchTranslator(
         item.promptId,
       )
 
+    val providerContext = buildContext(item, baseTranslationText, provider.supportsContext)
+
     return TranslationParams(
       text = withReplacedParams,
       textRaw = baseTranslationText,
@@ -184,6 +186,7 @@ class MtBatchTranslator(
       targetLanguageTag = targetLanguageTag,
       serviceInfo = context.getServiceInfo(item.targetLanguageId, item.service),
       metadata = metadata,
+      context = providerContext,
       isBatch = context.isBatch,
       pluralForms = pluralForms?.forms,
       pluralFormExamples =
@@ -194,6 +197,26 @@ class MtBatchTranslator(
             it,
           )
         },
+    )
+  }
+
+  /**
+   * Builds the context passed to providers supporting it (e.g. DeepL), delegating the actual
+   * assembly to [MetadataProvider]. Returns null when the provider ignores context or there is
+   * no key to derive context from.
+   */
+  private fun buildContext(
+    item: MtBatchItemParams,
+    baseTranslationText: String,
+    supportsContext: Boolean,
+  ): String? {
+    if (!supportsContext) return null
+    val keyId = item.keyId ?: return null
+    return MetadataProvider(context).getContext(
+      context.baseLanguage,
+      context.getLanguage(item.targetLanguageId),
+      MetadataKey(keyId, baseTranslationText, item.targetLanguageId),
+      context.keys[keyId]?.description,
     )
   }
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/DeeplTranslationProviderTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/DeeplTranslationProviderTest.kt
@@ -2,10 +2,14 @@ package io.tolgee.unit.component.machineTranslation
 
 import io.tolgee.component.machineTranslation.providers.DeeplApiService
 import io.tolgee.component.machineTranslation.providers.DeeplTranslationProvider
+import io.tolgee.component.machineTranslation.providers.ProviderTranslateParams
 import io.tolgee.configuration.tolgee.machineTranslation.DeeplMachineTranslationProperties
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 class DeeplTranslationProviderTest {
   private val provider =
@@ -13,6 +17,37 @@ class DeeplTranslationProviderTest {
       DeeplMachineTranslationProperties(),
       mock<DeeplApiService>(),
     )
+
+  @Test
+  fun `supports context`() {
+    assertThat(provider.supportsContext).isTrue()
+  }
+
+  @Test
+  fun `forwards the context to the DeepL API`() {
+    val apiService = mock<DeeplApiService>()
+    val provider = DeeplTranslationProvider(DeeplMachineTranslationProperties(), apiService)
+
+    provider.translate(
+      ProviderTranslateParams(
+        text = "Save",
+        textRaw = "Save",
+        keyName = "button.save",
+        sourceLanguageTag = "en",
+        targetLanguageTag = "de",
+        context = "Button label on the settings screen",
+        isBatch = false,
+      ),
+    )
+
+    verify(apiService).translate(
+      eq("Save"),
+      eq("EN"),
+      eq("DE"),
+      any(),
+      eq("Button label on the settings screen"),
+    )
+  }
 
   @Test
   fun `English regional variants resolve to en as source`() {


### PR DESCRIPTION
## TL;DR

DeepL's API has a free, untranslated [`context` parameter](https://www.deepl.com/en/blog/deepl-api-context-parameter) that disambiguates short strings. We now feed it from data Tolgee already has — the **key description** + **source texts of neighbouring keys** (big meta). Backend-only, opt-in per provider (`supportsContext`), context is part of the MT cache key, price unchanged. Verified live: "bank" (EN→ES) → `banco` normally, but `orilla` once a river-related description **or** river-related neighbour keys are present.

## What

DeepL's API accepts an optional [`context` parameter](https://www.deepl.com/en/blog/deepl-api-context-parameter): surrounding text that is **not translated and not billed**, but helps the model disambiguate short or ambiguous source strings (UI labels, single words, etc.).

Until now Tolgee sent DeepL only the raw text + languages + formality. This PR builds a context payload from the **key description** and the **source texts of neighbouring keys** (big meta) and passes it to DeepL.

## How

- `DeeplApiService.translate(...)` gains an optional `context` form field (added only when non-blank).
- `MtValueProvider` gets a `supportsContext` capability flag (default `false`, `true` for DeepL) so the extra work is only done for providers that actually use it.
- `MtBatchTranslator` delegates context assembly to `MetadataProvider.getContext()`, co-located with the existing `getCloseItems()` close-keys logic (reuses big meta rather than duplicating it). Building context is best-effort — a `DataAccessException` while fetching neighbours yields no context rather than failing the translation.
- `context` is threaded `TranslationParams` → `ProviderTranslateParams` and included in the MT **cache key**, so cached results invalidate when the context changes.
- Price is unchanged: DeepL does not bill context characters.

Only DeepL benefits today (Google/AWS/Baidu have no equivalent parameter); the LLM provider already had its own richer context path, which is untouched.

## Testing

- Unit test asserts the `context` value reaches `DeeplApiService` and that DeepL declares `supportsContext`.
- Full `TranslationSuggestionControllerMtTest` suite passes.
- Manually verified end-to-end against the live DeepL API (same source word "bank", EN→ES):
  - **key description** path — no context → `banco`; description "the land alongside a river" → `orilla`.
  - **big-meta neighbours** path (no description) — surrounding the key with river-themed neighbour keys → `orilla`; money-themed neighbours → `banco`.

The quality-difference check is manual by nature (non-deterministic, needs a live key); the deterministic guarantee is the unit test on the request payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional context support for machine translation. Context is derived from key descriptions and nearby translations and is passed only to providers that declare support (improves translation relevance). Cache keys now account for context.
* **Tests**
  * Added provider tests for context support and forwarding; updated mocks to cover nullable context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
