### PR TITLE
feat: add filter by description presence to key listing

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
@@ -279,6 +279,44 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
 
   @ProjectJWTAuthTestMethod
   @Test
+  fun `filters by hasDescription`() {
+    testData.addKeysWithDescriptions()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    performProjectAuthGet("/translations?filterHasDescription=true")
+      .andPrettyPrint.andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys") {
+          isArray.hasSize(3)
+          node("[0].keyName").isEqualTo("A key")
+          node("[1].keyName").isEqualTo("desc-real")
+          node("[2].keyName").isEqualTo("desc-ws")
+        }
+        node("page.totalElements").isEqualTo(3)
+      }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `filters by hasNoDescription`() {
+    testData.addKeysWithDescriptions()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    performProjectAuthGet("/translations?filterHasNoDescription=true")
+      .andPrettyPrint.andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys") {
+          isArray.hasSize(3)
+          node("[0].keyName").isEqualTo("Z key")
+          node("[1].keyName").isEqualTo("desc-null")
+          node("[2].keyName").isEqualTo("desc-empty")
+        }
+        node("page.totalElements").isEqualTo(3)
+      }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
   fun `filters by state`() {
     testDataService.saveTestData(testData.root)
     userAccount = testData.user

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyTrashFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyTrashFilterTest.kt
@@ -106,6 +106,35 @@ class KeyTrashFilterTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @ProjectJWTAuthTestMethod
   @Test
+  fun `trashed listing combined with filterHasDescription returns only trashed keys with a description`() {
+    keyService.softDeleteMultiple(
+      listOf(testData.keyWithDescription.id, testData.numberedKeys[0].id),
+      testData.user,
+    )
+
+    performProjectAuthGet("/keys/trash?filterHasDescription=true")
+      .andPrettyPrint.andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys") {
+          isArray.hasSize(1)
+          node("[0].name").isEqualTo("Key with description")
+        }
+        node("page.totalElements").isEqualTo(1)
+      }
+
+    performProjectAuthGet("/keys/trash?filterHasNoDescription=true")
+      .andPrettyPrint.andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys") {
+          isArray.hasSize(1)
+          node("[0].name").isEqualTo("key 01")
+        }
+        node("page.totalElements").isEqualTo(1)
+      }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
   fun `trashed listing combined with filterKeyName returns only trashed matching keys`() {
     val key05 = testData.numberedKeys[4]
     val key06 = testData.numberedKeys[5]

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeyTrashTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeyTrashTestData.kt
@@ -8,8 +8,9 @@ import io.tolgee.model.key.Key
  * Test data for [KeyTrashFilterTest].
  *
  * Creates a project with English (base) and German, 10 numbered keys ("key 01"–"key 10") with
- * translations in both languages, a second user with MANAGE permission, and 3 tagged keys
- * ("Key with tag", "Another key with tag", "Key with tag 2").
+ * translations in both languages, a second user with MANAGE permission, 3 tagged keys
+ * ("Key with tag", "Another key with tag", "Key with tag 2"), and one key with a description
+ * ("Key with description").
  *
  * All keys and users are exposed as public fields so tests can reference them directly without
  * calling service lookups.
@@ -31,6 +32,7 @@ class KeyTrashTestData : BaseTestData("franta", "Franta's project") {
   lateinit var keyWithTag: Key
   lateinit var anotherKeyWithTag: Key
   lateinit var keyWithTag2: Key
+  lateinit var keyWithDescription: Key
 
   init {
     root.apply {
@@ -106,6 +108,21 @@ class KeyTrashTestData : BaseTestData("franta", "Franta's project") {
           addTranslation {
             language = englishLanguage
             text = "Key with tag 2 EN"
+          }
+        }.self
+
+      keyWithDescription =
+        addKey {
+          name = "Key with description"
+        }.build {
+          setDescription("A trashed key description")
+          addTranslation {
+            language = germanLanguage
+            text = "Key with description DE"
+          }
+          addTranslation {
+            language = englishLanguage
+            text = "Key with description EN"
           }
         }.self
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsTestData.kt
@@ -268,6 +268,36 @@ class TranslationsTestData {
       }
   }
 
+  fun addKeysWithDescriptions() {
+    projectBuilder.addKey { name = "desc-real" }.build {
+      setDescription("A real description")
+      addTranslation {
+        language = englishLanguage
+        text = "desc-real text"
+      }
+    }
+    projectBuilder.addKey { name = "desc-null" }.build {
+      addTranslation {
+        language = englishLanguage
+        text = "desc-null text"
+      }
+    }
+    projectBuilder.addKey { name = "desc-empty" }.build {
+      setDescription("")
+      addTranslation {
+        language = englishLanguage
+        text = "desc-empty text"
+      }
+    }
+    projectBuilder.addKey { name = "desc-ws" }.build {
+      setDescription("   ")
+      addTranslation {
+        language = englishLanguage
+        text = "desc-ws text"
+      }
+    }
+  }
+
   fun generateLotOfData(count: Long = 99) {
     root.data.projects[0].apply {
       (1..count).forEach {

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
@@ -72,6 +72,12 @@ To add multiple languages, repeat this param (eg. ?languages=en&languages=de)"""
   @field:Parameter(description = "Selects only keys without screenshots")
   var filterHasNoScreenshot: Boolean? = false
 
+  @field:Parameter(description = "Selects only keys with a description")
+  var filterHasDescription: Boolean? = false
+
+  @field:Parameter(description = "Selects only keys without a description")
+  var filterHasNoDescription: Boolean? = false
+
   @field:Parameter(
     description = """Selects only keys with provided namespaces. 
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
@@ -83,6 +83,7 @@ class QueryBase<T>(
   val querySelection = QuerySelection()
   val fullTextFields: MutableSet<Expression<String>> = HashSet()
   lateinit var namespaceNameExpression: Path<String>
+  lateinit var descriptionExpression: Path<String>
   lateinit var screenshotCountExpression: Expression<Long>
   var branchJoin: Join<Key, Branch>? = null
   var deletedByJoin: Join<Key, UserAccount>? = null
@@ -212,6 +213,7 @@ class QueryBase<T>(
   private fun addDescription() {
     val keyMeta = this.root.join(Key_.keyMeta, JoinType.LEFT)
     val description = keyMeta.get(KeyMeta_.description)
+    descriptionExpression = description
     this.querySelection[KeyWithTranslationsView::keyDescription.name] = description
     this.fullTextFields.add(description)
   }
@@ -242,10 +244,12 @@ class QueryBase<T>(
     querySelection[KeyWithTranslationsView::deletedByUserAvatarHash.name] = deletedByJoin.get(UserAccount_.avatarHash)
     querySelection[KeyWithTranslationsView::deletedByUserDeletedAt.name] = deletedByJoin.get(UserAccount_.deletedAt)
   }
+}
 
-  val Expression<String>.isNotNullOrBlank: Predicate
-    get() = cb.and(cb.isNotNull(this), cb.notEqual(this, ""))
+fun CriteriaBuilder.isNotNullOrBlank(expression: Expression<String>): Predicate {
+  return and(isNotNull(expression), notEqual(expression, ""))
+}
 
-  val Expression<String>.isNullOrBlank: Predicate
-    get() = cb.or(cb.isNull(this), cb.equal(this, ""))
+fun CriteriaBuilder.isNullOrBlank(expression: Expression<String>): Predicate {
+  return or(isNull(expression), equal(expression, ""))
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
@@ -52,6 +52,8 @@ class QueryGlobalFiltering(
     filterTranslatedAny()
     filterHasScreenshot()
     filterHasNoScreenshot()
+    filterHasDescription()
+    filterHasNoDescription()
     filterSearch()
     filterRevisionId()
     filterFailedTargets()
@@ -111,6 +113,18 @@ class QueryGlobalFiltering(
   private fun filterHasScreenshot() {
     if (params.filterHasScreenshot == true) {
       queryBase.whereConditions.add(cb.gt(queryBase.screenshotCountExpression, 0))
+    }
+  }
+
+  private fun filterHasDescription() {
+    if (params.filterHasDescription == true) {
+      queryBase.whereConditions.add(cb.isNotNullOrBlank(queryBase.descriptionExpression))
+    }
+  }
+
+  private fun filterHasNoDescription() {
+    if (params.filterHasNoDescription == true) {
+      queryBase.whereConditions.add(cb.isNullOrBlank(queryBase.descriptionExpression))
     }
   }
 

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/TranslationsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/TranslationsE2eDataController.kt
@@ -52,6 +52,15 @@ class TranslationsE2eDataController(
     return mapOf("id" to testData.project.id)
   }
 
+  @GetMapping(value = ["/generate-for-description-filters"])
+  @Transactional
+  fun generateForDescriptionFilters(): Map<String, Long> {
+    val testData = TranslationsTestData()
+    testData.addKeysWithDescriptions()
+    testDataService.saveTestData(testData.root)
+    return mapOf("id" to testData.project.id)
+  }
+
   @GetMapping(value = ["/cleanup-for-filters"])
   @Transactional
   fun cleanupForFilters() {

--- a/e2e/cypress/common/apiCalls/testData/testData.ts
+++ b/e2e/cypress/common/apiCalls/testData/testData.ts
@@ -96,6 +96,11 @@ export const translationsTestData = {
     internalFetch('e2e-data/translations/generate-for-filters').then(
       (r) => r.body as ProjectDTO
     ),
+
+  generateForDescriptionFilters: () =>
+    internalFetch(
+      'e2e-data/translations/generate-for-description-filters'
+    ).then((r) => r.body as ProjectDTO),
 };
 
 export const translationsDisabled = generateTestDataObject(

--- a/e2e/cypress/e2e/translations/translationFilters.description.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.description.cy.ts
@@ -1,0 +1,73 @@
+import { ProjectDTO } from '../../../../webapp/src/service/response.types';
+import { visitTranslations } from '../../common/translations';
+import { waitForGlobalLoading } from '../../common/loading';
+import { translationsTestData } from '../../common/apiCalls/testData/testData';
+import { login } from '../../common/apiCalls/common';
+import { assertFilter } from '../../common/filters';
+
+describe('Translation filters - description', () => {
+  let project: ProjectDTO = null;
+
+  before(() => {
+    translationsTestData.cleanupForFilters();
+    translationsTestData
+      .generateForDescriptionFilters()
+      .then((p) => {
+        project = p;
+      })
+      .then(() => {
+        login('franta', 'admin');
+        visit();
+      });
+  });
+
+  beforeEach(() => {
+    login('franta', 'admin');
+    visit();
+    waitForGlobalLoading();
+  });
+
+  after(() => {
+    translationsTestData.cleanupForFilters();
+  });
+
+  it('filters keys with a description', () => {
+    assertFilter({
+      submenu: 'Description',
+      filterOption: ['With description'],
+      toSeeAfter: ['A key', 'desc-real', 'desc-ws'],
+      checkAfter() {
+        cy.gcy('translations-filter-select').contains('With description');
+      },
+    });
+  });
+
+  it('filters keys without a description', () => {
+    assertFilter({
+      submenu: 'Description',
+      filterOption: ['No description'],
+      toSeeAfter: ['Z key', 'desc-null', 'desc-empty'],
+      checkAfter() {
+        cy.gcy('translations-filter-select').contains('No description');
+      },
+    });
+  });
+
+  it('with/without description are mutually exclusive', () => {
+    assertFilter({
+      submenu: 'Description',
+      filterOption: ['With description'],
+      and() {
+        cy.gcy('filter-item').contains('No description').click();
+      },
+      toSeeAfter: ['Z key', 'desc-null', 'desc-empty'],
+      checkAfter() {
+        cy.gcy('translations-filter-select').contains('No description');
+      },
+    });
+  });
+
+  const visit = () => {
+    visitTranslations(project.id);
+  };
+});

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -17211,6 +17211,10 @@ export interface operations {
         filterHasScreenshot?: boolean;
         /** Selects only keys without screenshots */
         filterHasNoScreenshot?: boolean;
+        /** Selects only keys with a description */
+        filterHasDescription?: boolean;
+        /** Selects only keys without a description */
+        filterHasNoDescription?: boolean;
         /**
          * Selects only keys with provided namespaces.
          *
@@ -17347,6 +17351,10 @@ export interface operations {
         filterHasScreenshot?: boolean;
         /** Selects only keys without screenshots */
         filterHasNoScreenshot?: boolean;
+        /** Selects only keys with a description */
+        filterHasDescription?: boolean;
+        /** Selects only keys without a description */
+        filterHasNoDescription?: boolean;
         /**
          * Selects only keys with provided namespaces.
          *
@@ -17519,6 +17527,10 @@ export interface operations {
         filterHasScreenshot?: boolean;
         /** Selects only keys without screenshots */
         filterHasNoScreenshot?: boolean;
+        /** Selects only keys with a description */
+        filterHasDescription?: boolean;
+        /** Selects only keys without a description */
+        filterHasNoDescription?: boolean;
         /**
          * Selects only keys with provided namespaces.
          *
@@ -22451,6 +22463,10 @@ export interface operations {
         filterHasScreenshot?: boolean;
         /** Selects only keys without screenshots */
         filterHasNoScreenshot?: boolean;
+        /** Selects only keys with a description */
+        filterHasDescription?: boolean;
+        /** Selects only keys without a description */
+        filterHasNoDescription?: boolean;
         /**
          * Selects only keys with provided namespaces.
          *
@@ -22767,6 +22783,10 @@ export interface operations {
         filterHasScreenshot?: boolean;
         /** Selects only keys without screenshots */
         filterHasNoScreenshot?: boolean;
+        /** Selects only keys with a description */
+        filterHasDescription?: boolean;
+        /** Selects only keys without a description */
+        filterHasNoDescription?: boolean;
         /**
          * Selects only keys with provided namespaces.
          *

--- a/webapp/src/views/projects/translations/TranslationFilters/SubfilterDescription.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/SubfilterDescription.tsx
@@ -1,0 +1,91 @@
+import { useRef, useState } from 'react';
+import { T, useTranslate } from '@tolgee/react';
+import { Box, Menu } from '@mui/material';
+
+import { SubmenuItem } from 'tg.component/SubmenuItem';
+import { FilterItem } from './FilterItem';
+import { FiltersInternal, FilterActions } from './tools';
+
+type Props = {
+  projectId: number;
+  value: FiltersInternal;
+  actions: FilterActions;
+};
+
+export const SubfilterDescription = ({ value, actions, projectId }: Props) => {
+  const { t } = useTranslate();
+  const [open, setOpen] = useState(false);
+  const anchorEl = useRef<HTMLElement>(null);
+
+  return (
+    <>
+      <SubmenuItem
+        ref={anchorEl as any}
+        label={t('translations_filters_heading_description')}
+        onClick={() => setOpen(true)}
+        selected={Boolean(getDescriptionFiltersLength(value))}
+        open={open}
+      />
+      {open && (
+        <Menu
+          open={open}
+          anchorEl={anchorEl.current!}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          onClose={() => {
+            setOpen(false);
+          }}
+          slotProps={{ paper: { style: { minWidth: 250 } } }}
+        >
+          <Box display="grid">
+            <FilterItem
+              label={t('translations_filter_no_description')}
+              selected={Boolean(value.filterHasNoDescription)}
+              onClick={() => {
+                if (value.filterHasNoDescription) {
+                  actions.removeFilter('filterHasNoDescription');
+                } else {
+                  actions.addFilter('filterHasNoDescription');
+                }
+              }}
+            />
+            <FilterItem
+              label={t('translations_filter_with_description')}
+              selected={Boolean(value.filterHasDescription)}
+              onClick={() => {
+                if (value.filterHasDescription) {
+                  actions.removeFilter('filterHasDescription');
+                } else {
+                  actions.addFilter('filterHasDescription');
+                }
+              }}
+            />
+          </Box>
+        </Menu>
+      )}
+    </>
+  );
+};
+
+export function getDescriptionFiltersLength(value: FiltersInternal) {
+  return (
+    Number(Boolean(value.filterHasDescription)) +
+    Number(Boolean(value.filterHasNoDescription))
+  );
+}
+
+export function getDescriptionFiltersName(value: FiltersInternal) {
+  if (value.filterHasDescription) {
+    return <T keyName="translations_filter_with_description" />;
+  }
+
+  if (value.filterHasNoDescription) {
+    return <T keyName="translations_filter_no_description" />;
+  }
+}

--- a/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
@@ -12,6 +12,7 @@ import {
 } from './SubfilterNamespaces';
 import { SubfilterTranslations } from './SubfilterTranslations';
 import { SubfilterScreenshots } from './SubfilterScreenshots';
+import { SubfilterDescription } from './SubfilterDescription';
 import { SubfilterComments } from './SubfilterComments';
 import { SubfilterLabels } from 'tg.views/projects/translations/TranslationFilters/SubfilterLabels';
 import { SubfilterSuggestions } from './SubfilterSuggestions';
@@ -63,6 +64,11 @@ export const TranslationFiltersPopup = ({
           />
         )}
         <SubfilterScreenshots
+          value={value}
+          actions={actions}
+          projectId={projectId}
+        />
+        <SubfilterDescription
           value={value}
           actions={actions}
           projectId={projectId}

--- a/webapp/src/views/projects/translations/TranslationFilters/summary.ts
+++ b/webapp/src/views/projects/translations/TranslationFilters/summary.ts
@@ -11,6 +11,10 @@ import {
   getScreenshotFiltersLength,
   getScreenshotFiltersName,
 } from './SubfilterScreenshots';
+import {
+  getDescriptionFiltersLength,
+  getDescriptionFiltersName,
+} from './SubfilterDescription';
 import { getTagFiltersLength, getTagFiltersName } from './SubfilterTags';
 import {
   getTranslationFiltersLength,
@@ -38,6 +42,7 @@ export function countFilters(value: FiltersInternal) {
     getCommentsFiltersLength(value) +
     getNamespaceFiltersLength(value) +
     getScreenshotFiltersLength(value) +
+    getDescriptionFiltersLength(value) +
     getTagFiltersLength(value) +
     getTranslationFiltersLength(value) +
     getLabelFiltersLength(value) +
@@ -52,6 +57,7 @@ export function getFilterName(value: FiltersInternal, labels?: LabelModel[]) {
     getCommentsFiltersName(value) ||
     getNamespaceFiltersName(value) ||
     getScreenshotFiltersName(value) ||
+    getDescriptionFiltersName(value) ||
     getTagFiltersName(value) ||
     getTranslationFiltersName(value) ||
     getLabelFiltersName(value, labels) ||

--- a/webapp/src/views/projects/translations/TranslationFilters/tools.ts
+++ b/webapp/src/views/projects/translations/TranslationFilters/tools.ts
@@ -17,6 +17,8 @@ export type FiltersInternal = {
   filterTranslationState?: TranslationStateType[];
   filterHasScreenshot?: boolean;
   filterHasNoScreenshot?: boolean;
+  filterHasDescription?: boolean;
+  filterHasNoDescription?: boolean;
   filterHasUnresolvedComments?: boolean;
   filterHasComments?: boolean;
   filterQaCheckTypes?: QaCheckType[];
@@ -55,6 +57,8 @@ export type AddParams =
   | ['filterTranslationState', TranslationStateType]
   | ['filterHasScreenshot']
   | ['filterHasNoScreenshot']
+  | ['filterHasDescription']
+  | ['filterHasNoDescription']
   | ['filterHasUnresolvedComments']
   | ['filterHasComments']
   | ['filterQaCheckTypes', QaCheckType]

--- a/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
@@ -79,6 +79,18 @@ export const useTranslationFilters = ({
           filterHasNoScreenshot: true,
           filterHasScreenshot: undefined,
         });
+      case 'filterHasDescription':
+        return setFilters({
+          ...filters,
+          filterHasDescription: true,
+          filterHasNoDescription: undefined,
+        });
+      case 'filterHasNoDescription':
+        return setFilters({
+          ...filters,
+          filterHasNoDescription: true,
+          filterHasDescription: undefined,
+        });
       case 'filterHasUnresolvedComments':
         return setFilters({
           ...filters,
@@ -166,6 +178,16 @@ export const useTranslationFilters = ({
           ...filters,
           filterHasNoScreenshot: undefined,
         });
+      case 'filterHasDescription':
+        return setFilters({
+          ...filters,
+          filterHasDescription: undefined,
+        });
+      case 'filterHasNoDescription':
+        return setFilters({
+          ...filters,
+          filterHasNoDescription: undefined,
+        });
       case 'filterHasUnresolvedComments':
         return setFilters({
           ...filters,
@@ -218,6 +240,8 @@ export const useTranslationFilters = ({
     filterNoNamespace: filters.filterNoNamespace,
     filterHasScreenshot: filters.filterHasScreenshot,
     filterHasNoScreenshot: filters.filterHasNoScreenshot,
+    filterHasDescription: filters.filterHasDescription,
+    filterHasNoDescription: filters.filterHasNoDescription,
     filterDeletedByUserId: filters.filterDeletedByUserId,
   };
 


### PR DESCRIPTION
## Summary

- Adds a **Description** filter ("With description" / "No description") to the translations view, mirroring the existing Screenshots with/without filter. Resolves [discussion #3663](https://github.com/tolgee/tolgee-platform/discussions/3663).
- Backend: `filterHasDescription` / `filterHasNoDescription` on `TranslationFilters`; predicate built via reusable `CriteriaBuilder.isNotNullOrBlank` / `isNullOrBlank` extensions over the `KeyMeta.description` column. Empty string counts as *no description*; whitespace-only counts as *with description*.
- Applies consistently to the translations view, select-all, and trash key listings (shared `QueryGlobalFiltering` path).
- Frontend: new `SubfilterDescription` component with two mutually-exclusive options, wired into the filter popup, summary, and query.
- i18n keys created in the Tolgee project (not committed to local `i18n` files, per webapp conventions).
- Tests: backend `TranslationsControllerFilterTest` + `KeyTrashFilterTest` cases (assert by key name, both directions, incl. empty/whitespace edges and count-query), plus a new `translationFilters.description.cy.ts` Cypress spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added description-based filtering for translations: new filter options allow you to view only keys with descriptions or only keys without descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->