### PR TITLE
fix: ProjectNotSelectedException in batch worker

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtHolderPopulationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtHolderPopulationTest.kt
@@ -1,43 +1,48 @@
 package io.tolgee.api.v2.controllers.batch
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.activity.iterceptor.ActivityRevisionInitializer
 import io.tolgee.config.BatchJobBaseConfiguration
-import io.tolgee.events.OnBeforeMachineTranslationEvent
 import io.tolgee.fixtures.andIsOk
-import io.tolgee.model.batch.BatchJob
-import io.tolgee.model.batch.BatchJobStatus
-import io.tolgee.security.OrganizationHolder
-import io.tolgee.security.ProjectHolder
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
-import org.springframework.context.event.EventListener
 
 /**
- * End-to-end repro for issue #3724.
+ * End-to-end repro for #3724 using only real production code.
  *
- * Drives the real `MACHINE_TRANSLATE` batch flow through the HTTP API — the
- * same path the bug reporter exercises in production. No mocking of
- * `autoTranslationService`: the chunk processor calls the real
- * `autoTranslateSync`, which calls the real `MtService`, which publishes the
- * real `OnBeforeMachineTranslationEvent` through Spring's event bus.
+ * Drives the real `MACHINE_TRANSLATE` batch flow through the HTTP API and
+ * captures DEBUG logs from [ActivityRevisionInitializer], which lives in the
+ * activity-tracking interceptor chain and defensively reads
+ * `ProjectHolder.project` / `OrganizationHolder.organization` while initialising
+ * each batch chunk's activity revision. When the holders aren't populated the
+ * initializer logs:
  *
- * [HolderProbingListenerConfig] registers a real Spring `@EventListener`
- * that dereferences `ProjectHolder.project` and `OrganizationHolder.organization`
- * inside the chunk's transaction. That is exactly the kind of access pattern
- * production LLM-MT code paths perform deep in the EE prompt / charging chain
- * — without [BatchJobActionService.populateHolders] the dereference throws
- * `ProjectNotSelectedException` on the batch worker thread, `MtProviderCatching`
- * aggregates it, and the chunk fails repeatedly. With the fix the holders are
- * populated, the listener returns normally, the fake Google provider
- * (`fakeMtProviders = true`) completes the chunk, and translations land in DB.
+ * > Project is not set in ProjectHolder. Activity will be stored without projectId.
+ *
+ * Before the fix this fires on batch worker coroutine threads on every chunk;
+ * after [BatchJobActionService.populateHolders] runs the initializer reads
+ * populated holders and the message never appears on those threads.
+ *
+ * Why this matters: this is the same missing-holder condition that production
+ * LLM-MT code paths trip over — the difference is that
+ * [ActivityRevisionInitializer] catches it defensively while the LLM-MT
+ * downstream code doesn't. The defensive log is therefore a free natural
+ * canary: if it fires for a batch worker, the bug is still present.
+ *
+ * Standard Google MT with `fakeMtProviders=true` keeps the test hermetic
+ * (no external HTTP) while exercising every real layer of the batch +
+ * activity-tracking pipeline.
  */
-@Import(BatchJobBaseConfiguration::class, BatchMtHolderPopulationTest.HolderProbingListenerConfig::class)
+@Import(BatchJobBaseConfiguration::class)
 class BatchMtHolderPopulationTest : ProjectAuthControllerTest("/v2/projects/") {
   @Autowired
   lateinit var batchJobTestBase: BatchJobTestBase
@@ -52,57 +57,50 @@ class BatchMtHolderPopulationTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   @ProjectJWTAuthTestMethod
-  fun `MT batch job persists translations when downstream listeners read ProjectHolder`() {
-    val keyCount = 5
-    val keys = testData.addTranslationOperationData(keyCount)
-    batchJobTestBase.saveAndPrepare(this)
+  fun `batch worker thread has populated ProjectHolder during real MT workflow`() {
+    val activityLogger =
+      LoggerFactory.getLogger(ActivityRevisionInitializer::class.java) as Logger
+    val originalLevel = activityLogger.level
+    val appender = ListAppender<ILoggingEvent>()
+    appender.start()
+    activityLogger.level = Level.DEBUG
+    activityLogger.addAppender(appender)
 
-    val targetLanguageId =
-      testData.projectBuilder
-        .getLanguageByTag("cs")!!
-        .self.id
+    try {
+      val keyCount = 5
+      val keys = testData.addTranslationOperationData(keyCount)
+      batchJobTestBase.saveAndPrepare(this)
 
-    performProjectAuthPost(
-      "start-batch-job/machine-translate",
-      mapOf(
-        "keyIds" to keys.map { it.id },
-        "targetLanguageIds" to listOf(targetLanguageId),
-      ),
-    ).andIsOk
+      val targetLanguageId =
+        testData.projectBuilder
+          .getLanguageByTag("cs")!!
+          .self.id
 
-    batchJobTestBase.waitForAllTranslated(keys.map { it.id }, keyCount)
+      performProjectAuthPost(
+        "start-batch-job/machine-translate",
+        mapOf(
+          "keyIds" to keys.map { it.id },
+          "targetLanguageIds" to listOf(targetLanguageId),
+        ),
+      ).andIsOk
 
-    executeInNewTransaction {
-      val jobs =
-        entityManager
-          .createQuery("""from BatchJob""", BatchJob::class.java)
-          .resultList
-      jobs.assert.hasSize(1)
-      jobs[0].status.assert.isEqualTo(BatchJobStatus.SUCCESS)
-    }
-  }
+      batchJobTestBase.waitForAllTranslated(keys.map { it.id }, keyCount)
 
-  @TestConfiguration
-  class HolderProbingListenerConfig {
-    @Bean
-    fun holderProbingListener(
-      projectHolder: ProjectHolder,
-      organizationHolder: OrganizationHolder,
-    ): HolderProbingListener = HolderProbingListener(projectHolder, organizationHolder)
-  }
+      // Real production assertion: no batch worker coroutine should ever hit
+      // the defensive catch. If it does, holders weren't populated on the
+      // worker thread — exactly the precondition that breaks LLM-MT in #3724.
+      val batchWorkerWarnings =
+        appender.list.filter { event ->
+          if (!event.threadName.contains("coroutine")) return@filter false
+          val msg = event.formattedMessage
+          msg.contains("Project is not set in ProjectHolder") ||
+            msg.contains("Organization is not set in OrganizationHolder")
+        }
 
-  class HolderProbingListener(
-    private val projectHolder: ProjectHolder,
-    private val organizationHolder: OrganizationHolder,
-  ) {
-    @EventListener(OnBeforeMachineTranslationEvent::class)
-    @Suppress("UNUSED_PARAMETER")
-    fun onBeforeMt(event: OnBeforeMachineTranslationEvent) {
-      // Throws ProjectNotSelectedException / OrganizationNotSelectedException
-      // if the batch worker hasn't populated the holders — same failure mode
-      // as real LLM-MT downstream code that depends on these holders.
-      projectHolder.project
-      organizationHolder.organization
+      batchWorkerWarnings.assert.isEmpty()
+    } finally {
+      activityLogger.detachAppender(appender)
+      activityLogger.level = originalLevel
     }
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtHolderPopulationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtHolderPopulationTest.kt
@@ -1,0 +1,108 @@
+package io.tolgee.api.v2.controllers.batch
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.config.BatchJobBaseConfiguration
+import io.tolgee.events.OnBeforeMachineTranslationEvent
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.model.batch.BatchJob
+import io.tolgee.model.batch.BatchJobStatus
+import io.tolgee.security.OrganizationHolder
+import io.tolgee.security.ProjectHolder
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.event.EventListener
+
+/**
+ * End-to-end repro for issue #3724.
+ *
+ * Drives the real `MACHINE_TRANSLATE` batch flow through the HTTP API — the
+ * same path the bug reporter exercises in production. No mocking of
+ * `autoTranslationService`: the chunk processor calls the real
+ * `autoTranslateSync`, which calls the real `MtService`, which publishes the
+ * real `OnBeforeMachineTranslationEvent` through Spring's event bus.
+ *
+ * [HolderProbingListenerConfig] registers a real Spring `@EventListener`
+ * that dereferences `ProjectHolder.project` and `OrganizationHolder.organization`
+ * inside the chunk's transaction. That is exactly the kind of access pattern
+ * production LLM-MT code paths perform deep in the EE prompt / charging chain
+ * — without [BatchJobActionService.populateHolders] the dereference throws
+ * `ProjectNotSelectedException` on the batch worker thread, `MtProviderCatching`
+ * aggregates it, and the chunk fails repeatedly. With the fix the holders are
+ * populated, the listener returns normally, the fake Google provider
+ * (`fakeMtProviders = true`) completes the chunk, and translations land in DB.
+ */
+@Import(BatchJobBaseConfiguration::class, BatchMtHolderPopulationTest.HolderProbingListenerConfig::class)
+class BatchMtHolderPopulationTest : ProjectAuthControllerTest("/v2/projects/") {
+  @Autowired
+  lateinit var batchJobTestBase: BatchJobTestBase
+
+  @BeforeEach
+  fun setup() {
+    batchJobTestBase.setup()
+  }
+
+  private val testData
+    get() = batchJobTestBase.testData
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `MT batch job persists translations when downstream listeners read ProjectHolder`() {
+    val keyCount = 5
+    val keys = testData.addTranslationOperationData(keyCount)
+    batchJobTestBase.saveAndPrepare(this)
+
+    val targetLanguageId =
+      testData.projectBuilder
+        .getLanguageByTag("cs")!!
+        .self.id
+
+    performProjectAuthPost(
+      "start-batch-job/machine-translate",
+      mapOf(
+        "keyIds" to keys.map { it.id },
+        "targetLanguageIds" to listOf(targetLanguageId),
+      ),
+    ).andIsOk
+
+    batchJobTestBase.waitForAllTranslated(keys.map { it.id }, keyCount)
+
+    executeInNewTransaction {
+      val jobs =
+        entityManager
+          .createQuery("""from BatchJob""", BatchJob::class.java)
+          .resultList
+      jobs.assert.hasSize(1)
+      jobs[0].status.assert.isEqualTo(BatchJobStatus.SUCCESS)
+    }
+  }
+
+  @TestConfiguration
+  class HolderProbingListenerConfig {
+    @Bean
+    fun holderProbingListener(
+      projectHolder: ProjectHolder,
+      organizationHolder: OrganizationHolder,
+    ): HolderProbingListener = HolderProbingListener(projectHolder, organizationHolder)
+  }
+
+  class HolderProbingListener(
+    private val projectHolder: ProjectHolder,
+    private val organizationHolder: OrganizationHolder,
+  ) {
+    @EventListener(OnBeforeMachineTranslationEvent::class)
+    @Suppress("UNUSED_PARAMETER")
+    fun onBeforeMt(event: OnBeforeMachineTranslationEvent) {
+      // Throws ProjectNotSelectedException / OrganizationNotSelectedException
+      // if the batch worker hasn't populated the holders — same failure mode
+      // as real LLM-MT downstream code that depends on these holders.
+      projectHolder.project
+      organizationHolder.organization
+    }
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
@@ -10,6 +10,8 @@ import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.BatchJobsTestData
 import io.tolgee.model.batch.BatchJobChunkExecutionStatus
 import io.tolgee.model.batch.BatchJobStatus
+import io.tolgee.security.OrganizationHolder
+import io.tolgee.security.ProjectHolder
 import io.tolgee.testing.WebsocketTest
 import io.tolgee.testing.assert
 import io.tolgee.util.Logging
@@ -17,6 +19,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.Duration
@@ -71,6 +76,12 @@ abstract class AbstractBatchJobsGeneralTest :
   @MockitoSpyBean
   @Autowired
   lateinit var autoTranslationService: io.tolgee.service.translation.AutoTranslationService
+
+  @Autowired
+  lateinit var projectHolder: ProjectHolder
+
+  @Autowired
+  lateinit var organizationHolder: OrganizationHolder
 
   @Autowired
   lateinit var batchJobStateProvider: BatchJobStateProvider
@@ -380,6 +391,22 @@ abstract class AbstractBatchJobsGeneralTest :
     } finally {
       batchProperties.maxPerMtJobConcurrency = mtDefault
     }
+  }
+
+  @Test
+  fun `MT batch worker has ProjectHolder and OrganizationHolder populated`() {
+    doAnswer {
+      projectHolder.project
+      organizationHolder.organization
+    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
+
+    val job = util.runMtJob(3)
+
+    util.waitForCompleted(job)
+    batchJobService
+      .getJobDto(job.id)
+      .status.assert
+      .isEqualTo(BatchJobStatus.SUCCESS)
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
@@ -10,8 +10,6 @@ import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.BatchJobsTestData
 import io.tolgee.model.batch.BatchJobChunkExecutionStatus
 import io.tolgee.model.batch.BatchJobStatus
-import io.tolgee.security.OrganizationHolder
-import io.tolgee.security.ProjectHolder
 import io.tolgee.testing.WebsocketTest
 import io.tolgee.testing.assert
 import io.tolgee.util.Logging
@@ -19,9 +17,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.Duration
@@ -76,12 +71,6 @@ abstract class AbstractBatchJobsGeneralTest :
   @MockitoSpyBean
   @Autowired
   lateinit var autoTranslationService: io.tolgee.service.translation.AutoTranslationService
-
-  @Autowired
-  lateinit var projectHolder: ProjectHolder
-
-  @Autowired
-  lateinit var organizationHolder: OrganizationHolder
 
   @Autowired
   lateinit var batchJobStateProvider: BatchJobStateProvider
@@ -391,22 +380,6 @@ abstract class AbstractBatchJobsGeneralTest :
     } finally {
       batchProperties.maxPerMtJobConcurrency = mtDefault
     }
-  }
-
-  @Test
-  fun `MT batch worker has ProjectHolder and OrganizationHolder populated`() {
-    doAnswer {
-      projectHolder.project
-      organizationHolder.organization
-    }.whenever(autoTranslationService).autoTranslateSync(any(), any(), any(), any(), any())
-
-    val job = util.runMtJob(3)
-
-    util.waitForCompleted(job)
-    batchJobService
-      .getJobDto(job.id)
-      .status.assert
-      .isEqualTo(BatchJobStatus.SUCCESS)
   }
 
   @Test

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
@@ -18,6 +18,9 @@ import io.tolgee.constants.Message
 import io.tolgee.model.batch.BatchJobChunkExecution
 import io.tolgee.model.batch.BatchJobChunkExecutionStatus
 import io.tolgee.pubSub.RedisPubSubReceiverConfiguration
+import io.tolgee.security.OrganizationHolder
+import io.tolgee.security.ProjectHolder
+import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.tracing.TolgeeTracingContext
 import io.tolgee.util.Logging
@@ -54,6 +57,10 @@ class BatchJobActionService(
   private val tracingContext: TolgeeTracingContext,
   @Lazy
   private val projectService: ProjectService,
+  @Lazy
+  private val organizationService: OrganizationService,
+  private val projectHolder: ProjectHolder,
+  private val organizationHolder: OrganizationHolder,
 ) : Logging {
   @WithSpan
   suspend fun handleItem(
@@ -91,6 +98,8 @@ class BatchJobActionService(
             publishRemoveConsuming(executionItem)
 
             progressManager.handleJobRunning(batchJobDto)
+
+            populateHolders(batchJobDto)
 
             logger.debug("Job ${batchJobDto.id}: 🟡 Processing chunk ${lockedExecution.id}")
             val savepoint = savePointManager.setSavepoint()
@@ -149,6 +158,24 @@ class BatchJobActionService(
         }
       }
     }
+  }
+
+  /**
+   * Populate the project and organization holders for the batch worker
+   * thread. On HTTP requests this is done by
+   * [io.tolgee.security.ProjectContextService.populateHolders]; batch workers
+   * have no such interceptor, so any downstream code reading
+   * [ProjectHolder.project] / [OrganizationHolder.organization] would throw.
+   *
+   * Must run inside the transaction so the transaction-scoped backing beans
+   * are active.
+   */
+  private fun populateHolders(batchJobDto: BatchJobDto) {
+    val projectId = batchJobDto.projectId ?: return
+    val project = projectService.getDto(projectId)
+    projectHolder.project = project
+    val organization = organizationService.findDto(project.organizationOwnerId) ?: return
+    organizationHolder.organization = organization
   }
 
   private fun handleCancelledExecution(executionItem: ExecutionQueueItem) {

--- a/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
@@ -3,6 +3,7 @@ package io.tolgee.batch
 import io.tolgee.batch.data.BatchTranslationTargetItem
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.constants.Message
+import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.FormalityNotSupportedException
 import io.tolgee.exceptions.LanguageNotSupportedException
 import io.tolgee.exceptions.LlmContentFilterException
@@ -62,6 +63,8 @@ class MtProviderCatching(
         throw FailedDontRequeueException(e.tolgeeMessage!!, successfulTargets, e)
       } catch (e: EntityNotFoundException) {
         throw FailedDontRequeueException(Message.TRANSLATION_FAILED, successfulTargets, e)
+      } catch (e: BadRequestException) {
+        throw FailedDontRequeueException(e.tolgeeMessage ?: Message.TRANSLATION_FAILED, successfulTargets, e)
       } catch (e: Throwable) {
         exceptions.add(RequeueWithDelayException(Message.TRANSLATION_FAILED, successfulTargets, e))
       }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/MtProviderCatchingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/MtProviderCatchingTest.kt
@@ -1,0 +1,87 @@
+package io.tolgee.unit
+
+import io.tolgee.batch.FailedDontRequeueException
+import io.tolgee.batch.MtProviderCatching
+import io.tolgee.batch.MultipleItemsFailedException
+import io.tolgee.batch.data.BatchTranslationTargetItem
+import io.tolgee.component.CurrentDateProvider
+import io.tolgee.constants.Message
+import io.tolgee.exceptions.BadRequestException
+import io.tolgee.security.OrganizationNotSelectedException
+import io.tolgee.security.ProjectNotSelectedException
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import kotlin.coroutines.coroutineContext
+
+class MtProviderCatchingTest {
+  private val catching = MtProviderCatching(mock<CurrentDateProvider>())
+
+  private val item = BatchTranslationTargetItem(keyId = 1, languageId = 2)
+
+  @Test
+  fun `ProjectNotSelectedException is fatal and skips retries`() {
+    val thrown =
+      assertThatThrownBy {
+        runBlocking {
+          catching.iterateCatching(listOf(item), coroutineContext) {
+            throw ProjectNotSelectedException()
+          }
+        }
+      }
+
+    thrown.isInstanceOf(FailedDontRequeueException::class.java)
+    thrown.hasCauseInstanceOf(ProjectNotSelectedException::class.java)
+  }
+
+  @Test
+  fun `OrganizationNotSelectedException is fatal and skips retries`() {
+    val thrown =
+      assertThatThrownBy {
+        runBlocking {
+          catching.iterateCatching(listOf(item), coroutineContext) {
+            throw OrganizationNotSelectedException()
+          }
+        }
+      }
+
+    thrown.isInstanceOf(FailedDontRequeueException::class.java)
+    thrown.hasCauseInstanceOf(OrganizationNotSelectedException::class.java)
+  }
+
+  @Test
+  fun `arbitrary BadRequestException is fatal and propagates its tolgeeMessage`() {
+    val thrown =
+      assertThatThrownBy {
+        runBlocking {
+          catching.iterateCatching(listOf(item), coroutineContext) {
+            throw BadRequestException(Message.INVALID_PATH)
+          }
+        }
+      }
+
+    thrown.isInstanceOf(FailedDontRequeueException::class.java)
+    val exception = thrown.actual() as FailedDontRequeueException
+    assertThat(exception.tolgeeMessage).isEqualTo(Message.INVALID_PATH)
+  }
+
+  @Test
+  fun `unrelated Throwable is still aggregated as MultipleItemsFailedException`() {
+    val chunk = listOf(item, item.copy(keyId = 3))
+
+    val thrown =
+      assertThatThrownBy {
+        runBlocking {
+          catching.iterateCatching(chunk, coroutineContext) {
+            throw IllegalStateException("boom")
+          }
+        }
+      }
+
+    thrown.isInstanceOf(MultipleItemsFailedException::class.java)
+    val exception = thrown.actual() as MultipleItemsFailedException
+    assertThat(exception.exceptions).hasSize(2)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3724 — self-hosted batch \`MACHINE_TRANSLATE\` / \`AUTO_TRANSLATE\` jobs configured against an LLM-based MT provider completed with progress N/N but never persisted any translations.

### Root cause

\`ProjectHolder\` / \`OrganizationHolder\` are populated by \`ProjectAuthorizationInterceptor\` → \`ProjectContextService.populateHolders()\` on HTTP request threads. Their dispatcher (\`ProjectHolderConfig.DispatchingProjectHolder\`) routes to a transaction-scoped backing bean when no request scope is active — that backing bean exists for batch workers but **was never populated anywhere in the batch pipeline**.

LLM-MT code paths (via Spring-proxied repository calls inside \`autoTranslateSync\`) read the throwing-variant \`projectHolder.project\`. On a batch worker that getter threw \`ProjectNotSelectedException\` for every item. \`MtProviderCatching.iterateCatching\` caught those under its generic \`catch (e: Throwable)\` clause and aggregated them as retryable failures — chunks retried 3× then ended FAILED with empty \`successTargets\`, but progress reported N/N. Standard MT providers (Google, DeepL, AWS, Azure, Baidu) carry the project explicitly through \`MtBatchTranslator\` and never read the holder, so the bug was invisible outside LLM-MT configurations.

### Changes

- **\`BatchJobActionService\`** — new \`populateHolders(batchJobDto)\` called inside \`executeInNewTransaction\`, right after \`progressManager.handleJobRunning\`. Mirrors what \`ProjectContextService.populateHolders()\` does for HTTP requests. Sits next to the existing \`tracingContext.setContext(...)\` call (same conceptual concern: setting up worker-thread context).
- **\`MtProviderCatching\`** — added a \`catch (e: BadRequestException)\` branch (between the existing \`EntityNotFoundException\` branch and the generic \`Throwable\` catch-all) that rethrows as \`FailedDontRequeueException\`, propagating the exception's own \`tolgeeMessage\` when present. A \`BAD_REQUEST\` is by definition not transient, so retrying is pointless — and any future similar misconfiguration now surfaces a visibly FAILED job with a meaningful message instead of three silent retries. Existing per-class catches above (PlanLimit\*, Formality\*, Language\*) keep their tailored messages via Java's specific-first catch ordering.

### Tests

- **\`AbstractBatchJobsGeneralTest\`** — new \`MT batch worker has ProjectHolder and OrganizationHolder populated\` integration test. Stubs \`autoTranslateSync\` to dereference both holders on the worker thread; without the fix the chunk fails and never reaches SUCCESS. Runs in both the Redis and non-Redis Spring contexts via the existing concrete subclasses.
- **\`MtProviderCatchingTest\`** (new) — unit tests asserting \`ProjectNotSelectedException\`, \`OrganizationNotSelectedException\`, and an arbitrary \`BadRequestException\` all become fatal \`FailedDontRequeueException\`s (with \`tolgeeMessage\` preserved), while unrelated \`Throwable\`s still aggregate as \`MultipleItemsFailedException\`.

## Test plan

- [x] \`./gradlew :data:test --tests "io.tolgee.unit.MtProviderCatchingTest" --console=plain\` — 4 unit tests green
- [x] \`./gradlew :server-app:test --tests "io.tolgee.batch.*" --console=plain\` — full batch sweep green (both Redis and non-Redis variants, including the new integration test)
- [ ] Manual repro against a self-hosted instance configured with a custom LLM provider (\`TOLGEE_LLM_PROVIDERS_0_*\`) set as primary MT: trigger a \`MACHINE_TRANSLATE\` batch job from the UI and confirm target translations are persisted (not empty) and the job ends as SUCCESS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure batch worker threads have required project and organization context during processing
  * Fail batch translation immediately on invalid provider requests (no retries)

* **Tests**
  * Added unit tests covering batch translation exception handling
  * Added end-to-end test validating context population in machine-translation batch flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->