### PR TITLE
test: fix intermittent 16-minute deadlock in QaEventListenerTest

### DIFF
--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -16,6 +16,7 @@ import io.tolgee.ee.development.QaTestData
 import io.tolgee.ee.utils.QaTestUtil
 import io.tolgee.events.OnOrganizationFeaturesChanged
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.waitFor
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.repository.TranslationRepository
 import io.tolgee.security.ProjectHolder
@@ -86,6 +87,7 @@ class QaEventListenerTest : AuthorizedControllerTest() {
     val demoProjId = demoProjectId
     demoProjectId = null
     demoProjId?.let { id ->
+      waitForProjectBatchJobsCompleted(id)
       try {
         executeInNewTransaction(platformTransactionManager) {
           val project = projectService.get(id)
@@ -95,9 +97,23 @@ class QaEventListenerTest : AuthorizedControllerTest() {
         // Demo project may have already been cleaned up or failed to create
       }
     }
+    waitForProjectBatchJobsCompleted(testData.project.id)
     testDataService.cleanTestData(testData.root)
     userAccount = null
     enabledFeaturesProvider.forceEnabled = null
+  }
+
+  /**
+   * Deleting a project while its QA batch job is still running deadlocks: the job worker's
+   * nested transaction and the deleting transaction block each other via row locks, and the
+   * cycle is invisible to Postgres because one edge waits inside the JVM.
+   */
+  private fun waitForProjectBatchJobsCompleted(projectId: Long) {
+    waitFor(timeout = 30_000, pollTime = 100) {
+      executeInNewTransaction(platformTransactionManager) {
+        batchJobService.getAllByProjectId(projectId).all { it.status.completed }
+      }
+    }
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -87,8 +87,8 @@ class QaEventListenerTest : AuthorizedControllerTest() {
     val demoProjId = demoProjectId
     demoProjectId = null
     demoProjId?.let { id ->
-      waitForProjectBatchJobsCompleted(id)
       try {
+        waitForProjectBatchJobsCompleted(id)
         executeInNewTransaction(platformTransactionManager) {
           val project = projectService.get(id)
           projectHardDeletingService.hardDeleteProject(project)
@@ -97,7 +97,11 @@ class QaEventListenerTest : AuthorizedControllerTest() {
         // Demo project may have already been cleaned up or failed to create
       }
     }
-    waitForProjectBatchJobsCompleted(testData.project.id)
+    try {
+      waitForProjectBatchJobsCompleted(testData.project.id)
+    } catch (_: Exception) {
+      // Proceed with cleanup even if batch jobs did not complete in time
+    }
     testDataService.cleanTestData(testData.root)
     userAccount = null
     enabledFeaturesProvider.forceEnabled = null


### PR DESCRIPTION
## Problem

`ee-test:test` in CI intermittently takes **26–31 minutes instead of ~10** (roughly every other run on `main`, at least since June 11). When it crosses the 30-minute step timeout, the job fails outright.

The whole delay is a single test stalling for ~16 minutes: `QaEventListenerTest > demo project triggers activity and marks translations stale`.

## Root cause

The test's `@AfterEach` hard-deletes the demo project while the QA batch job spawned by demo-project creation is still running. This deadlocks — confirmed via thread dump + `pg_locks` on a live reproduction:

1. The batch-job worker (`BatchJobActionService.handleItem`) holds an **outer** transaction with locks on the batch-job rows, then opens a **nested** transaction (`persistChunkResults` → `executeInNewRepeatableTransaction`) — one thread, two connections.
2. The cleanup's `hardDeleteProject` transaction has already locked translation rows and blocks on the worker's outer transaction (`deleteAllByProjectId`).
3. The worker's nested transaction (`UPDATE translation`) blocks on the cleanup's row locks — while the outer one sits `idle in transaction`, waiting in the JVM for the nested one.

Cycle: cleanup → worker-outer → *(JVM edge)* → worker-nested → cleanup. Postgres can't detect it because one edge lives inside the JVM, so everything waits until some ~15-minute timeout breaks it.

## Fix

Cleanup now polls until all batch jobs of the project reach a completed status (30s cap) before deleting — for both the demo project and the test-data project.

## Verification

5 consecutive forced reruns of the class: 11/11 tests pass, ~20s per run (previously a reproduced local hang of 40+ minutes).

## Notes

- `ProjectHardDeletingService.hardDeleteProject` can hit the same deadlock in production when deleting a project with a running batch job — worth a separate issue.
- A default per-test timeout (`junit.jupiter.execution.timeout.default`) would have surfaced this weeks ago; also worth a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of QA-related processing by ensuring background work finishes before cleanup continues.
  * Reduced the chance of intermittent issues caused by unfinished jobs during test and environment teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->