### PR TITLE
chore: prevent TS7056 in the locales declaration build

### DIFF
--- a/library/src/constants/locales.ts
+++ b/library/src/constants/locales.ts
@@ -8,68 +8,72 @@ import daDateLocale from 'date-fns/locale/da';
 import jaDateLocale from 'date-fns/locale/ja';
 import zhCNDateLocale from 'date-fns/locale/zh-CN';
 
+// Explicit return type, not inference: otherwise tsc serializes each i18n JSON's full shape into
+// locales.d.ts, which trips TS7056 in the declaration build once the translation set grows large.
+type TranslationsData = Record<string, unknown>;
+
 export const locales = {
   en: {
     name: 'English',
     flag: '🇬🇧',
     dateFnsLocale: enDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/en.json').then((m) => m.default),
   },
   cs: {
     name: 'Čeština',
     flag: '🇨🇿',
     dateFnsLocale: csDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/cs.json').then((m) => m.default),
   },
   fr: {
     name: 'Français',
     flag: '🇫🇷',
     dateFnsLocale: frDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/fr.json').then((m) => m.default),
   },
   es: {
     name: 'Español',
     flag: '🇪🇸',
     dateFnsLocale: esDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/es.json').then((m) => m.default),
   },
   de: {
     name: 'Deutsch',
     flag: '🇩🇪',
     dateFnsLocale: deDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/de.json').then((m) => m.default),
   },
   pt: {
     name: 'Português',
     flag: '🇧🇷',
     dateFnsLocale: ptDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/pt.json').then((m) => m.default),
   },
   da: {
     name: 'Dansk',
     flag: '🇩🇰',
     dateFnsLocale: daDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/da.json').then((m) => m.default),
   },
   ja: {
     name: '日本語',
     flag: '🇯🇵',
     dateFnsLocale: jaDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/ja.json').then((m) => m.default),
   },
   zh: {
     name: '简体中文',
     flag: '🇨🇳',
     dateFnsLocale: zhCNDateLocale,
-    translations: () =>
+    translations: (): Promise<TranslationsData> =>
       import('../../../webapp/src/i18n/zh.json').then((m) => m.default),
   },
 };


### PR DESCRIPTION
## Summary

- `library/src/constants/locales.ts`: each locale's `translations` loader was inferred as returning the full i18n JSON module type. Across ~9 locales (~2900 keys each) the serialized `locales.d.ts` reached ~1.4 MB and crossed tsc's **TS7056** serialization limit during `build:types`.
- This surfaced only in CI's "Frontend static check", which runs `tsc:prod` **after** pulling the live (growing) translation set — so the threshold was crossed by translation growth, not by any code change (`main` passed earlier with a smaller live set).
- Fix: annotate each loader's return type as `Promise<Record<string, unknown>>` so the declaration no longer embeds the JSON shape. `locales.d.ts` drops ~1.4 MB → ~1.5 KB, making the build independent of the translation count.
- No behavior change. `keyof typeof locales` (the locale codes) and the missing-key check (`webapp/tolgee.prod.d.ts`, derived from `en.json` directly) are unaffected; the `translations()` loader is never invoked in app code.
- Verified locally: `library build:types` (locales.d.ts 1.4 MB → 1.5 KB), `webapp tsc:prod`, library lint, webapp tsc, webapp eslint — all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety for translation data handling across all supported locales to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->