### PR TITLE
chore: harden flaky-test CI script and document Snyk Code triage

### DIFF
--- a/.github/workflows/reportIntermittentTests.yml
+++ b/.github/workflows/reportIntermittentTests.yml
@@ -89,7 +89,9 @@ jobs:
       - name: Collect flaky and failed tests
         if: always()
         continue-on-error: true
-        run: python3 scripts/collect-flaky-tests.py "${{ steps.reportName.outputs.reportName }}"
+        run: |
+          python3 -m pip install --quiet defusedxml
+          python3 scripts/collect-flaky-tests.py "${{ steps.reportName.outputs.reportName }}"
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/docs/dev-notes/snyk-code-triage.md
+++ b/docs/dev-notes/snyk-code-triage.md
@@ -1,0 +1,61 @@
+# Snyk Code (SAST) triage
+
+Disposition record for the Snyk **Code** findings (static analysis of source, as
+opposed to Snyk Open Source, which scans dependencies). Each entry below has been
+reviewed against the actual code.
+
+Scanned with `snyk code test` (18 findings: 10 high, 2 medium, 6 low). After
+review, **none represent an exploitable vulnerability** — they are false
+positives or intentional design decisions. Two low-risk findings in a CI helper
+script were hardened anyway.
+
+How to apply: in the Snyk dashboard, mark each finding with the disposition and
+reason below (False positive / Ignore → won't fix). Re-review on a finding only
+if the surrounding code changes materially.
+
+---
+
+## Fixed in code (this change)
+
+| Finding | Location | Fix |
+|---|---|---|
+| XXE (`xml.etree.ElementTree`) | `scripts/collect-flaky-tests.py` | switched to `defusedxml.ElementTree` (input is trusted Gradle JUnit XML, hardened regardless) |
+| Path traversal (CLI arg → `open`) | `scripts/collect-flaky-tests.py` | `os.path.basename()` on the report name + reject `.`/`..` |
+
+---
+
+## False positive — mark "False positive" in the dashboard
+
+| Finding | Location | Why it is a false positive |
+|---|---|---|
+| SQL Injection (CWE-89) | `KeyTrashController.kt:79`, `:105` | Query is built with the **JPA Criteria API** (`em.criteriaBuilder` → typed `CriteriaQuery`). Filter input becomes bound parameters, never concatenated SQL. |
+| SQL Injection (CWE-89) | `SelectAllController.kt:74` | Same — JPA Criteria API via `TranslationsViewQueryBuilder`. |
+| SQL Injection (CWE-89) | `TranslationsController.kt:280` | Same — JPA Criteria API. The only `createNativeQuery` on this path is a hardcoded `DROP TABLE temp_…`. |
+| Regex Injection (CWE-400/730) | `GlossaryTermHighlightsController.kt:46` | Sink is `Regex.escape(search).toRegex()` in `GlossaryTermService.kt:282` — the user input is escaped before becoming a regex. |
+| Regex Injection (CWE-400/730) | `PublicController.kt:93` | Sink is `ALIAS_REGEX.replaceFirst(email, …)` (email normalization). The **pattern is a constant**; user input is the input string, not the pattern. Not injection. |
+| Hardcoded secret (CWE-547) | `useAuthService.tsx:27` | The flagged string is a **localStorage key name** (`'invitationCode'`/`'oauth2State'`/…), not a secret value. |
+| Hardcoded credentials (CWE-798) | `UserAccountService.kt:659`, `:706` | The string is `"___implicit_user"`, an internal **username constant** used to look up the legacy implicit user — not a credential. |
+
+---
+
+## Won't fix — accepted by design (mark "Ignore → won't fix" with reason)
+
+| Finding | Location | Reason |
+|---|---|---|
+| CSRF protection disabled (CWE-352) | `WebSecurityConfig.kt:83` | The API is **stateless Bearer-token auth** (`SessionCreationPolicy.STATELESS`, no cookie/session). CSRF does not apply when there is no ambient credential; enabling it would be incorrect. |
+| SQL Injection (CWE-89) | `SqlController.kt:17`, `:25` | `@InternalController("internal/sql")` is a **dev-only SQL console** that runs request-body SQL by design. The `/internal/**` paths are not exposed in production. |
+| Insecure hash MD5 (CWE-916) | `BaiduApiService.kt:67` | MD5 is required by **Baidu's translation API** for request signing (external protocol), not used as a security hash. |
+| Hardcoded password (CWE-798/259) | `PostgresAutostartProperties.kt:32` | Default password for the optional **bundled dev/Docker Postgres** (container-local, overridable via config). |
+| Hardcoded password (CWE-798/259) | `accountSecurity.cy.ts:29` | Cypress **e2e test fixture**, not production code. |
+| Path traversal (CWE-23) | `report-flaky-tests.py:84` | Opens `GITHUB_OUTPUT`, the path the **GitHub Actions runner** provides for step outputs. Writing to it is the documented mechanism; the value is trusted runner infrastructure. |
+
+---
+
+## Notes
+
+- Snyk Code repeatedly misses two safe patterns used heavily in this codebase:
+  the **JPA Criteria API** (it sees data flow into `createQuery` and assumes
+  string SQL) and **`Regex.escape(...)`** before `toRegex()`. Future findings of
+  the same shape can be dispositioned the same way.
+- Prefer per-issue dashboard dispositions over excluding whole paths from SAST,
+  so genuinely new issues in these files are still surfaced.

--- a/scripts/collect-flaky-tests.py
+++ b/scripts/collect-flaky-tests.py
@@ -20,8 +20,12 @@ Usage:
 from __future__ import annotations
 
 import glob
+import os
 import sys
-import xml.etree.ElementTree as ET
+
+# defusedxml hardens parsing against XXE / entity-expansion. The input here is
+# trusted (Gradle-generated JUnit XML from the same CI job), but parse defensively.
+import defusedxml.ElementTree as ET
 
 XML_GLOB = "**/build/test-results/**/TEST-*.xml"
 
@@ -64,7 +68,12 @@ def main() -> int:
     if len(sys.argv) != 2:
         print(__doc__, file=sys.stderr)
         return 2
-    report = sys.argv[1]
+    # Strip any path components: the report name only ever forms a file name in
+    # the current directory, never a path into another directory.
+    report = os.path.basename(sys.argv[1])
+    if not report or report in (".", ".."):
+        print("Invalid report name", file=sys.stderr)
+        return 2
     flaky, failed = collect()
     write(f"flaky-tests-{report}.txt", flaky)
     write(f"failed-tests-{report}.txt", failed)


### PR DESCRIPTION
Snyk **Code** (SAST) reports 18 source-level findings (10 high, 2 medium, 6 low) — separate from the dependency advisories handled in #3742–#3746. After reviewing each against the actual code, **none are exploitable**: they're false positives or intentional design. This PR documents the dispositions and hardens the only two findings worth a code change.

### Code hardening — `scripts/collect-flaky-tests.py`
- **XXE**: parse JUnit XML with `defusedxml` instead of `xml.etree` (input is trusted Gradle output, hardened regardless). Adds a `pip install defusedxml` to the one workflow step that runs it.
- **Path traversal**: `os.path.basename()` the report-name CLI arg before using it as an output filename.

Verified: `snyk code test` drops from 18 → 16 (both script findings cleared); script compiles and runs, and a `../evil` arg is correctly neutralized.

### Dispositions — `docs/dev-notes/snyk-code-triage.md`
Full per-finding record for marking in the Snyk dashboard. Highlights:

**False positives** (mark *False positive*):
- 4× "SQL Injection" — all use the **JPA Criteria API** (typed `CriteriaQuery`, bound params), not string SQL.
- 2× "Regex Injection" — one is `Regex.escape(...).toRegex()` (escaped); the other uses a **constant** pattern with user input as the haystack.
- "Hardcoded secret" — a localStorage **key name**; "hardcoded credentials" — the internal username constant `"___implicit_user"`.

**Won't fix / by design** (mark *Ignore → won't fix*):
- CSRF disabled — **stateless Bearer-token API**, CSRF N/A.
- Dev-only `@InternalController("internal/sql")` SQL console (not exposed in prod).
- MD5 in `BaiduApiService` — required by Baidu's API signing protocol.
- Default bundled-DB password; an e2e test fixture; the `GITHUB_OUTPUT` env path (trusted Actions mechanism).

Snyk Code notably misreads two patterns used heavily here — the JPA Criteria API and `Regex.escape()` — so future findings of the same shape disposition the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced test collection script with CLI argument validation to reject invalid names and improve XML parsing robustness.

* **Documentation**
  * Added security code analysis triage documentation with findings categorization and disposition guidance for code review and remediation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->