### PR TITLE
fix: use key's configured plural arg name for machine translation

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/KeyForMt.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/KeyForMt.kt
@@ -7,4 +7,5 @@ data class KeyForMt(
   val description: String?,
   var baseTranslation: String?,
   var isPlural: Boolean,
+  var pluralArgName: String? = null,
 )

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslator.kt
@@ -50,6 +50,9 @@ class MtBatchTranslator(
       }
 
     translated.translatedText =
+      translated.translatedText?.withPluralArgName(getPluralArgName(item, baseTranslationText))
+
+    translated.translatedText =
       if (context.project.icuPlaceholders) {
         translated.translatedText
       } else {
@@ -57,6 +60,25 @@ class MtBatchTranslator(
       }
 
     return translated
+  }
+
+  /**
+   * The MT provider (an LLM) returns the plural string with an argument name it picked itself, which
+   * is not guaranteed to match the key's configured one. Force the key's name, the same source of
+   * truth the save path uses.
+   */
+  private fun getPluralArgName(
+    item: MtBatchItemParams,
+    baseTranslationText: String,
+  ): String {
+    context.keys[item.keyId]?.pluralArgName?.let { return it }
+    context.getPluralForms(baseTranslationText)?.argName?.let { return it }
+    return DEFAULT_PLURAL_ARGUMENT_NAME
+  }
+
+  private fun String.withPluralArgName(argName: String): String {
+    val forms = context.getPluralForms(this) ?: return this
+    return forms.forms.toIcuPluralString(optimize = false, argName = argName)
   }
 
   private fun translatePluralSeparately(
@@ -102,7 +124,7 @@ class MtBatchTranslator(
         managerResult,
         withReplacedParams,
         item,
-        context.getPluralForms(baseTranslationText)?.argName ?: DEFAULT_PLURAL_ARGUMENT_NAME,
+        getPluralArgName(item, baseTranslationText),
       )
     }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtTranslatorContext.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtTranslatorContext.kt
@@ -121,7 +121,7 @@ class MtTranslatorContext(
       entityManger
         .createQuery(
           """
-        select new io.tolgee.service.machineTranslation.KeyForMt(k.id, k.name, ns.name, km.description, t.text, k.isPlural )
+        select new io.tolgee.service.machineTranslation.KeyForMt(k.id, k.name, ns.name, km.description, t.text, k.isPlural, k.pluralArgName )
         from Key k
         left join k.project.baseLanguage bl
         left join k.translations t on t.language.id = bl.id

--- a/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/service/machineTranslation/MtBatchTranslatorTest.kt
@@ -95,6 +95,52 @@ class MtBatchTranslatorTest {
     translated.actualPrice.assert.isEqualTo(100)
   }
 
+  @Test
+  fun `falls back to base plural arg name when key has none (gh-3772)`() {
+    prepareKeyWithBaseArgNameOnly()
+    prepareRawPluralResponse()
+
+    val translated = translateSingle(MtServiceType.PROMPT)
+
+    translated.translatedText.assert.isEqualTo(
+      "{count, plural,\n" +
+        "one {Jeden pes}\n" +
+        "other {'#' psů}\n" +
+        "}",
+    )
+  }
+
+  @Test
+  fun `forces configured key plural arg name even when base differs (gh-3772)`() {
+    prepareKeyWithMismatchedArgName()
+    prepareRawPluralResponse()
+
+    val translated = translateSingle(MtServiceType.PROMPT)
+
+    translated.translatedText.assert.isEqualTo(
+      "{count, plural,\n" +
+        "one {Jeden pes}\n" +
+        "other {'#' psů}\n" +
+        "}",
+    )
+  }
+
+  private fun translateSingle(service: MtServiceType): MtTranslatorResult {
+    val context = getMtTranslatorContext()
+    val translator = MtBatchTranslator(context)
+    return translator
+      .translate(
+        listOf(
+          MtBatchItemParams(
+            keyId = 1,
+            baseTranslationText = preparedKey.baseTranslation,
+            targetLanguageId = 1,
+            service = service,
+          ),
+        ),
+      ).first()
+  }
+
   private fun prepareValidKey() {
     preparedKey =
       KeyForMt(
@@ -104,6 +150,43 @@ class MtBatchTranslatorTest {
         description = "test",
         baseTranslation = "{value, plural, one {# dog} other {# dogs}}",
         isPlural = true,
+      )
+  }
+
+  private fun prepareKeyWithBaseArgNameOnly() {
+    preparedKey =
+      KeyForMt(
+        id = 1,
+        name = "key",
+        namespace = "test",
+        description = "test",
+        baseTranslation = "{count, plural, one {# dog} other {# dogs}}",
+        isPlural = true,
+        pluralArgName = null,
+      )
+  }
+
+  private fun prepareKeyWithMismatchedArgName() {
+    preparedKey =
+      KeyForMt(
+        id = 1,
+        name = "key",
+        namespace = "test",
+        description = "test",
+        baseTranslation = "{value, plural, one {# dog} other {# dogs}}",
+        isPlural = true,
+        pluralArgName = "count",
+      )
+  }
+
+  private fun prepareRawPluralResponse() {
+    mtServiceManagerResults =
+      listOf(
+        TranslateResult(
+          translatedText = "{value, plural, one {Jeden pes} other {# psů}}",
+          actualPrice = 100,
+          usedService = MtServiceType.PROMPT,
+        ),
       )
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
@@ -10,6 +10,7 @@ import io.tolgee.dtos.cacheable.ProjectDto
 import io.tolgee.ee.component.PromptLazyMap.Companion.Variable
 import io.tolgee.ee.service.glossary.GlossaryTermService
 import io.tolgee.exceptions.NotFoundException
+import io.tolgee.formats.DEFAULT_PLURAL_ARGUMENT_NAME
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.service.key.KeyService
@@ -226,6 +227,9 @@ class PromptVariablesHelper(
         )
       }
 
+    val pluralArgName =
+      key?.pluralArgName ?: pluralFormsWithReplacedParam?.argName ?: DEFAULT_PLURAL_ARGUMENT_NAME
+
     result.add(
       Variable(
         "pluralFormExamples",
@@ -243,7 +247,8 @@ class PromptVariablesHelper(
     result.add(
       Variable(
         "exampleIcuPlural",
-        value = pluralSourceExamples?.let { "{count, plural, ${it.map { "${it.key} {...}" }.joinToString(" ")}}" },
+        value =
+          pluralSourceExamples?.let { "{$pluralArgName, plural, ${it.map { "${it.key} {...}" }.joinToString(" ")}}" },
       ),
     )
     return result


### PR DESCRIPTION
Fixes #3772

## Problem

Machine translation of a plural key returned whatever plural argument name the model emitted, rather than the key's configured `pluralArgName`. Only the `PROMPT` (LLM) service supports plurals, and it returns raw text (`PromptServiceEeImpl.getTranslationFromPromptResult`); the MT pipeline stored that verbatim (`MtBatchTranslator` line 109) without ever consulting the key's setting. The *save* path normalizes to `key.pluralArgName`, which is why re-saving the key "fixed" it.

With a strong model the emitted name usually matches, so it looks fine. With a weaker model it breaks reliably — verified locally against Ollama `phi3`, where the source `{itemCount, plural, …}` came back as `{Betrag, …}` (translated) or `{count, …}` (copied from the prompt example), never `itemCount`.

Two contributing factors:
1. **The pipeline never enforced `key.pluralArgName`** — it trusted the model's output.
2. **The prompt's plural example hardcoded `count`** (`PromptVariablesHelper`), actively teaching weaker models to emit `count` regardless of the real arg name.

## Fix

- Thread the key's `pluralArgName` into `KeyForMt` (via the MT key query) and, in `MtBatchTranslator.translatePlural`, rewrite the translated plural's arg name using `getPluralArgName`: **key's `pluralArgName` → base translation's arg name → default (`value`)**. This is the same source of truth the save path uses, so MT output no longer depends on the model.
- Render the prompt's `exampleIcuPlural` with the actual arg name instead of the hardcoded `count`.

## Tests

New regression tests in `MtBatchTranslatorTest` covering both branches of the arg-name resolution:
- `falls back to base plural arg name when key has none` — `key.pluralArgName == null`, base carries the name.
- `forces configured key plural arg name even when base differs` — key setting wins over a mismatched base (the reporter's scenario).

Both assert the model's `{value, …}` output is rewritten to the correct name. Existing plural MT tests unchanged and passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plural argument names in machine-translated plural strings, so translated content now keeps the expected placeholder name more consistently.
  * When available, a key’s configured plural argument name is now used in generated plural examples and translations, with sensible fallback behavior when it isn’t set.
  * Added coverage for cases where the key’s plural argument name differs from the source translation or is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->