### PR TITLE
feat: per-language QA on/off switch

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/qa/LanguageQaConfig.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/qa/LanguageQaConfig.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.Type
 
 @Entity
@@ -26,4 +27,7 @@ class LanguageQaConfig(
   @Type(JsonBinaryType::class)
   @Column(columnDefinition = "jsonb")
   var settings: MutableMap<QaCheckType, QaCheckSeverity> = mutableMapOf(),
+  @ColumnDefault("true")
+  @Column(nullable = false)
+  var enabled: Boolean = true,
 ) : StandardAuditModel()

--- a/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/TranslationRepository.kt
@@ -235,12 +235,14 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     join t.key k
     where k.project.id = :projectId
       and k.branch.id = :branchId
+      and t.language.id in :languageIds
       and t.qaChecksStale = true
     """,
   )
-  fun getStaleKeyLanguagePairsByBranch(
+  fun getStaleKeyLanguagePairsByBranchAndLanguageIds(
     projectId: Long,
     branchId: Long,
+    languageIds: Collection<Long>,
   ): List<KeyLanguagePairView>
 
   @Query(
@@ -249,10 +251,14 @@ interface TranslationRepository : JpaRepository<Translation, Long> {
     from Translation t
     join t.key k
     where k.project.id = :projectId
+      and t.language.id in :languageIds
       and t.qaChecksStale = true
     """,
   )
-  fun getStaleKeyLanguagePairsByProject(projectId: Long): List<KeyLanguagePairView>
+  fun getStaleKeyLanguagePairsByProjectAndLanguageIds(
+    projectId: Long,
+    languageIds: Collection<Long>,
+  ): List<KeyLanguagePairView>
 
   @Query(
     """

--- a/backend/data/src/main/kotlin/io/tolgee/repository/qa/LanguageQaConfigRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/qa/LanguageQaConfigRepository.kt
@@ -17,6 +17,12 @@ interface LanguageQaConfigRepository : JpaRepository<LanguageQaConfig, Long> {
 
   fun findAllByLanguageProjectId(projectId: Long): List<LanguageQaConfig>
 
+  @Query(
+    "select c.language.id from LanguageQaConfig c " +
+      "where c.language.project.id = :projectId and c.enabled = false",
+  )
+  fun findDisabledLanguageIds(projectId: Long): Set<Long>
+
   fun deleteByLanguageProjectIdAndLanguageId(
     projectId: Long,
     languageId: Long,

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/LanguageStatsService.kt
@@ -10,6 +10,7 @@ import io.tolgee.model.branching.Branch
 import io.tolgee.model.views.projectStats.ProjectLanguageStatsResultView
 import io.tolgee.repository.LanguageStatsRepository
 import io.tolgee.repository.TranslationRepository
+import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.qa.TranslationQaIssueService
 import io.tolgee.service.queryBuilders.LanguageStatsProvider
@@ -35,6 +36,7 @@ class LanguageStatsService(
   private val platformTransactionManager: PlatformTransactionManager,
   private val translationQaIssueService: TranslationQaIssueService,
   private val projectFeatureGuard: ProjectFeatureGuard,
+  private val languageQaConfigRepository: LanguageQaConfigRepository,
 ) : Logging {
   fun refreshLanguageStats(
     projectId: Long,
@@ -72,6 +74,7 @@ class LanguageStatsService(
             } else {
               emptyMap()
             }
+          val qaDisabledLanguageIds = resolveQaDisabledLanguageIds(projectId, qaEnabled)
 
           allRawLanguageStats
             .sortedBy { it.languageName }
@@ -103,8 +106,9 @@ class LanguageStatsService(
                 this.untranslatedWords = baseWords - translatedOrReviewedWords
                 untranslatedPercentage = untranslatedWords.toDouble() / baseWords * 100
                 translationsUpdatedAt = lastUpdatedAt
-                qaIssueCount = qaIssueCounts[language.id] ?: 0
-                qaChecksStaleCount = qaChecksStaleCountMap[language.id] ?: 0
+                qaIssueCount = qaIssueCounts[language.id]?.takeIf { language.id !in qaDisabledLanguageIds } ?: 0
+                qaChecksStaleCount =
+                  qaChecksStaleCountMap[language.id]?.takeIf { language.id !in qaDisabledLanguageIds } ?: 0
               }
             }
 
@@ -182,5 +186,13 @@ class LanguageStatsService(
     branchId: Long?,
   ): List<ProjectLanguageStatsResultView> {
     return LanguageStatsProvider(entityManager, projectId, branchId).getResultForSingleProject()
+  }
+
+  private fun resolveQaDisabledLanguageIds(
+    projectId: Long,
+    qaEnabled: Boolean,
+  ): Set<Long> {
+    if (!qaEnabled) return emptySet()
+    return languageQaConfigRepository.findDisabledLanguageIds(projectId)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
@@ -61,6 +61,7 @@ class QueryBase<T>(
   private val params: TranslationFilters,
   private val entityManager: EntityManager,
   private val qaEnabled: Boolean,
+  val qaDisabledLanguageIds: Set<Long>,
   val isCountQuery: Boolean = false,
 ) {
   val whereConditions: MutableSet<Predicate> = HashSet()

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
@@ -157,8 +157,9 @@ class QueryTranslationFiltering(
    * QA filters — `filterHasQaIssuesInLang`, `filterQaCheckType` and `filterQaChecksStaleInLang`.
    */
   fun applyQaFilters() {
-    val hasIssuesLangIds = languageIdsForTags(params.filterHasQaIssuesInLang)
-    if (hasIssuesLangIds != null) {
+    val disabled = queryBase.qaDisabledLanguageIds
+    val hasIssuesLangIds = languageIdsForTags(params.filterHasQaIssuesInLang)?.filterNot { it in disabled }
+    if (!hasIssuesLangIds.isNullOrEmpty()) {
       queryBase.translationConditions.add(buildQaIssueExists(hasIssuesLangIds, checkTypes = null))
     }
     val checkTypeMap = filterByQaCheckTypeMap
@@ -167,14 +168,15 @@ class QueryTranslationFiltering(
         checkTypeMap.mapNotNull { (tag, types) ->
           if (types.isEmpty()) return@mapNotNull null
           val language = languageByTag(tag) ?: return@mapNotNull null
+          if (language.id in disabled) return@mapNotNull null
           buildQaIssueExists(listOf(language.id), checkTypes = types.toList())
         }
       if (perLangPredicates.isNotEmpty()) {
         queryBase.translationConditions.add(cb.or(*perLangPredicates.toTypedArray()))
       }
     }
-    val staleLangIds = languageIdsForTags(params.filterQaChecksStaleInLang)
-    if (staleLangIds != null) {
+    val staleLangIds = languageIdsForTags(params.filterQaChecksStaleInLang)?.filterNot { it in disabled }
+    if (!staleLangIds.isNullOrEmpty()) {
       queryBase.translationConditions.add(
         buildTranslationExists(staleLangIds) { t -> cb.isTrue(t.get(Translation_.qaChecksStale)) },
       )

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationViewDataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationViewDataProvider.kt
@@ -9,6 +9,7 @@ import io.tolgee.model.enums.TranslationSuggestionState
 import io.tolgee.model.enums.qa.QaIssueState
 import io.tolgee.model.views.KeyWithTranslationsView
 import io.tolgee.model.views.TranslationView
+import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.repository.qa.TranslationQaIssueRepository
 import io.tolgee.service.key.TagService
 import io.tolgee.service.label.LabelService
@@ -29,6 +30,7 @@ class TranslationViewDataProvider(
   private val tagService: TagService,
   private val labelService: LabelService,
   private val qaIssueRepository: TranslationQaIssueRepository,
+  private val languageQaConfigRepository: LanguageQaConfigRepository,
   private val projectFeatureGuard: ProjectFeatureGuard,
   private val projectService: ProjectService,
 ) {
@@ -46,14 +48,16 @@ class TranslationViewDataProvider(
   ): Page<KeyWithTranslationsView> {
     val project = projectService.get(projectId)
     val qaEnabled = projectFeatureGuard.isFeatureEnabled(Feature.QA_CHECKS, project)
+    val qaDisabledLanguageIds = resolveQaDisabledLanguageIds(projectId, qaEnabled)
 
     createFailedKeysInJobTempTable(params.filterFailedKeysOfJob)
 
-    val countBuilder = getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled)
+    val countBuilder =
+      getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled, qaDisabledLanguageIds)
     val count = em.createQuery(countBuilder.countQuery).singleResult
 
     val translationsViewQueryBuilder =
-      getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled)
+      getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled, qaDisabledLanguageIds)
     val query = em.createQuery(translationsViewQueryBuilder.dataQuery).setMaxResults(pageable.pageSize)
     if (cursor == null) {
       query.firstResult = pageable.offset.toInt()
@@ -67,7 +71,7 @@ class TranslationViewDataProvider(
     // Fetch translations + all per-translation counts (comments, suggestions, QA issues)
     // in a single query. The inline count subqueries are cheap because they only run on
     // the page's translations (~pageSize × langCount rows, typically <500).
-    populateTranslationsWithCounts(keyIds, languages, views, qaEnabled)
+    populateTranslationsWithCounts(keyIds, languages, views, qaEnabled, qaDisabledLanguageIds)
 
     val translationIds =
       views
@@ -85,7 +89,7 @@ class TranslationViewDataProvider(
       }
     }
     if (qaEnabled && includeQaIssues && translationIds.isNotEmpty()) {
-      populateQaIssues(translationIds, views)
+      populateQaIssues(translationIds, views, qaDisabledLanguageIds)
     }
     return PageImpl(views, pageable, count)
   }
@@ -100,15 +104,16 @@ class TranslationViewDataProvider(
    * `UNTRANSLATED` state so that every returned view has an entry for every requested language.
    *
    * This combines what would otherwise be 4 separate queries (translation fetch + 3 count
-   * queries) into 1. The QA issue count subquery is only included when [qaEnabled] is true;
-   * otherwise a literal `0L` is selected so the column layout (and the `COL_*` indices) stays
-   * stable.
+   * queries) into 1. The QA issue count expression ([qaCountExpr]) has three shapes: a literal
+   * `0L` when QA is off project-wide, a plain count subquery when enabled, and a count subquery
+   * with a `language.id not in (:qaDisabledLanguageIds)` exclusion when some languages have QA
+   * disabled. The `0L` shape keeps the column layout (and the `COL_*` indices) stable.
    *
    * Uses plain JPQL rather than Criteria API because the query has 5 inline correlated count
-   * subqueries plus conditional logic (`qaCountExpr` toggles between a real subquery and `0L`).
-   * Expressing that in Criteria API would require dozens of lines of nested `subquery.correlate()`
-   * and conditional builders. The JPQL string is more readable for a fixed-shape query with no
-   * dynamic predicates.
+   * subqueries. The only dynamic parts are the `qaCountExpr` shape above and its two conditional
+   * parameter binds (`openQa`, and `qaDisabledLanguageIds` only when the exclusion clause is
+   * present); expressing the 5 correlated subqueries in Criteria API would require dozens of lines
+   * of nested `subquery.correlate()`, so the JPQL string stays more readable.
    */
   @Suppress("LongMethod")
   private fun populateTranslationsWithCounts(
@@ -116,6 +121,7 @@ class TranslationViewDataProvider(
     languages: Set<LanguageDto>,
     views: List<KeyWithTranslationsView>,
     qaEnabled: Boolean,
+    qaDisabledLanguageIds: Set<Long>,
   ) {
     if (languages.isEmpty()) return
 
@@ -131,15 +137,8 @@ class TranslationViewDataProvider(
     val viewsByKeyId: Map<Long, KeyWithTranslationsView> = views.associateBy { it.keyId }
     val tagById: Map<Long, String> = languages.associate { it.id to it.tag }
 
-    // The QA issue count subquery is only included when QA checks are enabled for the project.
-    // When disabled, a literal 0L keeps the column layout stable so the COL_* indices stay valid.
-    val qaCountExpr =
-      if (qaEnabled) {
-        """(select count(qa) from TranslationQaIssue qa
-            where qa.translation.id = t.id and qa.state = :openQa)"""
-      } else {
-        "0L"
-      }
+    val excludeDisabled = qaEnabled && qaDisabledLanguageIds.isNotEmpty()
+    val qaCountExpr = qaCountExpr(qaEnabled, excludeDisabled)
 
     keyIds.chunked(IN_CLAUSE_CHUNK_SIZE).forEach { keyIdChunk ->
       val query =
@@ -168,6 +167,9 @@ class TranslationViewDataProvider(
           .setParameter("activeSuggestion", TranslationSuggestionState.ACTIVE)
       if (qaEnabled) {
         query.setParameter("openQa", QaIssueState.OPEN)
+      }
+      if (excludeDisabled) {
+        query.setParameter("qaDisabledLanguageIds", qaDisabledLanguageIds)
       }
 
       for (row in query.resultList) {
@@ -210,6 +212,28 @@ class TranslationViewDataProvider(
       qaChecksStale = false,
     )
 
+  private fun resolveQaDisabledLanguageIds(
+    projectId: Long,
+    qaEnabled: Boolean,
+  ): Set<Long> {
+    if (!qaEnabled) return emptySet()
+    return languageQaConfigRepository.findDisabledLanguageIds(projectId)
+  }
+
+  private fun qaCountExpr(
+    qaEnabled: Boolean,
+    excludeDisabled: Boolean,
+  ): String {
+    if (!qaEnabled) return "0L"
+    if (!excludeDisabled) {
+      return """(select count(qa) from TranslationQaIssue qa
+            where qa.translation.id = t.id and qa.state = :openQa)"""
+    }
+    return """(select count(qa) from TranslationQaIssue qa
+            where qa.translation.id = t.id and qa.state = :openQa
+              and t.language.id not in :qaDisabledLanguageIds)"""
+  }
+
   /**
    * Batch-loads the actual `TranslationQaIssue` objects for the page's translations and
    * attaches them to the matching `TranslationView.qaIssues` lists. Only called when the caller
@@ -218,10 +242,12 @@ class TranslationViewDataProvider(
   private fun populateQaIssues(
     translationIds: List<Long>,
     views: List<KeyWithTranslationsView>,
+    qaDisabledLanguageIds: Set<Long>,
   ) {
     val qaIssuesMap =
       qaIssueRepository
         .findByTranslationIds(translationIds)
+        .filterNot { it.translation.language.id in qaDisabledLanguageIds }
         .groupBy { it.translation.id }
     if (qaIssuesMap.isEmpty()) return
     views.forEach { view ->
@@ -273,6 +299,7 @@ class TranslationViewDataProvider(
   ): MutableList<Long> {
     val project = projectService.get(projectId)
     val qaEnabled = projectFeatureGuard.isFeatureEnabled(Feature.QA_CHECKS, project)
+    val qaDisabledLanguageIds = resolveQaDisabledLanguageIds(projectId, qaEnabled)
     createFailedKeysInJobTempTable(params.filterFailedKeysOfJob)
     val translationsViewQueryBuilder =
       TranslationsViewQueryBuilder(
@@ -283,6 +310,7 @@ class TranslationViewDataProvider(
         sort = Sort.by(Sort.Order.asc(KeyWithTranslationsView::keyId.name)),
         entityManager = em,
         qaEnabled = qaEnabled,
+        qaDisabledLanguageIds = qaDisabledLanguageIds,
       )
     val result = em.createQuery(translationsViewQueryBuilder.keyIdsQuery).resultList
     deleteFailedKeysInJobTempTable()
@@ -296,6 +324,7 @@ class TranslationViewDataProvider(
     pageable: Pageable,
     cursor: String?,
     qaEnabled: Boolean,
+    qaDisabledLanguageIds: Set<Long>,
   ) = TranslationsViewQueryBuilder(
     cb = em.criteriaBuilder,
     projectId = projectId,
@@ -305,5 +334,6 @@ class TranslationViewDataProvider(
     cursor = cursor?.let { CursorUtil.parseCursor(it) },
     entityManager = em,
     qaEnabled = qaEnabled,
+    qaDisabledLanguageIds = qaDisabledLanguageIds,
   )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
@@ -24,6 +24,7 @@ class TranslationsViewQueryBuilder(
   private val cursor: Map<String, CursorValue>? = null,
   private val entityManager: EntityManager,
   private val qaEnabled: Boolean,
+  private val qaDisabledLanguageIds: Set<Long>,
 ) {
   private fun <T> getBaseQuery(
     query: CriteriaQuery<T>,
@@ -37,6 +38,7 @@ class TranslationsViewQueryBuilder(
       params = params,
       entityManager,
       qaEnabled = qaEnabled,
+      qaDisabledLanguageIds = qaDisabledLanguageIds,
       isCountQuery = isCountQuery,
     )
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -690,22 +690,26 @@ class TranslationService(
   }
 
   @Transactional(readOnly = true)
-  fun getStaleKeyLanguagePairsByBranch(
+  fun getStaleKeyLanguagePairsByBranchAndLanguageIds(
     projectId: Long,
     branchId: Long,
+    languageIds: Collection<Long>,
   ): List<KeyLanguagePairView> {
-    return translationRepository.getStaleKeyLanguagePairsByBranch(projectId, branchId)
+    return translationRepository.getStaleKeyLanguagePairsByBranchAndLanguageIds(projectId, branchId, languageIds)
   }
 
   @Transactional(readOnly = true)
-  fun getStaleKeyLanguagePairsByProject(projectId: Long): List<KeyLanguagePairView> {
-    return translationRepository.getStaleKeyLanguagePairsByProject(projectId)
+  fun getStaleKeyLanguagePairsByProjectAndLanguageIds(
+    projectId: Long,
+    languageIds: Collection<Long>,
+  ): List<KeyLanguagePairView> {
+    return translationRepository.getStaleKeyLanguagePairsByProjectAndLanguageIds(projectId, languageIds)
   }
 
   @Transactional(readOnly = true)
   fun getKeyLanguagePairsForQaRecheck(
     projectId: Long,
-    languageIds: List<Long>? = null,
+    languageIds: Collection<Long>? = null,
     onlyStale: Boolean = false,
   ): List<KeyLanguagePairView> {
     val cb = entityManager.criteriaBuilder

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5604,4 +5604,11 @@
             DROP INDEX CONCURRENTLY IF EXISTS translation_qa_checks_stale_partial_idx;
         </rollback>
     </changeSet>
+    <changeSet author="anty (generated)" id="1775827900000-1">
+        <addColumn tableName="language_qa_config">
+            <column name="enabled" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/e2e/cypress/e2e/qa/settings.cy.ts
+++ b/e2e/cypress/e2e/qa/settings.cy.ts
@@ -75,6 +75,36 @@ describe('QA settings', () => {
       .should('contain.text', 'Off');
   });
 
+  it('toggles QA checks on/off for a single language', () => {
+    visitQaSettings();
+
+    gcy('qa-language-enabled-toggle')
+      .first()
+      .find('input')
+      .should('be.checked');
+
+    gcy('qa-language-enabled-toggle').first().click();
+    waitForGlobalLoading();
+    gcy('qa-language-enabled-toggle')
+      .first()
+      .find('input')
+      .should('not.be.checked');
+
+    // persists across reload
+    visitQaSettings();
+    gcy('qa-language-enabled-toggle')
+      .first()
+      .find('input')
+      .should('not.be.checked');
+
+    gcy('qa-language-enabled-toggle').first().click();
+    waitForGlobalLoading();
+    gcy('qa-language-enabled-toggle')
+      .first()
+      .find('input')
+      .should('be.checked');
+  });
+
   it('opens per-language settings dialog', () => {
     visitQaSettings();
 

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -657,6 +657,7 @@ declare namespace DataCy {
         "qa-language-dialog-inherited-banner": true;
         "qa-language-dialog-reset-to-global": true;
         "qa-language-dialog-save": true;
+        "qa-language-enabled-toggle": true;
         "qa-language-settings-button": true;
         "qa-panel-container": true;
         "qa-panel-container-disabled": true;

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueController.kt
@@ -7,6 +7,7 @@ import io.tolgee.activity.data.ActivityType
 import io.tolgee.constants.Feature
 import io.tolgee.ee.api.v2.hateoas.assemblers.qa.QaIssueModelAssembler
 import io.tolgee.ee.data.qa.QaCheckIssueIgnoreRequest
+import io.tolgee.ee.service.qa.ProjectQaConfigService
 import io.tolgee.ee.service.qa.QaIssueService
 import io.tolgee.hateoas.qa.QaIssueModel
 import io.tolgee.model.enums.Scope
@@ -15,6 +16,7 @@ import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.ReadOnlyOperation
 import io.tolgee.security.authorization.RequiresFeatures
 import io.tolgee.security.authorization.RequiresProjectPermissions
+import io.tolgee.service.translation.TranslationService
 import jakarta.validation.Valid
 import org.springframework.hateoas.CollectionModel
 import org.springframework.http.ResponseEntity
@@ -34,6 +36,8 @@ import org.springframework.web.bind.annotation.RestController
 class QaIssueController(
   private val qaIssueService: QaIssueService,
   private val qaIssueModelAssembler: QaIssueModelAssembler,
+  private val translationService: TranslationService,
+  private val projectQaConfigService: ProjectQaConfigService,
 ) {
   @GetMapping
   @Operation(summary = "Get persisted QA issues for a translation")
@@ -45,6 +49,11 @@ class QaIssueController(
     @PathVariable projectId: Long,
     @PathVariable translationId: Long,
   ): CollectionModel<QaIssueModel> {
+    val translation = translationService.get(projectId, translationId)
+    if (!projectQaConfigService.isLanguageQaEnabled(projectId, translation.language.id)) {
+      return CollectionModel.empty()
+    }
+
     val issues = qaIssueService.getIssuesForTranslation(projectId, translationId)
     return qaIssueModelAssembler.toCollectionModel(issues)
   }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsController.kt
@@ -166,4 +166,17 @@ class QaSettingsController(
   ) {
     projectQaConfigService.deleteLanguageSettings(projectHolder.project.id, languageId)
   }
+
+  @PutMapping("/languages/{languageId:[0-9]+}/enabled")
+  @Operation(summary = "Enable or disable QA checks for a specific language")
+  @RequiresProjectPermissions([Scope.PROJECT_EDIT])
+  @AllowApiAccess
+  @RequiresFeatures(Feature.QA_CHECKS)
+  fun setLanguageQaEnabled(
+    @PathVariable languageId: Long,
+    @RequestBody @Valid
+    dto: QaEnabledRequest,
+  ) {
+    projectQaConfigService.setLanguageQaEnabled(projectHolder.project.id, languageId, dto.enabled)
+  }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/qa/LanguageQaConfigModelAssembler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/qa/LanguageQaConfigModelAssembler.kt
@@ -16,7 +16,8 @@ class LanguageQaConfigModelAssembler(
   ): LanguageQaConfigModel {
     return LanguageQaConfigModel(
       language = languageModelAssembler.toModel(lang),
-      customSettings = entity?.settings?.toMap(),
+      customSettings = entity?.settings?.toMap()?.ifEmpty { null },
+      enabled = entity?.enabled ?: true,
     )
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/model/qa/LanguageQaConfigModel.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/model/qa/LanguageQaConfigModel.kt
@@ -10,4 +10,5 @@ import org.springframework.hateoas.server.core.Relation
 class LanguageQaConfigModel(
   val language: LanguageModel,
   val customSettings: Map<QaCheckType, QaCheckSeverity>?,
+  val enabled: Boolean,
 ) : RepresentationModel<LanguageQaConfigModel>()

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/qa/QaActivityListener.kt
@@ -11,6 +11,7 @@ import io.tolgee.batch.request.QaCheckRequest
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
 import io.tolgee.component.eventListeners.BypassableActivityListener
 import io.tolgee.constants.Feature
+import io.tolgee.ee.service.qa.ProjectQaConfigService
 import io.tolgee.ee.service.qa.QaRecheckService
 import io.tolgee.events.OnProjectActivityEvent
 import io.tolgee.model.Language
@@ -49,6 +50,7 @@ class QaActivityListener(
   private val qaRecheckService: QaRecheckService,
   private val enabledFeaturesProvider: EnabledFeaturesProvider,
   private val qaCheckChunkProcessor: QaCheckChunkProcessor,
+  private val projectQaConfigService: ProjectQaConfigService,
 ) : BypassableActivityListener {
   @Volatile
   override var bypass = false
@@ -124,8 +126,10 @@ class QaActivityListener(
     projectId: Long,
     entities: List<ActivityModifiedEntity>,
   ) {
-    val translationTargets = getTranslationChangeTargets(projectId, entities)
-    val maxCharLimitTargets = getMaxCharLimitChangeTargets(projectId, entities)
+    val enabledLanguageIds = projectQaConfigService.getEnabledLanguageIds(projectId)
+
+    val translationTargets = getTranslationChangeTargets(projectId, entities, enabledLanguageIds)
+    val maxCharLimitTargets = getMaxCharLimitChangeTargets(entities, enabledLanguageIds)
 
     val allTargets = (translationTargets + maxCharLimitTargets).distinct()
     startQaCheckBatchJob(projectId, allTargets)
@@ -179,6 +183,7 @@ class QaActivityListener(
   private fun getTranslationChangeTargets(
     projectId: Long,
     entities: List<ActivityModifiedEntity>,
+    enabledLanguageIds: Set<Long>,
   ): List<BatchTranslationTargetItem> {
     val textChangedEntities = getTextChangedTranslations(entities)
     if (textChangedEntities.isEmpty()) return emptyList()
@@ -188,26 +193,21 @@ class QaActivityListener(
       textChangedEntities.mapNotNull { entity ->
         val keyId = entity.describingRelations?.get("key")?.entityId ?: return@mapNotNull null
         val languageId = entity.describingRelations?.get("language")?.entityId ?: return@mapNotNull null
+        if (languageId !in enabledLanguageIds) return@mapNotNull null
         BatchTranslationTargetItem(keyId = keyId, languageId = languageId)
       }
-
-    if (directTargets.isEmpty()) return emptyList()
 
     // For base text changes, also include all project languages
     val baseLanguage = languageService.getProjectBaseLanguage(projectId)
     val baseLanguageKeyIds =
-      directTargets
-        .filter { it.languageId == baseLanguage.id }
-        .map { it.keyId }
+      textChangedEntities
+        .filter { it.describingRelations?.get("language")?.entityId == baseLanguage.id }
+        .mapNotNull { it.describingRelations?.get("key")?.entityId }
         .toSet()
 
     val siblingTargets =
       if (baseLanguageKeyIds.isNotEmpty()) {
-        val otherLanguageIds =
-          languageService
-            .getProjectLanguages(projectId)
-            .map { it.id }
-            .filter { it != baseLanguage.id }
+        val otherLanguageIds = enabledLanguageIds.filter { it != baseLanguage.id }
         otherLanguageIds.flatMap { langId ->
           baseLanguageKeyIds.map { keyId ->
             BatchTranslationTargetItem(keyId = keyId, languageId = langId)
@@ -239,14 +239,13 @@ class QaActivityListener(
   }
 
   private fun getMaxCharLimitChangeTargets(
-    projectId: Long,
     entities: List<ActivityModifiedEntity>,
+    enabledLanguageIds: Set<Long>,
   ): List<BatchTranslationTargetItem> {
     val keyIds = getMaxCharLimitChangedKeyIds(entities)
     if (keyIds.isEmpty()) return emptyList()
 
-    val allLanguageIds = languageService.getProjectLanguages(projectId).map { it.id }
-    return allLanguageIds.flatMap { langId ->
+    return enabledLanguageIds.flatMap { langId ->
       keyIds.map { keyId ->
         BatchTranslationTargetItem(keyId = keyId, languageId = langId)
       }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaTestData.kt
@@ -49,10 +49,25 @@ class QaTestData(
 
   lateinit var keyWithDeIssues: Key
 
+  /**
+   * Spanish has QA disabled at the language level ([LanguageQaConfig.enabled] = false) while the
+   * project QA feature stays on; [disabledLangTranslationWithIssues] seeds OPEN issues on it.
+   */
+  lateinit var spanishLanguage: Language
+  lateinit var disabledLangTranslationWithIssues: Translation
+
   init {
     project.useQaChecks = true
     projectBuilder.build {
       frenchLanguage = addFrench().self
+      val spanishBuilder =
+        addLanguage {
+          name = "Spanish"
+          tag = "es"
+          originalName = "Español"
+        }
+      spanishBuilder.setQaConfig { enabled = false }
+      spanishLanguage = spanishBuilder.self
       // testKey: clean. No QA issues — tests that a pristine translation.
       testKey =
         addKey {
@@ -86,6 +101,27 @@ class QaTestData(
                 replacement = "B"
               }
             }
+          disabledLangTranslationWithIssues =
+            addTranslation("es", "hola mundo")
+              .also { it.self.qaChecksStale = false }
+              .build {
+                addQaIssue {
+                  type = QaCheckType.PUNCTUATION_MISMATCH
+                  message = QaIssueMessage.QA_PUNCTUATION_ADD
+                  state = QaIssueState.OPEN
+                  positionStart = 11
+                  positionEnd = 11
+                  replacement = "."
+                }
+                addQaIssue {
+                  type = QaCheckType.CHARACTER_CASE_MISMATCH
+                  message = QaIssueMessage.QA_CASE_CAPITALIZE
+                  state = QaIssueState.OPEN
+                  positionStart = 0
+                  positionEnd = 1
+                  replacement = "H"
+                }
+              }.self
         }.self
       keyWithoutFrTranslation =
         addKey {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/ProjectQaConfigService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/ProjectQaConfigService.kt
@@ -54,6 +54,34 @@ class ProjectQaConfigService(
     }
   }
 
+  @Transactional
+  fun setLanguageQaEnabled(
+    projectId: Long,
+    languageId: Long,
+    enabled: Boolean,
+  ) {
+    requireQaEnabled(projectId)
+    languageService.getEntity(languageId, projectId)
+
+    val current = isLanguageQaEnabled(projectId, languageId)
+    if (current == enabled) return
+
+    val langConfig =
+      languageQaConfigRepository.findByLanguageProjectIdAndLanguageId(projectId, languageId)
+        ?: LanguageQaConfig(
+          language = entityManager.getReference(Language::class.java, languageId),
+        )
+    langConfig.enabled = enabled
+
+    languageQaConfigRepository.save(langConfig)
+
+    if (enabled) {
+      qaRecheckService.recheckTranslations(projectId, languageIds = listOf(languageId), onlyStale = true)
+      return
+    }
+    languageStatsService.refreshLanguageStatsAllBranches(projectId)
+  }
+
   fun getSettings(projectId: Long): Map<QaCheckType, QaCheckSeverity> {
     val config = projectQaConfigRepository.findByProjectId(projectId)
     val stored = config?.settings ?: emptyMap()
@@ -65,10 +93,18 @@ class ProjectQaConfigService(
     return settings.filterValues { it != QaCheckSeverity.OFF }.keys
   }
 
+  fun isLanguageQaEnabled(
+    projectId: Long,
+    languageId: Long,
+  ): Boolean {
+    return languageQaConfigRepository.findByLanguageProjectIdAndLanguageId(projectId, languageId)?.enabled ?: true
+  }
+
   fun getEnabledCheckTypesForLanguage(
     projectId: Long,
     languageId: Long,
   ): Set<QaCheckType> {
+    if (!isLanguageQaEnabled(projectId, languageId)) return emptySet()
     val settings = getResolvedSettingsForLanguage(projectId, languageId)
     return settings.filterValues { it != QaCheckSeverity.OFF }.keys
   }
@@ -78,7 +114,7 @@ class ProjectQaConfigService(
     languageId: Long,
   ): Map<QaCheckType, QaCheckSeverity>? {
     val langConfig = languageQaConfigRepository.findByLanguageProjectIdAndLanguageId(projectId, languageId)
-    return langConfig?.settings?.toMap()
+    return langConfig?.settings?.toMap()?.ifEmpty { null }
   }
 
   fun getResolvedSettingsForLanguage(
@@ -94,6 +130,16 @@ class ProjectQaConfigService(
 
   fun getSettingsForAllLanguages(projectId: Long): List<LanguageQaConfig> {
     return languageQaConfigRepository.findAllByLanguageProjectId(projectId)
+  }
+
+  fun getEnabledLanguageIds(projectId: Long): Set<Long> {
+    val languageIds = languageService.getProjectLanguages(projectId).map { it.id }.toSet()
+    val disabledLanguageIds = languageQaConfigRepository.findDisabledLanguageIds(projectId)
+    return languageIds - disabledLanguageIds
+  }
+
+  fun getDisabledLanguageIds(projectId: Long): Set<Long> {
+    return languageQaConfigRepository.findDisabledLanguageIds(projectId)
   }
 
   @Transactional
@@ -125,7 +171,6 @@ class ProjectQaConfigService(
     settings: Map<QaCheckType, QaCheckSeverity?>,
   ) {
     requireQaEnabled(projectId)
-    // Validate that the language belongs to this project
     languageService.getEntity(languageId, projectId)
 
     val langConfig =

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaCheckBatchServiceImpl.kt
@@ -78,9 +78,12 @@ class QaCheckBatchServiceImpl(
     items: List<BatchTranslationTargetItem>,
     progressCallback: () -> Unit,
   ): List<ItemResult> {
+    val qaDisabledLanguageIds = projectQaConfigService.getDisabledLanguageIds(project.id)
+    val enabledItems = items.filter { it.languageId !in qaDisabledLanguageIds }
+
     val baseLanguage = languageService.getProjectBaseLanguage(project.id)
-    val keyIds = items.map { it.keyId }.toSet()
-    val languageIds = items.map { it.languageId }.toSet()
+    val keyIds = enabledItems.map { it.keyId }.toSet()
+    val languageIds = enabledItems.map { it.languageId }.toSet()
 
     val translations =
       translationRepository.findAllWithKeyAndLanguageByKeyIdInAndLanguageIdIn(
@@ -88,7 +91,7 @@ class QaCheckBatchServiceImpl(
         languageIds + baseLanguage.id,
       )
 
-    val wantedPairs = items.map { it.keyId to it.languageId }.toSet()
+    val wantedPairs = enabledItems.map { it.keyId to it.languageId }.toSet()
     val translationByKeyAndLanguage =
       translations
         .filter { it.key.id to it.language.id in wantedPairs }
@@ -110,7 +113,7 @@ class QaCheckBatchServiceImpl(
     val enabledCheckTypesByLanguage: Map<Long, Set<QaCheckType>> =
       languageIds.associateWith { projectQaConfigService.getEnabledCheckTypesForLanguage(project.id, it) }
 
-    return items.mapNotNull { item ->
+    return enabledItems.mapNotNull { item ->
       // If the key has been deleted between job enqueue and processing, skip it
       val key = keyById[item.keyId] ?: return@mapNotNull null
       val languageTag = languageTagById[item.languageId] ?: return@mapNotNull null

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/QaRecheckService.kt
@@ -14,6 +14,7 @@ import io.tolgee.service.project.ProjectFeatureRegistry
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.translation.TranslationService
 import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -23,6 +24,7 @@ class QaRecheckService(
   private val translationService: TranslationService,
   private val projectService: ProjectService,
   private val entityManager: EntityManager,
+  @Lazy private val projectQaConfigService: ProjectQaConfigService,
 ) {
   @Transactional
   fun recheckTranslations(
@@ -33,18 +35,38 @@ class QaRecheckService(
   ) {
     if (checkTypes?.isEmpty() == true) return
 
-    val pairs = translationService.getKeyLanguagePairsForQaRecheck(projectId, languageIds, onlyStale)
-    if (pairs.isEmpty()) return
-
-    if (checkTypes == null && !onlyStale) {
-      if (languageIds == null) {
-        translationService.setQaChecksStaleByProjectId(projectId)
-      } else {
-        translationService.setQaChecksStaleByProjectIdAndLanguageIds(projectId, languageIds)
-      }
+    if (!onlyStale) {
+      markStaleForRecheck(projectId, checkTypes, languageIds)
     }
 
+    val enabledLanguageIds = projectQaConfigService.getEnabledLanguageIds(projectId)
+    val activeLanguageIds = languageIds?.filter { it in enabledLanguageIds } ?: enabledLanguageIds
+
+    val pairs = translationService.getKeyLanguagePairsForQaRecheck(projectId, activeLanguageIds, onlyStale)
+    if (pairs.isEmpty()) return
+
     recheckFromKeyLanguagePairs(projectId, pairs, checkTypes = checkTypes)
+  }
+
+  private fun markStaleForRecheck(
+    projectId: Long,
+    checkTypes: List<QaCheckType>?,
+    languageIds: List<Long>?,
+  ) {
+    if (checkTypes == null) {
+      if (languageIds == null) {
+        translationService.setQaChecksStaleByProjectId(projectId)
+        return
+      }
+      translationService.setQaChecksStaleByProjectIdAndLanguageIds(projectId, languageIds)
+      return
+    }
+    // QA-disabled languages are excluded from the recheck below; marking them stale defers
+    // their recheck to when QA is re-enabled for them (which only reprocesses stale ones).
+    val disabledLanguageIds = projectQaConfigService.getDisabledLanguageIds(projectId)
+    val disabledInScope = languageIds?.filter { it in disabledLanguageIds } ?: disabledLanguageIds.toList()
+    if (disabledInScope.isEmpty()) return
+    translationService.setQaChecksStaleByProjectIdAndLanguageIds(projectId, disabledInScope)
   }
 
   @Transactional
@@ -55,7 +77,13 @@ class QaRecheckService(
     val projectDto = projectService.getDto(projectId)
     if (!ProjectFeatureRegistry.isEnabledOnProject(Feature.QA_CHECKS, projectDto)) return
 
-    val pairs = translationService.getStaleKeyLanguagePairsByBranch(projectId, branchId)
+    val enabledLanguageIds = projectQaConfigService.getEnabledLanguageIds(projectId)
+    val pairs =
+      translationService.getStaleKeyLanguagePairsByBranchAndLanguageIds(
+        projectId,
+        branchId,
+        enabledLanguageIds,
+      )
     if (pairs.isEmpty()) return
 
     recheckFromKeyLanguagePairs(projectId, pairs)
@@ -67,7 +95,8 @@ class QaRecheckService(
     if (!ProjectFeatureRegistry.isEnabledOnProject(Feature.QA_CHECKS, projectDto)) return
     if (batchJobService.hasActiveJobForProject(projectId, BatchJobType.QA_CHECK)) return
 
-    val pairs = translationService.getStaleKeyLanguagePairsByProject(projectId)
+    val enabledLanguageIds = projectQaConfigService.getEnabledLanguageIds(projectId)
+    val pairs = translationService.getStaleKeyLanguagePairsByProjectAndLanguageIds(projectId, enabledLanguageIds)
     if (pairs.isEmpty()) return
 
     Sentry.captureMessage(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaDashboardStatsTest.kt
@@ -100,4 +100,23 @@ class QaDashboardStatsTest : AuthorizedControllerTest() {
       }
     }
   }
+
+  @Test
+  fun `language stats QA counts are zero only for a per-language disabled language`() {
+    languageStatsService.refreshLanguageStats(testData.project.id)
+
+    performAuthGet(
+      "/v2/projects/${testData.project.id}/stats",
+    ).andIsOk.andAssertThatJson {
+      node("languageStats").isArray.anySatisfy {
+        assertThatJson(it).node("languageTag").isEqualTo("es")
+        assertThatJson(it).node("qaIssueCount").isEqualTo(0)
+        assertThatJson(it).node("qaChecksStaleCount").isEqualTo(0)
+      }
+      node("languageStats").isArray.anySatisfy {
+        assertThatJson(it).node("languageTag").isEqualTo("de")
+        assertThatJson(it).node("qaIssueCount").isEqualTo(1)
+      }
+    }
+  }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaIssueControllerTest.kt
@@ -88,6 +88,16 @@ class QaIssueControllerTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `does not return QA issues for a translation whose language is QA-disabled`() {
+    performAuthGet(
+      "/v2/projects/${testData.project.id}/translations/" +
+        "${testData.disabledLangTranslationWithIssues.id}/qa-issues",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded").isAbsent()
+    }
+  }
+
+  @Test
   fun `returns empty when no QA issues exist`() {
     performAuthGet(
       "$translationUrl/qa-issues",

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
@@ -365,7 +365,10 @@ class QaSettingsControllerTest : AuthorizedControllerTest() {
     expected: Boolean,
   ) {
     executeInNewTransaction(platformTransactionManager) {
-      entityManager.find(Translation::class.java, translationId).qaChecksStale.assert.isEqualTo(expected)
+      entityManager
+        .find(Translation::class.java, translationId)
+        .qaChecksStale.assert
+        .isEqualTo(expected)
     }
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaSettingsControllerTest.kt
@@ -6,10 +6,14 @@ import io.tolgee.batch.data.BatchJobType
 import io.tolgee.constants.Feature
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
 import io.tolgee.ee.development.QaTestData
+import io.tolgee.ee.service.qa.ProjectQaConfigService
 import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.model.translation.Translation
+import io.tolgee.repository.qa.LanguageQaConfigRepository
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
@@ -37,6 +41,12 @@ class QaSettingsControllerTest : AuthorizedControllerTest() {
 
   @Autowired
   private lateinit var batchJobService: BatchJobService
+
+  @Autowired
+  private lateinit var languageQaConfigRepository: LanguageQaConfigRepository
+
+  @Autowired
+  private lateinit var projectQaConfigService: ProjectQaConfigService
 
   lateinit var testData: QaTestData
 
@@ -183,8 +193,8 @@ class QaSettingsControllerTest : AuthorizedControllerTest() {
       langUrl,
       mapOf("settings" to mapOf("SPACES_MISMATCH" to null)),
     ).andIsOk.andAssertThatJson {
-      // No override should remain for SPACES_MISMATCH
-      node("settings").isObject.doesNotContainKey("SPACES_MISMATCH")
+      // With the last override removed the row has empty settings, which collapses to null
+      node("settings").isNull()
     }
   }
 
@@ -258,6 +268,134 @@ class QaSettingsControllerTest : AuthorizedControllerTest() {
         assertThatJson(it).node("language.id").isEqualTo(testData.frenchLanguage.id)
         assertThatJson(it).node("customSettings.SPACES_MISMATCH").isEqualTo("OFF")
       }
+    }
+  }
+
+  private val frenchEnabledUrl
+    get() = "$settingsUrl/languages/${testData.frenchLanguage.id}/enabled"
+
+  @Test
+  fun `toggles QA enabled state for a language`() {
+    qa.saveDefaultQaConfig()
+
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+
+    performAuthGet("$settingsUrl/languages").andIsOk.andAssertThatJson {
+      isArray.anySatisfy {
+        assertThatJson(it).node("language.id").isEqualTo(testData.frenchLanguage.id)
+        assertThatJson(it).node("enabled").isEqualTo(false)
+      }
+    }
+
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to true)).andIsOk
+
+    performAuthGet("$settingsUrl/languages").andIsOk.andAssertThatJson {
+      isArray.anySatisfy {
+        assertThatJson(it).node("language.id").isEqualTo(testData.frenchLanguage.id)
+        assertThatJson(it).node("enabled").isEqualTo(true)
+      }
+    }
+  }
+
+  @Test
+  fun `disabled-only language reports enabled false and null customSettings`() {
+    qa.saveDefaultQaConfig()
+
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+
+    performAuthGet("$settingsUrl/languages").andIsOk.andAssertThatJson {
+      isArray.anySatisfy {
+        assertThatJson(it).node("language.id").isEqualTo(testData.frenchLanguage.id)
+        assertThatJson(it).node("enabled").isEqualTo(false)
+        assertThatJson(it).node("customSettings").isNull()
+      }
+    }
+
+    performAuthGet("$settingsUrl/languages/${testData.frenchLanguage.id}").andIsOk.andAssertThatJson {
+      node("settings").isNull()
+    }
+  }
+
+  @Test
+  fun `disabling a language keeps its custom overrides`() {
+    qa.saveDefaultQaConfig()
+    val langUrl = "$settingsUrl/languages/${testData.frenchLanguage.id}"
+
+    performAuthPut(langUrl, mapOf("settings" to mapOf("SPACES_MISMATCH" to "OFF"))).andIsOk
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+
+    performAuthGet("$settingsUrl/languages").andIsOk.andAssertThatJson {
+      isArray.anySatisfy {
+        assertThatJson(it).node("language.id").isEqualTo(testData.frenchLanguage.id)
+        assertThatJson(it).node("enabled").isEqualTo(false)
+        assertThatJson(it).node("customSettings.SPACES_MISMATCH").isEqualTo("OFF")
+      }
+    }
+  }
+
+  @Test
+  fun `re-enabling QA for a language triggers a scoped recheck of its stale translations`() {
+    qa.saveDefaultQaConfig()
+    // testData has a stale French translation (staleFrTranslation); re-enable should recheck it.
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to true)).andIsOk
+
+    waitForNotThrowing(timeout = 10_000, pollTime = 500) {
+      executeInNewTransaction(platformTransactionManager) {
+        val qaJobs =
+          batchJobService.getAllByProjectId(testData.project.id).filter { it.type == BatchJobType.QA_CHECK }
+        qaJobs.assert.isNotEmpty
+      }
+    }
+  }
+
+  @Test
+  fun `changing QA settings while a language is disabled marks its translations stale for re-check`() {
+    qa.saveDefaultQaConfig()
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+    assertTranslationStale(testData.freshFrTranslation.id, false)
+
+    performAuthPut(settingsUrl, mapOf("settings" to mapOf("SPACES_MISMATCH" to "OFF"))).andIsOk
+
+    assertTranslationStale(testData.freshFrTranslation.id, true)
+  }
+
+  private fun assertTranslationStale(
+    translationId: Long,
+    expected: Boolean,
+  ) {
+    executeInNewTransaction(platformTransactionManager) {
+      entityManager.find(Translation::class.java, translationId).qaChecksStale.assert.isEqualTo(expected)
+    }
+  }
+
+  @Test
+  fun `getEnabledCheckTypesForLanguage is empty for a QA-disabled language`() {
+    qa.saveDefaultQaConfig()
+    val frenchId = testData.frenchLanguage.id
+
+    executeInNewTransaction(platformTransactionManager) {
+      projectQaConfigService.getEnabledCheckTypesForLanguage(testData.project.id, frenchId).assert.isNotEmpty
+    }
+
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsOk
+
+    executeInNewTransaction(platformTransactionManager) {
+      projectQaConfigService.getEnabledCheckTypesForLanguage(testData.project.id, frenchId).assert.isEmpty()
+    }
+  }
+
+  @Test
+  fun `setting language enabled fails when project QA is disabled`() {
+    qa.saveDefaultQaConfig()
+    executeInNewTransaction(platformTransactionManager) {
+      val project = projectService.get(testData.project.id)
+      project.useQaChecks = false
+      entityManager.persist(project)
+    }
+
+    performAuthPut(frenchEnabledUrl, mapOf("enabled" to false)).andIsBadRequest.andAssertThatJson {
+      node("code").isEqualTo("qa_checks_not_enabled")
     }
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
@@ -172,7 +172,10 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
       null,
     )
 
-    qaIssueRepository.findAllByTranslationId(esTranslationId).size.assert.isEqualTo(countBefore)
+    qaIssueRepository
+      .findAllByTranslationId(esTranslationId)
+      .size.assert
+      .isEqualTo(countBefore)
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaTranslationFilterTest.kt
@@ -7,7 +7,10 @@ import io.tolgee.ee.development.QaTestData
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.repository.qa.TranslationQaIssueRepository
+import io.tolgee.service.qa.QaCheckBatchService
 import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assert
 import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -26,6 +29,12 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
 
   @Autowired
   private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  @Autowired
+  private lateinit var qaCheckBatchService: QaCheckBatchService
+
+  @Autowired
+  private lateinit var qaIssueRepository: TranslationQaIssueRepository
 
   lateinit var testData: QaTestData
 
@@ -109,6 +118,61 @@ class QaTranslationFilterTest : AuthorizedControllerTest() {
     ).andIsOk.andAssertThatJson {
       node("page.totalElements").isEqualTo(7)
     }
+  }
+
+  @Test
+  fun `disabling a language drops it from filterQaCheckType while keeping enabled languages`() {
+    performAuthGet(
+      "$translationsUrl?languages=en&languages=de&languages=es" +
+        "&filterQaCheckType=es,PUNCTUATION_MISMATCH&filterQaCheckType=de,SPACES_MISMATCH",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded.keys").isArray.hasSize(1)
+      node("_embedded.keys[0].keyName").isEqualTo("key-with-de-issues")
+    }
+  }
+
+  @Test
+  fun `filterHasQaIssuesInLang for a disabled-only language is ignored`() {
+    performAuthGet("$translationsUrl?filterHasQaIssuesInLang=es").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(7)
+    }
+  }
+
+  @Test
+  fun `filterQaChecksStaleInLang for a disabled-only language is ignored`() {
+    performAuthGet("$translationsUrl?filterQaChecksStaleInLang=es").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(7)
+    }
+  }
+
+  @Test
+  fun `qaIssueCount is zero for a disabled language in the translation view`() {
+    performAuthGet("$translationsUrl?languages=es&languages=de").andIsOk.andAssertThatJson {
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("key-with-issues")
+        assertThatJson(it).node("translations.es.qaIssueCount").isEqualTo(0)
+      }
+      node("_embedded.keys").isArray.anySatisfy {
+        assertThatJson(it).node("keyName").isEqualTo("key-with-de-issues")
+        assertThatJson(it).node("translations.de.qaIssueCount").isEqualTo(1)
+      }
+    }
+  }
+
+  @Test
+  fun `recheck does not delete QA issues for a disabled language`() {
+    val esTranslationId = testData.disabledLangTranslationWithIssues.id
+    val countBefore = qaIssueRepository.findAllByTranslationId(esTranslationId).size
+    countBefore.assert.isGreaterThan(0)
+
+    qaCheckBatchService.runChecksAndPersist(
+      testData.project.id,
+      testData.keyWithIssues.id,
+      testData.spanishLanguage.id,
+      null,
+    )
+
+    qaIssueRepository.findAllByTranslationId(esTranslationId).size.assert.isEqualTo(countBefore)
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -1,17 +1,21 @@
 package io.tolgee.ee.service.qa
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.posthog.server.PostHog
 import io.tolgee.batch.BatchJobService
 import io.tolgee.batch.data.BatchJobType
+import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.constants.Feature
 import io.tolgee.dtos.cacheable.ProjectDto
 import io.tolgee.dtos.request.LanguageRequest
 import io.tolgee.dtos.request.project.CreateProjectRequest
 import io.tolgee.dtos.request.project.EditProjectRequest
+import io.tolgee.dtos.request.translation.SetTranslationsWithKeyDto
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
 import io.tolgee.ee.development.QaTestData
 import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.events.OnOrganizationFeaturesChanged
+import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.repository.TranslationRepository
 import io.tolgee.security.ProjectHolder
@@ -312,6 +316,33 @@ class QaEventListenerTest : AuthorizedControllerTest() {
         // All translations should be stale because base language tag changed
         val staleTranslations = translations.filter { it.qaChecksStale }
         assertThat(staleTranslations).hasSameSizeAs(translations)
+      }
+    }
+  }
+
+  @Test
+  fun `base-text change does not enqueue a QA recheck for a per-language disabled sibling`() {
+    performAuthPut(
+      "/v2/projects/${testData.project.id}/translations",
+      SetTranslationsWithKeyDto(
+        key = "key-with-de-issues",
+        translations = mutableMapOf("en" to "Changed base text."),
+      ),
+    ).andIsOk
+
+    waitForNotThrowing(timeout = 10_000, pollTime = 500) {
+      executeInNewTransaction(platformTransactionManager) {
+        val qaJobs =
+          batchJobService.getAllByProjectId(testData.project.id).filter { it.type == BatchJobType.QA_CHECK }
+        qaJobs.assert.isNotEmpty
+        val mapper = jacksonObjectMapper()
+        val targetLanguageIds =
+          qaJobs
+            .flatMap { it.target }
+            .map { mapper.convertValue(it, BatchTranslationTargetItem::class.java).languageId }
+            .toSet()
+        targetLanguageIds.assert.contains(testData.germanLanguage.id)
+        targetLanguageIds.assert.doesNotContain(testData.spanishLanguage.id)
       }
     }
   }

--- a/webapp/src/ee/qa/components/QaLanguageRow.tsx
+++ b/webapp/src/ee/qa/components/QaLanguageRow.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
-import { Box, IconButton, Typography } from '@mui/material';
+import { Box, IconButton, Switch, Typography } from '@mui/material';
 import { useTranslate } from '@tolgee/react';
 import { Settings01 } from '@untitled-ui/icons-react';
 
+import { useProject } from 'tg.hooks/useProject';
+import { useApiMutation } from 'tg.service/http/useQueryApi';
 import { LanguageItem } from 'tg.component/languages/LanguageItem';
 import {
   TABLE_DIVIDER,
@@ -25,10 +27,24 @@ export const QaLanguageRow = ({
   disabled,
 }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const project = useProject();
   const summaryText = useLanguageSettingsSummary(
     languageConfig,
     globalSettings
   );
+
+  const toggleEnabledMutation = useApiMutation({
+    url: '/v2/projects/{projectId}/qa-settings/languages/{languageId}/enabled',
+    method: 'put',
+    invalidatePrefix: '/v2/projects/{projectId}/qa-settings',
+  });
+
+  function handleToggleEnabled() {
+    toggleEnabledMutation.mutate({
+      path: { projectId: project.id, languageId: languageConfig.language.id },
+      content: { 'application/json': { enabled: !languageConfig.enabled } },
+    });
+  }
 
   return (
     <>
@@ -44,7 +60,18 @@ export const QaLanguageRow = ({
         </Typography>
       </Box>
 
-      <div className={TABLE_LAST_CELL}>
+      <Box
+        className={TABLE_LAST_CELL}
+        sx={{ display: 'flex', alignItems: 'center' }}
+      >
+        <Switch
+          checked={languageConfig.enabled}
+          onChange={handleToggleEnabled}
+          size="small"
+          disabled={disabled || toggleEnabledMutation.isLoading}
+          data-cy="qa-language-enabled-toggle"
+          data-cy-language={languageConfig.language.tag}
+        />
         <IconButton
           onClick={() => setDialogOpen(true)}
           size="small"
@@ -54,7 +81,7 @@ export const QaLanguageRow = ({
         >
           <Settings01 />
         </IconButton>
-      </div>
+      </Box>
 
       {dialogOpen && (
         <QaLanguageSettingsDialog
@@ -73,12 +100,16 @@ function useLanguageSettingsSummary(
 ): string {
   const { t } = useTranslate();
 
+  if (!languageConfig.enabled) {
+    return t('project_settings_qa_languages_disabled');
+  }
+
   if (!languageConfig.customSettings) {
     return t('project_settings_qa_languages_inherited');
   }
   const effectiveSettings: Record<QaCheckType, QaCheckSeverity> = {
     ...globalSettings,
-    ...(languageConfig.customSettings ?? {}),
+    ...languageConfig.customSettings,
   };
 
   const values = Object.values(effectiveSettings);

--- a/webapp/src/ee/qa/components/SubfilterQaChecks.tsx
+++ b/webapp/src/ee/qa/components/SubfilterQaChecks.tsx
@@ -12,6 +12,7 @@ import { QaCheckType } from 'tg.service/apiSchemaTypes';
 import { useQaCategories, useQaCheckTypes } from 'tg.globalContext/helpers';
 import { CheckTypeFilterItem } from './CheckTypeFilterItem';
 import { CheckTypeFilterName } from 'tg.ee.module/qa/components/CheckTypeFilterName';
+import { useQaDisabledLanguageIds } from '../hooks/useQaDisabledLanguageIds';
 
 export const SubfilterQaChecks = ({
   value,
@@ -23,6 +24,11 @@ export const SubfilterQaChecks = ({
   const anchorEl = useRef<HTMLElement>(null);
   const [expanded, setExpanded] = useState(
     value.filterQaCheckTypeLanguage !== undefined
+  );
+
+  const qaDisabledLanguageIds = useQaDisabledLanguageIds();
+  const qaEnabledLanguages = selectedLanguages?.filter(
+    (lang) => !qaDisabledLanguageIds.has(lang.id)
   );
 
   const qaCheckCategories = useQaCategories();
@@ -140,7 +146,7 @@ export const SubfilterQaChecks = ({
                   onClick={() => toggleLanguageScope(false)}
                   exclusive
                 />
-                {selectedLanguages?.map((lang) => (
+                {qaEnabledLanguages?.map((lang) => (
                   <FilterItem
                     data-cy="translations-filter-apply-for-language"
                     key={lang.id}

--- a/webapp/src/ee/qa/hooks/useQaCheckPreview.ts
+++ b/webapp/src/ee/qa/hooks/useQaCheckPreview.ts
@@ -3,6 +3,7 @@ import { useEnabledFeatures } from 'tg.globalContext/helpers';
 import { useProject } from 'tg.hooks/useProject';
 import { useQaPreviewWebsocket } from './useQaPreviewWebsocket';
 import { QaPreviewIssue } from 'tg.ee.module/qa/models/QaPreviewWsModels';
+import { useQaDisabledLanguageTags } from 'tg.ee.module/qa/hooks/useQaDisabledLanguageIds';
 
 type QaCheckPreviewProps = {
   text: string | undefined | null;
@@ -34,6 +35,8 @@ export const useQaCheckPreview = ({
   const { isEnabled } = useEnabledFeatures();
   const qaFeatureEnabled = isEnabled('QA_CHECKS');
   const project = useProject();
+  const qaDisabledLanguageTags = useQaDisabledLanguageTags();
+  const qaLanguageEnabled = !qaDisabledLanguageTags.has(languageTag);
 
   const result = useQaPreviewWebsocket({
     projectId: project!.id,
@@ -41,13 +44,13 @@ export const useQaCheckPreview = ({
     languageTag,
     text,
     variant,
-    enabled: qaFeatureEnabled && enabled,
+    enabled: qaFeatureEnabled && qaLanguageEnabled && enabled,
     initialIssues,
   });
 
   const noopUpdateIssueState = useCallback(() => {}, []);
 
-  if (!qaFeatureEnabled) {
+  if (!qaFeatureEnabled || !qaLanguageEnabled) {
     return {
       issues: [],
       isLoading: false,

--- a/webapp/src/ee/qa/hooks/useQaDisabledLanguageIds.ts
+++ b/webapp/src/ee/qa/hooks/useQaDisabledLanguageIds.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+
+import { useApiQuery } from 'tg.service/http/useQueryApi';
+import { useProject } from 'tg.hooks/useProject';
+import { useQaChecksEnabled } from './useQaChecksEnabled';
+import { LanguageModel } from 'tg.service/apiSchemaTypes.generated';
+
+export const useQaDisabledLanguages = (): LanguageModel[] => {
+  const project = useProject();
+  const qaEnabled = useQaChecksEnabled();
+
+  const languagesLoadable = useApiQuery({
+    url: '/v2/projects/{projectId}/qa-settings/languages',
+    method: 'get',
+    path: { projectId: project.id },
+    options: { enabled: qaEnabled, staleTime: 60_000 },
+  });
+
+  return useMemo(
+    () =>
+      languagesLoadable.data
+        ?.filter((config) => !config.enabled)
+        ?.map((config) => config.language) ?? [],
+    [languagesLoadable.data]
+  );
+};
+
+export const useQaDisabledLanguageIds = (): Set<number> => {
+  const languages = useQaDisabledLanguages();
+
+  return useMemo(
+    () => new Set<number>(languages.map((language) => language.id)),
+    [languages]
+  );
+};
+
+export const useQaDisabledLanguageTags = (): Set<string> => {
+  const languages = useQaDisabledLanguages();
+
+  return useMemo(
+    () => new Set<string>(languages.map((language) => language.tag)),
+    [languages]
+  );
+};

--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -57,6 +57,7 @@ import {
 } from '../ee/qa/components/QaChecksPanel';
 export { QaBadge } from '../ee/qa/components/QaBadge';
 export { useQaChecksEnabled } from '../ee/qa/hooks/useQaChecksEnabled';
+export { useQaDisabledLanguageIds } from '../ee/qa/hooks/useQaDisabledLanguageIds';
 export { QaLanguageStats } from '../ee/qa/components/QaLanguageStats';
 export { QaCheckItem } from '../ee/qa/components/QaCheckItem';
 export { QaIssueHighlight } from '../ee/qa/components/QaIssueHighlight';

--- a/webapp/src/eeSetup/eeModule.oss.tsx
+++ b/webapp/src/eeSetup/eeModule.oss.tsx
@@ -39,6 +39,7 @@ export const TaskFilterPopover = Empty;
 export const TaskAllDonePlaceholder = Empty;
 export const QaBadge = (_props: QaBadgeProps) => Empty() as JSX.Element;
 export const useQaChecksEnabled = (): boolean => false;
+export const useQaDisabledLanguageIds = (): Set<number> => new Set();
 export const QaLanguageStats = (_props: QaLanguageStatsProps) =>
   Empty() as JSX.Element;
 export const QaCheckItem = Empty;

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -895,11 +895,11 @@ export interface paths {
     put: operations["updateLanguageSettings"];
     delete: operations["deleteLanguageSettings"];
   };
-  "/v2/projects/{projectId}/qa-settings/languages/{languageId}/resolved": {
-    get: operations["getLanguageSettingsResolved"];
-  };
   "/v2/projects/{projectId}/qa-settings/languages/{languageId}/enabled": {
     put: operations["setLanguageQaEnabled"];
+  };
+  "/v2/projects/{projectId}/qa-settings/languages/{languageId}/resolved": {
+    get: operations["getLanguageSettingsResolved"];
   };
   "/v2/projects/{projectId}/single-step-import": {
     /** Unlike the /v2/projects/{projectId}/import endpoint, imports the data in single request by provided files and parameters. This is useful for automated importing via API or CLI. */
@@ -19985,47 +19985,6 @@ export interface operations {
       };
     };
   };
-  setLanguageQaEnabled: {
-    parameters: {
-      path: {
-        projectId: number;
-        languageId: number;
-      };
-    };
-    responses: {
-      /** OK */
-      200: unknown;
-      /** Bad Request */
-      400: {
-        content: {
-          "application/json": string;
-        };
-      };
-      /** Unauthorized */
-      401: {
-        content: {
-          "application/json": string;
-        };
-      };
-      /** Forbidden */
-      403: {
-        content: {
-          "application/json": string;
-        };
-      };
-      /** Not Found */
-      404: {
-        content: {
-          "application/json": string;
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["QaEnabledRequest"];
-      };
-    };
-  };
   setQaEnabled: {
     parameters: {
       path: {
@@ -20223,6 +20182,47 @@ export interface operations {
         content: {
           "application/json": string;
         };
+      };
+    };
+  };
+  setLanguageQaEnabled: {
+    parameters: {
+      path: {
+        languageId: number;
+        projectId: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: unknown;
+      /** Bad Request */
+      400: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Unauthorized */
+      401: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Forbidden */
+      403: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Not Found */
+      404: {
+        content: {
+          "application/json": string;
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["QaEnabledRequest"];
       };
     };
   };

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -898,6 +898,9 @@ export interface paths {
   "/v2/projects/{projectId}/qa-settings/languages/{languageId}/resolved": {
     get: operations["getLanguageSettingsResolved"];
   };
+  "/v2/projects/{projectId}/qa-settings/languages/{languageId}/enabled": {
+    put: operations["setLanguageQaEnabled"];
+  };
   "/v2/projects/{projectId}/single-step-import": {
     /** Unlike the /v2/projects/{projectId}/import endpoint, imports the data in single request by provided files and parameters. This is useful for automated importing via API or CLI. */
     post: operations["singleStepFromFiles"];
@@ -4179,6 +4182,7 @@ export interface components {
     };
     LanguageQaConfigModel: {
       customSettings?: { [key: string]: "WARNING" | "OFF" };
+      enabled: boolean;
       language: components["schemas"]["LanguageModel"];
     };
     LanguageRequest: {
@@ -19978,6 +19982,47 @@ export interface operations {
         content: {
           "application/json": string;
         };
+      };
+    };
+  };
+  setLanguageQaEnabled: {
+    parameters: {
+      path: {
+        projectId: number;
+        languageId: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: unknown;
+      /** Bad Request */
+      400: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Unauthorized */
+      401: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Forbidden */
+      403: {
+        content: {
+          "application/json": string;
+        };
+      };
+      /** Not Found */
+      404: {
+        content: {
+          "application/json": string;
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["QaEnabledRequest"];
       };
     };
   };

--- a/webapp/src/views/projects/translations/TranslationsList/TranslationRead.tsx
+++ b/webapp/src/views/projects/translations/TranslationsList/TranslationRead.tsx
@@ -8,7 +8,7 @@ import { TranslationLanguage } from './TranslationLanguage';
 import { AiPlaygroundPreview } from '../translationVisual/AiPlaygroundPreview';
 import { TranslationLabels } from 'tg.views/projects/translations/TranslationsList/TranslationLabels';
 import { SuggestionsFirst } from '../Suggestions/SuggestionsFirst';
-import { useQaChecksEnabled } from 'tg.ee';
+import { useQaChecksEnabled, useQaDisabledLanguageIds } from 'tg.ee';
 import { getFirstPluralVariantWithQaIssues } from 'tg.fixtures/qaUtils';
 
 const StyledContainer = styled('div')`
@@ -93,6 +93,9 @@ export const TranslationRead: React.FC<Props> = ({
   } = tools;
 
   const qaChecksEnabled = useQaChecksEnabled();
+  const qaDisabledLanguageIds = useQaDisabledLanguageIds();
+  const languageQaEnabled =
+    qaChecksEnabled && !qaDisabledLanguageIds.has(language.id);
 
   const toggleEdit = () => (isEditing ? handleClose() : handleOpen());
 
@@ -160,7 +163,7 @@ export const TranslationRead: React.FC<Props> = ({
           disabled={disabled}
           showHighlights={isEditingRow && language.base}
           isPlural={keyData.keyIsPlural}
-          qaIssues={qaChecksEnabled ? translation?.qaIssues : undefined}
+          qaIssues={languageQaEnabled ? translation?.qaIssues : undefined}
           translationId={translation?.id}
         />
         {Boolean(translation?.suggestions?.length) && (

--- a/webapp/src/views/projects/translations/TranslationsTable/TranslationRead.tsx
+++ b/webapp/src/views/projects/translations/TranslationsTable/TranslationRead.tsx
@@ -8,7 +8,7 @@ import { TranslationFlags } from '../cell/TranslationFlags';
 import { AiPlaygroundPreview } from '../translationVisual/AiPlaygroundPreview';
 import { TranslationLabels } from 'tg.views/projects/translations/TranslationsList/TranslationLabels';
 import { SuggestionsFirst } from '../Suggestions/SuggestionsFirst';
-import { useQaChecksEnabled } from 'tg.ee';
+import { useQaChecksEnabled, useQaDisabledLanguageIds } from 'tg.ee';
 import { getFirstPluralVariantWithQaIssues } from 'tg.fixtures/qaUtils';
 
 const StyledContainer = styled('div')`
@@ -88,6 +88,9 @@ export const TranslationRead: React.FC<Props> = ({
   } = tools;
 
   const qaChecksEnabled = useQaChecksEnabled();
+  const qaDisabledLanguageIds = useQaDisabledLanguageIds();
+  const languageQaEnabled =
+    qaChecksEnabled && !qaDisabledLanguageIds.has(language.id);
 
   const toggleEdit = () => (isEditing ? handleClose() : handleOpen());
 
@@ -112,7 +115,7 @@ export const TranslationRead: React.FC<Props> = ({
           disabled={disabled}
           showHighlights={isEditingRow && language.base}
           isPlural={keyData.keyIsPlural}
-          qaIssues={qaChecksEnabled ? translation?.qaIssues : undefined}
+          qaIssues={languageQaEnabled ? translation?.qaIssues : undefined}
           translationId={translation?.id}
         />
         {Boolean(translation?.totalSuggestionCount) && (


### PR DESCRIPTION
## UI

<img width="824" height="264" alt="Screenshot 2026-06-06 at 10 56 07" src="https://github.com/user-attachments/assets/36dc7618-6331-4291-8a9d-0ec0a6c5a57e" />

## Summary

- Add a per-language **QA on/off toggle** in the "QA for languages" settings, backed by a new `LanguageQaConfig.enabled` flag and `PUT /v2/projects/{projectId}/qa-settings/languages/{languageId}/enabled`. The flag is orthogonal to per-check severities, so a language's preferences are remembered while QA is off for it.
- **Suppress-at-read**, mirroring the project-level `Project.useQaChecks` toggle one tier down: a disabled language's QA issues are excluded from the translation-view counts, the per-translation issues endpoint, the QA filters, and language stats. Issues are **never deleted**, so re-enabling is lossless — only stale translations are rechecked.
- Disabled languages are skipped during rechecks (activity-listener fan-out, recheck service and the batch processor), so existing issues survive edits and base-language changes while a language is off.
- **Frontend**: inline enable/disable switch per language with a "QA off" summary; disabled languages are filtered out of the QA filter and their issues are not rendered.
- Backend + Cypress coverage added; new Liquibase column `language_qa_config.enabled` (default `true`, backfills existing rows).

Closes #3699


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-language QA controls: enable/disable QA checks per project language via UI toggle and API; rechecks and QA processing honor these settings.
  * QA visibility: QA issues and counts are hidden/zeroed for disabled languages across views and stats.

* **Tests**
  * Added E2E and backend tests covering toggle behavior, stats, rechecks, and API responses for disabled languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->