### PR TITLE
feat: allow local addresses for webhooks via config flag

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/WebhookProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/WebhookProperties.kt
@@ -22,6 +22,20 @@ class WebhookProperties {
   )
   var autoDisableAfterDays: Int = 3
 
+  @DocProperty(
+    description =
+      "When enabled, webhook URLs may target otherwise-blocked address ranges — " +
+        "loopback, private/site-local, link-local, IPv6 unique-local, multicast and " +
+        "wildcard/any-local addresses. Useful for local development and integration testing.\n" +
+        "\n" +
+        ":::danger\n" +
+        "This removes SSRF protection for webhook targets. Keep it **disabled** on production " +
+        "and multi-tenant servers — anyone able to configure a webhook could otherwise reach " +
+        "internal services.\n" +
+        ":::\n\n",
+  )
+  var allowLocalAddresses: Boolean = false
+
   @PostConstruct
   fun validate() {
     require(autoDisableWarningAfterHours < autoDisableAfterDays * 24) {

--- a/backend/data/src/main/kotlin/io/tolgee/util/UrlSecurity.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/UrlSecurity.kt
@@ -4,7 +4,6 @@ import io.tolgee.configuration.tolgee.InternalProperties
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
 import org.springframework.stereotype.Component
-import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.URI
 
@@ -23,7 +22,10 @@ class UrlSecurity(
    *
    * Skipped when tolgee.internal.disable-url-ssrf-protection is true (E2E tests use localhost URLs).
    */
-  fun validateUrl(url: String) {
+  fun validateUrl(
+    url: String,
+    allowLocalAddresses: Boolean = false,
+  ) {
     if (internalProperties.disableUrlSsrfProtection) return
 
     val uri =
@@ -39,6 +41,8 @@ class UrlSecurity(
     }
 
     val host = uri.host ?: throw BadRequestException(Message.URL_NOT_VALID)
+
+    if (allowLocalAddresses) return
 
     val lowerHost = host.lowercase()
     if (lowerHost == "localhost" || lowerHost.endsWith(".localhost")) {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/util/UrlSecurityTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/util/UrlSecurityTest.kt
@@ -1,7 +1,9 @@
 package io.tolgee.unit.util
 
 import io.tolgee.configuration.tolgee.InternalProperties
+import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
+import io.tolgee.testing.assert
 import io.tolgee.util.UrlSecurity
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -56,6 +58,16 @@ class UrlSecurityTest {
   }
 
   @Test
+  fun `blocks multicast addresses`() {
+    assertThrows<BadRequestException> { urlSecurity.validateUrl("http://224.0.0.1/") }
+  }
+
+  @Test
+  fun `blocks IPv6 unique-local addresses`() {
+    assertThrows<BadRequestException> { urlSecurity.validateUrl("http://[fd00::1]/") }
+  }
+
+  @Test
   fun `blocks malformed URLs`() {
     assertThrows<BadRequestException> { urlSecurity.validateUrl("not-a-url") }
     assertThrows<BadRequestException> { urlSecurity.validateUrl("") }
@@ -65,5 +77,31 @@ class UrlSecurityTest {
   @Test
   fun `blocks URLs without host`() {
     assertThrows<BadRequestException> { urlSecurity.validateUrl("http://") }
+  }
+
+  @Test
+  fun `allows local addresses when allowLocalAddresses is true`() {
+    assertDoesNotThrow { urlSecurity.validateUrl("http://localhost/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://foo.localhost/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://127.0.0.1/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://192.168.1.10/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://[::1]/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://169.254.169.254/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://0.0.0.0/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://224.0.0.1/webhook", allowLocalAddresses = true) }
+    assertDoesNotThrow { urlSecurity.validateUrl("http://[fd00::1]/webhook", allowLocalAddresses = true) }
+  }
+
+  @Test
+  fun `still validates scheme and host when allowLocalAddresses is true`() {
+    assertUrlNotValid { urlSecurity.validateUrl("ftp://example.com/file", allowLocalAddresses = true) }
+    assertUrlNotValid { urlSecurity.validateUrl("file:///etc/passwd", allowLocalAddresses = true) }
+    assertUrlNotValid { urlSecurity.validateUrl("not-a-url", allowLocalAddresses = true) }
+    assertUrlNotValid { urlSecurity.validateUrl("http://", allowLocalAddresses = true) }
+  }
+
+  private fun assertUrlNotValid(executable: () -> Unit) {
+    val exception = assertThrows<BadRequestException>(executable)
+    exception.code.assert.isEqualTo(Message.URL_NOT_VALID.code)
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/WebhookConfigService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/WebhookConfigService.kt
@@ -4,6 +4,7 @@ import io.tolgee.component.automations.processors.WebhookEventType
 import io.tolgee.component.automations.processors.WebhookException
 import io.tolgee.component.automations.processors.WebhookExecutor
 import io.tolgee.component.automations.processors.WebhookRequest
+import io.tolgee.configuration.tolgee.WebhookProperties
 import io.tolgee.dtos.request.WebhookConfigRequest
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.model.Project
@@ -22,6 +23,7 @@ class WebhookConfigService(
   private val webhookExecutor: WebhookExecutor,
   private val automationService: AutomationService,
   private val urlSecurity: UrlSecurity,
+  private val webhookProperties: WebhookProperties,
 ) {
   fun get(
     projectId: Long,
@@ -46,7 +48,7 @@ class WebhookConfigService(
     project: Project,
     dto: WebhookConfigRequest,
   ): WebhookConfig {
-    urlSecurity.validateUrl(dto.url)
+    urlSecurity.validateUrl(dto.url, webhookProperties.allowLocalAddresses)
     val webhookConfig = WebhookConfig(project)
     webhookConfig.url = dto.url
     webhookConfig.webhookSecret = generateRandomWebhookSecret()
@@ -78,7 +80,7 @@ class WebhookConfigService(
     dto: WebhookConfigRequest,
   ): WebhookConfig {
     val webhookConfig = get(projectId, id)
-    urlSecurity.validateUrl(dto.url)
+    urlSecurity.validateUrl(dto.url, webhookProperties.allowLocalAddresses)
     webhookConfig.url = dto.url
     dto.enabled?.let { newEnabled ->
       webhookConfig.enabled = newEnabled

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/LlmProviderControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/LlmProviderControllerTest.kt
@@ -1,9 +1,13 @@
 package io.tolgee.ee.api.v2.controllers
 
+import io.tolgee.configuration.tolgee.WebhookProperties
 import io.tolgee.configuration.tolgee.machineTranslation.LlmProperties
+import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.PromptTestData
 import io.tolgee.dtos.request.llmProvider.LlmProviderRequest
 import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andHasErrorMessage
+import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
@@ -12,6 +16,7 @@ import io.tolgee.model.enums.LlmProviderType
 import io.tolgee.repository.LlmProviderRepository
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -21,6 +26,9 @@ class LlmProviderControllerTest : AuthorizedControllerTest() {
 
   @Autowired
   private lateinit var llmProviderRepository: LlmProviderRepository
+
+  @Autowired
+  private lateinit var webhookProperties: WebhookProperties
 
   @BeforeEach
   fun setup() {
@@ -35,6 +43,12 @@ class LlmProviderControllerTest : AuthorizedControllerTest() {
         ),
       )
     this.userAccount = testData.organizationOwner.self
+  }
+
+  @AfterEach
+  fun resetSsrfProperties() {
+    internalProperties.disableUrlSsrfProtection = true
+    webhookProperties.allowLocalAddresses = false
   }
 
   @Test
@@ -84,6 +98,16 @@ class LlmProviderControllerTest : AuthorizedControllerTest() {
       "/v2/organizations/${testData.organization.self.id}/llm-providers",
       LlmProviderRequest(name = "custom-provider", type = LlmProviderType.OPENAI, apiUrl = "https://api.example.com"),
     ).andIsOk
+  }
+
+  @Test
+  fun `keeps SSRF protection for provider url when webhook local addresses are allowed`() {
+    internalProperties.disableUrlSsrfProtection = false
+    webhookProperties.allowLocalAddresses = true
+    performAuthPost(
+      "/v2/organizations/${testData.organization.self.id}/llm-providers",
+      LlmProviderRequest(name = "local-provider", type = LlmProviderType.OPENAI, apiUrl = "http://localhost"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/WebhookConfigUrlSecurityTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/WebhookConfigUrlSecurityTest.kt
@@ -1,0 +1,107 @@
+package io.tolgee.ee.api.v2.controllers
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.configuration.tolgee.WebhookProperties
+import io.tolgee.constants.Feature
+import io.tolgee.constants.Message
+import io.tolgee.development.testDataBuilder.data.WebhooksTestData
+import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andHasErrorMessage
+import io.tolgee.fixtures.andIsBadRequest
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class WebhookConfigUrlSecurityTest : ProjectAuthControllerTest("/v2/projects/") {
+  lateinit var testData: WebhooksTestData
+
+  @Autowired
+  private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  @Autowired
+  private lateinit var webhookProperties: WebhookProperties
+
+  @BeforeEach
+  fun setup() {
+    testData = WebhooksTestData()
+    projectSupplier = { testData.projectBuilder.self }
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.WEBHOOKS)
+    internalProperties.disableUrlSsrfProtection = false
+    webhookProperties.allowLocalAddresses = false
+  }
+
+  @AfterEach
+  fun after() {
+    enabledFeaturesProvider.forceEnabled = null
+    internalProperties.disableUrlSsrfProtection = true
+    webhookProperties.allowLocalAddresses = false
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `rejects local url on create when allowLocalAddresses is false`() {
+    performProjectAuthPost(
+      "webhook-configs",
+      mapOf("url" to "http://localhost"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `allows local url on create when allowLocalAddresses is true`() {
+    webhookProperties.allowLocalAddresses = true
+    performProjectAuthPost(
+      "webhook-configs",
+      mapOf("url" to "http://localhost"),
+    ).andIsOk.andAssertThatJson {
+      node("url").isEqualTo("http://localhost")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `still rejects non-http scheme on create when allowLocalAddresses is true`() {
+    webhookProperties.allowLocalAddresses = true
+    performProjectAuthPost(
+      "webhook-configs",
+      mapOf("url" to "ftp://localhost"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `SSRF protection is active in this context`() {
+    performProjectAuthPost(
+      "webhook-configs",
+      mapOf("url" to "http://127.0.0.1"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `rejects changing url to local on update when allowLocalAddresses is false`() {
+    performProjectAuthPut(
+      "webhook-configs/${testData.webhookConfig.self.id}",
+      mapOf("url" to "http://localhost"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `allows changing url to local on update when allowLocalAddresses is true`() {
+    webhookProperties.allowLocalAddresses = true
+    performProjectAuthPut(
+      "webhook-configs/${testData.webhookConfig.self.id}",
+      mapOf("url" to "http://localhost"),
+    ).andIsOk.andAssertThatJson {
+      node("url").isEqualTo("http://localhost")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `tolgee.webhook.allow-local-addresses` (env `TOLGEE_WEBHOOK_ALLOW_LOCAL_ADDRESSES`), **disabled by default**. When enabled, webhook URL validation skips the local/private address classification, so self-hosted/dev setups can point webhooks at `localhost`/private hosts without a tunnel.
- The flag is webhook-scoped: it is threaded through `UrlSecurity.validateUrl(url, allowLocalAddresses)` only from `WebhookConfigService`. SSRF protection for LLM/MT provider URLs is unaffected (that call site keeps the default).
- Scheme (`http`/`https`) and host-presence validation still run even when the flag is on, so `file://`, `gopher://`, and host-less URLs remain rejected.
- `@DocProperty` on the new option carries a `:::danger` admonition documenting the full blast radius (loopback, private, link-local, IPv6 ULA, multicast, wildcard) — it removes SSRF protection for webhook targets and must stay disabled on production/multi-tenant servers.
- Tests: `UrlSecurityTest` gains block-side coverage for multicast and IPv6 ULA plus allow-flag pass/reject cases; new `WebhookConfigUrlSecurityTest` covers the webhook create/update endpoints; `LlmProviderControllerTest` gains a cross-service test pinning that provider URLs stay SSRF-protected when the webhook flag is on.

Closes #3711

> Note: the option is named `tolgee.webhook.allow-local-addresses` (rather than the issue's suggested `TOLGEE_ALLOW_LOCAL_WEBHOOKS`) to stay consistent with the existing `tolgee.webhook.*` property family.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to permit webhook URLs to target local and private address ranges (disabled by default).

* **Tests**
  * Enhanced test coverage for webhook URL security validation and SSRF protection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->