### PR TITLE
chore: add Snyk ignore policy for accepted/unfixable advisories

### DIFF
--- a/e2e/.snyk
+++ b/e2e/.snyk
@@ -1,0 +1,21 @@
+# Snyk (https://snyk.io) policy file.
+# These advisories live in the Cypress e2e test harness only. The code never
+# ships to users and never runs in production — it executes in CI against known
+# fixture files, not attacker-controlled input. xlsx (SheetJS) has no published
+# npm fix. Re-review on expiry.
+version: v1.25.0
+ignore:
+  SNYK-JS-XLSX-6252523:
+    - '*':
+        reason: >-
+          ReDoS in xlsx. Test-only dependency (Cypress e2e); never shipped,
+          never processes untrusted input. No npm fix available (SheetJS
+          distributes fixes via their own CDN only).
+        expires: 2027-06-11T00:00:00.000Z
+  SNYK-JS-XLSX-5457926:
+    - '*':
+        reason: >-
+          Prototype pollution in xlsx. Test-only dependency (Cypress e2e); never
+          shipped, never processes untrusted input. No npm fix available
+          (SheetJS distributes fixes via their own CDN only).
+        expires: 2027-06-11T00:00:00.000Z

--- a/webapp/.snyk
+++ b/webapp/.snyk
@@ -1,0 +1,31 @@
+# Snyk (https://snyk.io) policy file.
+# Documented risk-acceptances for advisories with no clean upstream fix. These
+# are browser-side issues whose only input crosses no trust boundary, so the
+# real-world impact is negligible. Re-review on expiry.
+version: v1.25.0
+ignore:
+  SNYK-JS-ZXCVBN-3257741:
+    - '*':
+        reason: >-
+          ReDoS in the client-side password-strength estimator. The only input
+          is the user's own password as they type it, so the worst case is a
+          user slowing down their own browser tab. No cross-user or server
+          impact. zxcvbn is unmaintained with no patched release; migrating to
+          @zxcvbn-ts/core is tracked as separate tech-debt.
+        expires: 2027-06-11T00:00:00.000Z
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: >-
+          Memory leak in a deprecated package reached only via
+          react-query > broadcast-channel > rimraf > glob, a Node-only
+          leader-election path that is not exercised in the browser bundle. No
+          upstream fix exists (package is deprecated).
+        expires: 2027-06-11T00:00:00.000Z
+  SNYK-JS-D3COLOR-1076592:
+    - '*':
+        reason: >-
+          ReDoS in d3-color via recharts. The parsed color strings come from the
+          app's own chart configuration, not attacker-controlled input. The fix
+          requires a major d3 bump that risks breaking recharts; deferred as
+          low-risk.
+        expires: 2027-06-11T00:00:00.000Z


### PR DESCRIPTION
Documents risk-acceptance for the advisories that remain after the dependency-fix PRs (#3742, #3743, #3744, #3745). None of these have a clean upstream fix, and none carry meaningful real-world risk — so rather than leave them flagged as open alerts (drowning out future *real* findings), they're explicitly accepted with a justification and a re-review expiry.

### `webapp/.snyk` — browser-side, input crosses no trust boundary
| Advisory | Package | Why accepted |
|---|---|---|
| `SNYK-JS-ZXCVBN-3257741` | zxcvbn (ReDoS) | input is the user's own password as they type; worst case is self-slowdown of their own tab. Unmaintained, no patched release. |
| `SNYK-JS-INFLIGHT-6095116` | inflight (leak) | reached only via a Node-only `broadcast-channel → rimraf → glob` path not exercised in the browser bundle. Deprecated, no fix. |
| `SNYK-JS-D3COLOR-1076592` | d3-color (ReDoS) | parses app-controlled chart colors, not untrusted input. Fix needs a major d3 bump that risks breaking recharts. |

### `e2e/.snyk` — test-only Cypress harness
| Advisory | Package | Why accepted |
|---|---|---|
| `SNYK-JS-XLSX-6252523` | xlsx (ReDoS) | never shipped, runs in CI against known fixtures. No npm fix (SheetJS distributes via CDN only). |
| `SNYK-JS-XLSX-5457926` | xlsx (prototype pollution) | same as above. |

Each entry has a one-year `expires` so they resurface for re-review. Verified locally — `snyk test` in `webapp/` and `e2e/` reports these as ignored (e2e is now clean).

Follow-up tech-debt (not security): migrate `zxcvbn` → the maintained `@zxcvbn-ts/core` fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security vulnerability management policies to the latest format and configuration standards across testing and application environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->