### PR TITLE
fix: patch OS-layer CVEs in the app Docker image

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,6 +2,10 @@ FROM postgres:13.23-alpine3.22
 
 ENTRYPOINT []
 
+# Pull the latest patched Alpine packages (openssl, libxml2, ...) on top of the
+# pinned base image, which lags behind the alpine3.22 branch on security fixes.
+RUN apk --no-cache upgrade
+
 RUN apk --no-cache add openjdk21-jre
 RUN apk --no-cache add libxml2
 


### PR DESCRIPTION
Patches the Alpine OS-layer vulnerabilities Snyk reports for the `tolgee/tolgee` image.

### Problem
The app image is built on `postgres:13.23-alpine3.22`. The base image's baked-in packages lag the `alpine3.22` security branch, so it ships vulnerable `openssl` (incl. a **critical** CVE) and `libxml2`.

### Fix
Add `RUN apk --no-cache upgrade` so the build pulls the latest patched packages from the alpine3.22 branch:
- `openssl` (libcrypto3/libssl3) → 3.5.7-r0
- `libxml2` → 2.13.9-r1
- plus the remaining flagged medium/low OS packages

### Verification
A Snyk container scan of the resulting OS layer (base + `apk upgrade` + the image's package adds) reports **no vulnerable paths** — down from 1 critical, 6 high, 2 medium, 17 low.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the image build process to apply Alpine security updates early during build, ensuring the runtime includes the latest patched packages before other dependencies are installed.
  * Improves overall runtime security posture and reduces exposure to known Alpine package vulnerabilities without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->