### PR TITLE
fix: keep session open for glossary highlight lazy loading

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/glossary/GlossaryTermService.kt
@@ -240,6 +240,7 @@ class GlossaryTermService(
     glossaryTermRepository.saveAll(terms)
   }
 
+  @Transactional
   fun getHighlights(
     organizationId: Long,
     projectId: Long,


### PR DESCRIPTION
## Problem

Sentry [TOLGEE-BACKEND-3RM](https://tolgee.sentry.io/issues/TOLGEE-BACKEND-3RM) — `LazyInitializationException: Unable to perform requested lazy initialization [io.tolgee.model.glossary.GlossaryTerm.flagCaseSensitive] - session is closed`. 2254 occurrences in production.

## Root cause

`GlossaryTermService.getHighlights` was not `@Transactional`. It:

1. Loads `GlossaryTermTranslation` entities via `glossaryTermTranslationService.findAll(...)`, which opens and closes its own short-lived session.
2. Then reads `translation.term.flagCaseSensitive` in `findTranslationPositions`.

`GlossaryTerm` is bytecode-enhanced for lazy loading, so reading `flagCaseSensitive` triggers a lazy DB read. On the QA check WebSocket path (`QaCheckPreviewWebSocketHandler.findGlossaryTerms` → `findQaGlossaryTerms`), the call runs in a coroutine with no surrounding transaction, so the session from step 1 is already closed → `LazyInitializationException`.

The exception is caught and reported to Sentry, so QA checks still run (without glossary terms) — degraded, not broken — but it floods Sentry.

The other caller, `getGlossaryTerms`, already wraps the same `getHighlights` call in `@Transactional`, which is why that path doesn't hit the bug.

## Fix

Annotate `getHighlights` with `@Transactional` so a single session spans both the translation query and the lazy `term.flagCaseSensitive` access.

Fixes TOLGEE-BACKEND-3RM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading glossary term highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->