### PR TITLE
feat: show up to 3 translation suggestions per cell by default

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
@@ -631,7 +631,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
       "/translations?filterHasSuggestionsInLang=${testData.czechLanguage.tag}",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys") {
-        isArray.hasSize(2)
+        isArray.hasSize(4)
         node("[0].keyName").isEqualTo("key 0")
       }
     }
@@ -640,7 +640,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
       "/translations?filterHasNoSuggestionsInLang=${testData.czechLanguage.tag}",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys") {
-        isArray.hasSize(3)
+        isArray.hasSize(1)
         node("[0].keyName").isEqualTo("key 1")
       }
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
@@ -184,6 +184,24 @@ class SuggestionsTestData(
         }
       }
 
+      keys[2].apply {
+        (1..4).forEach { i ->
+          addSuggestion {
+            this.language = czechLanguage
+            this.author = projectTranslator.self
+            this.translation = "Many suggestion 2-$i"
+          }
+        }
+      }
+
+      keys[3].apply {
+        addSuggestion {
+          this.language = czechLanguage
+          this.author = projectTranslator.self
+          this.translation = "Only suggestion 3-1"
+        }
+      }
+
       pluralKey =
         addKey(null, "pluralKey").apply {
           self.isPlural = true

--- a/e2e/cypress/e2e/projects/suggestions/suggestions.reviewer.cy.ts
+++ b/e2e/cypress/e2e/projects/suggestions/suggestions.reviewer.cy.ts
@@ -229,6 +229,42 @@ describe('Suggestions reviewer', () => {
     assertMessage('Suggestion accepted');
   });
 
+  it('read cell shows the next correct 3 suggestions after one is declined', () => {
+    getTranslationCell('key 2', 'cs')
+      .findDcy('translation-suggestion')
+      .should('have.length', 3);
+    getTranslationCell('key 2', 'cs').within(() => {
+      cy.contains('+1').should('be.visible');
+    });
+    getTranslationCell('key 2', 'cs').click();
+    waitForGlobalLoading();
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .first()
+      .should('contain', 'Many suggestion 2-4');
+    gcyAdvanced({ value: 'suggestion-action', action: 'decline' })
+      .first()
+      .click();
+    waitForGlobalLoading();
+    visitTranslations(projectId);
+    waitForGlobalLoading();
+    getTranslationCell('key 2', 'cs')
+      .findDcy('translation-suggestion')
+      .should('have.length', 3);
+    getTranslationCell('key 2', 'cs').within(() => {
+      cy.gcy('translation-suggestion')
+        .eq(0)
+        .should('contain', 'Many suggestion 2-3');
+      cy.gcy('translation-suggestion')
+        .eq(1)
+        .should('contain', 'Many suggestion 2-2');
+      cy.gcy('translation-suggestion')
+        .eq(2)
+        .should('contain', 'Many suggestion 2-1');
+      cy.contains('+1').should('not.exist');
+    });
+  });
+
   function acceptOnly(text: string) {
     cy.gcy('translation-suggestion')
       .contains(text)

--- a/e2e/cypress/e2e/projects/suggestions/suggestions.translator.cy.ts
+++ b/e2e/cypress/e2e/projects/suggestions/suggestions.translator.cy.ts
@@ -3,6 +3,7 @@ import { suggestionsTestData } from '../../../common/apiCalls/testData/testData'
 import { waitForGlobalLoading } from '../../../common/loading';
 import { gcyAdvanced } from '../../../common/shared';
 import {
+  getCellCancelButton,
   getPluralEditor,
   getTranslationCell,
   visitTranslations,
@@ -86,4 +87,61 @@ describe('Suggestions translator', () => {
       .contains('Navržený překlad 0-1')
       .should('not.exist');
   });
+
+  it('read cell shows the newest 3 suggestions + a +N badge, and keeps them after the editor opens and closes', () => {
+    visitTranslations(projectId);
+    assertReadCellSuggestions(['2-4', '2-3', '2-2']);
+    getTranslationCell('key 2', 'cs').within(() => {
+      cy.contains('+1').should('be.visible');
+    });
+    getTranslationCell('key 2', 'cs').click();
+    waitForGlobalLoading();
+    getCellCancelButton().click();
+    waitForGlobalLoading();
+    assertReadCellSuggestions(['2-4', '2-3', '2-2']);
+  });
+
+  it('keeps up to 3 read-cell suggestions after suggesting on a cell that already has some', () => {
+    visitTranslations(projectId);
+    getTranslationCell('key 2', 'cs').click();
+    cy.gcy('global-editor').clear().type('Brand new suggestion');
+    cy.gcy('translations-cell-main-action-button')
+      .should('contain', 'Suggest')
+      .click();
+    waitForGlobalLoading();
+    getTranslationCell('key 2', 'cs')
+      .findDcy('translation-suggestion')
+      .should('have.length', 3);
+    getTranslationCell('key 2', 'cs').within(() => {
+      cy.gcy('translation-suggestion')
+        .eq(0)
+        .should('contain', 'Brand new suggestion');
+      cy.gcy('translation-suggestion')
+        .eq(1)
+        .should('contain', 'Many suggestion 2-4');
+      cy.gcy('translation-suggestion')
+        .eq(2)
+        .should('contain', 'Many suggestion 2-3');
+    });
+  });
+
+  it('renders the 3-suggestion stack in table view too', () => {
+    visitTranslations(projectId);
+    cy.gcy('translations-view-table-button').click();
+    waitForGlobalLoading();
+    assertReadCellSuggestions(['2-4', '2-3', '2-2']);
+  });
+
+  function assertReadCellSuggestions(suffixes: string[]) {
+    getTranslationCell('key 2', 'cs')
+      .findDcy('translation-suggestion')
+      .should('have.length', suffixes.length);
+    getTranslationCell('key 2', 'cs').within(() => {
+      suffixes.forEach((suffix, index) => {
+        cy.gcy('translation-suggestion')
+          .eq(index)
+          .should('contain', `Many suggestion ${suffix}`);
+      });
+    });
+  }
 });

--- a/e2e/cypress/e2e/translations/translationFilters.suggestions.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.suggestions.cy.ts
@@ -30,7 +30,7 @@ describe('Translation filters suggestions', () => {
     assertFilter({
       submenu: 'Suggestions',
       filterOption: ['With suggestions'],
-      toSeeAfter: ['key 0', 'pluralKey'],
+      toSeeAfter: ['key 0', 'key 2', 'key 3', 'pluralKey'],
       checkAfter() {
         cy.gcy('translations-filter-select').contains('With suggestions');
       },
@@ -41,7 +41,7 @@ describe('Translation filters suggestions', () => {
     assertFilter({
       submenu: 'Suggestions',
       filterOption: ['No suggestions'],
-      toSeeAfter: ['key 1', 'key 2', 'key 3'],
+      toSeeAfter: ['key 1'],
       checkAfter() {
         cy.gcy('translations-filter-select').contains('No suggestions');
       },

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
@@ -13,28 +13,36 @@ import org.springframework.stereotype.Repository
 interface TranslationSuggestionRepository : JpaRepository<TranslationSuggestion, Long> {
   @Query(
     """
-      select distinct on (ts.language_id, ts.key_id)
-        ts.id as id,
-        ts.key_id as keyId,
-        ts.language_id as languageId,
-        l.tag as languageTag,
-        ts.translation as translation,
-        ts.state as state,
-        ts.is_plural as plural,
-        
-        u.id as authorId,
-        u.name as authorName,
-        u.username as authorUsername,
-        u.avatar_hash as authorAvatarHash,
-        u.deleted_at as authorDeletedAt
-      from translation_suggestion ts
-        left join language l on l.id = ts.language_id
-        left join user_account u on u.id = ts.author_id
-      where ts.key_id in :keyIds
-        and ts.project_id = :projectId
-        and ts.language_id in :languageIds
-        and ts.state = 'ACTIVE'
-      order by ts.language_id, ts.key_id, ts.created_at DESC
+      select id, keyId, languageId, languageTag, translation, state, plural,
+             authorId, authorName, authorUsername, authorAvatarHash, authorDeletedAt
+      from (
+        select
+          ts.id as id,
+          ts.key_id as keyId,
+          ts.language_id as languageId,
+          l.tag as languageTag,
+          ts.translation as translation,
+          ts.state as state,
+          ts.is_plural as plural,
+          u.id as authorId,
+          u.name as authorName,
+          u.username as authorUsername,
+          u.avatar_hash as authorAvatarHash,
+          u.deleted_at as authorDeletedAt,
+          row_number() over (
+            partition by ts.language_id, ts.key_id
+            order by ts.created_at desc, ts.id desc
+          ) as rn
+        from translation_suggestion ts
+          left join language l on l.id = ts.language_id
+          left join user_account u on u.id = ts.author_id
+        where ts.key_id in :keyIds
+          and ts.project_id = :projectId
+          and ts.language_id in :languageIds
+          and ts.state = 'ACTIVE'
+      ) sub
+      where sub.rn <= :maxPerKey
+      order by sub.languageId, sub.keyId, sub.rn
     """,
     nativeQuery = true,
   )
@@ -42,6 +50,7 @@ interface TranslationSuggestionRepository : JpaRepository<TranslationSuggestion,
     projectId: Long,
     languageIds: List<Long>,
     keyIds: List<Long>,
+    maxPerKey: Int,
   ): List<TranslationSuggestionView>
 
   @Query(

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
@@ -44,7 +44,7 @@ class TranslationSuggestionServiceEeImpl(
     keyIds: List<Long>,
     languageIds: List<Long>,
   ): Map<Pair<Long, String>, List<TranslationSuggestionView>> {
-    val data = translationSuggestionRepository.getByKeyId(projectId, languageIds, keyIds)
+    val data = translationSuggestionRepository.getByKeyId(projectId, languageIds, keyIds, MAX_DISPLAYED_SUGGESTIONS)
     val result = mutableMapOf<Pair<Long, String>, MutableList<TranslationSuggestionView>>()
     data.forEach {
       val pair = Pair(it.keyId, it.languageTag)
@@ -236,5 +236,10 @@ class TranslationSuggestionServiceEeImpl(
     if (text.length > tolgeeProperties.maxTranslationTextLength) {
       throw BadRequestException(Message.TRANSLATION_TEXT_TOO_LONG, listOf(tolgeeProperties.maxTranslationTextLength))
     }
+  }
+
+  companion object {
+    // Mirror of the frontend MAX_DISPLAYED_SUGGESTIONS (SuggestionsFirst.tsx) — both must change together.
+    const val MAX_DISPLAYED_SUGGESTIONS = 3
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SuggestionControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/SuggestionControllerTest.kt
@@ -15,15 +15,22 @@ import io.tolgee.model.enums.SuggestionsMode
 import io.tolgee.model.enums.TranslationSuggestionState
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.math.BigDecimal
+import java.util.Date
 
 class SuggestionControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   lateinit var testData: SuggestionsTestData
 
   @Autowired
   private lateinit var translationSuggestionRepository: TranslationSuggestionRepository
+
+  @AfterEach
+  fun resetClock() {
+    clearForcedDate()
+  }
 
   fun initTestData(suggestionsMode: SuggestionsMode = SuggestionsMode.ENABLED) {
     testData = SuggestionsTestData(suggestionsMode)
@@ -49,6 +56,102 @@ class SuggestionControllerTest : ProjectAuthControllerTest("/v2/projects/") {
           node("[1].author.name").isEqualTo("Project reviewer")
         }
         node("page.totalElements").isNumber.isEqualTo(BigDecimal(2))
+      }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `embeds up to MAX_DISPLAYED_SUGGESTIONS newest suggestions per cell in the translations view`() {
+    initTestData()
+    val manyKey = testData.keys[2].self
+    val oneKey = testData.keys[3].self
+    val twoKey = testData.keys[0].self
+    performProjectAuthGet(
+      "/translations?sort=id" +
+        "&filterKeyId=${twoKey.id}&filterKeyId=${manyKey.id}&filterKeyId=${oneKey.id}",
+    ).andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys[1].translations.cs") {
+          node("suggestions").isArray.hasSize(3)
+          node("suggestions[0].translation").isEqualTo("Many suggestion 2-4")
+          node("suggestions[1].translation").isEqualTo("Many suggestion 2-3")
+          node("suggestions[2].translation").isEqualTo("Many suggestion 2-2")
+          node("activeSuggestionCount").isNumber.isEqualTo(BigDecimal(4))
+        }
+        node("_embedded.keys[2].translations.cs") {
+          node("suggestions").isArray.hasSize(1)
+          node("suggestions[0].translation").isEqualTo("Only suggestion 3-1")
+          node("activeSuggestionCount").isNumber.isEqualTo(BigDecimal(1))
+        }
+        node("_embedded.keys[0].translations.cs") {
+          node("suggestions").isArray.hasSize(2)
+          node("activeSuggestionCount").isNumber.isEqualTo(BigDecimal(2))
+        }
+        node("_embedded.keys[0].translations.en") {
+          node("suggestions").isArray.hasSize(2)
+          node("activeSuggestionCount").isNumber.isEqualTo(BigDecimal(2))
+        }
+      }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `breaks createdAt ties by id desc in the embed`() {
+    initTestData()
+    val key = testData.keys[1].self
+    // both suggestions share one forced createdAt, so only the id desc tiebreaker can order them
+    setForcedDate(currentDateProvider.date)
+    performProjectAuthPost(
+      "languages/${testData.czechLanguage.id}/key/${key.id}/suggestion",
+      CreateTranslationSuggestionRequest(translation = "cs lower id"),
+    ).andIsOk
+    performProjectAuthPost(
+      "languages/${testData.czechLanguage.id}/key/${key.id}/suggestion",
+      CreateTranslationSuggestionRequest(translation = "cs higher id"),
+    ).andIsOk
+
+    performProjectAuthGet("/translations?sort=id&filterKeyId=${key.id}")
+      .andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys[0].translations.cs.suggestions") {
+          isArray.hasSize(2)
+          node("[0].translation").isEqualTo("cs higher id")
+          node("[1].translation").isEqualTo("cs lower id")
+        }
+      }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `embeds suggestions ordered by createdAt desc, not by id`() {
+    initTestData()
+    val key = testData.keys[1].self
+    val base = currentDateProvider.date.time
+
+    fun createAt(
+      offsetMillis: Long,
+      translation: String,
+    ) {
+      setForcedDate(Date(base + offsetMillis))
+      performProjectAuthPost(
+        "languages/${testData.czechLanguage.id}/key/${key.id}/suggestion",
+        CreateTranslationSuggestionRequest(translation = translation),
+      ).andIsOk
+    }
+
+    createAt(0, "cs oldest")
+    createAt(120_000, "cs newest")
+    createAt(60_000, "cs middle")
+
+    performProjectAuthGet("/translations?sort=id&filterKeyId=${key.id}")
+      .andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys[0].translations.cs.suggestions") {
+          isArray.hasSize(3)
+          node("[0].translation").isEqualTo("cs newest")
+          node("[1].translation").isEqualTo("cs middle")
+          node("[2].translation").isEqualTo("cs oldest")
+        }
       }
   }
 

--- a/webapp/src/views/projects/translations/Suggestions/SuggestionsFirst.tsx
+++ b/webapp/src/views/projects/translations/Suggestions/SuggestionsFirst.tsx
@@ -6,27 +6,42 @@ import { useTranslate } from '@tolgee/react';
 type TranslationSuggestionSimpleModel =
   components['schemas']['TranslationSuggestionSimpleModel'];
 
-const StyledContainer = styled('div')`
+// Mirror of TranslationSuggestionServiceEeImpl.MAX_DISPLAYED_SUGGESTIONS (backend caps the embed); keep in sync.
+export const MAX_DISPLAYED_SUGGESTIONS = 3;
+
+const StyledWrapper = styled('div')`
   display: grid;
-  grid-template-columns: 1fr auto;
-  align-items: start;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.palette.tokens.background.onDefaultGrey};
+`;
+
+const StyledLastLine = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  & > :first-child {
+    flex: 1;
+    min-width: 0;
+  }
 `;
 
 const StyledExtra = styled('div')`
   display: flex;
-  padding: 1px 8px;
+  flex-shrink: 0;
+  height: 22px;
+  min-width: 22px;
+  padding: 0 4px;
+  box-sizing: border-box;
   align-items: center;
-  border-radius: 13px;
-  background: ${({ theme }) => theme.palette.tokens.background.onDefaultGrey};
-  margin-top: 8px;
-  margin-left: 8px;
-`;
-
-const StyledWrapper = styled('div')`
-  display: grid;
-  gap: 8px;
-  border-radius: 8px;
-  background: ${({ theme }) => theme.palette.tokens.background.onDefaultGrey};
+  justify-content: center;
+  border-radius: 11px;
+  margin-right: 8px;
+  font-size: 12px;
+  line-height: 1;
+  color: ${({ theme }) => theme.palette.text.secondary};
+  background: ${({ theme }) => theme.palette.tokens.background['paper-1']};
+  border: 1px solid ${({ theme }) => theme.palette.divider};
 `;
 
 type Props = {
@@ -43,11 +58,12 @@ export const SuggestionsFirst = ({
   locale,
 }: Props) => {
   const { t } = useTranslate();
-  const extraCount = count - suggestions.length;
+  const displayed = suggestions.slice(0, MAX_DISPLAYED_SUGGESTIONS);
+  const extraCount = count - displayed.length;
   return (
-    <StyledContainer>
-      <StyledWrapper>
-        {suggestions.map((s) => (
+    <StyledWrapper>
+      {displayed.map((s, i) => {
+        const node = (
           <TranslationSuggestion
             key={s.id}
             suggestion={s}
@@ -55,13 +71,21 @@ export const SuggestionsFirst = ({
             locale={locale}
             maxLines={2}
           />
-        ))}
-      </StyledWrapper>
-      {Boolean(extraCount) && (
-        <Tooltip title={t('suggestions_other_tooltip')}>
-          <StyledExtra>+{extraCount}</StyledExtra>
-        </Tooltip>
-      )}
-    </StyledContainer>
+        );
+        const isLastLineWithExtra =
+          extraCount > 0 && i === displayed.length - 1;
+        if (isLastLineWithExtra) {
+          return (
+            <StyledLastLine key={s.id}>
+              {node}
+              <Tooltip title={t('suggestions_other_tooltip')}>
+                <StyledExtra>+{extraCount}</StyledExtra>
+              </Tooltip>
+            </StyledLastLine>
+          );
+        }
+        return node;
+      })}
+    </StyledWrapper>
   );
 };

--- a/webapp/src/views/projects/translations/Suggestions/SuggestionsList.tsx
+++ b/webapp/src/views/projects/translations/Suggestions/SuggestionsList.tsx
@@ -4,6 +4,7 @@ import { PanelHeader } from '../ToolsPanel/common/PanelHeader';
 import { T, useTranslate } from '@tolgee/react';
 import { components } from 'tg.service/apiSchema.generated';
 import { TranslationSuggestion } from './TranslationSuggestion';
+import { MAX_DISPLAYED_SUGGESTIONS } from './SuggestionsFirst';
 import { useApiMutation } from 'tg.service/http/useQueryApi';
 import { useProject } from 'tg.hooks/useProject';
 import { useTranslationsActions } from '../context/TranslationsContext';
@@ -133,10 +134,14 @@ export const SuggestionsList = ({
         lang: languageTag,
         data(translation) {
           const firstPage = suggestions.pages?.[0];
-          const firstSuggestion = firstPage?._embedded?.suggestions?.[0];
+          const shown =
+            firstPage?._embedded?.suggestions?.slice(
+              0,
+              MAX_DISPLAYED_SUGGESTIONS
+            ) ?? [];
           return {
             ...translation,
-            suggestions: firstSuggestion ? [firstSuggestion] : [],
+            suggestions: shown,
             activeSuggestionCount: firstPage.page?.totalElements ?? 0,
           };
         },

--- a/webapp/src/views/projects/translations/Suggestions/useInfiniteSuggestions.ts
+++ b/webapp/src/views/projects/translations/Suggestions/useInfiniteSuggestions.ts
@@ -33,7 +33,7 @@ export const useInfiniteSuggestions = ({
 }: Props) => {
   const params: SuggestionParams = {
     query: {
-      sort: ['createdAt,desc'],
+      sort: ['createdAt,desc', 'id,desc'],
       filterState,
       // @ts-ignore force react-query cache only requests with the same count expected
       expectedCount,

--- a/webapp/src/views/projects/translations/context/services/useEditService.tsx
+++ b/webapp/src/views/projects/translations/context/services/useEditService.tsx
@@ -17,6 +17,7 @@ import {
   usePutTranslation,
 } from 'tg.service/TranslationHooks';
 import { components } from 'tg.service/apiSchema.generated';
+import { MAX_DISPLAYED_SUGGESTIONS } from '../../Suggestions/SuggestionsFirst';
 
 import type { useTranslationsService } from './useTranslationsService';
 import type { useRefsService } from './useRefsService';
@@ -193,7 +194,10 @@ export const useEditService = ({
         lang: lang.tag,
         data(value) {
           return {
-            suggestions: [result],
+            suggestions: [result, ...(value.suggestions ?? [])].slice(
+              0,
+              MAX_DISPLAYED_SUGGESTIONS
+            ),
             activeSuggestionCount: (value.activeSuggestionCount ?? 0) + 1,
             totalSuggestionCount: (value.totalSuggestionCount ?? 0) + 1,
           } satisfies Partial<TranslationViewModel>;


### PR DESCRIPTION
## What

Part of the Community Translation v1.0 pitch (suggestion behavior changes). The translations list read view showed a single suggestion per cell; it now shows **up to 3** by default, keeping the existing **`+N`** overflow badge as the indicator (no new control).

Targets `jirikuchynka/public-projects` to be folded into that PR.

## Changes

**Backend**
- `TranslationSuggestionRepository.getByKeyId` swaps `DISTINCT ON` (1 row/group) for a `row_number()` windowed top-N (`rn <= :maxPerKey`) with an explicit outer `ORDER BY` — the window `OVER(...)` order only assigns `row_number()`, not the delivery order. Ordering is `created_at desc, id desc`.
- `MAX_DISPLAYED_SUGGESTIONS = 3` constant in `TranslationSuggestionServiceEeImpl` drives the cap.
- No new index: the `WHERE` predicate is unchanged from the previous query and the existing `(project_id, language_id, key_id)` composite index covers it.

**Frontend**
- The read view (`SuggestionsFirst`) renders up to 3 and self-caps in render; the `+N` badge is guarded non-negative.
- The cell cache stays at 3 across the editor **open/close**, **mutate**, and **suggest-create** paths (the suggest path previously collapsed the stack to 1).
- The editor suggestion query gains an `id,desc` sort tiebreaker so its order matches the embed.

## Tests
- Backend: embed cap (3) + `activeSuggestionCount`, per-`(key, language)` partition isolation, cap-by-constant, and a dedicated `created_at desc` primary-sort test (created via API at non-id-monotonic timestamps so id-order and createdAt-order disagree).
- Cypress: read-cell 3-stack + `+N`, open/close, suggest-keeps-3, decline-then-resync, and a table-view check.

Backend test suite green; frontend `eslint`/`tsc` green for `webapp` and `e2e`.