### PR TITLE
feat: expose MCP tools/list without authentication

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
@@ -101,7 +101,7 @@ class WebSecurityConfig(
         )
         it.requestMatchers(*PUBLIC_ENDPOINTS).permitAll()
         it.requestMatchers(*ADMIN_ENDPOINTS).hasRole("SUPPORTER")
-        it.requestMatchers("/api/**", "/v2/**", "/mcp/**").authenticated()
+        it.requestMatchers("/api/**", "/v2/**").authenticated()
         it.anyRequest().permitAll()
       }.headers { headers ->
         headers.xssProtection(Customizer.withDefaults())

--- a/backend/app/src/main/kotlin/io/tolgee/mcp/McpRequestContext.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/mcp/McpRequestContext.kt
@@ -3,6 +3,7 @@ package io.tolgee.mcp
 import io.tolgee.activity.ActivityHandlerInterceptor
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.constants.Message
+import io.tolgee.exceptions.AuthenticationException
 import io.tolgee.exceptions.PermissionException
 import io.tolgee.security.OrganizationHolder
 import io.tolgee.security.ProjectContextService
@@ -35,6 +36,9 @@ class McpRequestContext(
     projectId: Long? = null,
     block: () -> T,
   ): T {
+    // The /mcp/** path is not authenticated at the security filter chain (see WebSecurityConfig), so that list of tools is publicly available and can be health-checked by tools like glama.ai
+    // so unauthenticated tool calls reach this point and must be rejected here.
+    requireAuthenticated()
     // Order mirrors the HTTP interceptor chain:
     // 1. RateLimitInterceptor
     applyRateLimit(spec)
@@ -59,6 +63,12 @@ class McpRequestContext(
     setupActivity(spec)
     emitPostHogEvent(spec)
     return block()
+  }
+
+  private fun requireAuthenticated() {
+    if (authenticationFacade.authenticatedUserOrNull == null) {
+      throw AuthenticationException(Message.UNAUTHENTICATED)
+    }
   }
 
   /** Mirrors [AuthenticationInterceptor.preHandle] */

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/McpAuthenticationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/McpAuthenticationTest.kt
@@ -35,6 +35,21 @@ class McpAuthenticationTest : AbstractMcpTest() {
   }
 
   @Test
+  fun `initialize and listTools succeed without auth`() {
+    val client = createMcpClientWithoutAuth()
+    val tools = client.listTools()
+    assertThat(tools.tools()).isNotEmpty
+  }
+
+  @Test
+  fun `callTool fails without auth header`() {
+    val client = createMcpClientWithoutAuth()
+    assertThrows<Exception> {
+      callTool(client, "list_projects")
+    }
+  }
+
+  @Test
   fun `callTool succeeds with PAK for project-scoped tool`() {
     val pakData = createTestDataWithPak()
     val client = createMcpClientWithPak(pakData.apiKey.encodedKey!!)

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/spec/CheckAuthenticationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/spec/CheckAuthenticationTest.kt
@@ -1,0 +1,16 @@
+package io.tolgee.mcp.tools.spec
+
+import io.tolgee.exceptions.AuthenticationException
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
+
+class CheckAuthenticationTest : McpToolEndpointSpecTestBase() {
+  @Test
+  fun `no authenticated user throws AuthenticationException`() {
+    whenever(authenticationFacade.authenticatedUserOrNull).thenReturn(null)
+
+    assertThatThrownBy { sut.executeAs(spec()) {} }
+      .isInstanceOf(AuthenticationException::class.java)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/spec/McpToolEndpointSpecTestBase.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/spec/McpToolEndpointSpecTestBase.kt
@@ -3,6 +3,7 @@ package io.tolgee.mcp.tools.spec
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.activity.data.ActivityType
 import io.tolgee.constants.Feature
+import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.mcp.McpRequestContext
 import io.tolgee.mcp.RateLimitSpec
 import io.tolgee.mcp.ToolEndpointSpec
@@ -44,6 +45,7 @@ abstract class McpToolEndpointSpecTestBase {
     projectContextService = mock()
 
     whenever(activityHolder.businessEventData).thenReturn(businessEventData)
+    whenever(authenticationFacade.authenticatedUserOrNull).thenReturn(mock<UserAccountDto>())
 
     sut =
       McpRequestContext(

--- a/backend/testing/src/main/kotlin/io/tolgee/AbstractMcpTest.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/AbstractMcpTest.kt
@@ -32,13 +32,17 @@ abstract class AbstractMcpTest : AbstractSpringTest() {
 
   fun createMcpClientWithPak(pak: String): McpSyncClient = createMcpClientWithHeader("tgpak_$pak")
 
-  private fun createMcpClientWithHeader(apiKeyHeader: String): McpSyncClient {
+  fun createMcpClientWithoutAuth(): McpSyncClient = createMcpClientWithHeader(null)
+
+  private fun createMcpClientWithHeader(apiKeyHeader: String?): McpSyncClient {
     val transport =
       HttpClientStreamableHttpTransport
         .builder("http://localhost:$port")
         .endpoint("/mcp/developer")
         .customizeRequest { builder ->
-          builder.header("X-API-Key", apiKeyHeader)
+          if (apiKeyHeader != null) {
+            builder.header("X-API-Key", apiKeyHeader)
+          }
         }.build()
 
     val client =


### PR DESCRIPTION
Open the /mcp/** path at the security filter chain so unauthenticated clients can reach initialize/tools/list (MCP discovery & health checks, e.g. glama.ai). Tool calls stay protected: McpRequestContext.executeAs now rejects unauthenticated requests, so tools/call still requires a valid API key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MCP access handling so unauthenticated requests are allowed to reach general endpoints, while tool execution still requires authentication.
  * Added explicit authentication checks for MCP tool calls to prevent unauthorized use.
  * Improved test support for unauthenticated MCP clients and added coverage for both allowed and denied access cases.

* **Tests**
  * Added and updated tests covering MCP initialization, tool listing, and failed tool execution without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->