### PR TITLE
fix: Validate SSO provider URLs and use SecureRandom for generated codes

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/controllers/resetPassword/ResetPasswordRequestHandler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/controllers/resetPassword/ResetPasswordRequestHandler.kt
@@ -108,7 +108,7 @@ class ResetPasswordRequestHandler(
     userAccountService.setResetPasswordCode(userAccount!!, code)
   }
 
-  private fun generateCode(): String = RandomStringUtils.randomAlphabetic(50)
+  private fun generateCode(): String = RandomStringUtils.secure().nextAlphabetic(50)
 
   private fun getEncodedCodeString(code: String): String {
     val callbackString = code + "," + request.email

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/SsoOrganizationsProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/SsoOrganizationsProperties.kt
@@ -31,4 +31,19 @@ class SsoOrganizationsProperties {
         " able to access the server after the account has been disabled or deleted in the SSO provider.",
   )
   var sessionExpirationMinutes: Int = 10
+
+  @DocProperty(
+    description =
+      "When enabled, per-organization SSO provider URLs (`tokenUri`, `authorizationUri`) may target " +
+        "otherwise-blocked address ranges — loopback, private/site-local, link-local, IPv6 unique-local, " +
+        "multicast and wildcard/any-local addresses. Useful when the identity provider runs on an internal " +
+        "network in a self-hosted deployment.\n" +
+        "\n" +
+        ":::danger\n" +
+        "This removes SSRF protection for SSO provider URLs. Keep it **disabled** on production and " +
+        "multi-tenant servers — an organization owner able to configure SSO could otherwise make the server " +
+        "reach internal services.\n" +
+        ":::\n\n",
+  )
+  var allowLocalAddresses: Boolean = false
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
@@ -90,7 +90,7 @@ class InvitationService(
   }
 
   private fun getInvitationInstance(params: CreateInvitationParams): Invitation {
-    val code = RandomStringUtils.randomAlphabetic(50)
+    val code = RandomStringUtils.secure().nextAlphabetic(50)
     val invitation = Invitation(code = code)
     invitation.email = params.email
     invitation.name = params.name

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/sso/TenantServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/sso/TenantServiceImpl.kt
@@ -11,6 +11,7 @@ import io.tolgee.exceptions.PermissionException
 import io.tolgee.model.Organization
 import io.tolgee.model.SsoTenant
 import io.tolgee.service.TenantService
+import io.tolgee.util.UrlSecurity
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.context.annotation.Lazy
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service
 class TenantServiceImpl(
   private val tenantRepository: TenantRepository,
   private val properties: TolgeeProperties,
+  private val urlSecurity: UrlSecurity,
   @Suppress("SelfReferenceConstructorParameter") @Lazy
   private val self: TenantServiceImpl,
 ) : TenantService {
@@ -75,8 +77,18 @@ class TenantServiceImpl(
     if (!allowChangeDomain && tenant.domain != request.domain) {
       throw PermissionException(Message.SSO_DOMAIN_NOT_ALLOWED)
     }
+    validateProviderUrls(request)
     setTenantsFields(tenant, request, organization)
     return self.save(tenant)
+  }
+
+  private fun validateProviderUrls(request: SsoTenantDto) {
+    if (!request.enabled) {
+      return
+    }
+    val allowLocalAddresses = properties.authentication.ssoOrganizations.allowLocalAddresses
+    urlSecurity.validateUrl(request.tokenUri, allowLocalAddresses)
+    urlSecurity.validateUrl(request.authorizationUri, allowLocalAddresses)
   }
 
   private fun setTenantsFields(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SsoProviderControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SsoProviderControllerTest.kt
@@ -177,7 +177,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "dummy_client_id",
       "clientSecret" to "clientSecret",
       "authorizationUri" to "https://dummy-url.com",
-      "redirectUri" to "redirectUri",
       "tokenUri" to "tokenUri",
       "enabled" to true,
     )
@@ -188,7 +187,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "dummy_client_id1",
       "clientSecret" to "clientSecret1",
       "authorizationUri" to "https://dummy-url1.com",
-      "redirectUri" to "redirectUri1",
       "tokenUri" to "tokenUri1",
       "enabled" to true,
       "force" to true,
@@ -200,7 +198,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "dummy_client_id1",
       "clientSecret" to "clientSecret1",
       "authorizationUri" to "https://dummy-url1.com",
-      "redirectUri" to "redirectUri1",
       "tokenUri" to "tokenUri1",
       "enabled" to true,
       "force" to true,
@@ -212,7 +209,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "",
       "clientSecret" to "",
       "authorizationUri" to "",
-      "redirectUri" to "",
       "tokenUri" to "",
       "enabled" to false,
     )
@@ -223,7 +219,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "dummy_client_id",
       "clientSecret" to "clientSecret",
       "authorizationUri" to "https://dummy-url.com",
-      "redirectUri" to "redirectUri",
       "tokenUri" to "tokenUri",
       "enabled" to true,
     )
@@ -234,7 +229,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "",
       "clientSecret" to "",
       "authorizationUri" to "",
-      "redirectUri" to "",
       "tokenUri" to "",
       "enabled" to true,
     )
@@ -250,7 +244,6 @@ class SsoProviderControllerTest : AuthorizedControllerTest() {
       "clientId" to "dummy_client_id",
       "clientSecret" to "clientSecret",
       "authorizationUri" to "https://dummy-url.com",
-      "redirectUri" to "redirectUri",
       "tokenUri" to "tokenUri",
       "enabled" to true,
     )

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SsoProviderUrlSecurityTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SsoProviderUrlSecurityTest.kt
@@ -1,0 +1,148 @@
+package io.tolgee.ee.api.v2.controllers
+
+import io.tolgee.constants.Feature
+import io.tolgee.constants.Message
+import io.tolgee.development.testDataBuilder.data.SsoTestData
+import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andHasErrorMessage
+import io.tolgee.fixtures.andIsBadRequest
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.testing.AuthorizedControllerTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class SsoProviderUrlSecurityTest : AuthorizedControllerTest() {
+  private companion object {
+    // UrlSecurity.validateUrl resolves the host via InetAddress.getAllByName; an IP literal is used
+    // (not a hostname) so the positive cases never perform a real DNS lookup. TEST-NET-3 (203.0.113.0/24)
+    // is reserved for documentation, is non-private, and never routes anywhere.
+    const val PUBLIC_HOST = "203.0.113.10"
+  }
+
+  private lateinit var testData: SsoTestData
+
+  @Autowired
+  private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  @BeforeEach
+  fun setup() {
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.SSO)
+    tolgeeProperties.authentication.ssoOrganizations.enabled = true
+    tolgeeProperties.authentication.ssoOrganizations.allowLocalAddresses = false
+    internalProperties.disableUrlSsrfProtection = false
+    testData = SsoTestData()
+    testDataService.saveTestData(testData.root)
+    this.userAccount = testData.userAdmin
+  }
+
+  @AfterEach
+  fun tearDown() {
+    testDataService.cleanTestData(testData.root)
+    enabledFeaturesProvider.forceEnabled = null
+    tolgeeProperties.authentication.ssoOrganizations.enabled = false
+    tolgeeProperties.authentication.ssoOrganizations.allowLocalAddresses = false
+    internalProperties.disableUrlSsrfProtection = true
+  }
+
+  @Test
+  fun `rejects local provider urls when allowLocalAddresses is false`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "http://localhost/authorize", tokenUri = "http://localhost/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  fun `rejects loopback ip token uri`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "http://127.0.0.1/authorize", tokenUri = "http://127.0.0.1/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  fun `rejects non-http scheme token uri`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(tokenUri = "ftp://localhost/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  fun `allows local provider urls when allowLocalAddresses is true`() {
+    tolgeeProperties.authentication.ssoOrganizations.allowLocalAddresses = true
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "http://localhost/authorize", tokenUri = "http://localhost/token"),
+    ).andIsOk.andAssertThatJson {
+      node("tokenUri").isEqualTo("http://localhost/token")
+    }
+  }
+
+  @Test
+  fun `still rejects non-http scheme when allowLocalAddresses is true`() {
+    tolgeeProperties.authentication.ssoOrganizations.allowLocalAddresses = true
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(tokenUri = "ftp://localhost/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  fun `validates authorization uri in addition to token uri`() {
+    tolgeeProperties.authentication.ssoOrganizations.allowLocalAddresses = true
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "ftp://localhost/authorize", tokenUri = "http://localhost/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  @Test
+  fun `skips url validation when provider is disabled`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(tokenUri = "http://localhost/token", enabled = false),
+    ).andIsOk
+  }
+
+  @Test
+  fun `accepts public provider urls under active ssrf protection`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "https://$PUBLIC_HOST/authorize", tokenUri = "https://$PUBLIC_HOST/token"),
+    ).andIsOk.andAssertThatJson {
+      node("tokenUri").isEqualTo("https://$PUBLIC_HOST/token")
+    }
+  }
+
+  @Test
+  fun `rejects changing provider url to local on update`() {
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "https://$PUBLIC_HOST/authorize", tokenUri = "https://$PUBLIC_HOST/token"),
+    ).andIsOk
+
+    performAuthPut(
+      ssoUrl(),
+      requestTenant(authorizationUri = "https://$PUBLIC_HOST/authorize", tokenUri = "http://localhost/token"),
+    ).andIsBadRequest.andHasErrorMessage(Message.URL_NOT_VALID)
+  }
+
+  private fun ssoUrl() = "/v2/organizations/${testData.organization.id}/sso"
+
+  private fun requestTenant(
+    authorizationUri: String = "http://localhost/authorize",
+    tokenUri: String = "http://localhost/token",
+    enabled: Boolean = true,
+  ) = mapOf(
+    "domain" to "google",
+    "clientId" to "dummy_client_id",
+    "clientSecret" to "clientSecret",
+    "authorizationUri" to authorizationUri,
+    "tokenUri" to tokenUri,
+    "enabled" to enabled,
+  )
+}


### PR DESCRIPTION
## Summary

- Pass the per-organization SSO provider URLs (`tokenUri`, `authorizationUri`) through the same `UrlSecurity` validation already applied to webhook and LLM provider URLs; URLs are validated when a tenant is saved.
- Add `tolgee.authentication.sso-organizations.allow-local-addresses` (default `false`) so self-hosted deployments whose identity provider runs on an internal address can still configure it.
- Generate password-reset and invitation codes with `RandomStringUtils.secure()` (SecureRandom-backed), consistent with how other secrets are generated. Same alphabet and length, so the stored code format is unchanged.
- Add `SsoProviderUrlSecurityTest`; drop an unused `redirectUri` field from the SSO provider test helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Enhanced random code generation for password resets and invitations using cryptographically secure methods.
  * Added URL validation for Single Sign-On provider endpoints with SSRF protection.
  * New configuration option to control whether local/private addresses are permitted for SSO provider URLs.

* **Tests**
  * Added comprehensive test coverage for SSO provider URL security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->