### PR TITLE
feat: add "All/Base language only" options to translation language selector

### DIFF
--- a/e2e/cypress/common/shared.ts
+++ b/e2e/cypress/common/shared.ts
@@ -108,26 +108,23 @@ export const toggleInMultiselect = (
   chainable.find('div').first().click();
 
   getPopover().within(() => {
-    // first select all
+    // first select all (only real language items, not the All/Base/None actions)
     getPopover()
-      .get('input')
-      .each(
-        // cy.xpath(`.//*[text() = '${val}']/ancestor/ancestor::li//input`).each(
-        ($input) => {
-          const isChecked = $input.is(':checked');
-          if (!isChecked) {
-            cy.wrap($input).click();
-          }
+      .get('li[data-cy="translations-language-select-item"] input')
+      .each(($input) => {
+        const isChecked = $input.is(':checked');
+        if (!isChecked) {
+          cy.wrap($input).click();
         }
-      );
+      });
 
     // unselect necessary
     getPopover()
-      .get('.MuiListItemText-primary')
-      .each(($label) => {
-        const labelText = $label.text();
+      .get('li[data-cy="translations-language-select-item"]')
+      .each(($li) => {
+        const labelText = $li.find('.MuiListItemText-primary').text();
         if (!renderedValues.includes(labelText)) {
-          cy.wrap($label).click();
+          cy.wrap($li).find('.MuiListItemText-primary').click();
         }
       });
   });
@@ -140,7 +137,7 @@ export const assertMultiselect = (chainable: Chainable, values: string[]) => {
 
   getPopover().within(() => {
     getPopover()
-      .get('li.MuiMenuItem-root')
+      .get('li[data-cy="translations-language-select-item"]')
       .each(($li) => {
         const labelText = $li.find('.MuiListItemText-primary').text();
         const input = cy.wrap($li).find('input');

--- a/e2e/cypress/common/translations.ts
+++ b/e2e/cypress/common/translations.ts
@@ -207,6 +207,20 @@ export const toggleLang = (lang) => {
   waitForGlobalLoading();
 };
 
+export const selectAllLanguages = () => {
+  cy.gcy('translations-language-select-form-control').click();
+  cy.gcy('translations-language-select-all').click();
+  dismissMenu();
+  waitForGlobalLoading();
+};
+
+export const selectBaseLanguage = () => {
+  cy.gcy('translations-language-select-form-control').click();
+  cy.gcy('translations-language-select-base').click();
+  dismissMenu();
+  waitForGlobalLoading();
+};
+
 export const create4Translations = (projectId: number) => {
   const promises = [];
   for (let i = 1; i < 5; i++) {

--- a/e2e/cypress/e2e/translations/with5translations/options.cy.ts
+++ b/e2e/cypress/e2e/translations/with5translations/options.cy.ts
@@ -1,6 +1,8 @@
 import { ProjectDTO } from '../../../../../webapp/src/service/response.types';
 import {
   create4Translations,
+  selectAllLanguages,
+  selectBaseLanguage,
   toggleLang,
   translationsBeforeEach,
   visitTranslations,
@@ -33,6 +35,40 @@ describe('Options with 5 Translations', () => {
       cy.contains('Studený přeložený text 1').should('not.exist');
       toggleLang('English');
       cy.contains('Select at least one language').should('be.visible');
+    });
+
+    it('will select all languages', () => {
+      cy.contains('Cool translated text 1').should('be.visible');
+      cy.contains('Studený přeložený text 1').should('not.exist');
+      selectAllLanguages();
+      cy.contains('Cool translated text 1').should('be.visible');
+      cy.contains('Studený přeložený text 1').should('be.visible');
+    });
+
+    it('will select base language only', () => {
+      toggleLang('Česky');
+      cy.contains('Studený přeložený text 1').should('be.visible');
+      cy.contains('Cool translated text 1').should('be.visible');
+      selectBaseLanguage();
+      cy.contains('Cool translated text 1').should('be.visible');
+      cy.contains('Studený přeložený text 1').should('not.exist');
+    });
+
+    it('reflects selection state on the All/Base options', () => {
+      cy.gcy('translations-language-select-form-control').click();
+      cy.gcy('translations-language-select-base')
+        .find('input')
+        .should('be.checked');
+      cy.gcy('translations-language-select-all')
+        .find('input')
+        .should('not.be.checked');
+      cy.gcy('translations-language-select-all').click();
+      cy.gcy('translations-language-select-all')
+        .find('input')
+        .should('be.checked');
+      cy.gcy('translations-language-select-base')
+        .find('input')
+        .should('not.be.checked');
     });
 
     it('will search', () => {

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -903,6 +903,7 @@ declare namespace DataCy {
         "translations-key-edit-key-field": true;
         "translations-key-name": true;
         "translations-language-select-all": true;
+        "translations-language-select-base": true;
         "translations-language-select-form-control": true;
         "translations-language-select-item": true;
         "translations-language-select-none": true;

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -63,8 +63,17 @@ export const getLanguagesContent = ({
     value.includes(lang.tag)
   );
 
-  // Показываем кнопки "All" и "None" только для batch операций
   const isBatchOperation = context === 'batch-operations';
+  const isTranslations = context === 'translations';
+
+  const baseLang = languages.find((l) => l.base)?.tag;
+  const isOnlyBaseSelected = value.length === 1 && value[0] === baseLang;
+
+  const handleSelectBase = () => {
+    if (baseLang) {
+      onChange([baseLang]);
+    }
+  };
 
   const languageItems = languages.map((lang) => (
     <MenuItem
@@ -79,9 +88,8 @@ export const getLanguagesContent = ({
     </MenuItem>
   ));
 
-  if (isBatchOperation) {
+  if (isTranslations) {
     return [
-      // All button
       <MenuItem
         key="select-all"
         onClick={handleSelectAll}
@@ -90,7 +98,32 @@ export const getLanguagesContent = ({
         <Checkbox checked={allSelected} size="small" />
         <ListItemText primary={t('languages_permitted_list_select_all')} />
       </MenuItem>,
-      // None button
+      <MenuItem
+        key="select-base"
+        onClick={handleSelectBase}
+        disabled={!baseLang}
+        data-cy="translations-language-select-base"
+      >
+        <Checkbox checked={isOnlyBaseSelected} size="small" />
+        <ListItemText
+          primary={t('languages_select_base_language', 'Base language')}
+        />
+      </MenuItem>,
+      <Divider key="divider" />,
+      ...languageItems,
+    ];
+  }
+
+  if (isBatchOperation) {
+    return [
+      <MenuItem
+        key="select-all"
+        onClick={handleSelectAll}
+        data-cy="translations-language-select-all"
+      >
+        <Checkbox checked={allSelected} size="small" />
+        <ListItemText primary={t('languages_permitted_list_select_all')} />
+      </MenuItem>,
       <MenuItem
         key="select-none"
         onClick={handleSelectNone}
@@ -99,13 +132,10 @@ export const getLanguagesContent = ({
         <Checkbox checked={false} size="small" />
         <ListItemText primary={t('llm_provider_form_select_priority_none')} />
       </MenuItem>,
-      // Divider
       <Divider key="divider" />,
-      // Individual language items
       ...languageItems,
     ];
   }
 
-  // Для обычного фильтра языков возвращаем только список языков без кнопок "All" и "None"
   return languageItems;
 };

--- a/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
+++ b/webapp/src/component/common/form/LanguagesSelect/getLanguagesContent.tsx
@@ -106,7 +106,7 @@ export const getLanguagesContent = ({
       >
         <Checkbox checked={isOnlyBaseSelected} size="small" />
         <ListItemText
-          primary={t('languages_select_base_language', 'Base language')}
+          primary={t('languages_select_base_language', 'Base language only')}
         />
       </MenuItem>,
       <Divider key="divider" />,


### PR DESCRIPTION
## Summary

Reworks the language dropdown in the translations view to offer two quick-select options at the top of the menu (mirroring the batch-operations selector):

- **All languages** — selects every available language
- **Base language only** — selects only the base language

Each option has a checkbox reflecting the current selection state (All languages is checked when everything is selected; Base language is checked when only the base language is selected).

Closes #3336

> Supersedes #3518, which GitHub auto-marked as *merged* after its commits briefly landed on `main` by accident (the branch had a wrong upstream). `main` was reset; this PR carries the same work plus a small label tweak.

## Notes

- Based on current `main`.
- The base-language option uses `t('languages_select_base_language', 'Base language only')` with a default value. Per the current webapp translation workflow, the `languages_select_base_language` key should be created in Tolgee via the API; the default value keeps the UI correct until then. The All-languages option reuses the existing `languages_permitted_list_select_all` key.

## Test plan

- [x] Translations view → open language dropdown → "All languages" and "Base language only" appear at the top, above a divider, followed by the language list
- [x] Click "All languages" → all languages become selected
- [x] Select extra languages → click "Base language only" → only the base language remains selected
- [x] Checkboxes reflect the current selection state
- [x] Batch operations language selector unchanged (still shows All/None)

## E2E

`e2e/cypress/e2e/translations/with5translations/options.cy.ts`:
- `will select all languages`
- `will select base language only`
- `reflects selection state on the All/Base options`

The generic `toggleInMultiselect` / `assertMultiselect` helpers are scoped to actual language rows so they ignore the new All/Base checkbox options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced language selection in the translations interface with new "Select All Languages" and "Base Language Only" options for more granular control over translation filtering.

* **Tests**
  * Added comprehensive test coverage for language selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->