### PR TITLE
feat: split suggestion accept into "accept only" and "accept and decline others"

### DIFF
--- a/e2e/cypress/e2e/projects/suggestions/suggestions.reviewer.cy.ts
+++ b/e2e/cypress/e2e/projects/suggestions/suggestions.reviewer.cy.ts
@@ -3,6 +3,7 @@ import { suggestionsTestData } from '../../../common/apiCalls/testData/testData'
 import { waitForGlobalLoading } from '../../../common/loading';
 import {
   assertMessage,
+  assertNotMessage,
   gcyAdvanced,
   visitProjectDashboard,
 } from '../../../common/shared';
@@ -60,18 +61,49 @@ describe('Suggestions reviewer', () => {
     cy.gcy('translation-suggestion').contains('návrhů').should('be.visible');
   });
 
-  it('reviewer can accept suggestion', () => {
-    acceptSuggestion();
-    assertMessage('Suggestion accepted, other variants declined (1)');
+  it('reviewer can accept only, leaving the other suggestion active', () => {
+    cy.intercept('PUT', /\/suggestion\/\d+\/accept/).as('accept');
+    getTranslationCell('key 0', 'cs').click();
+    waitForGlobalLoading();
+    acceptOnly('Navržený překlad 0-1');
+    cy.wait('@accept')
+      .its('request.url')
+      .should('not.contain', 'declineOther=true');
+    assertMessage('Suggestion accepted');
+    assertNotMessage('declined');
+    waitForGlobalLoading();
+    getTranslationCell('key 0', 'cs').click();
+    cy.gcy('suggestions-list')
+      .findDcy('translation-panel-items-count')
+      .should('contain', '1');
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .contains('Navržený překlad 0-2')
+      .should('exist');
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .contains('Navržený překlad 0-1')
+      .should('not.exist');
   });
 
   it('accepted suggestion stays reviewed', () => {
-    acceptSuggestion();
+    getTranslationCell('key 0', 'cs').click();
+    waitForGlobalLoading();
+    acceptOnly('Navržený překlad 0-1');
+    waitForGlobalLoading();
     assertHasState('Navržený překlad 0-1', 'Reviewed');
   });
 
-  it('acceptation of suggestion declines other suggestions', () => {
-    acceptSuggestion();
+  it('accept and decline others declines the rest', () => {
+    cy.intercept('PUT', /\/suggestion\/\d+\/accept/).as('accept');
+    getTranslationCell('key 0', 'cs').click();
+    waitForGlobalLoading();
+    openRowMenu('Navržený překlad 0-1', 'accept-decline-others');
+    cy.wait('@accept')
+      .its('request.url')
+      .should('contain', 'declineOther=true');
+    assertMessage('Suggestion accepted, other variants declined (1)');
+    waitForGlobalLoading();
     getTranslationCell('key 0', 'cs').click();
     cy.gcy('suggestions-list')
       .findDcy('translation-panel-items-count')
@@ -79,7 +111,10 @@ describe('Suggestions reviewer', () => {
   });
 
   it('reviewer can reverse inactive suggestion', () => {
-    acceptSuggestion();
+    getTranslationCell('key 0', 'cs').click();
+    waitForGlobalLoading();
+    openRowMenu('Navržený překlad 0-1', 'accept-decline-others');
+    waitForGlobalLoading();
     getTranslationCell('key 0', 'cs').click();
     cy.gcy('suggestions-list')
       .findDcy('translation-tools-suggestions-show-all-checkbox')
@@ -108,16 +143,33 @@ describe('Suggestions reviewer', () => {
   it('reviewer can decline suggestion', () => {
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
-    gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'decline',
-    })
-      .first()
-      .click();
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .should('have.length', 2);
+    cy.gcy('translation-suggestion')
+      .contains('Navržený překlad 0-1')
+      .closest('[data-cy="translation-suggestion"]')
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'decline' }).click();
+      });
     waitForGlobalLoading();
     cy.gcy('suggestions-list')
       .findDcy('translation-suggestion')
-      .should('have.length', 1);
+      .should('have.length', 1)
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'accept' }).should(
+          'exist'
+        );
+        gcyAdvanced({ value: 'suggestion-action', action: 'menu' }).click();
+      });
+    gcyAdvanced({
+      value: 'translation-suggestion-action-menu-item',
+      action: 'delete',
+    }).should('exist');
+    gcyAdvanced({
+      value: 'translation-suggestion-action-menu-item',
+      action: 'accept-decline-others',
+    }).should('not.exist');
 
     visitProjectDashboard(projectId);
     gcyAdvanced({
@@ -129,12 +181,7 @@ describe('Suggestions reviewer', () => {
   it('reviewer can delete his own suggestion', () => {
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
-    gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'delete',
-    })
-      .should('exist')
-      .click();
+    openRowMenu('Navržený překlad 0-2', 'delete');
     waitForGlobalLoading();
     cy.gcy('translation-suggestion')
       .contains('Navržený překlad 0-2')
@@ -150,15 +197,7 @@ describe('Suggestions reviewer', () => {
   it('reviewer can accept his own suggestion', () => {
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
-    gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'menu',
-    })
-      .should('exist')
-      .click();
-    cy.gcy('translation-suggestion-action-menu-item')
-      .contains('Accept suggestion')
-      .click();
+    openRowMenu('Navržený překlad 0-2', 'accept-decline-others');
     waitForGlobalLoading();
     cy.gcy('translation-suggestion')
       .contains('Navržený překlad 0-2')
@@ -172,15 +211,46 @@ describe('Suggestions reviewer', () => {
     }).should('contain', 'Navržený překlad 0-1');
   });
 
-  function acceptSuggestion() {
-    getTranslationCell('key 0', 'cs').click();
+  it('single active suggestion shows accept inline without the overflow menu', () => {
+    getTranslationCell('pluralKey', 'cs').click();
     waitForGlobalLoading();
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .should('have.length', 1)
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'accept' }).should(
+          'exist'
+        );
+        gcyAdvanced({ value: 'suggestion-action', action: 'menu' }).should(
+          'not.exist'
+        );
+        gcyAdvanced({ value: 'suggestion-action', action: 'accept' }).click();
+      });
+    assertMessage('Suggestion accepted');
+  });
+
+  function acceptOnly(text: string) {
+    cy.gcy('translation-suggestion')
+      .contains(text)
+      .closest('[data-cy="translation-suggestion"]')
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'accept' }).click();
+      });
+  }
+
+  function openRowMenu(
+    text: string,
+    action: 'accept-decline-others' | 'delete'
+  ) {
+    cy.gcy('translation-suggestion')
+      .contains(text)
+      .closest('[data-cy="translation-suggestion"]')
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'menu' }).click();
+      });
     gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'accept',
-    })
-      .first()
-      .click();
-    waitForGlobalLoading();
+      value: 'translation-suggestion-action-menu-item',
+      action,
+    }).click();
   }
 });

--- a/e2e/cypress/e2e/projects/suggestions/suggestions.translator.cy.ts
+++ b/e2e/cypress/e2e/projects/suggestions/suggestions.translator.cy.ts
@@ -58,13 +58,12 @@ describe('Suggestions translator', () => {
     visitTranslations(projectId);
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
+    cy.gcy('suggestions-list')
+      .findDcy('translation-suggestion')
+      .should('have.length', 2);
     gcyAdvanced({
       value: 'suggestion-action',
       action: 'accept',
-    }).should('not.exist');
-    gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'menu',
     }).should('not.exist');
   });
 
@@ -72,12 +71,16 @@ describe('Suggestions translator', () => {
     visitTranslations(projectId);
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
+    cy.gcy('translation-suggestion')
+      .contains('Navržený překlad 0-1')
+      .closest('[data-cy="translation-suggestion"]')
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'menu' }).click();
+      });
     gcyAdvanced({
-      value: 'suggestion-action',
+      value: 'translation-suggestion-action-menu-item',
       action: 'delete',
-    })
-      .should('exist')
-      .click();
+    }).click();
     waitForGlobalLoading();
     cy.gcy('translation-suggestion')
       .contains('Navržený překlad 0-1')

--- a/e2e/cypress/e2e/projects/suggestions/suggestions.unprotected.cy.ts
+++ b/e2e/cypress/e2e/projects/suggestions/suggestions.unprotected.cy.ts
@@ -45,12 +45,12 @@ describe('Suggestions in when translations are not protected', () => {
     visitTranslations(projectId);
     getTranslationCell('key 0', 'cs').click();
     waitForGlobalLoading();
-    gcyAdvanced({
-      value: 'suggestion-action',
-      action: 'accept',
-    })
-      .first()
-      .click();
+    cy.gcy('translation-suggestion')
+      .contains('Navržený překlad 0-1')
+      .closest('[data-cy="translation-suggestion"]')
+      .within(() => {
+        gcyAdvanced({ value: 'suggestion-action', action: 'accept' }).click();
+      });
     waitForGlobalLoading();
     assertHasState('Navržený překlad 0-1', 'Reviewed');
   });

--- a/webapp/src/views/projects/translations/Suggestions/SuggestionsList.tsx
+++ b/webapp/src/views/projects/translations/Suggestions/SuggestionsList.tsx
@@ -12,6 +12,7 @@ import { useInfiniteSuggestions } from './useInfiniteSuggestions';
 import { LabelHint } from 'tg.component/common/LabelHint';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
 import { useUser } from 'tg.globalContext/helpers';
+import { applyAcceptedSuggestion } from './utils';
 
 const FETCH_NEXT_PAGE_SCROLL_THRESHOLD_IN_PIXELS = 220;
 
@@ -156,6 +157,10 @@ export const SuggestionsList = ({
   const suggestionsLoadable =
     showAll && allLoaded ? allSuggestions : activeSuggestions;
 
+  const activeCount =
+    activeSuggestions.data?.pages?.[0]?.page?.totalElements ??
+    translation.activeSuggestionCount;
+
   function handleDecline(suggestionId: number) {
     declineLoadable.mutate({
       path: { projectId, keyId, languageId, suggestionId },
@@ -189,9 +194,10 @@ export const SuggestionsList = ({
             data(translation) {
               return {
                 ...translation,
-                text: data.accepted.translation,
-                suggestions: [],
-                activeSuggestionCount: 0,
+                ...applyAcceptedSuggestion(translation, {
+                  acceptedTranslation: data.accepted.translation,
+                  declinedCount: data.declined.length,
+                }),
               };
             },
           });
@@ -211,8 +217,11 @@ export const SuggestionsList = ({
   }
 
   function handleAccept(suggestionId: number) {
-    const firstPage = activeSuggestions.data?.pages?.[0];
-    acceptSuggestion(suggestionId, (firstPage?.page?.totalElements ?? 0) > 1);
+    acceptSuggestion(suggestionId, false);
+  }
+
+  function handleAcceptAndDeclineOthers(suggestionId: number) {
+    acceptSuggestion(suggestionId, true);
   }
 
   const handleFetchMore = () => {
@@ -309,6 +318,11 @@ export const SuggestionsList = ({
                     lastUpdated={itemWithDate.createdAt}
                     onAccept={
                       canReview ? () => handleAccept(item.id) : undefined
+                    }
+                    onAcceptAndDeclineOthers={
+                      canReview && activeCount > 1
+                        ? () => handleAcceptAndDeclineOthers(item.id)
+                        : undefined
                     }
                     onDecline={
                       canReview ? () => handleDecline(item.id) : undefined

--- a/webapp/src/views/projects/translations/Suggestions/TranslationSuggestion.tsx
+++ b/webapp/src/views/projects/translations/Suggestions/TranslationSuggestion.tsx
@@ -14,6 +14,7 @@ import { components } from 'tg.service/apiSchema.generated';
 import { useTimeDistance } from 'tg.hooks/useTimeDistance';
 import {
   Check,
+  CheckDone01,
   DotsVertical,
   ReverseLeft,
   Trash01,
@@ -99,6 +100,7 @@ type Props = {
   isLoading?: boolean;
   onDecline?: () => void;
   onAccept?: () => void;
+  onAcceptAndDeclineOthers?: () => void;
   onDelete?: () => void;
   onReverse?: () => void;
   sx?: SxProps;
@@ -110,6 +112,7 @@ export const TranslationSuggestion = ({
   locale,
   maxLines = 3,
   onAccept,
+  onAcceptAndDeclineOthers,
   onDecline,
   onDelete,
   onReverse,
@@ -125,10 +128,53 @@ export const TranslationSuggestion = ({
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLButtonElement>(null);
 
-  const actions: ActionItem[] = [];
+  const active = suggestion.state === 'ACTIVE';
 
+  const inlineActions: ActionItem[] = [];
+  if (active) {
+    if (onAccept) {
+      inlineActions.push({
+        action: 'accept',
+        label: onAcceptAndDeclineOthers
+          ? t('translation_suggestion_accept_only')
+          : t('translation_suggestion_accept_tooltip'),
+        onClick: onAccept,
+        icon: Check,
+        color: theme.palette.tokens.success.main,
+        disabled: isLoading,
+      });
+    }
+    if (onDecline) {
+      inlineActions.push({
+        action: 'decline',
+        label: t('translation_suggestion_decline_tooltip'),
+        onClick: onDecline,
+        icon: XClose,
+        disabled: isLoading,
+      });
+    }
+  } else if (onReverse) {
+    inlineActions.push({
+      action: 'reverse',
+      label: t('translation_suggestion_reverse_tooltip'),
+      onClick: onReverse,
+      icon: ReverseLeft,
+      disabled: isLoading,
+    });
+  }
+
+  const menuItems: ActionItem[] = [];
+  if (active && onAcceptAndDeclineOthers) {
+    menuItems.push({
+      action: 'accept-decline-others',
+      label: t('translation_suggestion_accept_and_decline_others'),
+      onClick: onAcceptAndDeclineOthers,
+      icon: CheckDone01,
+      disabled: isLoading,
+    });
+  }
   if (onDelete && suggestion.author.id === user?.id) {
-    actions.push({
+    menuItems.push({
       action: 'delete',
       label: t('translation_suggestion_delete_tooltip'),
       onClick: onDelete,
@@ -137,48 +183,15 @@ export const TranslationSuggestion = ({
       disabled: isLoading,
     });
   }
-  if (suggestion.state !== 'ACTIVE') {
-    if (onReverse) {
-      actions.push({
-        action: 'reverse',
-        label: t('translation_suggestion_reverse_tooltip'),
-        onClick: onReverse,
-        icon: ReverseLeft,
-        disabled: isLoading,
-      });
-    }
-  } else {
-    if (onAccept) {
-      actions.push({
-        action: 'accept',
-        label: t('translation_suggestion_accept_tooltip'),
-        onClick: onAccept,
-        icon: Check,
-        color: theme.palette.tokens.success.main,
-        disabled: isLoading,
-      });
-    }
-    if (onDecline) {
-      actions.push({
-        action: 'decline',
-        label: t('translation_suggestion_decline_tooltip'),
-        onClick: onDecline,
-        icon: XClose,
-        disabled: isLoading,
-      });
-    }
-  }
 
-  const showMenu = actions.length > 2;
-  const regularItems = showMenu ? actions.slice(0, 1) : actions;
-  const menuItems = showMenu ? actions.slice(1) : [];
-  const active = suggestion.state === 'ACTIVE';
+  const hasActions = inlineActions.length > 0 || menuItems.length > 0;
+
   return (
     <StyledContainer
       {...{
         sx,
         className: clsx(
-          { withActions: actions.length !== 0, showActions: menuOpen },
+          { withActions: hasActions, showActions: menuOpen },
           className
         ),
       }}
@@ -209,7 +222,7 @@ export const TranslationSuggestion = ({
         <StyledRightPart>
           <StyledDate className="date">{formatDate(lastUpdated)}</StyledDate>
           <StyledActions className="actions">
-            {regularItems.map((action, i) => (
+            {inlineActions.map((action, i) => (
               <SuggestionAction
                 key={i}
                 tooltip={action.label}
@@ -220,12 +233,13 @@ export const TranslationSuggestion = ({
                 action={action.action}
               />
             ))}
-            {showMenu && (
+            {menuItems.length > 0 && (
               <>
                 <SuggestionAction
                   tooltip={t('translation_suggestion_show_more_tooltip')}
                   icon={DotsVertical}
                   color="default"
+                  disabled={isLoading}
                   onClick={() => setMenuOpen(true)}
                   ref={menuRef}
                   action="menu"
@@ -235,21 +249,23 @@ export const TranslationSuggestion = ({
                   anchorEl={menuRef.current}
                   onClose={() => setMenuOpen(false)}
                 >
-                  {menuItems.map((action, i) => {
-                    const Icon = action.icon;
+                  {menuItems.map((item, i) => {
+                    const Icon = item.icon;
                     return (
                       <MenuItem
                         key={i}
                         onClick={() => {
-                          action.onClick();
+                          item.onClick();
                           setMenuOpen(false);
                         }}
-                        sx={{ color: action.color }}
+                        disabled={item.disabled}
+                        sx={{ color: item.color }}
                         data-cy="translation-suggestion-action-menu-item"
+                        data-cy-action={item.action}
                       >
                         <Box display="flex" gap={1} alignItems="center">
                           <Icon width={20} height={20} />
-                          <span>{action.label}</span>
+                          <span>{item.label}</span>
                         </Box>
                       </MenuItem>
                     );

--- a/webapp/src/views/projects/translations/Suggestions/__tests__/utils.test.ts
+++ b/webapp/src/views/projects/translations/Suggestions/__tests__/utils.test.ts
@@ -1,0 +1,69 @@
+import { applyAcceptedSuggestion } from '../utils';
+
+describe('applyAcceptedSuggestion', () => {
+  it('keeps the preview untouched and decrements the count when siblings remain', () => {
+    const result = applyAcceptedSuggestion(
+      { activeSuggestionCount: 2 },
+      { acceptedTranslation: 'accepted', declinedCount: 0 }
+    );
+    expect(result).toEqual({ text: 'accepted', activeSuggestionCount: 1 });
+    expect(result).not.toHaveProperty('suggestions');
+  });
+
+  it('clears the preview and count when it was the only active suggestion', () => {
+    const result = applyAcceptedSuggestion(
+      { activeSuggestionCount: 1 },
+      { acceptedTranslation: 'accepted', declinedCount: 0 }
+    );
+    expect(result).toEqual({
+      text: 'accepted',
+      suggestions: [],
+      activeSuggestionCount: 0,
+    });
+  });
+
+  it('clears the preview and count when the rest were declined', () => {
+    const result = applyAcceptedSuggestion(
+      { activeSuggestionCount: 2 },
+      { acceptedTranslation: 'accepted', declinedCount: 1 }
+    );
+    expect(result).toEqual({
+      text: 'accepted',
+      suggestions: [],
+      activeSuggestionCount: 0,
+    });
+  });
+
+  it('clamps a stale-cache over-count to zero rather than going negative', () => {
+    const result = applyAcceptedSuggestion(
+      { activeSuggestionCount: 2 },
+      { acceptedTranslation: 'accepted', declinedCount: 3 }
+    );
+    expect(result).toEqual({
+      text: 'accepted',
+      suggestions: [],
+      activeSuggestionCount: 0,
+    });
+  });
+
+  it('treats a missing activeSuggestionCount as zero', () => {
+    const result = applyAcceptedSuggestion(
+      {},
+      { acceptedTranslation: 'accepted', declinedCount: 0 }
+    );
+    expect(result).toEqual({
+      text: 'accepted',
+      suggestions: [],
+      activeSuggestionCount: 0,
+    });
+  });
+
+  it('decrements correctly when siblings remain after declines (keep-branch arithmetic)', () => {
+    const result = applyAcceptedSuggestion(
+      { activeSuggestionCount: 5 },
+      { acceptedTranslation: 'accepted', declinedCount: 2 }
+    );
+    expect(result).toEqual({ text: 'accepted', activeSuggestionCount: 2 });
+    expect(result).not.toHaveProperty('suggestions');
+  });
+});

--- a/webapp/src/views/projects/translations/Suggestions/utils.ts
+++ b/webapp/src/views/projects/translations/Suggestions/utils.ts
@@ -1,0 +1,36 @@
+import { components } from 'tg.service/apiSchema.generated';
+
+type TranslationViewModel = components['schemas']['TranslationViewModel'];
+
+type AcceptedSuggestionUpdate = Pick<TranslationViewModel, 'text'> &
+  Partial<Pick<TranslationViewModel, 'suggestions' | 'activeSuggestionCount'>>;
+
+/**
+ * `translation.suggestions` is only a single-item display preview; the real total
+ * lives in `activeSuggestionCount`. When siblings remain, decrement the count
+ * alone — do NOT re-sync the preview array to it (the surviving sibling can't be
+ * derived here; the refetch reconciles it). Clear the preview only when none remain.
+ */
+export function applyAcceptedSuggestion(
+  translation: { activeSuggestionCount?: number },
+  {
+    acceptedTranslation,
+    declinedCount,
+  }: {
+    acceptedTranslation: string | undefined;
+    declinedCount: number;
+  }
+): AcceptedSuggestionUpdate {
+  const remainingActive = Math.max(
+    0,
+    (translation.activeSuggestionCount ?? 0) - 1 - declinedCount
+  );
+  if (remainingActive === 0) {
+    return {
+      text: acceptedTranslation,
+      suggestions: [],
+      activeSuggestionCount: 0,
+    };
+  }
+  return { text: acceptedTranslation, activeSuggestionCount: remainingActive };
+}


### PR DESCRIPTION
Part of the Community Translation v1.0 pitch (suggestion resolution split). Stacked on top of `jirikuchynka/public-projects` — merge that first.

## What

Splits the single suggestion **Accept** action into two:

- **Accept only** — accepts this suggestion and leaves the competing suggestions active (`declineOther=false`).
- **Accept and decline others** — accepts this one and declines the rest (`declineOther=true`, the previous behavior).

### UI (decided with design)

- Inline row actions: **✓ Accept only** and **✕ Decline** (inactive rows show **↺ Reactivate**).
- Overflow **⋮** menu holds the secondary actions: **Accept and decline others** and **Delete** (the latter only on your own suggestion). The menu only renders when at least one of those applies.

## Scope

Frontend-only — the backend already supported `declineOther` on the accept endpoint (`SuggestionController.acceptSuggestion`), so no backend, migration, or API-schema changes.

## Notable details

- Optimistic cache fix in `applyAcceptedSuggestion`: on accept-only it decrements `activeSuggestionCount` but leaves the single-item preview for the `invalidatePrefix` refetch to reconcile — so the surviving sibling stays visible and no stale count / phantom `+N` chip flashes. Covered by a vitest unit test.
- `accept-and-decline-others` is gated on the row being **active** (so it never appears on declined rows in show-all view).

## i18n

Two new keys created in the **Tolgee itself** project via the Tolgee API (tagged `draft: suggestion-resolution-split`): `translation_suggestion_accept_only`, `translation_suggestion_accept_and_decline_others`. The previously-unused `translation_suggestion_show_more_tooltip` is referenced again by the kebab.

## Tests

- Vitest: `applyAcceptedSuggestion` (6 cases).
- Cypress: reworked the suggestion specs for the inline/kebab split (accept-only keeps the sibling, accept-and-decline-others clears it, kebab delete, single-suggestion has no kebab, translator can't accept).

### Known follow-ups
- The `active &&` guard's show-all false-branch is not e2e-covered (a 3-active fixture would break the backend `filters by suggestion` test and key-0 count assertions; the cheap route later is a pure action-builder helper unit-tested in vitest).
- In-flight `disabled` on menu items not e2e-asserted (flaky to test deterministically).