### PR TITLE
fix: patch Snyk-reported OpenTelemetry API vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,9 @@ subprojects {
     ext['netty.version'] = nettyVersion
     ext['thymeleaf.version'] = thymeleafVersion
     ext['postgresql.version'] = postgresqlVersion
+    // Security override: the Spring Boot BOM pins the OpenTelemetry core (opentelemetry-bom) to an
+    // older, CVE-affected version; force it to the version we manage. Drop when the BOM catches up.
+    ext['opentelemetry.version'] = opentelemetryApiVersion
 
     tasks.withType(Test).configureEach {
         testLogging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,10 +24,10 @@ nettyVersion=4.1.133.Final
 thymeleafVersion=3.1.5.RELEASE
 postgresqlVersion=42.7.11
 # OpenTelemetry versions - see docs/observability/
-opentelemetryJavaagentVersion=2.26.1
-opentelemetryInstrumentationVersion=2.26.1
-# Agent 2.26.x targets API 1.60.1 - see https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
-opentelemetryApiVersion=1.60.1
+opentelemetryJavaagentVersion=2.28.1
+opentelemetryInstrumentationVersion=2.28.1
+# Agent 2.28.x targets API 1.62.0 - see https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
+opentelemetryApiVersion=1.62.0
 org.gradle.caching=true
 ktlintVersion=1.7.1
 ktlintGradlePluginVersion=13.1.0


### PR DESCRIPTION
Clears the high-severity Snyk advisory in `opentelemetry-api` that ships in the `tolgee/tolgee` image (the last shipped high from the Snyk report).

### Changes
- OpenTelemetry API/SDK `1.60.1` → `1.62.0`
- Java agent + instrumentation `2.26.1` → `2.28.1` (the agent `2.N` ↔ API `1.(N+34)` pairing; `2.28.x` is the latest agent that targets API `1.62`)
- Override the Spring Boot BOM's managed `opentelemetry.version` (`1.49.0`)

The BOM override matters: Spring Boot 3.5.14 pins `opentelemetry.version=1.49.0`, which transitively held `opentelemetry-extension-kotlin` at a stale, CVE-affected `1.49.0` in `server-app` even though `opentelemetryApiVersion` was already higher (it only escaped for `api`/`context`, which `server-app` declares directly). Forcing the managed version makes **every** shipped `opentelemetry-*` jar resolve to `1.62.0`.

The Docker image's OTEL agent download uses this same `opentelemetryJavaagentVersion` via a build-arg, so the agent stays in lockstep automatically.

### Verification
Built `bootJar` shows all `opentelemetry-*` jars at `1.62.0` (`-instrumentation-annotations` at `2.28.1`). Gradle Snyk scan: **no opentelemetry findings remain**. Full compile + data unit tests (623) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry dependencies (javaagent, instrumentation, and API) to their latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->