### PR TITLE
fix: false QA checks on numbers

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheck.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheck.kt
@@ -26,8 +26,16 @@ class MissingNumbersCheck : QaCheck {
     if (base.isBlank()) return emptyList()
     if (text.isBlank()) return emptyList()
 
-    val baseNumbers = extractNumbers(base)
-    val textNumbers = extractNumbers(text)
+    var baseNumbers = extractNumbers(base)
+    var textNumbers = extractNumbers(text)
+
+    //compare both numbers if they have comma then make them same and then compare
+    val baseNumbersNormalized = baseNumbers.map { it.replace(",", "") }
+    val textNumbersNormalized = textNumbers.map { it.replace(",", "") }
+
+    if(baseNumbersNormalized == textNumbersNormalized) {
+      baseNumbers = textNumbers
+    }
 
     val baseMultiset = baseNumbers.groupingBy { it }.eachCount()
     val textMultiset = textNumbers.groupingBy { it }.eachCount()
@@ -50,10 +58,24 @@ class MissingNumbersCheck : QaCheck {
   }
 
   companion object {
+    private val LENIENT_BLOCK_REGEX = Regex("""\d+(?:[^0-9]\d+)*""")
     private val NUMBER_REGEX = Regex("""\d+([.,]\d+)*""")
 
     fun extractNumbers(text: String): List<String> {
-      return NUMBER_REGEX.findAll(text).map { it.value }.toList()
+      return LENIENT_BLOCK_REGEX.findAll(text).mapNotNull { matchResult ->
+        val rawBlock = matchResult.value
+        
+        // Step 2: Cycle through and keep ONLY digits, periods, and commas
+        val filteredString = rawBlock.filter { it.isDigit() || it == '.' || it == ',' }
+        
+        // Step 3: Pass the filtered string through your target regex
+        // If it matches completely, we return the value; otherwise, we discard it (mapNotNull)
+        if (NUMBER_REGEX.matches(filteredString)) {
+            filteredString
+        } else {
+            null 
+        }
+      }.toList()
     }
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheckTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/checks/MissingNumbersCheckTest.kt
@@ -88,4 +88,14 @@ class MissingNumbersCheckTest {
   fun `all types are MISSING_NUMBERS`() {
     check.check(params("Bonjour", "Hello 42")).assertAllHaveType(QaCheckType.MISSING_NUMBERS)
   }
+
+  @Test
+  fun `does not report grouped number with space as missing`() {
+    check.check(params("Cuckoo's Nest (2,000 CZK)", "Kukaččí hnízdo (2 000 Kč)")).assertNoIssues()
+  }
+
+  @Test
+  fun `does not report grouped number with special characters as missing`() {
+    check.check(params("Cuckoo's Nest (2,000 CZK)", "Kukaččí hnízdo (2_0_00 Kč)")).assertNoIssues()
+  }
 }


### PR DESCRIPTION
The rationale behind the code changes is **not** to find all the special characters and handle it explicitly within the code but rather strip all the unnecessary characters encountered between the numbers (except `.,`) and create a normalized string which are then compared to find the errors.

The algorithm works as follows:
- Finds all the strings which starts and ends with numbers including atleast one special character between 2 numbers.
- Then strip all the characters which are not number, dot or comma
- Finally match the string with the NUMBERS_REGEX, if it passes then add it to the list and return.
- If the extracted numbers which are present in either text or base text are separated with comma then remove comma and perform the comparison because comma has no numerical value it's just a logical separator.

Resolves https://github.com/tolgee/tolgee-platform/issues/3753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number checking so formatted values with separators are handled more consistently.
  * Reduced false alerts for numbers written with different grouping styles, such as spaces or other separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->