### PR TITLE
fix: protect MT placeholders from AWS Translate mangling for Traditional Chinese

### DIFF
--- a/backend/data/src/main/java/io/tolgee/helpers/TextHelper.kt
+++ b/backend/data/src/main/java/io/tolgee/helpers/TextHelper.kt
@@ -4,6 +4,12 @@ import java.util.regex.MatchResult
 import java.util.regex.Pattern
 
 object TextHelper {
+  private const val PARAM_PLACEHOLDER_PREFIX = "{xx"
+  private const val PARAM_PLACEHOLDER_SUFFIX = "xx}"
+
+  val paramPlaceholderRegex =
+    Regex(Regex.escape(PARAM_PLACEHOLDER_PREFIX) + "\\d+" + Regex.escape(PARAM_PLACEHOLDER_SUFFIX))
+
   @JvmStatic
   fun splitOnNonEscapedDelimiter(
     string: String,
@@ -100,7 +106,7 @@ object TextHelper {
         buffer.append(char)
 
         if (openCount < 1) {
-          val paramPlaceholder = "{xx${params.size}xx}"
+          val paramPlaceholder = "$PARAM_PLACEHOLDER_PREFIX${params.size}$PARAM_PLACEHOLDER_SUFFIX"
           params[paramPlaceholder] = buffer.toString()
           buffer.clear()
           result.append(paramPlaceholder)

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AbstractMtValueProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AbstractMtValueProvider.kt
@@ -4,6 +4,8 @@ import io.tolgee.component.machineTranslation.MtValueProvider
 import io.tolgee.component.machineTranslation.metadata.MtMetadata
 
 abstract class AbstractMtValueProvider : MtValueProvider {
+  protected open val placeholderProtector: MtPlaceholderProtector = NoopMtPlaceholderProtector
+
   private val String.toSuitableTag: String?
     get() = getSuitableTag(this)
 
@@ -33,12 +35,17 @@ abstract class AbstractMtValueProvider : MtValueProvider {
       )
     }
 
-    return translateViaProvider(
-      params.apply {
-        sourceLanguageTag = suitableSourceTag
-        targetLanguageTag = suitableTargetTag
-      },
-    )
+    val preparedParams =
+      params
+        .copy(text = placeholderProtector.protect(params.text))
+        .apply {
+          sourceLanguageTag = suitableSourceTag
+          targetLanguageTag = suitableTargetTag
+        }
+
+    return translateViaProvider(preparedParams).also {
+      it.translated = it.translated?.let(placeholderProtector::restore)
+    }
   }
 
   override fun getMetadata(

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AwsMtValueProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AwsMtValueProvider.kt
@@ -17,6 +17,8 @@ class AwsMtValueProvider(
   private val awsMachineTranslationProperties: AwsMachineTranslationProperties,
   private val amazonTranslate: TranslateClient?,
 ) : AbstractMtValueProvider() {
+  override val placeholderProtector = HtmlNoTranslatePlaceholderProtector
+
   override val isEnabled: Boolean
     get() =
       awsMachineTranslationProperties.enabled

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/HtmlNoTranslatePlaceholderProtector.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/HtmlNoTranslatePlaceholderProtector.kt
@@ -1,0 +1,25 @@
+package io.tolgee.component.machineTranslation.providers
+
+import io.tolgee.helpers.TextHelper
+
+/**
+ * Wraps placeholders in `<span translate="no">…</span>`. Engines that honor the HTML `translate="no"`
+ * attribute (notably AWS Translate) return the wrapped content verbatim and keep the tags in the output,
+ * which [restore] then strips. Without this, AWS rewrites the bare `{xxNxx}` sentinel for some targets
+ * (e.g. Traditional Chinese), breaking placeholder restoration.
+ *
+ * docs: https://docs.aws.amazon.com/translate/latest/dg/customizing-translations-tags.html
+ */
+object HtmlNoTranslatePlaceholderProtector : MtPlaceholderProtector {
+  private const val OPEN = "<span translate=\"no\">"
+  private const val CLOSE = "</span>"
+
+  // AWS may echo the attribute back without quotes (e.g. `translate=no`), so accept both on restore.
+  private val wrappedRegex =
+    Regex("<span translate=\"?no\"?>(${TextHelper.paramPlaceholderRegex.pattern})</span>")
+
+  override fun protect(text: String): String =
+    TextHelper.paramPlaceholderRegex.replace(text) { "$OPEN${it.value}$CLOSE" }
+
+  override fun restore(text: String): String = wrappedRegex.replace(text) { it.groupValues[1] }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/MtPlaceholderProtector.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/MtPlaceholderProtector.kt
@@ -1,0 +1,24 @@
+package io.tolgee.component.machineTranslation.providers
+
+/**
+ * Shields Tolgee's ICU-parameter placeholders (`{xxNxx}` sentinels produced by
+ * [io.tolgee.helpers.TextHelper.replaceIcuParams]) from being altered by an MT engine.
+ *
+ * The translated text is matched back to the original placeholders by exact string, so a provider
+ * that rewrites a sentinel (e.g. AWS Translate "translating" `{xx1xx}` into CJK) breaks restoration
+ * and leaks a broken placeholder. Providers whose engine needs an engine-specific escaping mechanism
+ * override [io.tolgee.component.machineTranslation.providers.AbstractMtValueProvider.placeholderProtector].
+ */
+interface MtPlaceholderProtector {
+  /** Wraps placeholders so the engine leaves them untouched. Called on the text sent to the engine. */
+  fun protect(text: String): String
+
+  /** Removes the protection wrapping. Called on the text returned by the engine. */
+  fun restore(text: String): String
+}
+
+object NoopMtPlaceholderProtector : MtPlaceholderProtector {
+  override fun protect(text: String): String = text
+
+  override fun restore(text: String): String = text
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/HtmlNoTranslatePlaceholderProtectorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/component/machineTranslation/HtmlNoTranslatePlaceholderProtectorTest.kt
@@ -1,0 +1,57 @@
+package io.tolgee.unit.component.machineTranslation
+
+import io.tolgee.component.machineTranslation.providers.HtmlNoTranslatePlaceholderProtector
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class HtmlNoTranslatePlaceholderProtectorTest {
+  private val protector = HtmlNoTranslatePlaceholderProtector
+
+  @Test
+  fun `wraps each placeholder in a translate=no span`() {
+    assertThat(protector.protect("{xx0xx} / {xx1xx}"))
+      .isEqualTo("<span translate=\"no\">{xx0xx}</span> / <span translate=\"no\">{xx1xx}</span>")
+  }
+
+  @Test
+  fun `leaves text without placeholders untouched`() {
+    assertThat(protector.protect("no placeholders here")).isEqualTo("no placeholders here")
+  }
+
+  @Test
+  fun `restores wrapped placeholders`() {
+    val wrapped = "<span translate=\"no\">{xx0xx}</span> / <span translate=\"no\">{xx1xx}</span>"
+    assertThat(protector.restore(wrapped)).isEqualTo("{xx0xx} / {xx1xx}")
+  }
+
+  @Test
+  fun `restores when the engine drops the attribute quotes`() {
+    assertThat(protector.restore("<span translate=no>{xx0xx}</span>")).isEqualTo("{xx0xx}")
+  }
+
+  @Test
+  fun `restores the exact output AWS returns for the reported case`() {
+    // AWS keeps the wrapped tokens verbatim but collapses the surrounding ` / ` to `/` for zh-TW.
+    val awsOutput = "<span translate=\"no\">{xx0xx}</span>/<span translate=\"no\">{xx1xx}</span>"
+    assertThat(protector.restore(awsOutput)).isEqualTo("{xx0xx}/{xx1xx}")
+  }
+
+  @Test
+  fun `protect wraps only the sentinel and leaves a user-authored translate=no span untouched`() {
+    val text = "<span translate=\"no\">Brand</span> has {xx0xx}"
+    assertThat(protector.protect(text))
+      .isEqualTo("<span translate=\"no\">Brand</span> has <span translate=\"no\">{xx0xx}</span>")
+  }
+
+  @Test
+  fun `restore unwraps only our sentinel spans and preserves a user-authored translate=no span`() {
+    val awsOutput = "<span translate=\"no\">Brand</span> 有 <span translate=\"no\">{xx0xx}</span>"
+    assertThat(protector.restore(awsOutput)).isEqualTo("<span translate=\"no\">Brand</span> 有 {xx0xx}")
+  }
+
+  @Test
+  fun `protect then restore is a round trip when the engine preserves the wrapping`() {
+    val sentinelText = "{xx0xx} / {xx1xx}"
+    assertThat(protector.restore(protector.protect(sentinelText))).isEqualTo(sentinelText)
+  }
+}


### PR DESCRIPTION
## Problem

For some MT targets — notably **Traditional Chinese** (`zh-Hant`, sent to AWS as `zh-TW`) — AWS Translate rewrites Tolgee's ICU-parameter placeholders, so the translated suggestion comes back broken.

Tolgee protects ICU params before MT by swapping `{current} / {max}` for bare sentinel tokens `{xx0xx} / {xx1xx}` (`TextHelper.replaceIcuParams`) and restores them afterward by **exact string match** (`MtBatchTranslator.replaceParams`). The token `xxNxx` is a lowercase, word-like string, and AWS's CJK model *translates* it, so the exact-match restore no longer finds it and a broken placeholder leaks through:

```
{current} / {max}  ->  {七十八次}/{xx1 次}
```

The mangling is **intermittent** (AWS rewrites the token only sometimes), which matches the client report that "the `xx1` pattern comes back often".

## Root cause

The bare `{xxNxx}` sentinel is not opaque to MT engines. It was introduced in the very first MT commit and has never been validated to survive any provider round-trip — it merely happened to work for Latin-script targets. CJK is the first target aggressive enough to translate it.

## Fix

Add a provider-overridable `MtPlaceholderProtector` applied at the single shared choke point (`AbstractMtValueProvider.translate()`):

- **`NoopMtPlaceholderProtector`** (default) — identity; every non-AWS provider is unchanged.
- **`HtmlNoTranslatePlaceholderProtector`** (AWS) — wraps each sentinel in `<span translate="no">…</span>`. AWS Translate honors `translate="no"` and returns the wrapped content verbatim; the wrapping is stripped from the response.

`restore` only unwraps spans whose inner content is a sentinel, so a user-authored `<span translate="no">…</span>` in the source is never touched.

## Verification

Confirmed directly against AWS Translate (`en` → `zh-TW`):

| Input | AWS output | Result |
|-------|-----------|--------|
| `{xx0xx} / {xx1xx}` | `{七十八次}/{xx1 次}` | 🔴 reproduces the bug |
| `<span translate="no">{xx0xx}</span> / <span translate="no">{xx1xx}</span>` | `<span translate="no">{xx0xx}</span>/<span translate="no">{xx1xx}</span>` | 🟢 tokens verbatim |
| `Hello <span translate="no">DoNotTranslateMe</span> world` | `你好 <span translate="no">DoNotTranslateMe</span> 世界` | 🟢 `translate="no"` honored |

The same token AWS mangles when bare comes back untouched when wrapped. 8 unit tests cover the protect/restore round-trip, the exact real-world AWS output, quote-less attributes, and preservation of user-authored spans.

> Local AWS verification requires a separately-issued, translate-only AWS key — prod authenticates via ambient cluster identity, so there is no static key to reuse for a local run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of placeholder values during machine translation, helping keep variable tokens intact.
  * Added support for protecting placeholders in translations using HTML “do not translate” markers where needed.

* **Bug Fixes**
  * Reduced the risk of placeholders being altered, dropped, or merged by translation engines.
  * Improved restoration of original placeholder text after translation, including tricky HTML formatting cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->