### PR TITLE
feat: community permissions for public projects

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/ProjectStatsController.kt
@@ -24,6 +24,7 @@ import io.tolgee.service.project.ProjectFeatureGuard
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.project.ProjectStatsService
 import io.tolgee.service.qa.TranslationQaIssueService
+import io.tolgee.service.security.SecurityService
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
@@ -47,6 +48,7 @@ class ProjectStatsController(
   private val branchService: BranchService,
   private val projectFeatureGuard: ProjectFeatureGuard,
   private val translationQaIssueService: TranslationQaIssueService,
+  private val securityService: SecurityService,
 ) {
   @Operation(summary = "Get project stats")
   @GetMapping("", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -82,7 +84,7 @@ class ProjectStatsController(
       baseWordsCount = totals.baseWordsCount,
       translatedPercentage = totals.translatedPercent,
       reviewedPercentage = totals.reviewedPercent,
-      membersCount = projectStats.memberCount,
+      membersCount = visibleMembersCount(projectStats.memberCount),
       tagCount = projectStats.tagCount,
       languageStats =
         statsLanguagePairs.map {
@@ -113,5 +115,10 @@ class ProjectStatsController(
   @AllowApiAccess
   fun getProjectDailyActivity(): Map<LocalDate, Long> {
     return projectStatsService.getProjectDailyActivity(projectHolder.project.id)
+  }
+
+  private fun visibleMembersCount(memberCount: Long): Long {
+    if (!securityService.shouldExposeMemberInfo()) return 0
+    return memberCount
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/dataImport/ImportSettingsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/dataImport/ImportSettingsController.kt
@@ -8,9 +8,11 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.dtos.request.dataImport.ImportSettingsRequest
 import io.tolgee.hateoas.dataImport.ImportSettingsModel
+import io.tolgee.model.enums.Scope
 import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authentication.AuthenticationFacade
+import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
 import io.tolgee.service.dataImport.ImportSettingsService
 import jakarta.validation.Valid
@@ -57,7 +59,7 @@ class ImportSettingsController(
     description = "Stores import settings for the authenticated user and the project.",
   )
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.KEYS_CREATE])
   fun store(
     @Valid @RequestBody dto: ImportSettingsRequest,
   ): ImportSettingsModel {

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/machineTranslation/MtCreditsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/machineTranslation/MtCreditsController.kt
@@ -4,10 +4,11 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.dtos.MtCreditBalanceDto
 import io.tolgee.hateoas.machineTranslation.CreditBalanceModel
+import io.tolgee.model.enums.Scope
 import io.tolgee.security.ProjectHolder
 import io.tolgee.security.authentication.AllowApiAccess
 import io.tolgee.security.authorization.RequiresOrganizationRole
-import io.tolgee.security.authorization.UseDefaultPermissions
+import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.service.machineTranslation.mtCreditsConsumption.MtCreditsService
 import io.tolgee.service.organization.OrganizationService
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -30,7 +31,7 @@ class MtCreditsController(
     summary = "Get credit balance for project",
     description = "Returns machine translation credit balance for specified project",
   )
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.ORGANIZATION_QUOTAS_VIEW])
   @AllowApiAccess
   fun getProjectCredits(
     @PathVariable projectId: Long,

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsPublishingController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsPublishingController.kt
@@ -41,8 +41,9 @@ class ProjectsPublishingController(
   @PutMapping(value = ["/{projectId:[0-9]+}/publishing"])
   @Operation(
     summary = "Set project publishing state",
-    description = "Marks the project as public or private. " +
-      "Only the organization owner or a server admin can change this.",
+    description =
+      "Marks the project as public or private. " +
+        "Only the organization owner or a server admin can change this.",
   )
   @RequestActivity(ActivityType.EDIT_PROJECT)
   @RequiresProjectPermissions([Scope.PROJECT_EDIT])

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsPublishingController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsPublishingController.kt
@@ -28,7 +28,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @CrossOrigin(origins = ["*"])
 @RequestMapping(value = ["/v2/projects"])
-@Tag(name = "Project Publishing", description = "Marks a project as public or private (organization owner only)")
+@Tag(
+  name = "Project Publishing",
+  description = "Marks a project as public or private (organization owner or server admin)",
+)
 class ProjectsPublishingController(
   private val projectService: ProjectService,
   private val projectHolder: ProjectHolder,
@@ -38,7 +41,8 @@ class ProjectsPublishingController(
   @PutMapping(value = ["/{projectId:[0-9]+}/publishing"])
   @Operation(
     summary = "Set project publishing state",
-    description = "Marks the project as public or private. Only the organization owner can change this.",
+    description = "Marks the project as public or private. " +
+      "Only the organization owner or a server admin can change this.",
   )
   @RequestActivity(ActivityType.EDIT_PROJECT)
   @RequiresProjectPermissions([Scope.PROJECT_EDIT])

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/activity/ProjectActivityModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/activity/ProjectActivityModelAssembler.kt
@@ -4,6 +4,7 @@ import io.tolgee.api.IProjectActivityModelAssembler
 import io.tolgee.api.v2.controllers.ApiKeyController
 import io.tolgee.model.views.activity.ProjectActivityView
 import io.tolgee.service.AvatarService
+import io.tolgee.service.security.SecurityService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component
 class ProjectActivityModelAssembler(
   private val avatarService: AvatarService,
   private val modifiedEntityModelAssembler: ModifiedEntityModelAssembler,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<ProjectActivityView, ProjectActivityModel>(
     ApiKeyController::class.java,
     ProjectActivityModel::class.java,
@@ -26,7 +28,7 @@ class ProjectActivityModelAssembler(
           ProjectActivityAuthorModel(
             id = view.authorId!!,
             name = view.authorName,
-            username = view.authorUsername!!,
+            username = securityService.maskedMemberField(view.authorUsername),
             avatar = avatarService.getAvatarLinks(view.authorAvatarHash),
             deleted = view.authorDeleted,
           )

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/key/trash/TrashedKeyModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/key/trash/TrashedKeyModelAssembler.kt
@@ -5,6 +5,7 @@ import io.tolgee.hateoas.userAccount.SimpleUserAccountModel
 import io.tolgee.service.AvatarService
 import io.tolgee.service.key.KeySearchResultView
 import io.tolgee.service.key.KeyTrashPurgeScheduler
+import io.tolgee.service.security.SecurityService
 import io.tolgee.util.addDays
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component
 @Component
 class TrashedKeyModelAssembler(
   private val avatarService: AvatarService,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<KeySearchResultView, TrashedKeyModel>(
     KeyTrashController::class.java,
     TrashedKeyModel::class.java,
@@ -34,7 +36,7 @@ class TrashedKeyModelAssembler(
     return entity.deletedByUserId?.let { userId ->
       SimpleUserAccountModel(
         id = userId,
-        username = entity.deletedByUserUsername ?: "",
+        username = securityService.maskedMemberField(entity.deletedByUserUsername),
         name = entity.deletedByUserName,
         avatar = avatarService.getAvatarLinks(entity.deletedByUserAvatarHash),
         deleted = entity.deletedByUserDeleted ?: false,

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/key/trash/TrashedKeyWithTranslationsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/key/trash/TrashedKeyWithTranslationsModelAssembler.kt
@@ -8,6 +8,7 @@ import io.tolgee.hateoas.userAccount.SimpleUserAccountModel
 import io.tolgee.model.views.KeyWithTranslationsView
 import io.tolgee.service.AvatarService
 import io.tolgee.service.key.KeyTrashPurgeScheduler
+import io.tolgee.service.security.SecurityService
 import io.tolgee.util.addDays
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Component
 class TrashedKeyWithTranslationsModelAssembler(
   private val avatarService: AvatarService,
   private val screenshotModelAssembler: ScreenshotModelAssembler,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<KeyWithTranslationsView, TrashedKeyWithTranslationsModel>(
     KeyTrashController::class.java,
     TrashedKeyWithTranslationsModel::class.java,
@@ -62,7 +64,7 @@ class TrashedKeyWithTranslationsModelAssembler(
     return view.deletedByUserId?.let { userId ->
       SimpleUserAccountModel(
         id = userId,
-        username = view.deletedByUserUsername ?: "",
+        username = securityService.maskedMemberField(view.deletedByUserUsername),
         name = view.deletedByUserName,
         avatar = avatarService.getAvatarLinks(view.deletedByUserAvatarHash),
         deleted = view.deletedByUserDeletedAt != null,

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectModelAssembler.kt
@@ -73,6 +73,7 @@ class ProjectModelAssembler(
       view.organizationOwner.basePermission,
       view.directPermission,
       authenticationFacade.authenticatedUserOrNull?.role,
+      isProjectPublic = view.public,
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
@@ -41,6 +41,7 @@ class ProjectWithStatsModelAssembler(
         view.organizationOwner.basePermission,
         view.directPermission,
         authenticationFacade.authenticatedUserOrNull?.role,
+        isProjectPublic = view.public,
       )
 
     return ProjectWithStatsModel(

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/TranslationHistoryModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/TranslationHistoryModelAssembler.kt
@@ -4,12 +4,14 @@ import io.tolgee.api.v2.controllers.translation.TranslationsController
 import io.tolgee.dtos.queryResults.TranslationHistoryView
 import io.tolgee.hateoas.userAccount.SimpleUserAccountModel
 import io.tolgee.service.AvatarService
+import io.tolgee.service.security.SecurityService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 
 @Component
 class TranslationHistoryModelAssembler(
   private val avatarService: AvatarService,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<TranslationHistoryView, TranslationHistoryModel>(
     TranslationsController::class.java,
     TranslationHistoryModel::class.java,
@@ -24,7 +26,7 @@ class TranslationHistoryModelAssembler(
           SimpleUserAccountModel(
             id = it,
             name = view.authorName,
-            username = view.authorEmail ?: "",
+            username = securityService.maskedMemberField(view.authorEmail),
             avatar = avatar,
             deleted = view.authorDeletedAt != null,
           )

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/suggestions/TranslationSuggestionSimpleModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/suggestions/TranslationSuggestionSimpleModelAssembler.kt
@@ -4,12 +4,14 @@ import io.tolgee.api.v2.controllers.translation.TranslationsController
 import io.tolgee.hateoas.userAccount.SimpleUserAccountModel
 import io.tolgee.model.views.TranslationSuggestionView
 import io.tolgee.service.AvatarService
+import io.tolgee.service.security.SecurityService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 
 @Component
 class TranslationSuggestionSimpleModelAssembler(
   private val avatarService: AvatarService,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<TranslationSuggestionView, TranslationSuggestionSimpleModel>(
     TranslationsController::class.java,
     TranslationSuggestionSimpleModel::class.java,
@@ -22,7 +24,7 @@ class TranslationSuggestionSimpleModelAssembler(
         SimpleUserAccountModel(
           id = entity.authorId,
           name = entity.authorName,
-          username = entity.authorUsername,
+          username = securityService.maskedMemberField(entity.authorUsername),
           avatar = avatarService.getAvatarLinks(entity.authorAvatarHash),
           deleted = entity.authorDeletedAt != null,
         ),

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/userAccount/SimpleUserAccountModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/userAccount/SimpleUserAccountModelAssembler.kt
@@ -4,12 +4,14 @@ import io.tolgee.api.v2.controllers.V2UserController
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.model.UserAccount
 import io.tolgee.service.AvatarService
+import io.tolgee.service.security.SecurityService
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport
 import org.springframework.stereotype.Component
 
 @Component
 class SimpleUserAccountModelAssembler(
   private val avatarService: AvatarService,
+  private val securityService: SecurityService,
 ) : RepresentationModelAssemblerSupport<UserAccount, SimpleUserAccountModel>(
     V2UserController::class.java,
     SimpleUserAccountModel::class.java,
@@ -19,7 +21,7 @@ class SimpleUserAccountModelAssembler(
 
     return SimpleUserAccountModel(
       id = entity.id,
-      username = entity.username,
+      username = securityService.maskedMemberField(entity.username),
       name = entity.name,
       avatar = avatar,
       deleted = entity.deletedAt != null,
@@ -31,7 +33,7 @@ class SimpleUserAccountModelAssembler(
 
     return SimpleUserAccountModel(
       id = dto.id,
-      username = dto.username,
+      username = securityService.maskedMemberField(dto.username),
       name = dto.name,
       avatar = avatar,
       deleted = dto.deleted,

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/userAccount/UserAccountInProjectModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/userAccount/UserAccountInProjectModelAssembler.kt
@@ -23,6 +23,8 @@ class UserAccountInProjectModelAssembler(
     UserAccountInProjectModel::class.java,
   ) {
   override fun toModel(view: ExtendedUserAccountInProject): UserAccountInProjectModel {
+    // Deliberately ignores whether project is public: the members list shows each member's
+    // configured, editable permissions, not the project-wide community permissions.
     val computedPermissions =
       permissionService.computeProjectPermission(
         view.organizationRole,

--- a/backend/api/src/main/kotlin/io/tolgee/websocket/ActivityWebsocketListener.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/websocket/ActivityWebsocketListener.kt
@@ -55,7 +55,7 @@ class ActivityWebsocketListener(
       val user = userAccountService.findDto(userId) ?: return@let null
       // These events fan out to every project subscriber and a recipient's MEMBERS_VIEW can't be
       // checked per-recipient at fan-out, so the realtime channel never carries the author email (the
-      // `username` field) — REST applies the per-caller members.view gate. Name + avatar still show.
+      // `username` field) — REST applies the per-caller members.view gate.
       val data = simpleUserAccountModelAssembler.toModel(user).copy(username = "")
       ActorInfo(type = ActorType.USER, data = data)
     } ?: ActorInfo(type = ActorType.UNKNOWN, data = null)

--- a/backend/api/src/main/kotlin/io/tolgee/websocket/ActivityWebsocketListener.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/websocket/ActivityWebsocketListener.kt
@@ -53,10 +53,11 @@ class ActivityWebsocketListener(
   fun getActorInfo(userId: Long?): ActorInfo {
     return userId?.let {
       val user = userAccountService.findDto(userId) ?: return@let null
-      ActorInfo(
-        type = ActorType.USER,
-        data = simpleUserAccountModelAssembler.toModel(user),
-      )
+      // These events fan out to every project subscriber and a recipient's MEMBERS_VIEW can't be
+      // checked per-recipient at fan-out, so the realtime channel never carries the author email (the
+      // `username` field) — REST applies the per-caller members.view gate. Name + avatar still show.
+      val data = simpleUserAccountModelAssembler.toModel(user).copy(username = "")
+      ActorInfo(type = ActorType.USER, data = data)
     } ?: ActorInfo(type = ActorType.UNKNOWN, data = null)
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/CommunityPermissionComputationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/CommunityPermissionComputationTest.kt
@@ -1,0 +1,126 @@
+package io.tolgee.api.v2.controllers
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.constants.ComputedPermissionOrigin
+import io.tolgee.dtos.ComputedPermissionDto
+import io.tolgee.dtos.cacheable.IPermission
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
+import io.tolgee.model.enums.ProjectPermissionType
+import io.tolgee.model.enums.Scope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class CommunityPermissionComputationTest : AbstractSpringTest() {
+  @Test
+  fun `org member with a NONE base is floored to community on a public project`() {
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = OrganizationRoleType.MEMBER,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = null,
+        userRole = UserAccount.Role.USER,
+        isProjectPublic = true,
+      )
+    assertThat(computed.origin).isEqualTo(ComputedPermissionOrigin.COMMUNITY)
+    assertThat(computed.expandedScopes)
+      .contains(Scope.TRANSLATIONS_SUGGEST, Scope.TRANSLATIONS_COMMENTS_ADD)
+  }
+
+  @Test
+  fun `org member with a NONE base is NOT floored on a private project`() {
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = OrganizationRoleType.MEMBER,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = null,
+        userRole = UserAccount.Role.USER,
+        isProjectPublic = false,
+      )
+    assertThat(computed.expandedScopes)
+      .doesNotContain(Scope.TRANSLATIONS_SUGGEST, Scope.TRANSLATIONS_COMMENTS_ADD)
+  }
+
+  @Test
+  fun `a supporter non-member is never below a regular user on a public project`() {
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = null,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = null,
+        userRole = UserAccount.Role.SUPPORTER,
+        isProjectPublic = true,
+      )
+    assertThat(computed.expandedScopes).contains(
+      Scope.TRANSLATIONS_SUGGEST,
+      Scope.TRANSLATIONS_COMMENTS_ADD,
+      Scope.MEMBERS_VIEW,
+      Scope.TASKS_VIEW,
+    )
+  }
+
+  @Test
+  fun `a server admin still gets full admin on a public project`() {
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = null,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = null,
+        userRole = UserAccount.Role.ADMIN,
+        isProjectPublic = true,
+      )
+    assertThat(computed.origin).isEqualTo(ComputedPermissionOrigin.SERVER_ADMIN)
+    assertThat(computed.expandedScopes).contains(Scope.ADMIN)
+  }
+
+  @Test
+  fun `community floor lifts view and suggest language restrictions but keeps translate restricted`() {
+    val restrictedToOneLanguage =
+      object : IPermission {
+        override val scopes =
+          arrayOf(
+            Scope.TRANSLATIONS_VIEW,
+            Scope.SCREENSHOTS_VIEW,
+            Scope.ACTIVITY_VIEW,
+            Scope.TRANSLATIONS_SUGGEST,
+            Scope.TRANSLATIONS_COMMENTS_ADD,
+            Scope.TRANSLATIONS_EDIT,
+          )
+        override val projectId: Long? = null
+        override val organizationId: Long? = null
+        override val viewLanguageIds = setOf(1L)
+        override val translateLanguageIds = setOf(1L)
+        override val stateChangeLanguageIds = setOf(1L)
+        override val suggestLanguageIds = setOf(1L)
+        override val type = ProjectPermissionType.EDIT
+        override val granular = true
+      }
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = null,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = restrictedToOneLanguage,
+        userRole = UserAccount.Role.USER,
+        isProjectPublic = true,
+      )
+    assertThat(computed.viewLanguageIds).isNull()
+    assertThat(computed.suggestLanguageIds).isNull()
+    assertThat(computed.translateLanguageIds).containsExactly(1L)
+  }
+
+  @Test
+  fun `public project grants nothing without an authenticated user`() {
+    val computed =
+      permissionService.computeProjectPermission(
+        organizationRole = null,
+        organizationBasePermission = ComputedPermissionDto.NONE,
+        directPermission = null,
+        userRole = null,
+        isProjectPublic = true,
+      )
+    assertThat(computed.expandedScopes).isEmpty()
+    assertThat(computed.origin).isNotEqualTo(ComputedPermissionOrigin.COMMUNITY)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/CommunityPermissionTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/CommunityPermissionTest.kt
@@ -1,0 +1,213 @@
+package io.tolgee.api.v2.controllers
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.development.testDataBuilder.data.ProjectPublishingTestData
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsForbidden
+import io.tolgee.fixtures.andIsNotFound
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class CommunityPermissionTest : ProjectAuthControllerTest("/v2/projects/") {
+  private lateinit var testData: ProjectPublishingTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = ProjectPublishingTestData()
+    testDataService.saveTestData(testData.root)
+    projectSupplier = { testData.project }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `authenticated non-member gets the community permission on a public project`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performAuthGet(projectUrl()).andIsOk.andAssertThatJson {
+      node("computedPermission.origin").isEqualTo("COMMUNITY")
+      node("computedPermission.scopes").isArray.contains(
+        "translations.view",
+        "screenshots.view",
+        "activity.view",
+        "translations.suggest",
+        "translation-comments.add",
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community permission never grants write or restricted scopes`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performAuthGet(projectUrl()).andIsOk.andAssertThatJson {
+      node("computedPermission.scopes").isArray.isNotEmpty
+      node("computedPermission.scopes")
+        .isArray
+        .doesNotContain("translations.edit", "members.view", "organization-quotas.view")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `non-member cannot access a private project`() {
+    userAccount = testData.communityUser
+    performAuthGet(projectUrl()).andIsNotFound
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `un-publishing revokes community access`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performAuthGet(projectUrl()).andIsOk
+
+    setPublic(false)
+    performAuthGet(projectUrl()).andIsNotFound
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `member count is hidden from community users`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performProjectAuthGet("stats").andIsOk.andAssertThatJson {
+      node("membersCount").isEqualTo(0)
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `member count is hidden from members lacking members-view`() {
+    userAccount = testData.viewer
+    performProjectAuthGet("stats").andIsOk.andAssertThatJson {
+      node("membersCount").isEqualTo(0)
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `member count and credits stay visible to members with members-view`() {
+    setPublic(true)
+    userAccount = testData.manager
+    performProjectAuthGet("stats").andIsOk.andAssertThatJson {
+      node("membersCount").isEqualTo(4)
+    }
+    performProjectAuthGet("machine-translation-credit-balance").andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot read organization MT credit balance`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performProjectAuthGet("machine-translation-credit-balance").andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot store import settings`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performProjectAuthPut("import-settings", mapOf<String, Any>()).andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `granular member without the credits scope cannot read MT credit balance`() {
+    userAccount = testData.granularUser
+    performProjectAuthGet("machine-translation-credit-balance").andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `a narrow direct permission is floored with the community scopes on a public project`() {
+    setPublic(true)
+    userAccount = testData.granularUser
+    performAuthGet(projectUrl()).andIsOk.andAssertThatJson {
+      node("computedPermission.origin").isEqualTo("DIRECT")
+      node("computedPermission.scopes").isArray.contains(
+        "translations.view",
+        "screenshots.view",
+        "activity.view",
+        "translations.suggest",
+        "translation-comments.add",
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `a VIEW member is floored with community suggest and comment on a public project`() {
+    setPublic(true)
+    userAccount = testData.viewer
+    performAuthGet(projectUrl()).andIsOk.andAssertThatJson {
+      node("computedPermission.origin").isEqualTo("DIRECT")
+      node("computedPermission.scopes").isArray.contains(
+        "translations.suggest",
+        "translation-comments.add",
+      )
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user may mint an API key within community scopes (intentional for v1)`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performAuthPost(
+      "/v2/api-keys",
+      mapOf(
+        "projectId" to testData.project.id,
+        "scopes" to setOf("translations.suggest"),
+      ),
+    ).andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot mint an API key with scopes outside the community set`() {
+    setPublic(true)
+    userAccount = testData.communityUser
+    performAuthPost(
+      "/v2/api-keys",
+      mapOf(
+        "projectId" to testData.project.id,
+        "scopes" to setOf("translations.edit"),
+      ),
+    ).andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `key-deleter email is hidden from community in the trash listing`() {
+    setPublic(true)
+    val key = keyService.get(testData.project.id, "trash-me", null)
+    executeInNewTransaction {
+      keyService.softDeleteMultiple(listOf(key.id), deletedBy = testData.manager)
+    }
+
+    userAccount = testData.communityUser
+    performProjectAuthGet("keys/trash").andIsOk.andAssertThatJson {
+      node("_embedded.keys[0].deletedBy.username").isEqualTo("")
+      node("_embedded.keys[0].deletedBy.name").isEqualTo("Project Manager")
+    }
+
+    userAccount = testData.manager
+    performProjectAuthGet("keys/trash").andIsOk.andAssertThatJson {
+      node("_embedded.keys[0].deletedBy.username").isEqualTo("project_manager")
+    }
+  }
+
+  private fun setPublic(public: Boolean) {
+    projectService.setPublic(testData.project.id, public)
+  }
+
+  private fun projectUrl() = "/v2/projects/${testData.project.id}"
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
@@ -94,6 +94,15 @@ class ProjectStatsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     `returns stats`()
   }
 
+  @ProjectApiKeyAuthTestMethod(
+    scopes = [Scope.TRANSLATIONS_VIEW, Scope.KEYS_VIEW],
+  )
+  fun `hides member count from API key lacking members-view`() {
+    performProjectAuthGet("stats").andIsOk.andAssertThatJson {
+      node("membersCount").isEqualTo(0)
+    }
+  }
+
   @Test
   @ProjectJWTAuthTestMethod
   fun `returns daily activity`() {

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/ProjectStatsControllerTest.kt
@@ -7,6 +7,7 @@ import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
 import io.tolgee.fixtures.isValidId
 import io.tolgee.fixtures.node
+import io.tolgee.model.enums.Scope
 import io.tolgee.testing.annotations.ProjectApiKeyAuthTestMethod
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import org.junit.jupiter.api.AfterEach
@@ -86,7 +87,9 @@ class ProjectStatsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     }
   }
 
-  @ProjectApiKeyAuthTestMethod
+  @ProjectApiKeyAuthTestMethod(
+    scopes = [Scope.TRANSLATIONS_EDIT, Scope.KEYS_EDIT, Scope.TRANSLATIONS_VIEW, Scope.KEYS_VIEW, Scope.MEMBERS_VIEW],
+  )
   fun `returns stats with API key`() {
     `returns stats`()
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/notification/NotificationControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/notification/NotificationControllerTest.kt
@@ -39,6 +39,7 @@ class NotificationControllerTest : AuthorizedControllerTest() {
       node("_embedded.notificationModelList").isArray.hasSize(4)
       node("_embedded.notificationModelList[0].linkedTask.name").isEqualTo("Notification task 104")
       node("_embedded.notificationModelList[0].originatingUser.name").isEqualTo("originating user")
+      node("_embedded.notificationModelList[0].originatingUser.username").isEqualTo("notificationsOriginatingUser")
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
@@ -74,7 +74,8 @@ abstract class AbstractWebsocketTest : ProjectAuthControllerTest("/v2/projects/"
       },
     ) {
       assertThatJson(it.poll()).apply {
-        node("actor.data.username").isEqualTo("test_username")
+        node("actor.data.username").isEqualTo("")
+        node("actor.data.name").isEqualTo("Test user name")
         node("data.keys[0]") {
           node("id").isValidId
           node("modifications.name") {
@@ -274,6 +275,7 @@ abstract class AbstractWebsocketTest : ProjectAuthControllerTest("/v2/projects/"
 
   private fun prepareTestData() {
     testData = BaseTestData()
+    testData.user.name = "Test user name"
     testData.root.addUserAccount {
       username = "anotherUser"
       anotherUser = this

--- a/backend/data/src/main/kotlin/io/tolgee/constants/ComputedPermissionOrigin.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/ComputedPermissionOrigin.kt
@@ -7,4 +7,5 @@ enum class ComputedPermissionOrigin {
   NONE,
   SERVER_ADMIN,
   SERVER_SUPPORTER,
+  COMMUNITY,
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectPublishingTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectPublishingTestData.kt
@@ -2,11 +2,15 @@ package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.ProjectPermissionType
+import io.tolgee.model.enums.Scope
 
 class ProjectPublishingTestData : BaseTestData() {
   val owner: UserAccount get() = user
   lateinit var manager: UserAccount
   lateinit var serverAdmin: UserAccount
+  lateinit var viewer: UserAccount
+  lateinit var granularUser: UserAccount
+  lateinit var communityUser: UserAccount
 
   init {
     root.apply {
@@ -16,16 +20,44 @@ class ProjectPublishingTestData : BaseTestData() {
         manager = this
       }
       addUserAccount {
+        username = "project_viewer"
+        name = "Project Viewer"
+        viewer = this
+      }
+      addUserAccount {
         username = "server_admin"
         name = "Server Admin"
         role = UserAccount.Role.ADMIN
         serverAdmin = this
+      }
+      addUserAccount {
+        username = "granular_user"
+        name = "Granular User"
+        granularUser = this
+      }
+      addUserAccount {
+        username = "community_user"
+        name = "Community User"
+        communityUser = this
       }
     }
     projectBuilder.build {
       addPermission {
         user = this@ProjectPublishingTestData.manager
         type = ProjectPermissionType.MANAGE
+      }
+      addPermission {
+        user = this@ProjectPublishingTestData.viewer
+        type = ProjectPermissionType.VIEW
+      }
+      addPermission {
+        user = this@ProjectPublishingTestData.granularUser
+        scopes = arrayOf(Scope.TRANSLATIONS_VIEW)
+      }
+      addKey {
+        name = "trash-me"
+      }.build {
+        addTranslation("en", "To be trashed")
       }
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
@@ -177,6 +177,13 @@ class SuggestionsTestData(
         )
       }
 
+      czechTranslations[0].apply {
+        addComment {
+          text = "Member comment"
+          author = this@SuggestionsTestData.user
+        }
+      }
+
       pluralKey =
         addKey(null, "pluralKey").apply {
           self.isPlural = true

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
@@ -20,6 +20,7 @@ class SuggestionsTestData(
   var projectTranslator: UserAccountBuilder
   var czechTranslator: UserAccountBuilder
   var czechReviewer: UserAccountBuilder
+  var communityUser: UserAccountBuilder
   var relatedProject: ProjectBuilder
   var keys: MutableList<KeyBuilder> = mutableListOf()
   val czechSuggestions: MutableList<SuggestionBuilder> = mutableListOf()
@@ -71,6 +72,12 @@ class SuggestionsTestData(
       root.addUserAccount {
         username = "cs.reviewer@test.com"
         name = "Czech reviewer"
+      }
+
+    communityUser =
+      root.addUserAccount {
+        username = "community@test.com"
+        name = "Community user"
       }
 
     userAccountBuilder.defaultOrganizationBuilder.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/ComputedPermissionDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/ComputedPermissionDto.kt
@@ -88,6 +88,14 @@ class ComputedPermissionDto(
     return this
   }
 
+  fun withCommunityFloor(): ComputedPermissionDto {
+    val hasCommunityScopes = expandedScopes.toSet().containsAll(COMMUNITY.scopes.toList())
+    val viewAndSuggestUnrestricted = viewLanguageIds.isNullOrEmpty() && suggestLanguageIds.isNullOrEmpty()
+    if (hasCommunityScopes && viewAndSuggestUnrestricted) return this
+    if (scopes.isEmpty()) return COMMUNITY
+    return ComputedPermissionDto(getCommunityFlooredPermission(this), origin = origin)
+  }
+
   constructor(permission: IPermission) : this(
     permission,
     origin =
@@ -136,6 +144,17 @@ class ComputedPermissionDto(
       }
     }
 
+    private fun getCommunityFlooredPermission(base: IPermission): IPermission {
+      return object : IPermission by getExtendedPermission(base, COMMUNITY.scopes) {
+        // All-language view + suggest: a language-restricted base must not leave a member
+        // viewing/suggesting in fewer languages than a non-member.
+        override val viewLanguageIds: Set<Long>?
+          get() = null
+        override val suggestLanguageIds: Set<Long>?
+          get() = null
+      }
+    }
+
     val ComputedPermissionDto.isAllReadOnlyPermitted: Boolean
       get() = expandedScopes.toSet().containsAll(Scope.readOnlyScopes.toList())
 
@@ -167,6 +186,23 @@ class ComputedPermissionDto(
             type = ProjectPermissionType.VIEW,
           ),
           origin = ComputedPermissionOrigin.SERVER_SUPPORTER,
+        )
+
+    val COMMUNITY
+      get() =
+        ComputedPermissionDto(
+          getEmptyPermission(
+            scopes =
+              arrayOf(
+                Scope.TRANSLATIONS_VIEW,
+                Scope.SCREENSHOTS_VIEW,
+                Scope.ACTIVITY_VIEW,
+                Scope.TRANSLATIONS_SUGGEST,
+                Scope.TRANSLATIONS_COMMENTS_ADD,
+              ),
+            type = ProjectPermissionType.VIEW,
+          ),
+          origin = ComputedPermissionOrigin.COMMUNITY,
         )
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/ProjectPermissionType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/ProjectPermissionType.kt
@@ -11,6 +11,7 @@ enum class ProjectPermissionType(
       Scope.ACTIVITY_VIEW,
       Scope.KEYS_VIEW,
       Scope.TASKS_VIEW,
+      Scope.ORGANIZATION_QUOTAS_VIEW,
     ),
   ),
   TRANSLATE(
@@ -25,6 +26,7 @@ enum class ProjectPermissionType(
       Scope.TRANSLATIONS_COMMENTS_SET_STATE,
       Scope.TASKS_VIEW,
       Scope.TRANSLATION_LABEL_ASSIGN,
+      Scope.ORGANIZATION_QUOTAS_VIEW,
     ),
   ),
   REVIEW(
@@ -40,6 +42,7 @@ enum class ProjectPermissionType(
       Scope.TRANSLATIONS_STATE_EDIT,
       Scope.TASKS_VIEW,
       Scope.TRANSLATION_LABEL_ASSIGN,
+      Scope.ORGANIZATION_QUOTAS_VIEW,
     ),
   ),
   EDIT(
@@ -66,6 +69,7 @@ enum class ProjectPermissionType(
       Scope.PROMPTS_VIEW,
       Scope.PROMPTS_EDIT,
       Scope.TRANSLATION_LABEL_ASSIGN,
+      Scope.ORGANIZATION_QUOTAS_VIEW,
     ),
   ),
   MANAGE(

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/Scope.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/Scope.kt
@@ -45,6 +45,7 @@ enum class Scope(
   ALL_VIEW("all.view"),
   BRANCH_MANAGEMENT("branch.management"),
   BRANCH_PROTECTED_MODIFY("branch.protected-modify"),
+  ORGANIZATION_QUOTAS_VIEW("organization-quotas.view"),
   ;
 
   fun expand() = Scope.expand(this)
@@ -160,6 +161,7 @@ enum class Scope(
               batchJobsView,
               tasksView,
               promptsView,
+              HierarchyItem(ORGANIZATION_QUOTAS_VIEW),
             ),
           ),
           HierarchyItem(BRANCH_MANAGEMENT),

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -308,6 +308,7 @@ class ProjectService(
               organization.basePermission,
               permission,
               userAccount.role ?: UserAccount.Role.USER,
+              isProjectPublic = project.public,
             ).scopes
         fromEntityAndPermission(project, scopes)
       }.toList()

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/PermissionService.kt
@@ -120,6 +120,7 @@ class PermissionService(
         organizationBasePermission = organizationBasePermission,
         directPermission = projectPermission,
         userAccountService.findDto(userAccountId)?.role ?: throw IllegalStateException("User not found"),
+        isProjectPublic = project.public,
       )
 
     return ProjectPermissionData(
@@ -232,6 +233,7 @@ class PermissionService(
     organizationBasePermission: IPermission,
     directPermission: IPermission?,
     userRole: UserAccount.Role? = null,
+    isProjectPublic: Boolean = false,
   ): ComputedPermissionDto {
     val computed =
       when {
@@ -245,6 +247,10 @@ class PermissionService(
 
         else -> ComputedPermissionDto.NONE
       }
+
+    if (isProjectPublic && userRole != null) {
+      return computed.withCommunityFloor().getAdminOrSupporterPermissions(userRole)
+    }
 
     return computed.getAdminOrSupporterPermissions(userRole)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
@@ -31,6 +31,7 @@ import io.tolgee.service.task.ITaskService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
+import org.springframework.web.context.request.RequestContextHolder
 
 @Service
 class SecurityService(
@@ -77,6 +78,19 @@ class SecurityService(
     return getCurrentPermittedScopes(projectHolder.project.id).containsAll(scopes)
   }
 
+  fun maskedMemberField(value: String?): String {
+    if (shouldExposeMemberInfo()) return value ?: ""
+    return ""
+  }
+
+  fun shouldExposeMemberInfo(): Boolean {
+    // Off-request threads (e.g. @Async activity-websocket broadcasts) have no request scope, where
+    // reading projectHolder.projectOrNull throws; there is also no caller whose scope could gate this.
+    if (RequestContextHolder.getRequestAttributes() == null) return true
+    if (projectHolder.projectOrNull == null) return true
+    return currentPermittedScopesContain(Scope.MEMBERS_VIEW)
+  }
+
   /**
    * Returns current permitted scopes, expanded
    */
@@ -118,26 +132,23 @@ class SecurityService(
     this.checkApiKeyScopes(listOf(requiredPermission), apiKey)
   }
 
-  fun hasTaskEditScopeOrIsAssigned(
+  fun checkTaskEditScopeOrAssigned(
     projectId: Long,
     taskNumber: Long,
-  ) {
-    try {
-      checkProjectPermission(projectId, Scope.TASKS_EDIT)
-    } catch (err: PermissionException) {
-      val assignees = taskService.findAssigneeById(projectId, taskNumber, activeUser.id)
-      if (assignees.isEmpty() || assignees[0].id != activeUser.id) {
-        throw err
-      }
-    }
-  }
+  ) = checkTaskScopeOrAssigned(projectId, taskNumber, Scope.TASKS_EDIT)
 
-  fun hasTaskViewScopeOrIsAssigned(
+  fun checkTaskViewScopeOrAssigned(
     projectId: Long,
     taskNumber: Long,
+  ) = checkTaskScopeOrAssigned(projectId, taskNumber, Scope.TASKS_VIEW)
+
+  private fun checkTaskScopeOrAssigned(
+    projectId: Long,
+    taskNumber: Long,
+    scope: Scope,
   ) {
     try {
-      checkProjectPermission(projectId, Scope.TASKS_VIEW)
+      checkProjectPermission(projectId, scope)
     } catch (err: PermissionException) {
       val assignees = taskService.findAssigneeById(projectId, taskNumber, activeUser.id)
       if (assignees.isEmpty() || assignees[0].id != activeUser.id) {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/CommunityPermissionScopesTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/CommunityPermissionScopesTest.kt
@@ -1,0 +1,75 @@
+package io.tolgee.unit
+
+import io.tolgee.constants.ComputedPermissionOrigin
+import io.tolgee.dtos.ComputedPermissionDto
+import io.tolgee.model.enums.ProjectPermissionType
+import io.tolgee.model.enums.Scope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CommunityPermissionScopesTest {
+  @Test
+  fun `community grant has the COMMUNITY origin`() {
+    assertThat(ComputedPermissionDto.COMMUNITY.origin).isEqualTo(ComputedPermissionOrigin.COMMUNITY)
+  }
+
+  @Test
+  fun `community raw scopes are exactly the expected set`() {
+    assertThat(ComputedPermissionDto.COMMUNITY.scopes.toSet())
+      .containsExactlyInAnyOrder(
+        Scope.TRANSLATIONS_VIEW,
+        Scope.SCREENSHOTS_VIEW,
+        Scope.ACTIVITY_VIEW,
+        Scope.TRANSLATIONS_SUGGEST,
+        Scope.TRANSLATIONS_COMMENTS_ADD,
+      )
+  }
+
+  @Test
+  fun `community expanded scopes pull in the implied read scopes`() {
+    assertThat(ComputedPermissionDto.COMMUNITY.expandedScopes.toSet())
+      .contains(Scope.TRANSLATIONS_VIEW, Scope.KEYS_VIEW)
+  }
+
+  @Test
+  fun `community never grants write, member, or restricted-internals scopes`() {
+    assertThat(ComputedPermissionDto.COMMUNITY.expandedScopes.toSet())
+      .doesNotContain(
+        Scope.TRANSLATIONS_EDIT,
+        Scope.TRANSLATIONS_STATE_EDIT,
+        Scope.KEYS_EDIT,
+        Scope.KEYS_CREATE,
+        Scope.KEYS_DELETE,
+        Scope.LANGUAGES_EDIT,
+        Scope.MEMBERS_VIEW,
+        Scope.MEMBERS_EDIT,
+        Scope.BRANCH_MANAGEMENT,
+        Scope.ORGANIZATION_QUOTAS_VIEW,
+        Scope.PROMPTS_VIEW,
+        Scope.ADMIN,
+      )
+  }
+
+  @Test
+  fun `community grant carries no language restriction (all languages)`() {
+    val permission = ComputedPermissionDto.COMMUNITY
+    assertThat(permission.viewLanguageIds).isNull()
+    assertThat(permission.translateLanguageIds).isNull()
+    assertThat(permission.suggestLanguageIds).isNull()
+    assertThat(permission.stateChangeLanguageIds).isNull()
+  }
+
+  @Test
+  fun `standard member permission types grant the organization-quotas scope`() {
+    listOf(
+      ProjectPermissionType.VIEW,
+      ProjectPermissionType.TRANSLATE,
+      ProjectPermissionType.REVIEW,
+      ProjectPermissionType.EDIT,
+      ProjectPermissionType.MANAGE,
+    ).forEach { type ->
+      assertThat(Scope.expand(type.availableScopes).toSet())
+        .contains(Scope.ORGANIZATION_QUOTAS_VIEW)
+    }
+  }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/MemberInfoMaskingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/MemberInfoMaskingTest.kt
@@ -1,0 +1,23 @@
+package io.tolgee.unit
+
+import io.tolgee.security.ProjectHolder
+import io.tolgee.service.security.SecurityService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class MemberInfoMaskingTest {
+  @Test
+  fun `maskedMemberField exposes the value off-request without touching the project holder`() {
+    val projectHolder =
+      mock<ProjectHolder> {
+        whenever(it.projectOrNull).thenThrow(IllegalStateException("project holder must not be read off-request"))
+      }
+    val securityService =
+      SecurityService(mock(), mock(), mock(), projectHolder = projectHolder, branchService = mock())
+
+    assertThat(securityService.shouldExposeMemberInfo()).isTrue()
+    assertThat(securityService.maskedMemberField("translator@test.com")).isEqualTo("translator@test.com")
+  }
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/TaskController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/TaskController.kt
@@ -127,8 +127,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): TaskModel {
-    // users can view tasks assigned to them
-    securityService.hasTaskViewScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskViewScopeOrAssigned(projectHolder.project.id, taskNumber)
     val task = taskService.getTask(projectHolder.project.id, taskNumber)
     return taskModelAssembler.toModel(task)
   }
@@ -179,8 +178,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): TaskModel {
-    // users can only finish tasks assigned to them
-    securityService.hasTaskEditScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskEditScopeOrAssigned(projectHolder.project.id, taskNumber)
     val task = taskService.setTaskState(projectHolder.project.id, taskNumber, TaskState.FINISHED)
     return taskModelAssembler.toModel(task)
   }
@@ -240,7 +238,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): List<TaskPerUserReportModel> {
-    securityService.hasTaskViewScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskViewScopeOrAssigned(projectHolder.project.id, taskNumber)
 
     val result = taskService.getReport(projectHolder.projectEntity, taskNumber)
     return result.map { taskPerUserReportModelAssembler.toModel(it) }
@@ -258,7 +256,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): ResponseEntity<ByteArrayResource> {
-    securityService.hasTaskViewScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskViewScopeOrAssigned(projectHolder.project.id, taskNumber)
     val byteArray = taskService.getExcelFile(projectHolder.projectEntity, taskNumber)
     val resource = ByteArrayResource(byteArray)
 
@@ -279,7 +277,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): TaskKeysResponse {
-    securityService.hasTaskViewScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskViewScopeOrAssigned(projectHolder.project.id, taskNumber)
     return TaskKeysResponse(
       keys = taskService.getTaskKeys(projectHolder.project.id, taskNumber),
     )
@@ -310,6 +308,7 @@ class TaskController(
     @PathVariable
     taskNumber: Long,
   ): List<Long> {
+    securityService.checkTaskViewScopeOrAssigned(projectHolder.project.id, taskNumber)
     return taskService.getBlockingTasks(projectHolder.project.id, taskNumber)
   }
 
@@ -330,8 +329,7 @@ class TaskController(
     @RequestBody @Valid
     dto: UpdateTaskKeyRequest,
   ): UpdateTaskKeyResponse {
-    // users can only update tasks assigned to them
-    securityService.hasTaskEditScopeOrIsAssigned(projectHolder.project.id, taskNumber)
+    securityService.checkTaskEditScopeOrAssigned(projectHolder.project.id, taskNumber)
     return taskService.updateTaskKey(projectHolder.project.id, taskNumber, keyId, dto)
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchController.kt
@@ -177,7 +177,7 @@ class BranchController(
   @GetMapping(value = ["/merge"])
   @Operation(summary = "Get branch merges")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(4)
   fun getBranchMerges(
     @ParameterObject
@@ -191,7 +191,7 @@ class BranchController(
   @PostMapping(value = ["/merge/preview"])
   @Operation(summary = "Creates a merge, dry-runs source branch to target branch and return preview")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(5)
   fun dryRunMerge(
     @RequestBody request: DryRunMergeBranchRequest,
@@ -204,7 +204,7 @@ class BranchController(
   @GetMapping(value = ["/merge/{mergeId}/preview"])
   @Operation(summary = "Get branch merge session preview")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(6)
   fun getBranchMergeSessionPreview(
     @PathVariable mergeId: Long,
@@ -217,7 +217,7 @@ class BranchController(
   @PostMapping(value = ["/merge/{mergeId}/refresh"])
   @Operation(summary = "Refresh branch merge session preview")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(11)
   fun refreshBranchMerge(
     @PathVariable mergeId: Long,
@@ -230,7 +230,7 @@ class BranchController(
   @GetMapping(value = ["/merge/{mergeId}/conflicts"])
   @Operation(summary = "Get branch merge session conflicts")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(7)
   fun getBranchMergeSessionConflicts(
     @ParameterObject
@@ -245,7 +245,7 @@ class BranchController(
   @GetMapping(value = ["/merge/{mergeId}/changes"])
   @Operation(summary = "Get branch merge session changes")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(7)
   fun getBranchMergeSessionChanges(
     @ParameterObject pageable: Pageable,
@@ -260,7 +260,7 @@ class BranchController(
   @GetMapping(value = ["/merge/{mergeId}/changes/{changeId}"])
   @Operation(summary = "Get single branch merge session change")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(8)
   fun getBranchMergeSessionChange(
     @PathVariable mergeId: Long,
@@ -274,7 +274,7 @@ class BranchController(
   @PutMapping(value = ["/merge/{mergeId}/resolve"])
   @Operation(summary = "Resolve branch merge session conflicts")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(9)
   fun resolveConflict(
     @PathVariable mergeId: Long,
@@ -287,7 +287,7 @@ class BranchController(
   @PutMapping(value = ["/merge/{mergeId}/resolve-all"])
   @Operation(summary = "Resolve all branch merge session conflicts")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(10)
   fun resolveAllConflicts(
     @PathVariable mergeId: Long,
@@ -300,7 +300,7 @@ class BranchController(
   @DeleteMapping(value = ["/merge/{mergeId}"])
   @Operation(summary = "Delete branch merge session")
   @AllowApiAccess
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(11)
   fun deleteBranchMerge(
     @PathVariable mergeId: Long,
@@ -313,7 +313,7 @@ class BranchController(
   @Operation(summary = "Merge source branch to target branch")
   @AllowApiAccess
   @RequestActivity(ActivityType.BRANCH_MERGE)
-  @UseDefaultPermissions
+  @RequiresProjectPermissions([Scope.BRANCH_MANAGEMENT])
   @OpenApiOrderExtension(12)
   fun merge(
     @PathVariable mergeId: Long,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
@@ -158,16 +158,6 @@ class CommunitySuggestionTest : ProjectAuthControllerTest("/v2/projects/") {
   @Test
   @ProjectJWTAuthTestMethod
   fun `comment author emails are hidden from community`() {
-    userAccount = testData.user
-    performProjectAuthPost(
-      "translations/create-comment",
-      TranslationCommentWithLangKeyDto(
-        keyId = testData.keys[0].self.id,
-        languageId = testData.czechLanguage.id,
-        text = "Member comment",
-      ),
-    ).andIsCreated
-
     val translationId =
       transactionTemplate.execute {
         translationService.find(testData.keys[0].self, testData.czechLanguage).get().id

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
@@ -1,0 +1,200 @@
+package io.tolgee.ee.api.v2.controllers
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
+import io.tolgee.dtos.request.translation.SetTranslationsWithKeyDto
+import io.tolgee.dtos.request.translation.comment.TranslationCommentWithLangKeyDto
+import io.tolgee.ee.data.translationSuggestion.CreateTranslationSuggestionRequest
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsCreated
+import io.tolgee.fixtures.andIsForbidden
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CommunitySuggestionTest : ProjectAuthControllerTest("/v2/projects/") {
+  private lateinit var testData: SuggestionsTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = SuggestionsTestData()
+    projectSupplier = { testData.relatedProject.self }
+    testDataService.saveTestData(testData.root)
+    projectService.setPublic(testData.relatedProject.self.id, true)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user can suggest on a public project`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthPost(
+      "languages/${testData.czechLanguage.id}/key/${testData.keys[0].self.id}/suggestion",
+      CreateTranslationSuggestionRequest(translation = "Community suggested translation"),
+    ).andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `a language-restricted member can suggest outside their languages on a public project`() {
+    userAccount = testData.czechTranslator.self
+    performProjectAuthPost(
+      "languages/${testData.englishLanguage.id}/key/${testData.keys[0].self.id}/suggestion",
+      CreateTranslationSuggestionRequest(translation = "English suggestion from a Czech-only translator"),
+    ).andIsOk
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user can comment on a public project`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthPost(
+      "translations/create-comment",
+      TranslationCommentWithLangKeyDto(
+        keyId = testData.keys[0].self.id,
+        languageId = testData.czechLanguage.id,
+        text = "Community comment",
+      ),
+    ).andIsCreated
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot accept a suggestion`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthPut(
+      "languages/${testData.czechLanguage.id}/key/${testData.keys[0].self.id}" +
+        "/suggestion/${testData.czechSuggestions[0].self.id}/accept",
+      null,
+    ).andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot reach branch merge sessions`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthGet("branches/merge").andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `a member without branch-management cannot start a branch merge`() {
+    userAccount = testData.projectTranslator.self
+    performProjectAuthPost("branches/merge/preview", mapOf<String, Any>()).andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `community user cannot read blocking tasks`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthGet("tasks/1/blocking-tasks").andIsForbidden
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `author emails are hidden from community but the name stays visible`() {
+    val path = "languages/${testData.czechLanguage.id}/key/${testData.keys[0].self.id}/suggestion"
+
+    userAccount = testData.communityUser.self
+    performProjectAuthGet(path).andIsOk.andAssertThatJson {
+      node("_embedded.suggestions[0].author.username").isEqualTo("")
+      node("_embedded.suggestions[0].author.name").isEqualTo("Project translator")
+    }
+
+    userAccount = testData.user
+    performProjectAuthGet(path).andIsOk.andAssertThatJson {
+      node("_embedded.suggestions[0].author.username").isEqualTo("translator@test.com")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `author emails are hidden from community in the embedded translations list`() {
+    val path = "/translations?sort=id&filterKeyId=${testData.keys[0].self.id}"
+
+    userAccount = testData.communityUser.self
+    performProjectAuthGet(path).andIsOk.andAssertThatJson {
+      node("_embedded.keys[0].translations.cs.suggestions[0].author.username").isEqualTo("")
+      node("_embedded.keys[0].translations.cs.suggestions[0].author.name").isEqualTo("Project reviewer")
+    }
+
+    userAccount = testData.user
+    performProjectAuthGet(path).andIsOk.andAssertThatJson {
+      node("_embedded.keys[0].translations.cs.suggestions[0].author.username").isEqualTo("reviewer@test.com")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `author emails are hidden from community in the activity feed and translation history`() {
+    userAccount = testData.user
+    performProjectAuthPut(
+      "translations",
+      SetTranslationsWithKeyDto(testData.keys[0].self.name, null, mutableMapOf("cs" to "Edited by member")),
+    ).andIsOk
+
+    val translationId =
+      transactionTemplate.execute {
+        translationService.find(testData.keys[0].self, testData.czechLanguage).get().id
+      }!!
+
+    userAccount = testData.communityUser.self
+    performProjectAuthGet("activity").andIsOk.andAssertThatJson {
+      node("_embedded.activities[0].author.username").isEqualTo("")
+      node("_embedded.activities[0].author.name").isEqualTo("Tasks test user")
+    }
+    performProjectAuthGet("translations/$translationId/history").andIsOk.andAssertThatJson {
+      node("_embedded.revisions[0].author.username").isEqualTo("")
+      node("_embedded.revisions[0].author.name").isEqualTo("Tasks test user")
+    }
+
+    userAccount = testData.user
+    performProjectAuthGet("activity").andIsOk.andAssertThatJson {
+      node("_embedded.activities[0].author.username").isEqualTo("suggestionsuggestionsTestUser")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `comment author emails are hidden from community`() {
+    userAccount = testData.user
+    performProjectAuthPost(
+      "translations/create-comment",
+      TranslationCommentWithLangKeyDto(
+        keyId = testData.keys[0].self.id,
+        languageId = testData.czechLanguage.id,
+        text = "Member comment",
+      ),
+    ).andIsCreated
+
+    val translationId =
+      transactionTemplate.execute {
+        translationService.find(testData.keys[0].self, testData.czechLanguage).get().id
+      }!!
+
+    userAccount = testData.communityUser.self
+    performProjectAuthGet("translations/$translationId/comments").andIsOk.andAssertThatJson {
+      node("_embedded.translationComments[0].author.username").isEqualTo("")
+      node("_embedded.translationComments[0].author.name").isEqualTo("Tasks test user")
+    }
+
+    userAccount = testData.user
+    performProjectAuthGet("translations/$translationId/comments").andIsOk.andAssertThatJson {
+      node("_embedded.translationComments[0].author.username").isEqualTo("suggestionsuggestionsTestUser")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `suggesting does not turn the community user into a member`() {
+    userAccount = testData.communityUser.self
+    performProjectAuthPost(
+      "languages/${testData.czechLanguage.id}/key/${testData.keys[0].self.id}/suggestion",
+      CreateTranslationSuggestionRequest(translation = "Community suggested translation"),
+    ).andIsOk
+    performAuthGet("/v2/projects/${testData.relatedProject.self.id}").andIsOk.andAssertThatJson {
+      node("computedPermission.origin").isEqualTo("COMMUNITY")
+    }
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SuggestionControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SuggestionControllerTest.kt
@@ -40,12 +40,12 @@ class SuggestionControllerTest : ProjectAuthControllerTest("/v2/projects/") {
       .andAssertThatJson {
         node("_embedded.suggestions") {
           node("[0].translation").isEqualTo("Navržený překlad 0-1")
-          node("[0].author.username").isEqualTo("translator@test.com")
+          node("[0].author.username").isEqualTo("")
           node("[0].author.name").isEqualTo("Project translator")
         }
         node("_embedded.suggestions") {
           node("[1].translation").isEqualTo("Navržený překlad 0-2")
-          node("[1].author.username").isEqualTo("reviewer@test.com")
+          node("[1].author.username").isEqualTo("")
           node("[1].author.name").isEqualTo("Project reviewer")
         }
         node("page.totalElements").isNumber.isEqualTo(BigDecimal(2))
@@ -89,7 +89,7 @@ class SuggestionControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     ).andAssertThatJson {
       node("accepted") {
         node("translation").isEqualTo("Navržený překlad 0-1")
-        node("author.username").isEqualTo("translator@test.com")
+        node("author.username").isEqualTo("")
         node("state").isEqualTo("ACCEPTED")
       }
       node("declined").isArray.hasSize(0)
@@ -148,7 +148,7 @@ class SuggestionControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     ).andAssertThatJson {
       node("accepted") {
         node("translation").isEqualTo("Navržený překlad 0-1")
-        node("author.username").isEqualTo("translator@test.com")
+        node("author.username").isEqualTo("")
         node("state").isEqualTo("ACCEPTED")
       }
       node("declined[0]").isEqualTo(testData.czechSuggestions[1].self.id)

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerPermissionsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerPermissionsTest.kt
@@ -53,6 +53,7 @@ class TaskControllerPermissionsTest : ProjectAuthControllerTest("/v2/projects/")
     performProjectAuthGet("tasks/${testData.translateTask.self.number}/per-user-report").andIsOk
     performProjectAuthGet("tasks/${testData.translateTask.self.number}/xlsx-report").andIsOk
     performProjectAuthGet("tasks/${testData.translateTask.self.number}/keys").andIsOk
+    performProjectAuthGet("tasks/${testData.translateTask.self.number}/blocking-tasks").andIsOk
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerTest.kt
@@ -81,6 +81,25 @@ class TaskControllerTest : ProjectAuthControllerTest("/v2/projects/") {
 
   @Test
   @ProjectJWTAuthTestMethod
+  fun `task author email is hidden from a member lacking members-view`() {
+    userAccount = testData.projectViewRoleUser.self
+    performProjectAuthGet(
+      "tasks/${testData.translateTask.self.number}",
+    ).andAssertThatJson {
+      node("author.username").isEqualTo("")
+      node("author.name").isEqualTo("Project user")
+    }
+
+    userAccount = testData.projectManageRoleUser.self
+    performProjectAuthGet(
+      "tasks/${testData.translateTask.self.number}",
+    ).andAssertThatJson {
+      node("author.username").isEqualTo("project.user@test.com")
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
   fun `creates new task which triggers notification`() {
     val keys = testData.keysOutOfTask.map { it.self.id }.toMutableSet()
     performProjectAuthPost(

--- a/webapp/src/component/PermissionsSettings/usePermissionsStructure.ts
+++ b/webapp/src/component/PermissionsSettings/usePermissionsStructure.ts
@@ -118,6 +118,9 @@ export const usePermissionsStructure = () => {
         ],
       },
       {
+        value: 'organization-quotas.view',
+      },
+      {
         label: t('permissions_item_members'),
         children: [
           {

--- a/webapp/src/component/PermissionsSettings/useScopeTranslations.tsx
+++ b/webapp/src/component/PermissionsSettings/useScopeTranslations.tsx
@@ -53,6 +53,7 @@ export const useScopeTranslations = () => {
     'all.view': t('permissions_item_all_view'),
     'branch.management': t('permissions_item_branch_management'),
     'branch.protected-modify': t('permissions_item_branch_protected_modify'),
+    'organization-quotas.view': t('permissions_item_organization_quotas_view'),
   };
 
   return {

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -878,7 +878,7 @@ export interface paths {
     delete: operations["deletePrompt"];
   };
   "/v2/projects/{projectId}/publishing": {
-    /** Marks the project as public or private. Only the organization owner can change this. */
+    /** Marks the project as public or private. Only the organization owner or a server admin can change this. */
     put: operations["setProjectPublic"];
   };
   "/v2/projects/{projectId}/qa-settings": {
@@ -19909,7 +19909,7 @@ export interface operations {
       };
     };
   };
-  /** Marks the project as public or private. Only the organization owner can change this. */
+  /** Marks the project as public or private. Only the organization owner or a server admin can change this. */
   setProjectPublic: {
     parameters: {
       path: {

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -1435,6 +1435,7 @@ export interface components {
         | "all.view"
         | "branch.management"
         | "branch.protected-modify"
+        | "organization-quotas.view"
       )[];
       /**
        * @description List of languages user can change state to. If null, changing state of all language values is permitted.
@@ -2088,7 +2089,8 @@ export interface components {
         | "ORGANIZATION_OWNER"
         | "NONE"
         | "SERVER_ADMIN"
-        | "SERVER_SUPPORTER";
+        | "SERVER_SUPPORTER"
+        | "COMMUNITY";
       permissionModel?: components["schemas"]["PermissionModel"];
       /**
        * @deprecated
@@ -2145,6 +2147,7 @@ export interface components {
         | "all.view"
         | "branch.management"
         | "branch.protected-modify"
+        | "organization-quotas.view"
       )[];
       /**
        * @description List of languages user can change state to. If null, changing state of all language values is permitted.
@@ -3423,7 +3426,8 @@ export interface components {
         | "translation-labels.assign"
         | "all.view"
         | "branch.management"
-        | "branch.protected-modify";
+        | "branch.protected-modify"
+        | "organization-quotas.view";
     };
     IdentifyRequest: {
       anonymousUserId: string;
@@ -4917,6 +4921,7 @@ export interface components {
         | "all.view"
         | "branch.management"
         | "branch.protected-modify"
+        | "organization-quotas.view"
       )[];
       /**
        * @description List of languages user can change state to. If null, changing state of all language values is permitted.
@@ -5013,6 +5018,7 @@ export interface components {
         | "all.view"
         | "branch.management"
         | "branch.protected-modify"
+        | "organization-quotas.view"
       )[];
       /**
        * @description List of languages user can change state to. If null, changing state of all language values is permitted.
@@ -24575,6 +24581,7 @@ export interface operations {
               | "all.view"
               | "branch.management"
               | "branch.protected-modify"
+              | "organization-quotas.view"
             )[];
           };
         };

--- a/webapp/src/views/projects/dashboard/ProjectTotals.tsx
+++ b/webapp/src/views/projects/dashboard/ProjectTotals.tsx
@@ -299,12 +299,16 @@ export const ProjectTotals: React.FC<{
         >
           <StyledTileDataItem data-cy="project-dashboard-members-count">
             <StyledTileValue>
-              {Number(stats.membersCount).toLocaleString(locale)}
+              {canViewMembers
+                ? Number(stats.membersCount).toLocaleString(locale)
+                : '—'}
             </StyledTileValue>
             <StyledTileDescription>
-              {t('project_dashboard_member_count_plural', {
-                value: Number(stats.membersCount),
-              })}
+              {canViewMembers
+                ? t('project_dashboard_member_count_plural', {
+                    value: Number(stats.membersCount),
+                  })
+                : t('project_menu_members')}
             </StyledTileDescription>
           </StyledTileDataItem>
           {membersEditable && (

--- a/webapp/src/views/projects/translations/Suggestions/TranslationSuggestion.tsx
+++ b/webapp/src/views/projects/translations/Suggestions/TranslationSuggestion.tsx
@@ -188,7 +188,10 @@ export const TranslationSuggestion = ({
         title={
           <T
             keyName="suggestion_author_tooltip"
-            params={{ user: user?.name ?? user?.username, b: <b /> }}
+            params={{
+              user: suggestion.author.name ?? suggestion.author.username,
+              b: <b />,
+            }}
           />
         }
       >


### PR DESCRIPTION
Permission-resolution slice of Community Translation v1.0 (#3763). Stacked on `jirikuchynka/public-projects` — review/merge that first.

## What this does
Authenticated users on a **public** project now get a **computed** "community" permission (read subset of VIEW + `translations.suggest` + `translation-comments.add`, all languages; origin `COMMUNITY`) **without a stored `Permission` row** — so they contribute translations without taking a paid seat.

- **Floor, not a fallback:** any direct/organization permission layers on top of the community grant, and server admin/supporter elevation also layers on top — so **no authenticated user is ever below a non-member** on a public project, on either the scope or language axis. Anonymous users still get nothing.
- View + suggest are floored to **all languages** (language-restricted members can still only translate/state-change their granted languages).

## Member privacy (gated on `MEMBERS_VIEW`)
- Member emails (the `username` field) and project member count are redacted across project-scoped REST surfaces: suggestions, activity feed, translation history, comments, key-trash, members list, stats. Name + avatar + id are preserved.
- The realtime activity/batch **websocket never carries the author email** — a fan-out broadcast can't evaluate each recipient's `MEMBERS_VIEW`, so the email is stripped unconditionally there (REST applies the per-caller gate).

## `@UseDefaultPermissions` endpoint gating
The community scope set is non-empty, so it passes every project-scoped `@UseDefaultPermissions` endpoint. Audited all of them; out-of-surface ones are now restricted:
- MT credit balance → **`ORGANIZATION_QUOTAS_VIEW`** (new scope, under the VIEW group)
- import-settings store → `KEYS_CREATE`
- branch-merge session endpoints (×11) → `BRANCH_MANAGEMENT`
- `getBlockingTasks` → task-view-or-assigned (matching its siblings)

Intended community-visible reads (languages, namespaces, tags, labels, stats, comments, project metadata, **read-only MT/auto-translation settings**) stay open by design. Writes are self-guarding (`setTranslations` enforces `TRANSLATIONS_EDIT` in the facade, so community can't overwrite strings).

## ⚠️ Breaking changes
- `GET /v2/projects/{id}/machine-translation-credit-balance` now requires **`ORGANIZATION_QUOTAS_VIEW`** (granted by the VIEW/TRANSLATE/REVIEW/EDIT/MANAGE types). Pre-existing **granular/custom permissions** and **API keys** lacking it (or `all.view`) get **403** and must be re-granted. The platform webapp does not call this endpoint, so no UI breaks.
- Branch-merge session endpoints now require `BRANCH_MANAGEMENT`. This includes the read-only `GET` merge/preview/conflicts/changes endpoints, so members without `BRANCH_MANAGEMENT` (e.g. translators) lose read visibility into merge sessions — intentional, since `BRANCH_MANAGEMENT` is currently the only branch scope.
- **Member email masking is global, not public-only.** Author username/email is now redacted for **any** caller lacking `MEMBERS_VIEW` on **every** project, including private ones — previously a private-project member without `MEMBERS_VIEW` could still see author emails on suggestions/activity/history/comments. Treated as intentional privacy hardening; integrators relying on author emails must hold `MEMBERS_VIEW`.

## Tests
New: `CommunityPermissionTest` (HTTP), `CommunityPermissionComputationTest` (floor computation incl. supporter/admin/language cases), `CommunityPermissionScopesTest`, `MemberInfoMaskingTest`, `CommunitySuggestionTest`; plus redaction/gating assertions across suggestion/task/trash/websocket/notification suites. All green.

## Notes
- New i18n keys (`permissions_item_organization_quotas_view`, `project_settings_public_*`) were created in Tolgee; the generated `src/i18n/en.json` is intentionally **not** committed (it syncs from Tolgee).
- `WebsocketWithRedisTest` is flaky locally on Docker-Redis startup (env, not this change); `WebsocketWithoutRedisTest` covers the same code.
