### PR TITLE
fix: patch Snyk-reported backend dependency vulnerabilities

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -161,6 +161,7 @@ dependencies {
      * Google translation API
      */
     implementation platform(libs.googleCloud)
+    implementation platform(libs.grpcBom)
     implementation 'com.google.cloud:google-cloud-translate'
 
     /**

--- a/backend/data/build.gradle
+++ b/backend/data/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     implementation libs.micrometerPrometheus
     implementation 'org.dom4j:dom4j:2.1.4'
     implementation libs.jacksonKotlin
-    implementation("org.apache.commons:commons-configuration2:2.10.1")
+    implementation("org.apache.commons:commons-configuration2:2.15.0")
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
     implementation("com.fasterxml.woodstox:woodstox-core:7.1.1")
 
@@ -205,6 +205,7 @@ dependencies {
      * Google translation API
      */
     implementation platform(libs.googleCloud)
+    implementation platform(libs.grpcBom)
     implementation 'com.google.cloud:google-cloud-translate'
 
     /**

--- a/backend/testing/build.gradle
+++ b/backend/testing/build.gradle
@@ -126,6 +126,7 @@ dependencies {
      * Google translation API
      */
     implementation platform(libs.googleCloud)
+    implementation platform(libs.grpcBom)
     implementation 'com.google.cloud:google-cloud-translate'
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,12 @@ subprojects {
     ext['netty.version'] = nettyVersion
     ext['thymeleaf.version'] = thymeleafVersion
     ext['postgresql.version'] = postgresqlVersion
+    ext['spring-framework.version'] = springFrameworkVersion
+    ext['spring-data-bom.version'] = springDataBomVersion
+    ext['spring-hateoas.version'] = springHateoasVersion
+    ext['spring-retry.version'] = springRetryVersion
+    ext['micrometer.version'] = micrometerVersion
+    ext['reactor-bom.version'] = reactorBomVersion
 
     tasks.withType(Test).configureEach {
         testLogging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,12 +17,26 @@ springDependencyManagementVersion=1.1.7
 jacksonVersion=2.18.7
 slackSdkVersion=1.37.0
 commonsLang3Version=3.18.0
-# Security overrides: patched versions not yet shipped by the Spring Boot BOM.
-# Remove once Spring Boot's managed versions reach or exceed these.
+# Security overrides: versions bumped ahead of the Spring Boot BOM to pull in CVE fixes.
+# Each line below overrides a version the Spring Boot BOM manages and is TEMPORARY —
+# delete it once Spring Boot's managed version reaches or exceeds the one pinned here.
 tomcatVersion=10.1.55
-nettyVersion=4.1.133.Final
+# netty.version — CVEs incl. the critical netty-handler issue
+nettyVersion=4.1.135.Final
 thymeleafVersion=3.1.5.RELEASE
 postgresqlVersion=42.7.11
+# spring-framework.version — spring-web/webmvc/core/expression/websocket CVEs
+springFrameworkVersion=6.2.19
+# spring-data-bom.version — spring-data-commons DoS
+springDataBomVersion=2025.0.12
+# spring-hateoas.version — resource-exhaustion CVEs
+springHateoasVersion=2.5.3
+# spring-retry.version — resource-exhaustion CVE
+springRetryVersion=2.0.13
+# micrometer.version — micrometer-core resource-exhaustion CVE
+micrometerVersion=1.15.12
+# reactor-bom.version — reactor-netty-http cleartext-transmission CVE
+reactorBomVersion=2024.0.18
 # OpenTelemetry versions - see docs/observability/
 opentelemetryJavaagentVersion=2.26.1
 opentelemetryInstrumentationVersion=2.26.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -62,6 +62,10 @@ dependencyResolutionManagement {
             library('amazonSTS', "software.amazon.awssdk:sts:$amazonAwsSdkVersion")
             library('amazonTranslate', "software.amazon.awssdk:translate:$amazonAwsSdkVersion")
             library('googleCloud', "com.google.cloud:libraries-bom:26.61.0")
+            // Security override: forces the grpc family ahead of the version libraries-bom pulls
+            // (CVE in grpc-netty-shaded). Temporary — drop it once libraries-bom ships grpc >= 1.75.0.
+            // Imported as a platform in every module that uses libs.googleCloud.
+            library('grpcBom', "io.grpc:grpc-bom:1.75.0")
             library('liquibaseCore', "org.liquibase:liquibase-core:4.30.0")
             library('liquibaseHibernate', "org.liquibase.ext:liquibase-hibernate6:4.30.0")
             library('liquibasePicoli', "info.picocli:picocli:4.6.3")
@@ -75,7 +79,7 @@ dependencyResolutionManagement {
             library('slackApiModelKotlinExtension', "com.slack.api:slack-api-model-kotlin-extension:$slackSdkVersion")
             library('slackApiClientKotlinExtension', "com.slack.api:slack-api-client-kotlin-extension:$slackSdkVersion")
             library('jakartaMail', 'org.eclipse.angus', 'jakarta.mail').version('2.0.4')
-            library('mcpBom', 'io.modelcontextprotocol.sdk', 'mcp-bom').version('0.17.2')
+            library('mcpBom', 'io.modelcontextprotocol.sdk', 'mcp-bom').version('0.18.0')
             library('mcp', 'io.modelcontextprotocol.sdk', 'mcp').withoutVersion()
             library('mcpSpringWebmvc', 'io.modelcontextprotocol.sdk', 'mcp-spring-webmvc').withoutVersion()
 


### PR DESCRIPTION
Bumps security-affected backend dependencies to their fixed versions to clear vulnerabilities reported by Snyk in the `tolgee/tolgee` image and the platform code.

### Changes
All flagged runtime dependencies are raised to their Snyk-listed fix versions. Where the fix is shipped by a newer Spring Boot BOM that isn't released yet (Spring Boot 3.5.15 does not exist — 3.5.14 is the latest in the 3.5 line), the managed version is overridden directly, matching the existing "security overrides" pattern in `gradle.properties` / `build.gradle`.

| Dependency | From | To | Severity cleared |
|---|---|---|---|
| Spring Framework | 6.2.18 | 6.2.19 | High + Medium (web/webmvc/core/expression/websocket) |
| netty | 4.1.133 | 4.1.135 | **Critical** (netty-handler) + High |
| grpc (grpc-bom) | 1.70.0 | 1.75.0 | High (grpc-netty-shaded) |
| AWS SDK | 2.20.8 | 2.41.34 | High (cloudfront) |
| spring-data | 2025.0.11 | 2025.0.12 | High (DoS) |
| spring-hateoas | 2.5.2 | 2.5.3 | High x2 |
| spring-retry | 2.0.12 | 2.0.13 | High |
| micrometer | 1.15.11 | 1.15.12 | High |
| reactor | 2024.0.17 | 2024.0.18 | Medium |
| commons-configuration2 | 2.10.1 | 2.15.0 | Medium |
| mcp | 0.17.2 | 0.18.0 | High (origin validation) |

`grpc-bom` is added as an explicit platform import because `libraries-bom` pulls a vulnerable grpc; `mcp` is taken to `0.18.0` (not `1.0.x`, which removes the `mcp-spring-webmvc` artifact and would require migrating the MCP server wiring).

### Verification
Confirmed against the built `bootJar` (the image's `/app/lib`) that every flagged artifact resolves to its fixed version, and a Gradle Snyk scan shows the runtime findings cleared.

Tests: full compile + CloudFront cache-purging (11) + data unit (609) + MCP integration (60) — all green.

### Out of scope (follow-ups)
- Docker OS layer (`openssl`, `libxml2` apk packages) — handled separately.
- `opentelemetry-api` 1.60.1 → 1.62.0 — a newly-disclosed high requiring a coordinated agent + API + instrumentation bump.
- Frontend webapp npm advisories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Apache Commons Configuration to 2.15.0 and bumped Netty for stability.
  * Added a gRPC Bill of Materials to align/manage gRPC dependency versions across modules.
  * Introduced explicit Spring and observability version properties for consistent dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->