### PR TITLE
fix: dispatch Redis job-queue events in order to prevent dropped chunk retries

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/pubSub/RedisPubSubReceiverConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/pubSub/RedisPubSubReceiverConfiguration.kt
@@ -10,6 +10,7 @@ import org.springframework.data.redis.listener.PatternTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
 import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
 @Configuration
 @ConditionalOnExpression(
@@ -49,12 +50,36 @@ class RedisPubSubReceiverConfiguration(
   }
 
   @Bean
-  fun redisPubsubContainer(): RedisMessageListenerContainer {
+  fun redisWebsocketPubsubContainer(): RedisMessageListenerContainer {
     val container = RedisMessageListenerContainer()
     container.setConnectionFactory(connectionFactory)
     if (tolgeeProperties.websocket.useRedis) {
       container.addMessageListener(redisWebsocketPubsubListenerAdapter(), PatternTopic(WEBSOCKET_TOPIC))
     }
+    return container
+  }
+
+  /**
+   * Job-queue and job-cancel messages mutate the in-memory [io.tolgee.batch.BatchJobChunkExecutionQueue]
+   * and must be applied in the order they were published. A single consume cycle publishes a REMOVE
+   * (consuming) immediately followed by an ADD (retry requeue) for the same chunk; if the ADD is applied
+   * before the REMOVE, the REMOVE deletes the requeued chunk and it is silently dropped until the next
+   * DB re-scan. RedisMessageListenerContainer's default executor is an unbounded SimpleAsyncTaskExecutor
+   * that dispatches every message on a new thread, so order is not preserved. A single-threaded executor
+   * forces sequential, in-order delivery.
+   */
+  @Bean
+  fun redisJobPubsubContainer(): RedisMessageListenerContainer {
+    val container = RedisMessageListenerContainer()
+    container.setConnectionFactory(connectionFactory)
+    container.setTaskExecutor(
+      ThreadPoolTaskExecutor().apply {
+        corePoolSize = 1
+        maxPoolSize = 1
+        setThreadNamePrefix("redis-job-pubsub-")
+        initialize()
+      },
+    )
     container.addMessageListener(redisJobQueuePubsubListenerAdapter(), PatternTopic(JOB_QUEUE_TOPIC))
     container.addMessageListener(redisJobCancelPubsubListenerAdapter(), PatternTopic(JOB_CANCEL_TOPIC))
     return container


### PR DESCRIPTION
## Problem

Flaky test `BatchJobsGeneralWithRedisTest.retries and fails on management exceptions issues()` — only the **WithRedis** variant fails; the WithoutRedis variant always passes. CI failure is a wait timeout: `org.opentest4j.AssertionFailedError at waitFor.kt:55` (the job never reaches `FAILED`).

## Root cause

A Redis pub/sub **message-reordering** bug:

1. Each retry cycle, `BatchJobActionService.handleItem` publishes two messages to `JOB_QUEUE_TOPIC` for the *same* chunk, back-to-back: a **REMOVE** (`publishRemoveConsuming`) immediately followed by an **ADD** (the retry requeue).
2. `RedisMessageListenerContainer` was created without a `taskExecutor`, so it defaults to an unbounded `SimpleAsyncTaskExecutor` that dispatches **every message on a new thread** — no ordering guarantee.
3. When the **ADD is applied before the stale REMOVE**, `BatchJobChunkExecutionQueue.onJobItemEvent` deletes the just-requeued chunk by `chunkExecutionId`. The chunk is **silently dropped** from the in-memory queue (still `PENDING` in the DB).
4. The launcher only polls the in-memory queue; the only recovery is the `@Scheduled(fixedDelay = 60000)` `populateQueue()`. So a retried chunk can stall up to ~60s, never reaching its terminal `FAILED` state — the job never completes. In the test (forced clock + 10s wait) it never recovers → timeout.

This is a real production issue (stalled retries under multi-node), not just a test artifact. Only the Redis variant can hit it because the non-Redis path requeues synchronously and locally.

## Fix

Split the shared listener container: job-queue and job-cancel topics get a **dedicated single-thread `RedisMessageListenerContainer`** so their events are applied in publication order (REMOVE before its later ADD). The high-volume websocket topic keeps its own async container, so its throughput is unaffected.

## Verification

Controlled experiment — injected a worst-case reorder delay; the **only** variable changed was the executor:

| Executor | 15ms reorder delay | Result |
|---|---|---|
| Default async (`SimpleAsyncTaskExecutor`) | yes | **3/3 FAIL** — exact CI signature `waitFor.kt:55` |
| Single-thread (this fix) | yes | **3/3 PASS** |

Regression (this fix, no instrumentation): the flaky test **20/20 PASS**, and the full `BatchJobsGeneralWithRedisTest` class **14/14 PASS** (incl. `removes from queue using event`, which relies on the self-delivered REMOVE on the now-dedicated container).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved reliability of real-time message delivery for websocket connections
  * Enhanced background job processing with better order preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->