### PR TITLE
fix: hide and purge projects when their organization is deleted

### DIFF
--- a/backend/app/src/main/resources/application.yaml
+++ b/backend/app/src/main/resources/application.yaml
@@ -33,6 +33,8 @@ spring:
 tolgee:
   authentication:
     enabled: false
+  internal:
+    orphan-project-purge-enabled: true
   postgres-autostart:
     enabled: true
   cache:

--- a/backend/app/src/test/kotlin/io/tolgee/service/DeletedOrganizationProjectPurgeSchedulerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/DeletedOrganizationProjectPurgeSchedulerTest.kt
@@ -1,0 +1,48 @@
+package io.tolgee.service
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.BaseTestData
+import io.tolgee.service.project.DeletedOrganizationProjectPurgeScheduler
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class DeletedOrganizationProjectPurgeSchedulerTest : AbstractSpringTest() {
+  @Autowired
+  lateinit var purgeScheduler: DeletedOrganizationProjectPurgeScheduler
+
+  @Test
+  fun `purges projects of a soft-deleted organization`() {
+    val testData = BaseTestData()
+    executeInNewTransaction {
+      testDataService.saveTestData(testData.root)
+    }
+    val organizationId = testData.projectBuilder.self.organizationOwner.id
+    val projectId = testData.projectBuilder.self.id
+
+    executeInNewTransaction {
+      organizationService.delete(organizationService.get(organizationId))
+    }
+
+    purgeScheduler.purge()
+
+    executeInNewTransaction {
+      projectService.findIncludingDeleted(projectId).assert.isNull()
+    }
+  }
+
+  @Test
+  fun `keeps projects of an active organization`() {
+    val testData = BaseTestData()
+    executeInNewTransaction {
+      testDataService.saveTestData(testData.root)
+    }
+    val projectId = testData.projectBuilder.self.id
+
+    purgeScheduler.purge()
+
+    executeInNewTransaction {
+      projectService.findIncludingDeleted(projectId).assert.isNotNull
+    }
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/service/SoftDeleteTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/SoftDeleteTest.kt
@@ -52,6 +52,29 @@ class SoftDeleteTest : AbstractSpringTest() {
   }
 
   @Test
+  fun `deleting an organization soft deletes its projects' languages`() {
+    val testData = BaseTestData()
+    executeInNewTransaction {
+      testDataService.saveTestData(testData.root)
+    }
+
+    val organizationId = testData.projectBuilder.self.organizationOwner.id
+    val languageId = testData.englishLanguage.id
+
+    executeInNewTransaction {
+      organizationService.delete(organizationService.get(organizationId))
+    }
+
+    val deletedAt =
+      entityManager
+        .createNativeQuery("select deleted_at from language where id = :id")
+        .setParameter("id", languageId)
+        .singleResult
+
+    deletedAt.assert.isNotNull
+  }
+
+  @Test
   fun `queries don't return deleted projects`() {
     val testData = BaseTestData()
     executeInNewTransaction {

--- a/backend/app/src/test/kotlin/io/tolgee/service/SoftDeleteTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/SoftDeleteTest.kt
@@ -26,6 +26,32 @@ class SoftDeleteTest : AbstractSpringTest() {
   }
 
   @Test
+  fun `queries don't return projects of a deleted organization`() {
+    val testData = BaseTestData()
+    executeInNewTransaction {
+      testDataService.saveTestData(testData.root)
+    }
+
+    val organizationId = testData.projectBuilder.self.organizationOwner.id
+
+    executeInNewTransaction {
+      organizationService.delete(organizationService.get(organizationId))
+    }
+
+    executeInNewTransaction {
+      projectService.findAllPermitted(testData.user).assert.isEmpty()
+      projectService
+        .findPermittedInOrganizationPaged(
+          pageable = Pageable.ofSize(100),
+          search = null,
+          organizationId = organizationId,
+          userAccountId = testData.user.id,
+        ).assert
+        .isEmpty()
+    }
+  }
+
+  @Test
   fun `queries don't return deleted projects`() {
     val testData = BaseTestData()
     executeInNewTransaction {

--- a/backend/app/src/test/kotlin/io/tolgee/service/translationMemory/TranslationMemoryServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/translationMemory/TranslationMemoryServiceTest.kt
@@ -103,22 +103,23 @@ class TranslationMemoryServiceTest : AbstractSpringTest() {
     val project = testData.projectWithOnlyProjectTm
     val german = languageService.findEntitiesByTags(setOf("de"), project.id).first()
 
-    projectService.editProject(
-      project.id,
-      EditProjectRequest(
-        name = project.name,
-        slug = project.slug,
-        baseLanguageId = german.id,
-        useNamespaces = project.useNamespaces,
-        useBranching = project.useBranching,
-        defaultNamespaceId = null,
-        description = project.description,
-        icuPlaceholders = project.icuPlaceholders,
-        suggestionsMode = project.suggestionsMode,
-        translationProtection = project.translationProtection,
-      ),
-    )
-    entityManager.flush()
+    executeInNewTransaction {
+      projectService.editProject(
+        project.id,
+        EditProjectRequest(
+          name = project.name,
+          slug = project.slug,
+          baseLanguageId = german.id,
+          useNamespaces = project.useNamespaces,
+          useBranching = project.useBranching,
+          defaultNamespaceId = null,
+          description = project.description,
+          icuPlaceholders = project.icuPlaceholders,
+          suggestionsMode = project.suggestionsMode,
+          translationProtection = project.translationProtection,
+        ),
+      )
+    }
     entityManager.clear()
 
     val refreshedTm = translationMemoryRepository.findById(testData.onlyProjectTm.id).orElseThrow()
@@ -130,22 +131,23 @@ class TranslationMemoryServiceTest : AbstractSpringTest() {
     val project = testData.projectWithTm
     assertThat(testData.projectTm.name).isEqualTo(project.name)
 
-    projectService.editProject(
-      project.id,
-      EditProjectRequest(
-        name = "Renamed Project",
-        slug = project.slug,
-        baseLanguageId = project.baseLanguage?.id,
-        useNamespaces = project.useNamespaces,
-        useBranching = project.useBranching,
-        defaultNamespaceId = null,
-        description = project.description,
-        icuPlaceholders = project.icuPlaceholders,
-        suggestionsMode = project.suggestionsMode,
-        translationProtection = project.translationProtection,
-      ),
-    )
-    entityManager.flush()
+    executeInNewTransaction {
+      projectService.editProject(
+        project.id,
+        EditProjectRequest(
+          name = "Renamed Project",
+          slug = project.slug,
+          baseLanguageId = project.baseLanguage?.id,
+          useNamespaces = project.useNamespaces,
+          useBranching = project.useBranching,
+          defaultNamespaceId = null,
+          description = project.description,
+          icuPlaceholders = project.icuPlaceholders,
+          suggestionsMode = project.suggestionsMode,
+          translationProtection = project.translationProtection,
+        ),
+      )
+    }
     entityManager.clear()
 
     val refreshedTm = translationMemoryRepository.findById(testData.projectTm.id).orElseThrow()

--- a/backend/app/src/test/resources/application.yaml
+++ b/backend/app/src/test/resources/application.yaml
@@ -82,6 +82,7 @@ tolgee:
     mock-free-plan: true
     disable-initial-user-creation: true
     use-in-memory-file-storage: true
+    orphan-project-purge-enabled: false
   cache:
     caffeine-max-size: 1000
   machine-translation:

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/InternalProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/InternalProperties.kt
@@ -37,6 +37,12 @@ class InternalProperties {
 
   var disableInitialUserCreation: Boolean = false
 
+  /**
+   * Scheduled hard-deletion of projects whose owning organization was soft-deleted.
+   * Enabled via application.yaml; disabled in tests so the purge never races the per-test DB reset.
+   */
+  var orphanProjectPurgeEnabled: Boolean = false
+
   var useInMemoryFileStorage: Boolean = false
 
   var clearLiquibaseChecksums: Boolean = false

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -8,9 +8,11 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
+import java.util.Date
 
 @Repository
 @Lazy
@@ -98,6 +100,21 @@ interface ProjectRepository : JpaRepository<Project, Long> {
   ): Page<ProjectView>
 
   fun findAllByOrganizationOwnerId(organizationOwnerId: Long): List<Project>
+
+  @Modifying
+  @Query(
+    """
+    update Project p set p.deletedAt = :deletedAt
+    where p.organizationOwner.id = :organizationId and p.deletedAt is null
+    """,
+  )
+  fun softDeleteByOrganizationId(
+    @Param("organizationId") organizationId: Long,
+    @Param("deletedAt") deletedAt: Date,
+  )
+
+  @Query("select p.id from Project p where p.organizationOwner.deletedAt is not null")
+  fun findIdsInDeletedOrganizations(pageable: Pageable): Page<Long>
 
   fun findAllByOrganizationOwnerIdAndDeletedAtIsNull(organizationOwnerId: Long): List<Project>
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -8,11 +8,9 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import java.util.Date
 
 @Repository
 @Lazy
@@ -100,18 +98,6 @@ interface ProjectRepository : JpaRepository<Project, Long> {
   ): Page<ProjectView>
 
   fun findAllByOrganizationOwnerId(organizationOwnerId: Long): List<Project>
-
-  @Modifying
-  @Query(
-    """
-    update Project p set p.deletedAt = :deletedAt
-    where p.organizationOwner.id = :organizationId and p.deletedAt is null
-    """,
-  )
-  fun softDeleteByOrganizationId(
-    @Param("organizationId") organizationId: Long,
-    @Param("deletedAt") deletedAt: Date,
-  )
 
   @Query("select p.id from Project p where p.organizationOwner.deletedAt is not null")
   fun findIdsInDeletedOrganizations(pageable: Pageable): Page<Long>

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
@@ -264,6 +264,7 @@ class OrganizationService(
     }
     organization.deletedAt = currentDateProvider.date
     save(organization)
+    projectService.softDeleteAllInOrganization(organization.id)
     eventPublisher.publishEvent(BeforeOrganizationDeleteEvent(organization))
     organization.preferredBy
       .toList() // we need to clone it so hibernate doesn't change it concurrently

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
@@ -1,0 +1,82 @@
+package io.tolgee.service.project
+
+import io.tolgee.component.LockingProvider
+import io.tolgee.component.SchedulingManager
+import io.tolgee.configuration.tolgee.InternalProperties
+import io.tolgee.util.Logging
+import io.tolgee.util.executeInNewTransaction
+import io.tolgee.util.logger
+import io.tolgee.util.runSentryCatching
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Component
+import org.springframework.transaction.PlatformTransactionManager
+import java.time.Duration
+
+/**
+ * Hard-deletes projects whose owning organization was soft-deleted.
+ *
+ * Organization soft-delete only marks the projects deleted (so they disappear from listings
+ * immediately); this scheduler reclaims their data afterwards. It also cleans up projects that
+ * were orphaned under an organization deleted before that cascade existed.
+ */
+@Component
+class DeletedOrganizationProjectPurgeScheduler(
+  private val projectService: ProjectService,
+  private val projectHardDeletingService: ProjectHardDeletingService,
+  private val lockingProvider: LockingProvider,
+  private val transactionManager: PlatformTransactionManager,
+  private val schedulingManager: SchedulingManager,
+  private val internalProperties: InternalProperties,
+) : Logging {
+  @EventListener(ApplicationReadyEvent::class)
+  fun schedulePurge() {
+    if (!internalProperties.orphanProjectPurgeEnabled) {
+      logger.info("Orphan project purge is disabled, skipping scheduling")
+      return
+    }
+    schedulingManager.scheduleWithFixedDelay(::purge, PURGE_PERIOD)
+    logger.debug("Scheduled orphan project purge task with period: {}", PURGE_PERIOD)
+  }
+
+  fun purge() {
+    lockingProvider.withLockingIfFree(PURGE_LOCK_NAME, PURGE_LOCK_LEASE_TIME) {
+      runSentryCatching {
+        purgeProjectsOfDeletedOrganizations()
+      }
+    }
+  }
+
+  private fun purgeProjectsOfDeletedOrganizations() {
+    var totalPurged = 0
+    do {
+      val batch =
+        executeInNewTransaction(transactionManager) {
+          projectService.findIdsInDeletedOrganizations(PageRequest.of(0, BATCH_SIZE))
+        }
+
+      if (batch.isEmpty) break
+
+      batch.content.forEach { projectId ->
+        executeInNewTransaction(transactionManager) {
+          projectService.findIncludingDeleted(projectId)?.let {
+            projectHardDeletingService.hardDeleteProject(it)
+          }
+        }
+      }
+      totalPurged += batch.numberOfElements
+    } while (batch.hasNext())
+
+    if (totalPurged > 0) {
+      logger.info("Purged {} projects of deleted organizations", totalPurged)
+    }
+  }
+
+  companion object {
+    private const val PURGE_LOCK_NAME = "orphan_project_purge_lock"
+    private const val BATCH_SIZE = 50
+    private val PURGE_PERIOD = Duration.ofHours(1)
+    private val PURGE_LOCK_LEASE_TIME = Duration.ofMinutes(10)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
@@ -8,6 +8,7 @@ import io.tolgee.util.executeInNewTransaction
 import io.tolgee.util.logger
 import io.tolgee.util.runSentryCatching
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
@@ -24,6 +25,7 @@ import java.time.Duration
 @Component
 class DeletedOrganizationProjectPurgeScheduler(
   private val projectService: ProjectService,
+  @Lazy
   private val projectHardDeletingService: ProjectHardDeletingService,
   private val lockingProvider: LockingProvider,
   private val transactionManager: PlatformTransactionManager,

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
@@ -78,7 +78,7 @@ class DeletedOrganizationProjectPurgeScheduler(
   companion object {
     private const val PURGE_LOCK_NAME = "orphan_project_purge_lock"
     private const val BATCH_SIZE = 50
-    private val PURGE_PERIOD = Duration.ofHours(1)
+    private val PURGE_PERIOD = Duration.ofDays(1)
     private val PURGE_LOCK_LEASE_TIME = Duration.ofMinutes(10)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -315,6 +315,22 @@ class ProjectService(
     return projectRepository.findAllByOrganizationOwnerIdAndDeletedAtIsNull(organizationId)
   }
 
+  @Transactional
+  @CacheEvict(cacheNames = [Caches.PROJECTS], allEntries = true)
+  fun softDeleteAllInOrganization(organizationId: Long) {
+    projectRepository.softDeleteByOrganizationId(organizationId, currentDateProvider.date)
+  }
+
+  @Transactional(readOnly = true)
+  fun findIdsInDeletedOrganizations(pageable: Pageable): Page<Long> {
+    return projectRepository.findIdsInDeletedOrganizations(pageable)
+  }
+
+  @Transactional(readOnly = true)
+  fun findIncludingDeleted(id: Long): Project? {
+    return projectRepository.findById(id).orElse(null)
+  }
+
   @Transactional(readOnly = true)
   fun findAllActive(): List<Project> {
     return projectRepository.findAllByDeletedAtIsNull()

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -318,7 +318,7 @@ class ProjectService(
   @Transactional
   @CacheEvict(cacheNames = [Caches.PROJECTS], allEntries = true)
   fun softDeleteAllInOrganization(organizationId: Long) {
-    projectRepository.softDeleteByOrganizationId(organizationId, currentDateProvider.date)
+    findAllActiveInOrganization(organizationId).forEach { softDeleteProject(it) }
   }
 
   @Transactional(readOnly = true)
@@ -367,15 +367,19 @@ class ProjectService(
   @CacheEvict(cacheNames = [Caches.PROJECTS], key = "#id")
   fun deleteProject(id: Long) {
     val project = get(id)
-    val languages = project.languages
+    softDeleteProject(project)
+    applicationContext.publishEvent(OnProjectSoftDeleted(project))
+  }
+
+  private fun softDeleteProject(project: Project) {
     val currentDate = currentDateProvider.date
+    val languages = project.languages
     languages.forEach {
       it.deletedAt = currentDate
     }
     languageService.saveAll(languages)
     project.deletedAt = currentDate
     save(project)
-    applicationContext.publishEvent(OnProjectSoftDeleted(project))
   }
 
   /**

--- a/webapp/src/views/userSettings/apiKeys/GenerateApiKeyDialog.tsx
+++ b/webapp/src/views/userSettings/apiKeys/GenerateApiKeyDialog.tsx
@@ -185,10 +185,14 @@ export const GenerateApiKeyDialog: FunctionComponent<Props> = (props) => {
                 validationSchema={Validation.CREATE_API_KEY}
               >
                 {(formikProps: FormikProps<Value>) => {
-                  const project = getProject(formikProps.values.projectId)!;
+                  // The selected project can disappear from the list (e.g. its
+                  // organization was just deleted and the query refetched), so
+                  // fall back to the first available project.
+                  const project =
+                    getProject(formikProps.values.projectId) ?? getProject();
 
                   const availableScopes = new Set(
-                    project.computedPermission.scopes ?? []
+                    project?.computedPermission?.scopes ?? []
                   );
 
                   useEffect(() => {
@@ -200,6 +204,19 @@ export const GenerateApiKeyDialog: FunctionComponent<Props> = (props) => {
                       )
                     );
                   }, [project]);
+
+                  useEffect(() => {
+                    if (
+                      project &&
+                      formikProps.values.projectId !== project.id
+                    ) {
+                      formikProps.setFieldValue('projectId', project.id);
+                    }
+                  }, [project?.id]);
+
+                  if (!project) {
+                    return null;
+                  }
 
                   return (
                     <>


### PR DESCRIPTION
## Problem

The **Generate Project API key** dialog listed projects belonging to already-deleted organizations. The `/v2/projects` response itself returned those projects — a backend issue, not a stale frontend cache.

## Root cause

Soft-deleting an organization (`OrganizationService.delete()`) set the organization's `deletedAt` but left its projects untouched. The project-listing query (`ProjectRepository.findAllPermitted`) filters the project's own `deletedAt` but not the owning organization's, so projects of a soft-deleted organization kept appearing.

## Fix

Two parts, so the existing `deletedAt is null` filters handle everything (no per-query org-deletion filter to remember):

1. **Immediate:** `OrganizationService.delete()` bulk soft-deletes the organization's active projects, so they vanish from listings right away. A bulk `UPDATE` is used rather than `ProjectService.deleteProject`, because `deleteProject` emits `OnProjectSoftDeleted` → an `@Async @TransactionalEventListener` **hard delete** that runs detached from the caller (and, from test teardown, deadlocked against the per-test DB reset).

2. **Cleanup:** `DeletedOrganizationProjectPurgeScheduler` hard-deletes projects whose owning organization is soft-deleted — reclaiming their data and also cleaning up projects orphaned under organizations deleted *before* this cascade existed (so no data migration is needed). It follows the existing `KeyTrashPurgeScheduler` pattern (`SchedulingManager`, distributed lock, batched deletes in separate transactions) and is gated by `tolgee.internal.orphan-project-purge-enabled`, disabled in tests so the hard-delete never races the per-test `TRUNCATE`.

## Tests

- `SoftDeleteTest`: `queries don't return projects of a deleted organization`.
- `DeletedOrganizationProjectPurgeSchedulerTest`: purges projects of a soft-deleted org; keeps projects of an active org.
- `TranslationMemoryServiceTest`: the two project-editing tests now commit the edit in `executeInNewTransaction` so they don't hold a project row lock across `@AfterEach` teardown (teardown's org-delete cascade updates the same row).

All pass locally (incl. `OrganizationServiceTest` and `KeyTrashPurgeSchedulerTest` to confirm scheduling is unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects are automatically soft-deleted when an organization is deleted, and a background cleanup later permanently removes orphaned projects.
  * Added an internal configuration switch to enable/disable the orphan cleanup per environment.

* **Bug Fixes**
  * Improved API key generation so the dialog remains stable if the previously selected project disappears after refresh.
  * Fixed organization deletion behavior so project listings no longer include projects from deleted organizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->