### PR TITLE
feat: public badge + organization on project list rows

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModel.kt
@@ -31,6 +31,8 @@ open class ProjectWithStatsModel(
   val computedPermission: ComputedPermissionModel,
   val stats: ProjectStatistics,
   val languages: List<LanguageModel>,
+  @Schema(description = "Whether the project is public — discoverable and open to community suggestions")
+  val public: Boolean,
   @Schema(description = "Whether to disable ICU placeholder visualization in the editor and it's support.")
   var icuPlaceholders: Boolean,
 ) : RepresentationModel<ProjectWithStatsModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/project/ProjectWithStatsModelAssembler.kt
@@ -56,6 +56,7 @@ class ProjectWithStatsModelAssembler(
       computedPermission = computedPermissionModelAssembler.toModel(computedPermissions),
       stats = view.stats,
       languages = view.languages.map { languageModelAssembler.toModel(it) },
+      public = view.public,
       icuPlaceholders = view.icuPlaceholders,
     )
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationProjectsControllerTest.kt
@@ -2,6 +2,7 @@ package io.tolgee.api.v2.controllers.organizationController
 
 import io.tolgee.development.testDataBuilder.data.PermissionsTestData
 import io.tolgee.development.testDataBuilder.data.ProjectTranslationsStatsTestData
+import io.tolgee.development.testDataBuilder.data.PublicProjectsStatsTestData
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
@@ -131,6 +132,30 @@ class OrganizationProjectsControllerTest : AuthorizedControllerTest() {
       .andPrettyPrint
       .andAssertThatJson {
         node("_embedded.projects").isArray.hasSize(1)
+      }
+  }
+
+  @Test
+  fun `projects-with-stats serializes the public flag`() {
+    val testData = PublicProjectsStatsTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.admin.self
+    val organizationId = testData.organizationBuilder.self.id
+
+    performAuthGet("/v2/organizations/$organizationId/projects-with-stats?search=alpha")
+      .andIsOk
+      .andAssertThatJson {
+        node("_embedded.projects").isArray.hasSize(1)
+        node("_embedded.projects[0].name").isEqualTo("Alpha Public")
+        node("_embedded.projects[0].public").isEqualTo(true)
+      }
+
+    performAuthGet("/v2/organizations/$organizationId/projects-with-stats?search=beta")
+      .andIsOk
+      .andAssertThatJson {
+        node("_embedded.projects").isArray.hasSize(1)
+        node("_embedded.projects[0].name").isEqualTo("Beta Private")
+        node("_embedded.projects[0].public").isEqualTo(false)
       }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsListDashboardTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsListDashboardTestData.kt
@@ -2,7 +2,6 @@ package io.tolgee.development.testDataBuilder.data
 
 class ProjectsListDashboardTestData : ProjectsTestData() {
   init {
-    userAccountBuilder.defaultOrganizationBuilder.self.name = "Dashboard Test Org"
     project2.public = true
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsListDashboardTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsListDashboardTestData.kt
@@ -1,0 +1,8 @@
+package io.tolgee.development.testDataBuilder.data
+
+class ProjectsListDashboardTestData : ProjectsTestData() {
+  init {
+    userAccountBuilder.defaultOrganizationBuilder.self.name = "Dashboard Test Org"
+    project2.public = true
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectsTestData.kt
@@ -9,7 +9,7 @@ import io.tolgee.model.enums.TaskType
 import io.tolgee.model.enums.TranslationState
 import io.tolgee.model.task.Task
 
-class ProjectsTestData : BaseTestData() {
+open class ProjectsTestData : BaseTestData() {
   lateinit var project2English: Language
   lateinit var project2Deutsch: Language
   lateinit var project2: Project

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsStatsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsStatsTestData.kt
@@ -1,0 +1,31 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.development.testDataBuilder.builders.OrganizationBuilder
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.development.testDataBuilder.builders.UserAccountBuilder
+
+class PublicProjectsStatsTestData {
+  var organizationBuilder: OrganizationBuilder
+  var admin: UserAccountBuilder
+
+  val root: TestDataBuilder =
+    TestDataBuilder().apply {
+      admin = addUserAccount { username = "public-stats-admin@admin.com" }
+
+      organizationBuilder = admin.defaultOrganizationBuilder
+      organizationBuilder.self.name = "StatsOrg"
+
+      addProject {
+        name = "Alpha Public"
+        public = true
+      }.build {
+        addEnglish()
+      }
+
+      addProject {
+        name = "Beta Private"
+      }.build {
+        addEnglish()
+      }
+    }
+}

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/ProjectListDashboardE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/ProjectListDashboardE2eDataController.kt
@@ -2,7 +2,7 @@ package io.tolgee.controllers.internal.e2eData
 
 import io.tolgee.controllers.internal.InternalController
 import io.tolgee.development.testDataBuilder.TestDataService
-import io.tolgee.development.testDataBuilder.data.ProjectsTestData
+import io.tolgee.development.testDataBuilder.data.ProjectsListDashboardTestData
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.UserAccountService
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +17,7 @@ class ProjectListDashboardE2eDataController(
   @GetMapping(value = ["/generate"])
   @Transactional
   fun generateBasicTestData() {
-    val data = ProjectsTestData()
+    val data = ProjectsListDashboardTestData()
     data.user.username = "projectListDashboardUser"
     data.user.name = "Test User"
     testDataService.saveTestData(data.root)
@@ -32,7 +32,7 @@ class ProjectListDashboardE2eDataController(
       }
       userAccountService.delete(it)
     }
-    userAccountService.findActive(ProjectsTestData().userWithTranslatePermission.username)?.let {
+    userAccountService.findActive(ProjectsListDashboardTestData().userWithTranslatePermission.username)?.let {
       userAccountService.delete(it)
     }
   }

--- a/e2e/cypress/e2e/projects/projectsListDashboard.cy.ts
+++ b/e2e/cypress/e2e/projects/projectsListDashboard.cy.ts
@@ -55,7 +55,7 @@ describe('Projects Dashboard', () => {
     cy.contains('Project 2')
       .closestDcy('dashboard-projects-list-item')
       .findDcy('project-list-org-name')
-      .should('contain', 'Dashboard Test Org');
+      .should('contain', 'test_username');
   });
 
   it('does not show public badge on a private project', () => {

--- a/e2e/cypress/e2e/projects/projectsListDashboard.cy.ts
+++ b/e2e/cypress/e2e/projects/projectsListDashboard.cy.ts
@@ -46,6 +46,25 @@ describe('Projects Dashboard', () => {
     assertTooltip('Deutsch');
   });
 
+  it('shows public badge and organization on a public project', () => {
+    cy.contains('Project 2')
+      .closestDcy('dashboard-projects-list-item')
+      .findDcy('project-list-public-badge')
+      .should('be.visible')
+      .and('contain', 'public');
+    cy.contains('Project 2')
+      .closestDcy('dashboard-projects-list-item')
+      .findDcy('project-list-org-name')
+      .should('contain', 'Dashboard Test Org');
+  });
+
+  it('does not show public badge on a private project', () => {
+    cy.contains('test_project')
+      .closestDcy('dashboard-projects-list-item')
+      .findDcy('project-list-public-badge')
+      .should('not.exist');
+  });
+
   afterEach(() => {
     projectListData.clean();
     setBypassSeatCountCheck(false);

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -570,6 +570,8 @@ declare namespace DataCy {
         "project-leave-button": true;
         "project-list-languages": true;
         "project-list-more-button": true;
+        "project-list-org-name": true;
+        "project-list-public-badge": true;
         "project-list-qa-badge-button": true;
         "project-list-translations-button": true;
         "project-member-item": true;

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -5491,6 +5491,8 @@ export interface components {
       organizationOwner?: components["schemas"]["SimpleOrganizationModel"];
       /** @enum {string} */
       organizationRole?: "MEMBER" | "OWNER" | "MAINTAINER";
+      /** @description Whether the project is public — discoverable and open to community suggestions */
+      public: boolean;
       slug?: string;
       stats: components["schemas"]["ProjectStatistics"];
     };

--- a/webapp/src/views/projects/DashboardProjectListItem.tsx
+++ b/webapp/src/views/projects/DashboardProjectListItem.tsx
@@ -21,6 +21,7 @@ import { useGlobalContext } from 'tg.globalContext/GlobalContext';
 import { useEnabledFeatures, useQaCheckTypes } from 'tg.globalContext/helpers';
 import { QuickStartHighlight } from 'tg.component/layout/QuickStartGuide/QuickStartHighlight';
 import { CircledLanguageIconList } from 'tg.component/languages/CircledLanguageIconList';
+import { TransparentChip } from 'tg.component/common/chips/TransparentChip';
 import { QaBadge } from 'tg.ee';
 
 const StyledContainer = styled('div')`
@@ -117,6 +118,28 @@ const StyledProjectName = styled(Typography)`
   word-break: break-word;
 `;
 
+const StyledPublicLine = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  margin-top: 2px;
+`;
+
+const StyledPublicChip = styled(TransparentChip)`
+  flex-shrink: 0;
+  & .MuiChip-label {
+    font-size: 13px;
+  }
+`;
+
+const StyledOrganizationName = styled(Typography)`
+  color: ${({ theme }) => theme.palette.text.secondary};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 type ProjectWithStatsModel = components['schemas']['ProjectWithStatsModel'];
 
 const DashboardProjectListItem = (p: ProjectWithStatsModel) => {
@@ -163,6 +186,23 @@ const DashboardProjectListItem = (p: ProjectWithStatsModel) => {
         </StyledImage>
         <StyledTitle>
           <StyledProjectName variant="h3">{p.name}</StyledProjectName>
+          {p.public && (
+            <StyledPublicLine>
+              <StyledPublicChip
+                size="small"
+                label={t('project_list_public_badge')}
+                data-cy="project-list-public-badge"
+              />
+              {p.organizationOwner?.name && (
+                <StyledOrganizationName
+                  variant="body2"
+                  data-cy="project-list-org-name"
+                >
+                  {p.organizationOwner.name}
+                </StyledOrganizationName>
+              )}
+            </StyledPublicLine>
+          )}
         </StyledTitle>
         <StyledKeyCount>
           <Typography variant="body1">


### PR DESCRIPTION
Part of the Community Translation v1.0 pitch (#3763), PR 1 — Public projects. Targets the `jirikuchynka/public-projects` branch.

## What

Public projects now show a **second line** under the project name in the project list row: an outlined lowercase **`public`** badge followed by the **organization name**. Per the shaped pitch, this list-row badge is the *only* public indicator — there is no separate icon in the project detail view.

## Changes

- **Backend**: add `public: Boolean` to `ProjectWithStatsModel` + map it in `ProjectWithStatsModelAssembler`; regenerate the frontend API schema.
- **Frontend**: `DashboardProjectListItem` renders the badge (`TransparentChip`, i18n key `project_list_public_badge`) + organization name when the project is public.
- **Tests**: backend `OrganizationProjectsControllerTest` asserts the `public` flag is serialized (public + private); cypress `projectsListDashboard.cy.ts` asserts the badge + org name render on a public row and are absent on a private row.

## Verification

- Backend test green; ktlint green.
- webapp + e2e eslint + tsc green.
- Cypress `projectsListDashboard.cy.ts` — all 5 tests pass (incl. the 2 new badge tests) against a live dev stack.

## Notes

- i18n key `project_list_public_badge` ("public") created in the Tolgee project; no inline default in code (matches sibling keys).
- In the normal org list the title column is 150px, so very long org names ellipsize (consistent with the existing project-name layout). Full names show in the wider community/public list layouts (later PRs in this pitch).