### PR TITLE
feat: show org name in API key project selector for multi-org users

### DIFF
--- a/webapp/src/views/userSettings/apiKeys/GenerateApiKeyDialog.tsx
+++ b/webapp/src/views/userSettings/apiKeys/GenerateApiKeyDialog.tsx
@@ -97,6 +97,27 @@ export const GenerateApiKeyDialog: FunctionComponent<Props> = (props) => {
 
   const expirationDateOptions = useExpirationDateOptions();
 
+  const projectList = projects.data?._embedded?.projects;
+  const showOrganization =
+    new Set(
+      projectList
+        ?.map((p) => p.organizationOwner?.id)
+        .filter((id) => id !== undefined)
+    ).size > 1;
+
+  const renderProjectLabel = (
+    project: components['schemas']['ProjectModel']
+  ) => (
+    <>
+      {project.name}
+      {showOrganization && project.organizationOwner && (
+        <Box component="span" ml={1} sx={{ color: 'text.secondary' }}>
+          {project.organizationOwner.name}
+        </Box>
+      )}
+    </>
+  );
+
   const getProject = (projectId?: number) => {
     return (
       projects.data?._embedded?.projects?.find(
@@ -188,19 +209,20 @@ export const GenerateApiKeyDialog: FunctionComponent<Props> = (props) => {
                           name="projectId"
                           label="Project"
                           minHeight={false}
-                          renderValue={(v) =>
-                            projects.data?._embedded?.projects?.find(
+                          renderValue={(v) => {
+                            const selected = projectList?.find(
                               (r) => r.id === v
-                            )?.name
-                          }
+                            );
+                            return selected && renderProjectLabel(selected);
+                          }}
                         >
-                          {projects.data?._embedded?.projects?.map((r) => (
+                          {projectList?.map((r) => (
                             <MenuItem
                               data-cy="api-keys-project-select-item"
                               key={r.id}
                               value={r.id}
                             >
-                              {r.name}
+                              {renderProjectLabel(r)}
                             </MenuItem>
                           ))}
                         </Select>


### PR DESCRIPTION
When generating a project API key, projects from different organizations were indistinguishable if they shared a name. Show the organization name greyed-out next to the project name when the project list spans more than one organization.
<img width="426" height="198" alt="Screenshot 2026-06-25 at 10 36 18" src="https://github.com/user-attachments/assets/857f4b5a-eda6-4ef1-bcf9-bed4f272ddcb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the API key generation dialog with clearer project labels.
  * Project dropdown entries can now include owning organization names (when applicable) to make selecting the right project easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->