### PR TITLE
feat: warn before saving key names with leading/trailing whitespace

### DIFF
--- a/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
+++ b/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
@@ -78,7 +78,9 @@ describe('Key name whitespace warning', () => {
     assertMessage('Key created');
     waitForGlobalLoading();
 
-    openKeyEditDialog('preexisting key');
+    // exact-text lookup would miss the trailing space, so match by substring
+    cy.gcy('translations-key-name').contains('preexisting key').click();
+    cy.gcy('translations-key-edit-key-field').should('be.visible');
     cy.gcy('key-name-whitespace-warning').should('be.visible');
   });
 });

--- a/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
+++ b/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
@@ -65,4 +65,20 @@ describe('Key name whitespace warning', () => {
     dialog.getKeyNameInput().type('clean key');
     cy.gcy('key-name-whitespace-warning').should('not.exist');
   });
+
+  it('warns when editing a key whose whitespace was already there', () => {
+    visitTranslations(projectId);
+    waitForGlobalLoading();
+    const dialog = new E2TranslationsView().openKeyCreateDialog();
+
+    // persist a key that keeps its outer whitespace (no trim)
+    dialog.getKeyNameInput().type('preexisting key x{backspace}');
+    cy.gcy('key-name-whitespace-warning').should('be.visible');
+    dialog.save();
+    assertMessage('Key created');
+    waitForGlobalLoading();
+
+    openKeyEditDialog('preexisting key');
+    cy.gcy('key-name-whitespace-warning').should('be.visible');
+  });
 });

--- a/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
+++ b/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
@@ -1,0 +1,69 @@
+import { login } from '../../common/apiCalls/common';
+import { translationSingleTestData } from '../../common/apiCalls/testData/testData';
+import { waitForGlobalLoading } from '../../common/loading';
+import { assertMessage, confirmStandard } from '../../common/shared';
+import {
+  getCellSaveButton,
+  openKeyEditDialog,
+  typeNewKeyName,
+  visitTranslations,
+} from '../../common/translations';
+import { E2TranslationsView } from '../../compounds/E2TranslationsView';
+
+describe('Key name whitespace warning', () => {
+  let projectId: number;
+
+  beforeEach(() => {
+    translationSingleTestData.clean();
+    translationSingleTestData.generate().then((data) => {
+      projectId = data.body.id;
+      login('pepa', 'admin');
+    });
+  });
+
+  afterEach(() => {
+    waitForGlobalLoading();
+    translationSingleTestData.clean();
+  });
+
+  it('warns about outer spaces when creating a key', () => {
+    visitTranslations(projectId);
+    waitForGlobalLoading();
+    const dialog = new E2TranslationsView().openKeyCreateDialog();
+    // type a trailing space without it being the final keystroke (Cypress drops that)
+    dialog.getKeyNameInput().type('spaced key x{backspace}');
+    dialog.save();
+
+    cy.gcy('global-confirmation-dialog').should('be.visible');
+    cy.gcy('global-confirmation-cancel').click();
+    cy.gcy('global-confirmation-dialog').should('not.exist');
+
+    dialog.save();
+    confirmStandard();
+    assertMessage('Key created');
+  });
+
+  it('warns when an edit introduces outer spaces', () => {
+    visitTranslations(projectId);
+    openKeyEditDialog('A key');
+    typeNewKeyName('A key x{backspace}');
+    getCellSaveButton().click();
+
+    cy.gcy('global-confirmation-dialog').should('be.visible');
+    confirmStandard();
+    waitForGlobalLoading();
+    cy.gcy('translations-key-edit-key-field').should('not.exist');
+  });
+
+  it('does not warn when an edit keeps the name trimmed', () => {
+    visitTranslations(projectId);
+    openKeyEditDialog('A key');
+    typeNewKeyName('A key edited');
+    getCellSaveButton().click();
+
+    waitForGlobalLoading();
+    cy.gcy('global-confirmation-dialog').should('not.exist');
+    cy.gcy('translations-key-edit-key-field').should('not.exist');
+    cy.contains('A key edited').should('be.visible');
+  });
+});

--- a/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
+++ b/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
@@ -1,7 +1,7 @@
 import { login } from '../../common/apiCalls/common';
 import { translationSingleTestData } from '../../common/apiCalls/testData/testData';
 import { waitForGlobalLoading } from '../../common/loading';
-import { assertMessage, confirmStandard } from '../../common/shared';
+import { assertMessage } from '../../common/shared';
 import {
   getCellSaveButton,
   openKeyEditDialog,
@@ -26,46 +26,43 @@ describe('Key name whitespace warning', () => {
     translationSingleTestData.clean();
   });
 
-  it('warns about outer spaces when creating a key', () => {
+  it('warns about outer spaces on create and trims them', () => {
     visitTranslations(projectId);
     waitForGlobalLoading();
     const dialog = new E2TranslationsView().openKeyCreateDialog();
-    // type a trailing space without it being the final keystroke (Cypress drops that)
+
+    // trailing space typed without it being the final keystroke (Cypress drops that)
     dialog.getKeyNameInput().type('spaced key x{backspace}');
-    dialog.save();
+    cy.gcy('key-name-whitespace-warning').should('be.visible');
 
-    cy.gcy('global-confirmation-dialog').should('be.visible');
-    cy.gcy('global-confirmation-cancel').click();
-    cy.gcy('global-confirmation-dialog').should('not.exist');
+    cy.gcy('key-name-whitespace-trim').click();
+    cy.gcy('key-name-whitespace-warning').should('not.exist');
 
     dialog.save();
-    confirmStandard();
     assertMessage('Key created');
+    cy.gcy('translations-table-cell')
+      .contains('spaced key')
+      .should('be.visible');
   });
 
-  it('warns when an edit introduces outer spaces', () => {
+  it('warns when an edit introduces outer spaces and trims them', () => {
     visitTranslations(projectId);
     openKeyEditDialog('A key');
     typeNewKeyName('A key x{backspace}');
-    getCellSaveButton().click();
+    cy.gcy('key-name-whitespace-warning').should('be.visible');
 
-    cy.gcy('global-confirmation-dialog').should('be.visible');
-    confirmStandard();
+    cy.gcy('key-name-whitespace-trim').click();
+    cy.gcy('key-name-whitespace-warning').should('not.exist');
+
+    getCellSaveButton().click();
     waitForGlobalLoading();
     cy.gcy('translations-key-edit-key-field').should('not.exist');
   });
 
-  it('does not warn when an edit keeps the name trimmed', () => {
+  it('does not warn when the key name is trimmed', () => {
     visitTranslations(projectId);
-    openKeyEditDialog('A key');
-    typeNewKeyName('A key edited');
-    getCellSaveButton().click();
-
-    waitForGlobalLoading();
-    cy.gcy('global-confirmation-dialog').should('not.exist');
-    cy.gcy('translations-key-edit-key-field').should('not.exist');
-    cy.gcy('translations-table-cell')
-      .contains('A key edited')
-      .should('be.visible');
+    const dialog = new E2TranslationsView().openKeyCreateDialog();
+    dialog.getKeyNameInput().type('clean key');
+    cy.gcy('key-name-whitespace-warning').should('not.exist');
   });
 });

--- a/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
+++ b/e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts
@@ -64,6 +64,8 @@ describe('Key name whitespace warning', () => {
     waitForGlobalLoading();
     cy.gcy('global-confirmation-dialog').should('not.exist');
     cy.gcy('translations-key-edit-key-field').should('not.exist');
-    cy.contains('A key edited').should('be.visible');
+    cy.gcy('translations-table-cell')
+      .contains('A key edited')
+      .should('be.visible');
   });
 });

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -360,6 +360,8 @@ declare namespace DataCy {
         "key-edit-tab-custom-properties": true;
         "key-edit-tab-general": true;
         "key-name-msgctxt": true;
+        "key-name-whitespace-trim": true;
+        "key-name-whitespace-warning": true;
         "key-plural-checkbox": true;
         "key-plural-variable-name": true;
         "label-autocomplete-option": true;

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -58,7 +58,7 @@ const StyledEditor = styled('div')`
   }
 
   & .cm-keyname-space-indicator {
-    background-color: #ddeffe;
+    background-color: ${({ theme }) => theme.palette.label.lightBlue};
     border-radius: 2px;
   }
 `;

--- a/webapp/src/component/editor/Editor.tsx
+++ b/webapp/src/component/editor/Editor.tsx
@@ -15,6 +15,7 @@ import {
 
 import { Direction } from 'tg.fixtures/getLanguageDirection';
 import { useScrollMargins } from 'tg.hooks/useScrollMargins';
+import { visibleKeyNameSpacesPlugin } from './utils/codemirrorVisibleWhitespace';
 
 const StyledEditor = styled('div')`
   font-size: 14px;
@@ -54,6 +55,11 @@ const StyledEditor = styled('div')`
     background-color: ${({ theme }) => theme.palette.tooltip.background};
     padding: 4px 8px;
     margin-top: 4px;
+  }
+
+  & .cm-keyname-space-indicator {
+    background-color: #ddeffe;
+    border-radius: 2px;
   }
 `;
 
@@ -192,7 +198,7 @@ export const Editor: React.FC<EditorProps> = ({
         );
         break;
       case 'keyName':
-        placeholderPlugins.push(KeyNamePlugin());
+        placeholderPlugins.push(KeyNamePlugin(), visibleKeyNameSpacesPlugin());
         break;
     }
     const syntaxPlugins =

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -6,23 +6,28 @@ import {
 } from '@codemirror/state';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 
+import {
+  KEY_NAME_LEADING_WHITESPACE_REGEX,
+  KEY_NAME_TRAILING_WHITESPACE_REGEX,
+} from 'tg.fixtures/keyName';
+
 // Marks the css class for space
 const spaceDecoration = Decoration.mark({
   attributes: { class: 'cm-keyname-space-indicator' },
 });
 
-//Decorates the leading and trailing spaces
+//Decorates the leading and trailing whitespace
 function buildDecorations(state: EditorState) {
   const builder = new RangeSetBuilder<Decoration>();
   const text = state.doc.toString();
 
-  const leading = text.match(/^( +)/);
+  const leading = text.match(KEY_NAME_LEADING_WHITESPACE_REGEX);
   const leadingLength = leading?.[1].length ?? 0;
   for (let i = 0; i < leadingLength; i += 1) {
     builder.add(i, i + 1, spaceDecoration);
   }
 
-  const trailing = text.match(/( +)$/);
+  const trailing = text.match(KEY_NAME_TRAILING_WHITESPACE_REGEX);
   const trailingLength = trailing?.[1].length ?? 0;
   const trailingStart = Math.max(text.length - trailingLength, leadingLength);
   for (let i = trailingStart; i < text.length; i += 1) {

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -1,4 +1,9 @@
-import { EditorState, Extension, RangeSetBuilder, StateField } from '@codemirror/state';
+import {
+  EditorState,
+  Extension,
+  RangeSetBuilder,
+  StateField,
+} from '@codemirror/state';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 
 // Marks the css class for space
@@ -6,7 +11,7 @@ const spaceDecoration = Decoration.mark({
   attributes: { class: 'cm-keyname-space-indicator' },
 });
 
-//Decorates the leading and trailing spaces 
+//Decorates the leading and trailing spaces
 function buildDecorations(state: EditorState) {
   const builder = new RangeSetBuilder<Decoration>();
   const text = state.doc.toString();
@@ -41,4 +46,6 @@ const visibleSpaceField = StateField.define<DecorationSet>({
   provide: (field) => EditorView.decorations.from(field),
 });
 
-export const visibleKeyNameSpacesPlugin = (): Extension[] => [visibleSpaceField];
+export const visibleKeyNameSpacesPlugin = (): Extension[] => [
+  visibleSpaceField,
+];

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -1,0 +1,41 @@
+import { EditorState, Extension, RangeSetBuilder, StateField } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
+
+const spaceDecoration = Decoration.mark({
+  attributes: { class: 'cm-keyname-space-indicator' },
+});
+
+function buildDecorations(state: EditorState) {
+  const builder = new RangeSetBuilder<Decoration>();
+  const text = state.doc.toString();
+
+  const leading = text.match(/^( +)/);
+  const leadingLength = leading?.[1].length ?? 0;
+  for (let i = 0; i < leadingLength; i += 1) {
+    builder.add(i, i + 1, spaceDecoration);
+  }
+
+  const trailing = text.match(/( +)$/);
+  const trailingLength = trailing?.[1].length ?? 0;
+  const trailingStart = Math.max(text.length - trailingLength, leadingLength);
+  for (let i = trailingStart; i < text.length; i += 1) {
+    builder.add(i, i + 1, spaceDecoration);
+  }
+
+  return builder.finish();
+}
+
+const visibleSpaceField = StateField.define<DecorationSet>({
+  create(state) {
+    return buildDecorations(state);
+  },
+  update(decorations, tr) {
+    if (!tr.docChanged) {
+      return decorations;
+    }
+    return buildDecorations(tr.state);
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+export const visibleKeyNameSpacesPlugin = (): Extension[] => [visibleSpaceField];

--- a/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
+++ b/webapp/src/component/editor/utils/codemirrorVisibleWhitespace.ts
@@ -1,10 +1,12 @@
 import { EditorState, Extension, RangeSetBuilder, StateField } from '@codemirror/state';
 import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 
+// Marks the css class for space
 const spaceDecoration = Decoration.mark({
   attributes: { class: 'cm-keyname-space-indicator' },
 });
 
+//Decorates the leading and trailing spaces 
 function buildDecorations(state: EditorState) {
   const builder = new RangeSetBuilder<Decoration>();
   const text = state.doc.toString();
@@ -25,6 +27,7 @@ function buildDecorations(state: EditorState) {
   return builder.finish();
 }
 
+//Marks the field with the decorator
 const visibleSpaceField = StateField.define<DecorationSet>({
   create(state) {
     return buildDecorations(state);

--- a/webapp/src/constants/GlobalValidationSchema.tsx
+++ b/webapp/src/constants/GlobalValidationSchema.tsx
@@ -257,7 +257,7 @@ export class Validation {
     });
 
   static readonly PROJECT_SETTINGS = Yup.object().shape({
-    name: Yup.string().required().min(3).max(100),
+    name: Yup.string().trim().required().min(3).max(100),
     description: Yup.string().nullable().min(3).max(2000),
   });
 

--- a/webapp/src/constants/GlobalValidationSchema.tsx
+++ b/webapp/src/constants/GlobalValidationSchema.tsx
@@ -240,7 +240,7 @@ export class Validation {
 
   static readonly PROJECT_CREATION = (t: (string) => string) =>
     Yup.object().shape({
-      name: Yup.string().required().min(3).max(50),
+      name: Yup.string().trim().required().min(3).max(50),
       languages: Yup.array()
         .required()
         .min(1, t('project_creation_add_at_least_one_language'))

--- a/webapp/src/fixtures/__tests__/keyName.test.ts
+++ b/webapp/src/fixtures/__tests__/keyName.test.ts
@@ -1,4 +1,8 @@
-import { PO_MSGCTXT_KEY_SEPARATOR, splitKeyName } from '../keyName';
+import {
+  hasOuterWhitespace,
+  PO_MSGCTXT_KEY_SEPARATOR,
+  splitKeyName,
+} from '../keyName';
 
 describe('splitKeyName', () => {
   it('returns only msgid for name without separator', () => {
@@ -30,4 +34,20 @@ describe('splitKeyName', () => {
   it('returns empty msgid for empty input', () => {
     expect(splitKeyName('')).toEqual({ msgid: '' });
   });
+});
+
+describe('hasOuterWhitespace', () => {
+  it.each(['key', '', 'inner key', 'a.b.c'])(
+    'returns false for clean name %p',
+    (name) => {
+      expect(hasOuterWhitespace(name)).toBe(false);
+    }
+  );
+
+  it.each([' key', 'key ', '  key  ', '\tkey', 'key\t', '\tkey\t'])(
+    'returns true for name with outer whitespace %p',
+    (name) => {
+      expect(hasOuterWhitespace(name)).toBe(true);
+    }
+  );
 });

--- a/webapp/src/fixtures/keyName.ts
+++ b/webapp/src/fixtures/keyName.ts
@@ -13,6 +13,12 @@ export function splitKeyName(name: string): SplitKeyName {
   return { msgctxt: name.slice(0, i), msgid: name.slice(i + 1) };
 }
 
+export const KEY_NAME_LEADING_WHITESPACE_REGEX = /^(\s+)/;
+export const KEY_NAME_TRAILING_WHITESPACE_REGEX = /(\s+)$/;
+
 export function hasOuterWhitespace(name: string): boolean {
-  return name !== name.trim();
+  return (
+    KEY_NAME_LEADING_WHITESPACE_REGEX.test(name) ||
+    KEY_NAME_TRAILING_WHITESPACE_REGEX.test(name)
+  );
 }

--- a/webapp/src/fixtures/keyName.ts
+++ b/webapp/src/fixtures/keyName.ts
@@ -12,3 +12,11 @@ export function splitKeyName(name: string): SplitKeyName {
   if (i < 0) return { msgid: name };
   return { msgctxt: name.slice(0, i), msgid: name.slice(i + 1) };
 }
+
+export function hasOuterWhitespace(name: string): boolean {
+  return name !== name.trim();
+}
+
+export function hasNewOuterWhitespace(original: string, next: string): boolean {
+  return hasOuterWhitespace(next) && !hasOuterWhitespace(original);
+}

--- a/webapp/src/fixtures/keyName.ts
+++ b/webapp/src/fixtures/keyName.ts
@@ -16,7 +16,3 @@ export function splitKeyName(name: string): SplitKeyName {
 export function hasOuterWhitespace(name: string): boolean {
   return name !== name.trim();
 }
-
-export function hasNewOuterWhitespace(original: string, next: string): boolean {
-  return hasOuterWhitespace(next) && !hasOuterWhitespace(original);
-}

--- a/webapp/src/views/projects/project/ProjectCreateView.tsx
+++ b/webapp/src/views/projects/project/ProjectCreateView.tsx
@@ -36,6 +36,7 @@ export const ProjectCreateView: FunctionComponent = () => {
     usePreferredOrganization();
 
   const onSubmit = (values: CreateProjectValueType) => {
+    values.name = values.name.trim();
     values.languages = values.languages.filter((l) => !!l);
     createProjectLoadable.mutate(
       {

--- a/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
+++ b/webapp/src/views/projects/project/ProjectSettingsGeneral.tsx
@@ -100,6 +100,7 @@ export const ProjectSettingsGeneral = () => {
           useNamespaces: project.useNamespaces,
           useBranching: project.useBranching,
           ...values,
+          name: values.name.trim(),
           description: values.description || undefined,
           unassignConflictingTms,
         },

--- a/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
+++ b/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
@@ -29,8 +29,7 @@ import { PluralFormCheckbox } from 'tg.component/common/form/PluralFormCheckbox'
 import { CharLimitCheckbox } from 'tg.component/common/form/CharLimitCheckbox';
 import { ControlsEditorSmall } from '../cell/ControlsEditorSmall';
 import { getVisibleCharCount } from '../cell/getVisibleCharCount';
-import ConfirmationDialog from 'tg.component/common/ConfirmationDialog';
-import { hasOuterWhitespace } from 'tg.fixtures/keyName';
+import { KeyNameWhitespaceWarning } from '../KeyNameWhitespaceWarning';
 
 const StyledContainer = styled('div')`
   display: grid;
@@ -85,7 +84,6 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
   const isPlural = form.values.isPlural;
 
   const [mode, setMode] = useState<'placeholders' | 'syntax'>('placeholders');
-  const [whitespaceWarningOpen, setWhitespaceWarningOpen] = useState(false);
 
   const maxCharLimit = form.values.maxCharLimit;
   const isBaseOverCharLimit =
@@ -95,17 +93,9 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
       (v) => getVisibleCharCount({ text: v, nested: isPlural }) > maxCharLimit
     );
 
-  const submitWithWhitespaceCheck = () => {
-    if (hasOuterWhitespace(form.values.name)) {
-      setWhitespaceWarningOpen(true);
-      return;
-    }
-    form.handleSubmit();
-  };
-
   const handleEnterSubmit = () => {
     if (!isBaseOverCharLimit) {
-      submitWithWhitespaceCheck();
+      form.handleSubmit();
     }
     return true;
   };
@@ -152,6 +142,12 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
                     </StyledEdtorWrapper>
                   </EditorWrapper>
                   <FieldError error={meta.touched && meta.error} />
+                  <KeyNameWhitespaceWarning
+                    value={field.value}
+                    onTrim={() =>
+                      form.setFieldValue(field.name, field.value.trim())
+                    }
+                  />
                 </div>
               );
             }}
@@ -315,27 +311,12 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
             variant="contained"
             disabled={!form.isValid || isBaseOverCharLimit}
             type="submit"
-            onClick={() => submitWithWhitespaceCheck()}
+            onClick={() => form.handleSubmit()}
           >
             <T keyName="global_form_save" />
           </LoadingButton>
         </Box>
       </Box>
-      {whitespaceWarningOpen && (
-        <ConfirmationDialog
-          title={t('key_whitespace_warning_title', 'Key has extra spaces')}
-          message={t(
-            'key_whitespace_warning_message',
-            'Leading or trailing spaces can cause duplicate or mismatched keys. Save anyway?'
-          )}
-          confirmButtonText={t('key_whitespace_warning_confirm', 'Save anyway')}
-          onCancel={() => setWhitespaceWarningOpen(false)}
-          onConfirm={() => {
-            setWhitespaceWarningOpen(false);
-            form.handleSubmit();
-          }}
-        />
-      )}
     </>
   );
 };

--- a/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
+++ b/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
@@ -323,10 +323,10 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
       </Box>
       {whitespaceWarningOpen && (
         <ConfirmationDialog
-          title={t('key_whitespace_warning_title', 'Spaces around key name')}
+          title={t('key_whitespace_warning_title', 'Key has extra spaces')}
           message={t(
             'key_whitespace_warning_message',
-            'This key name starts or ends with a space. Such spaces are easy to miss and can lead to duplicate or mismatched keys. Do you want to save it anyway?'
+            'Leading or trailing spaces can cause duplicate or mismatched keys. Save anyway?'
           )}
           confirmButtonText={t('key_whitespace_warning_confirm', 'Save anyway')}
           onCancel={() => setWhitespaceWarningOpen(false)}

--- a/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
+++ b/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
@@ -29,6 +29,8 @@ import { PluralFormCheckbox } from 'tg.component/common/form/PluralFormCheckbox'
 import { CharLimitCheckbox } from 'tg.component/common/form/CharLimitCheckbox';
 import { ControlsEditorSmall } from '../cell/ControlsEditorSmall';
 import { getVisibleCharCount } from '../cell/getVisibleCharCount';
+import ConfirmationDialog from 'tg.component/common/ConfirmationDialog';
+import { hasOuterWhitespace } from 'tg.fixtures/keyName';
 
 const StyledContainer = styled('div')`
   display: grid;
@@ -83,6 +85,7 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
   const isPlural = form.values.isPlural;
 
   const [mode, setMode] = useState<'placeholders' | 'syntax'>('placeholders');
+  const [whitespaceWarningOpen, setWhitespaceWarningOpen] = useState(false);
 
   const maxCharLimit = form.values.maxCharLimit;
   const isBaseOverCharLimit =
@@ -92,9 +95,17 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
       (v) => getVisibleCharCount({ text: v, nested: isPlural }) > maxCharLimit
     );
 
+  const submitWithWhitespaceCheck = () => {
+    if (hasOuterWhitespace(form.values.name)) {
+      setWhitespaceWarningOpen(true);
+      return;
+    }
+    form.handleSubmit();
+  };
+
   const handleEnterSubmit = () => {
     if (!isBaseOverCharLimit) {
-      form.handleSubmit();
+      submitWithWhitespaceCheck();
     }
     return true;
   };
@@ -304,12 +315,27 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
             variant="contained"
             disabled={!form.isValid || isBaseOverCharLimit}
             type="submit"
-            onClick={() => form.handleSubmit()}
+            onClick={() => submitWithWhitespaceCheck()}
           >
             <T keyName="global_form_save" />
           </LoadingButton>
         </Box>
       </Box>
+      {whitespaceWarningOpen && (
+        <ConfirmationDialog
+          title={t('key_whitespace_warning_title', 'Spaces around key name')}
+          message={t(
+            'key_whitespace_warning_message',
+            'This key name starts or ends with a space. Such spaces are easy to miss and can lead to duplicate or mismatched keys. Do you want to save it anyway?'
+          )}
+          confirmButtonText={t('key_whitespace_warning_confirm', 'Save anyway')}
+          onCancel={() => setWhitespaceWarningOpen(false)}
+          onConfirm={() => {
+            setWhitespaceWarningOpen(false);
+            form.handleSubmit();
+          }}
+        />
+      )}
     </>
   );
 };

--- a/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
+++ b/webapp/src/views/projects/translations/KeyCreateForm/FormBody.tsx
@@ -141,13 +141,16 @@ export const FormBody: React.FC<Props> = ({ onCancel, autofocus }) => {
                       />
                     </StyledEdtorWrapper>
                   </EditorWrapper>
-                  <FieldError error={meta.touched && meta.error} />
-                  <KeyNameWhitespaceWarning
-                    value={field.value}
-                    onTrim={() =>
-                      form.setFieldValue(field.name, field.value.trim())
-                    }
-                  />
+                  {meta.touched && meta.error ? (
+                    <FieldError error={meta.error} />
+                  ) : (
+                    <KeyNameWhitespaceWarning
+                      value={field.value}
+                      onTrim={() =>
+                        form.setFieldValue(field.name, field.value.trim())
+                      }
+                    />
+                  )}
                 </div>
               );
             }}

--- a/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
@@ -25,6 +25,7 @@ import { KeyCustomValues } from './KeyCustomValues';
 import { DeletableKeyWithTranslationsModelType } from '../context/types';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
 import ConfirmationDialog from 'tg.component/common/ConfirmationDialog';
+import { hasNewOuterWhitespace } from 'tg.fixtures/keyName';
 
 type TabsType = 'general' | 'advanced' | 'context' | 'customValues';
 
@@ -76,6 +77,7 @@ export const KeyEditModal: React.FC<Props> = ({
   const { updateKey } = useTranslationsActions();
   const keyId = data.keyId;
   const [warningOpen, setWarningOpen] = useState(false);
+  const [whitespaceWarningOpen, setWhitespaceWarningOpen] = useState(false);
 
   const keyInfoLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/keys/{id}',
@@ -134,6 +136,13 @@ export const KeyEditModal: React.FC<Props> = ({
       enableReinitialize
       validationSchema={Validation.KEY_SETTINGS_FORM(t)}
       onSubmit={async (values, helpers) => {
+        if (
+          hasNewOuterWhitespace(data.keyName, values.name) &&
+          !whitespaceWarningOpen
+        ) {
+          setWhitespaceWarningOpen(true);
+          return;
+        }
         const custom = JSON.parse(values.custom);
         try {
           const data = await updateKeyLoadable.mutateAsync(
@@ -259,6 +268,24 @@ export const KeyEditModal: React.FC<Props> = ({
                 title={t('key_edit_modal_force_plural_change_title')}
                 message={t('key_edit_modal_force_plural_change_message')}
                 onCancel={() => setWarningOpen(false)}
+                onConfirm={() => submitForm()}
+                />
+            )}
+            {whitespaceWarningOpen && (
+              <ConfirmationDialog
+                title={t(
+                  'key_whitespace_warning_title',
+                  'Key has extra spaces'
+                )}
+                message={t(
+                  'key_whitespace_warning_message',
+                  'Leading or trailing spaces can cause duplicate or mismatched keys. Save anyway?'
+                )}
+                confirmButtonText={t(
+                  'key_whitespace_warning_confirm',
+                  'Save anyway'
+                )}
+                onCancel={() => setWhitespaceWarningOpen(false)}
                 onConfirm={() => submitForm()}
               />
             )}

--- a/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
@@ -269,7 +269,7 @@ export const KeyEditModal: React.FC<Props> = ({
                 message={t('key_edit_modal_force_plural_change_message')}
                 onCancel={() => setWarningOpen(false)}
                 onConfirm={() => submitForm()}
-                />
+              />
             )}
             {whitespaceWarningOpen && (
               <ConfirmationDialog

--- a/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyEditModal.tsx
@@ -25,7 +25,6 @@ import { KeyCustomValues } from './KeyCustomValues';
 import { DeletableKeyWithTranslationsModelType } from '../context/types';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
 import ConfirmationDialog from 'tg.component/common/ConfirmationDialog';
-import { hasNewOuterWhitespace } from 'tg.fixtures/keyName';
 
 type TabsType = 'general' | 'advanced' | 'context' | 'customValues';
 
@@ -77,7 +76,6 @@ export const KeyEditModal: React.FC<Props> = ({
   const { updateKey } = useTranslationsActions();
   const keyId = data.keyId;
   const [warningOpen, setWarningOpen] = useState(false);
-  const [whitespaceWarningOpen, setWhitespaceWarningOpen] = useState(false);
 
   const keyInfoLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/keys/{id}',
@@ -136,13 +134,6 @@ export const KeyEditModal: React.FC<Props> = ({
       enableReinitialize
       validationSchema={Validation.KEY_SETTINGS_FORM(t)}
       onSubmit={async (values, helpers) => {
-        if (
-          hasNewOuterWhitespace(data.keyName, values.name) &&
-          !whitespaceWarningOpen
-        ) {
-          setWhitespaceWarningOpen(true);
-          return;
-        }
         const custom = JSON.parse(values.custom);
         try {
           const data = await updateKeyLoadable.mutateAsync(
@@ -268,24 +259,6 @@ export const KeyEditModal: React.FC<Props> = ({
                 title={t('key_edit_modal_force_plural_change_title')}
                 message={t('key_edit_modal_force_plural_change_message')}
                 onCancel={() => setWarningOpen(false)}
-                onConfirm={() => submitForm()}
-              />
-            )}
-            {whitespaceWarningOpen && (
-              <ConfirmationDialog
-                title={t(
-                  'key_whitespace_warning_title',
-                  'Key has extra spaces'
-                )}
-                message={t(
-                  'key_whitespace_warning_message',
-                  'Leading or trailing spaces can cause duplicate or mismatched keys. Save anyway?'
-                )}
-                confirmButtonText={t(
-                  'key_whitespace_warning_confirm',
-                  'Save anyway'
-                )}
-                onCancel={() => setWhitespaceWarningOpen(false)}
                 onConfirm={() => submitForm()}
               />
             )}

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -14,6 +14,7 @@ import { LabelHint } from 'tg.component/common/LabelHint';
 import { PluralFormCheckbox } from 'tg.component/common/form/PluralFormCheckbox';
 import { CharLimitCheckbox } from 'tg.component/common/form/CharLimitCheckbox';
 import { useProject } from 'tg.hooks/useProject';
+import { KeyNameWhitespaceWarning } from '../KeyNameWhitespaceWarning';
 import clsx from 'clsx';
 
 const StyledSection = styled('div')``;
@@ -76,6 +77,10 @@ export const KeyGeneral = () => {
             />
           </EditorWrapper>
           <FieldError error={errors.name} />
+          <KeyNameWhitespaceWarning
+            value={values.name}
+            onTrim={() => setFieldValue('name', values.name.trim())}
+          />
         </StyledSection>
         {project.useNamespaces && (
           <StyledSection>

--- a/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
+++ b/webapp/src/views/projects/translations/KeyEdit/KeyGeneral.tsx
@@ -76,11 +76,14 @@ export const KeyGeneral = () => {
               minHeight="unset"
             />
           </EditorWrapper>
-          <FieldError error={errors.name} />
-          <KeyNameWhitespaceWarning
-            value={values.name}
-            onTrim={() => setFieldValue('name', values.name.trim())}
-          />
+          {errors.name ? (
+            <FieldError error={errors.name} />
+          ) : (
+            <KeyNameWhitespaceWarning
+              value={values.name}
+              onTrim={() => setFieldValue('name', values.name.trim())}
+            />
+          )}
         </StyledSection>
         {project.useNamespaces && (
           <StyledSection>

--- a/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
+++ b/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
@@ -1,15 +1,18 @@
-import { styled } from '@mui/material';
+import { Link, styled } from '@mui/material';
 import { T } from '@tolgee/react';
 import { AlertTriangle } from '@untitled-ui/icons-react';
 
 import { hasOuterWhitespace } from 'tg.fixtures/keyName';
 
+const StyledSlot = styled('div')`
+  min-height: 1.25rem;
+`;
+
 const StyledWarning = styled('div')`
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 4px;
-  font-size: 13px;
+  font-size: 12px;
   color: ${({ theme }) => theme.palette.warning.main};
 
   & svg {
@@ -21,21 +24,6 @@ const StyledMessage = styled('span')`
   flex-grow: 1;
 `;
 
-const StyledTrim = styled('button')`
-  flex-shrink: 0;
-  border: none;
-  background: none;
-  padding: 0;
-  cursor: pointer;
-  font: inherit;
-  font-weight: 500;
-  color: ${({ theme }) => theme.palette.primary.main};
-
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
 type Props = {
   value: string;
   onTrim: () => void;
@@ -45,26 +33,27 @@ export const KeyNameWhitespaceWarning: React.FC<Props> = ({
   value,
   onTrim,
 }) => {
-  if (!value || !hasOuterWhitespace(value)) {
-    return null;
-  }
-
   return (
-    <StyledWarning data-cy="key-name-whitespace-warning">
-      <AlertTriangle width={16} height={16} />
-      <StyledMessage>
-        <T
-          keyName="key_whitespace_warning_message"
-          defaultValue="This key has extra spaces. They can cause duplicate or mismatched keys."
-        />
-      </StyledMessage>
-      <StyledTrim
-        type="button"
-        data-cy="key-name-whitespace-trim"
-        onClick={onTrim}
-      >
-        <T keyName="key_whitespace_warning_trim" defaultValue="Trim" />
-      </StyledTrim>
-    </StyledWarning>
+    <StyledSlot>
+      {Boolean(value) && hasOuterWhitespace(value) && (
+        <StyledWarning data-cy="key-name-whitespace-warning">
+          <AlertTriangle width={15} height={15} />
+          <StyledMessage>
+            <T
+              keyName="key_whitespace_warning_message"
+              defaultValue="This key has extra spaces. They can cause duplicate or mismatched keys."
+            />
+          </StyledMessage>
+          <Link
+            component="button"
+            type="button"
+            data-cy="key-name-whitespace-trim"
+            onClick={onTrim}
+          >
+            <T keyName="key_whitespace_warning_trim" defaultValue="Trim" />
+          </Link>
+        </StyledWarning>
+      )}
+    </StyledSlot>
   );
 };

--- a/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
+++ b/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
@@ -1,6 +1,5 @@
 import { Link, styled } from '@mui/material';
 import { T } from '@tolgee/react';
-import { AlertTriangle } from '@untitled-ui/icons-react';
 
 import { hasOuterWhitespace } from 'tg.fixtures/keyName';
 
@@ -11,18 +10,12 @@ const StyledSlot = styled('div')`
 const StyledWarning = styled('div')`
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   font-size: 12px;
   color: ${({ theme }) => theme.palette.warning.main};
-
-  & svg {
-    flex-shrink: 0;
-  }
 `;
 
-const StyledMessage = styled('span')`
-  flex-grow: 1;
-`;
+const StyledMessage = styled('span')``;
 
 type Props = {
   value: string;
@@ -37,7 +30,6 @@ export const KeyNameWhitespaceWarning: React.FC<Props> = ({
     <StyledSlot>
       {Boolean(value) && hasOuterWhitespace(value) && (
         <StyledWarning data-cy="key-name-whitespace-warning">
-          <AlertTriangle width={15} height={15} />
           <StyledMessage>
             <T
               keyName="key_whitespace_warning_message"

--- a/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
+++ b/webapp/src/views/projects/translations/KeyNameWhitespaceWarning.tsx
@@ -1,0 +1,70 @@
+import { styled } from '@mui/material';
+import { T } from '@tolgee/react';
+import { AlertTriangle } from '@untitled-ui/icons-react';
+
+import { hasOuterWhitespace } from 'tg.fixtures/keyName';
+
+const StyledWarning = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+  font-size: 13px;
+  color: ${({ theme }) => theme.palette.warning.main};
+
+  & svg {
+    flex-shrink: 0;
+  }
+`;
+
+const StyledMessage = styled('span')`
+  flex-grow: 1;
+`;
+
+const StyledTrim = styled('button')`
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 500;
+  color: ${({ theme }) => theme.palette.primary.main};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+type Props = {
+  value: string;
+  onTrim: () => void;
+};
+
+export const KeyNameWhitespaceWarning: React.FC<Props> = ({
+  value,
+  onTrim,
+}) => {
+  if (!value || !hasOuterWhitespace(value)) {
+    return null;
+  }
+
+  return (
+    <StyledWarning data-cy="key-name-whitespace-warning">
+      <AlertTriangle width={16} height={16} />
+      <StyledMessage>
+        <T
+          keyName="key_whitespace_warning_message"
+          defaultValue="This key has extra spaces. They can cause duplicate or mismatched keys."
+        />
+      </StyledMessage>
+      <StyledTrim
+        type="button"
+        data-cy="key-name-whitespace-trim"
+        onClick={onTrim}
+      >
+        <T keyName="key_whitespace_warning_trim" defaultValue="Trim" />
+      </StyledTrim>
+    </StyledWarning>
+  );
+};


### PR DESCRIPTION
Builds on and supersedes #3750, completing the UI safeguards from #3359.

## What this adds

**Key names — visualize _and_ warn (the missing half of #3359)**
- Leading/trailing whitespace in the key-name editor is highlighted (carried over from #3750), now using the theme `label.lightBlue` token so the highlight is clearly visible in **both** light and dark mode (the original hardcoded colour washed out in light mode).
- An **inline warning** appears under the key-name field whenever the name has outer whitespace, with a **Trim** action to remove it in one click. This fires on both **create** and **edit**, for newly typed *and* pre-existing whitespace — consistent with the editor highlight, which is also unconditional. The Trim action doubles as a quick fix for cleaning up legacy/imported keys.
- Nothing is auto-trimmed; the user clicks **Trim** explicitly (respects the issue's No-Goes).
- The warning and the editor highlight share one whitespace definition (leading/trailing spaces **and** tabs), so what is flagged matches what is highlighted.

**Project name**
- Trimmed on the new-project page as well (the settings page already trimmed it in #3750), with validation running against the trimmed value.

## Tests
- `webapp/src/fixtures/__tests__/keyName.test.ts` — unit tests for `hasOuterWhitespace` covering clean names plus leading/trailing spaces and tabs.
- `e2e/cypress/e2e/translations/keyNameWhitespace.cy.ts` — covers: create warns + Trim, edit warns when whitespace is newly added + Trim, clean rename does **not** warn, and editing a key whose whitespace was already present **does** warn.

## Translations
- Keys `key_whitespace_warning_message` / `key_whitespace_warning_trim` created in Tolgee (tagged `draft: pr-3750-whitespace`).

Resolves #3359. Original key-name visualization work by @uvais724 in #3750.

Co-authored-by: Uvais [uvais724@gmail.com](mailto:uvais724@gmail.com).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible warning when project translation key names include leading or trailing whitespace, with a one-click trim action.
  * Highlighted whitespace directly in the translation key editor to make it easier to spot before saving.

* **Bug Fixes**
  * Project names are now trimmed automatically when creating or updating projects, preventing accidental extra spaces from being saved.

* **Tests**
  * Added end-to-end coverage for whitespace warning behavior in translation key create/edit flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->