### PR TITLE
fix: Leading/Trailing spaces for Project Name/Keys when saving/updating the same

### DIFF
--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -15,6 +15,7 @@ import {
 
 import { Direction } from 'tg.fixtures/getLanguageDirection';
 import { useScrollMargins } from 'tg.hooks/useScrollMargins';
+import { visibleKeyNameSpacesPlugin } from './utils/codemirrorVisibleWhitespace';
 
 const StyledEditor = styled('div')`
   font-size: 14px;
@@ -54,6 +55,11 @@ const StyledEditor = styled('div')`
     background-color: ${({ theme }) => theme.palette.tooltip.background};
     padding: 4px 8px;
     margin-top: 4px;
+  }
+
+  & .cm-keyname-space-indicator {
+    background-color: #ddeffe;
+    border-radius: 2px;
   }
 `;
 
@@ -192,7 +198,7 @@ export const Editor: React.FC<EditorProps> = ({
         );
         break;
       case 'keyName':
-        placeholderPlugins.push(KeyNamePlugin());
+        placeholderPlugins.push(KeyNamePlugin(), visibleKeyNameSpacesPlugin());
         break;
     }
     const syntaxPlugins =

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -1,0 +1,41 @@
+import { EditorState, Extension, RangeSetBuilder, StateField } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+
+const spaceDecoration = Decoration.mark({
+  attributes: { class: 'cm-keyname-space-indicator' },
+});
+
+function buildDecorations(state: EditorState) {
+  const builder = new RangeSetBuilder<Decoration>();
+  const text = state.doc.toString();
+
+  const leading = text.match(/^( +)/);
+  const leadingLength = leading?.[1].length ?? 0;
+  for (let i = 0; i < leadingLength; i += 1) {
+    builder.add(i, i + 1, spaceDecoration);
+  }
+
+  const trailing = text.match(/( +)$/);
+  const trailingLength = trailing?.[1].length ?? 0;
+  const trailingStart = Math.max(text.length - trailingLength, leadingLength);
+  for (let i = trailingStart; i < text.length; i += 1) {
+    builder.add(i, i + 1, spaceDecoration);
+  }
+
+  return builder.finish();
+}
+
+const visibleSpaceField = StateField.define<DecorationSet>({
+  create(state) {
+    return buildDecorations(state);
+  },
+  update(decorations, tr) {
+    if (!tr.docChanged) {
+      return decorations;
+    }
+    return buildDecorations(tr.state);
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+export const visibleKeyNameSpacesPlugin = (): Extension[] => [visibleSpaceField];

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -1,10 +1,12 @@
 import { EditorState, Extension, RangeSetBuilder, StateField } from '@codemirror/state';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 
+// Marks the css class for space
 const spaceDecoration = Decoration.mark({
   attributes: { class: 'cm-keyname-space-indicator' },
 });
 
+//Decorates the leading and trailing spaces 
 function buildDecorations(state: EditorState) {
   const builder = new RangeSetBuilder<Decoration>();
   const text = state.doc.toString();
@@ -25,6 +27,7 @@ function buildDecorations(state: EditorState) {
   return builder.finish();
 }
 
+//Marks the field with the decorator
 const visibleSpaceField = StateField.define<DecorationSet>({
   create(state) {
     return buildDecorations(state);

--- a/webapp/src/constants/GlobalValidationSchema.tsx
+++ b/webapp/src/constants/GlobalValidationSchema.tsx
@@ -257,7 +257,7 @@ export class Validation {
     });
 
   static readonly PROJECT_SETTINGS = Yup.object().shape({
-    name: Yup.string().required().min(3).max(100),
+    name: Yup.string().trim().required().min(3).max(100),
     description: Yup.string().nullable().min(3).max(2000),
   });
 

--- a/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
+++ b/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
@@ -100,6 +100,7 @@ export const ProjectSettingsGeneral = () => {
           useNamespaces: project.useNamespaces,
           useBranching: project.useBranching,
           ...values,
+          name: values.name.trim(),
           description: values.description || undefined,
           unassignConflictingTms,
         },


### PR DESCRIPTION
The PR includes the following changes:

**Project Name**
- Previously was saved with leading and trailing spaces
- Now the spaces are trimmed before saving.

**Keys**
- Added a new CodeMirror extension in `codemirrorVisibleWhitespace.ts`.
  - Detects leading and trailing spaces in editor content.
  - Marks each leading/trailing space individually using a decoration.
  - Does not alter the underlying text value.
- Updated `Editor.tsx`
  - Added `visibleKeyNameSpacesPlugin` only for `mode=='keyname'`.
  - Added `.cm-keyname-space-indicator` styles.
  - Leading/trailing spaces are now highlighted with a light blue background.

<img width="903" height="565" alt="Screenshot from 2026-06-13 23-18-04" src="https://github.com/user-attachments/assets/0b97a5b1-1690-45b0-a03d-7318b79d5dae" />

Resolves https://github.com/tolgee/tolgee-platform/issues/3719, https://github.com/tolgee/tolgee-platform/issues/3359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visible leading and trailing space indicators in the editor.
  * Enabled “space” indicators specifically when viewing key names to improve readability.
* **Bug Fixes**
  * Trimmed whitespace from the project name before saving.
  * Updated project settings validation so names are validated after trimming, preventing whitespace-only edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->