### PR TITLE
fix: keep zero plural form in Apple XLIFF export

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/AppleXliffExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/AppleXliffExporter.kt
@@ -5,6 +5,7 @@ import io.tolgee.formats.PossiblePluralConversionResult
 import io.tolgee.formats.apple.APPLE_CORRESPONDING_STRINGS_FILE_ORIGINAL
 import io.tolgee.formats.apple.APPLE_FILE_ORIGINAL_CUSTOM_KEY
 import io.tolgee.formats.apple.APPLE_PLURAL_PROPERTY_CUSTOM_KEY
+import io.tolgee.formats.getPluralFormsForLocale
 import io.tolgee.formats.xliff.model.XliffFile
 import io.tolgee.formats.xliff.model.XliffModel
 import io.tolgee.formats.xliff.model.XliffTransUnit
@@ -231,10 +232,13 @@ class AppleXliffExporter(
     languageTag: String,
     conversionResult: PossiblePluralConversionResult?,
   ): Map<String, String> {
-    if (conversionResult?.formsResult == null) {
-      return emptyMap()
-    }
-    return io.tolgee.formats.populateForms(languageTag, conversionResult.formsResult)
+    val forms = conversionResult?.formsResult ?: return emptyMap()
+    // Apple's plural formats (stringsdict/xcstrings) accept any form the user actually wrote
+    // (e.g. "zero"), not just the forms CLDR defines for the target locale, so we keep every
+    // authored form in addition to filling in the ones CLDR expects (e.g. "many" for cs).
+    val otherForm = forms["other"] ?: ""
+    val allForms = getPluralFormsForLocale(languageTag) + forms.keys
+    return allForms.associateWith { forms[it] ?: otherForm }
   }
 
   private fun getResultXliffFile(

--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/AppleXliffExporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/AppleXliffExporter.kt
@@ -5,6 +5,7 @@ import io.tolgee.formats.PossiblePluralConversionResult
 import io.tolgee.formats.apple.APPLE_CORRESPONDING_STRINGS_FILE_ORIGINAL
 import io.tolgee.formats.apple.APPLE_FILE_ORIGINAL_CUSTOM_KEY
 import io.tolgee.formats.apple.APPLE_PLURAL_PROPERTY_CUSTOM_KEY
+import io.tolgee.formats.formKeywords
 import io.tolgee.formats.getPluralFormsForLocale
 import io.tolgee.formats.xliff.model.XliffFile
 import io.tolgee.formats.xliff.model.XliffModel
@@ -233,12 +234,19 @@ class AppleXliffExporter(
     conversionResult: PossiblePluralConversionResult?,
   ): Map<String, String> {
     val forms = conversionResult?.formsResult ?: return emptyMap()
-    // Apple's plural formats (stringsdict/xcstrings) accept any form the user actually wrote
-    // (e.g. "zero"), not just the forms CLDR defines for the target locale, so we keep every
-    // authored form in addition to filling in the ones CLDR expects (e.g. "many" for cs).
     val otherForm = forms["other"] ?: ""
-    val allForms = getPluralFormsForLocale(languageTag) + forms.keys
-    return allForms.associateWith { forms[it] ?: otherForm }
+    // Apple's plural formats (stringsdict/xcstrings) take the CLDR forms for the locale plus any
+    // named category the user actually wrote (e.g. "zero" for en), but only the six named
+    // categories — Apple has no equivalent for ICU "=N" exact matches, so those are dropped.
+    val authoredNamedForms = forms.keys.filter { it in formKeywords }
+    val allForms = getPluralFormsForLocale(languageTag) + authoredNamedForms
+    val result = allForms.associateWithTo(mutableMapOf()) { forms[it] ?: otherForm }
+    // Apple can't express an "=0" exact match, so if the user wrote one and there is no explicit
+    // "zero", surface it as "zero" — the closest the format has.
+    if ("zero" !in result) {
+      forms["=0"]?.let { result["zero"] = it }
+    }
+    return result
   }
 
   private fun getResultXliffFile(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
@@ -309,6 +309,51 @@ class AppleXliffFileExporterTest {
   }
 
   @Test
+  fun `keeps a zero plural form that is not in the target locale's CLDR forms`() {
+    val built =
+      buildExportTranslationList {
+        add(
+          languageTag = "en",
+          keyName = "attendee_count",
+          text = "{count, plural, zero {No participants} one {1 Participant} other {Many participants}}",
+        ) {
+          key.isPlural = true
+          key.custom = mapOf(APPLE_FILE_ORIGINAL_CUSTOM_KEY to "Localizable.xcstrings")
+        }
+      }
+    val exporter = getExporter(built.translations, emptyList())
+    val data = getExported(exporter)
+    data.assertFile(
+      "en.xliff",
+      """
+    |<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+    |<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    |  <file datatype="plaintext" original="Localizable.xcstrings" source-language="tag" target-language="en">
+    |    <header>
+    |      <tool tool-id="tolgee.io" tool-name="Tolgee"/>
+    |    </header>
+    |    <body>
+    |      <trans-unit id="attendee_count|==|plural.one">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">1 Participant</target>
+    |      </trans-unit>
+    |      <trans-unit id="attendee_count|==|plural.other">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">Many participants</target>
+    |      </trans-unit>
+    |      <trans-unit id="attendee_count|==|plural.zero">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">No participants</target>
+    |      </trans-unit>
+    |    </body>
+    |  </file>
+    |</xliff>
+    |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
   fun `honors the provided fileStructureTemplate`() {
     val exporter =
       getExporter(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/AppleXliffFileExporterTest.kt
@@ -354,6 +354,51 @@ class AppleXliffFileExporterTest {
   }
 
   @Test
+  fun `folds an explicit =0 into the zero form Apple can express`() {
+    val built =
+      buildExportTranslationList {
+        add(
+          languageTag = "en",
+          keyName = "attendee_count",
+          text = "{count, plural, =0 {No participants} one {1 Participant} other {Many participants}}",
+        ) {
+          key.isPlural = true
+          key.custom = mapOf(APPLE_FILE_ORIGINAL_CUSTOM_KEY to "Localizable.xcstrings")
+        }
+      }
+    val exporter = getExporter(built.translations, emptyList())
+    val data = getExported(exporter)
+    data.assertFile(
+      "en.xliff",
+      """
+    |<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+    |<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    |  <file datatype="plaintext" original="Localizable.xcstrings" source-language="tag" target-language="en">
+    |    <header>
+    |      <tool tool-id="tolgee.io" tool-name="Tolgee"/>
+    |    </header>
+    |    <body>
+    |      <trans-unit id="attendee_count|==|plural.one">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">1 Participant</target>
+    |      </trans-unit>
+    |      <trans-unit id="attendee_count|==|plural.other">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">Many participants</target>
+    |      </trans-unit>
+    |      <trans-unit id="attendee_count|==|plural.zero">
+    |        <source xml:space="preserve"/>
+    |        <target xml:space="preserve">No participants</target>
+    |      </trans-unit>
+    |    </body>
+    |  </file>
+    |</xliff>
+    |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
   fun `honors the provided fileStructureTemplate`() {
     val exporter =
       getExporter(


### PR DESCRIPTION
## Problem

Apple XLIFF export drops any plural form that CLDR doesn't define for the target locale. English only has `one` and `other` in CLDR, so a key with a `zero` form (e.g. "No participants" / "1 Participant" / "%d Participants") gets exported without `plural.zero` at all. The string is just gone from the file.

`AppleXliffExporter.handlePlural` runs the converted forms through `populateForms`, which builds its output set from `getPluralFormsForLocale(languageTag)` only. Any form outside that set gets dropped instead of exported. This is locale-specific behavior, not something Apple's formats actually require: `AppleXcstringsExporter` (the `.xcstrings` exporter) skips this filtering entirely and just writes out whatever forms `formsResult` contains. That's why the reporter's `.xcstrings` workaround kept the zero case while XLIFF/stringsdict export lost it.

## Change

`AppleXliffExporter`'s `populateForms` now keeps every form that's actually present in the message, on top of the locale's CLDR forms (so `many` for Czech still gets filled in from `other` when the message doesn't specify it, same as before). This lines XLIFF export up with what the xcstrings exporter already does, so a `zero` form the user wrote makes it into the export regardless of whether the target locale's CLDR data includes it.

I left `io.tolgee.formats.populateForms` (used by the Android XML resources exporter) alone. Android's plural resources really are constrained to CLDR quantities, so filtering there is correct.

## Tests

Added a test to `AppleXliffFileExporterTest` with an English key carrying `zero`/`one`/`other` forms and checked all three trans-units, including `plural.zero`, show up in the exported XLIFF.

No JDK on this machine, so I couldn't run `./gradlew :data:test` locally. I traced the fix by hand against `PluralsFormUtilTest` (which already asserts `getPluralFormsForLocale("en")` returns only `one, other`) and against how `AppleXcstringsExporter` builds its output. Would appreciate CI confirming the new test passes.

Fixes #3074


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple XLIFF exports now include the plural forms required for each locale.
  * Explicit zero plural translations are preserved, including `=0` translations that are mapped to the zero category when appropriate.
  * Missing plural values fall back to the “other” translation to help prevent incomplete exports.

* **Tests**
  * Added coverage for English exports containing explicit zero and `=0` plural forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->