### PR TITLE
chore: increase logging of the orphan project purge scheduler

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/DeletedOrganizationProjectPurgeScheduler.kt
@@ -39,7 +39,7 @@ class DeletedOrganizationProjectPurgeScheduler(
       return
     }
     schedulingManager.scheduleWithFixedDelay(::purge, PURGE_PERIOD)
-    logger.debug("Scheduled orphan project purge task with period: {}", PURGE_PERIOD)
+    logger.info("Scheduled orphan project purge task with period: {}", PURGE_PERIOD)
   }
 
   fun purge() {
@@ -51,6 +51,7 @@ class DeletedOrganizationProjectPurgeScheduler(
   }
 
   private fun purgeProjectsOfDeletedOrganizations() {
+    logger.info("Running orphan project purge")
     var totalPurged = 0
     do {
       val batch =
@@ -70,9 +71,7 @@ class DeletedOrganizationProjectPurgeScheduler(
       totalPurged += batch.numberOfElements
     } while (batch.hasNext())
 
-    if (totalPurged > 0) {
-      logger.info("Purged {} projects of deleted organizations", totalPurged)
-    }
+    logger.info("Orphan project purge finished, purged {} projects", totalPurged)
   }
 
   companion object {


### PR DESCRIPTION
Follow-up to #3783.

That PR added `DeletedOrganizationProjectPurgeScheduler`, but in production its scheduled run leaves no trace — the "scheduled" line is DEBUG and the purge count is only logged when it's greater than 0 — so we can't tell whether it ran and found nothing or didn't run at all.

This raises those log lines to INFO and always logs the run outcome (scheduled / running / finished with count), so the suspicious scheduled runner can be tracked in prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved visibility of the orphan project purge process with clearer status messages.
  - The purge now always logs when it starts and when it finishes, making progress easier to track.
  - Scheduled purge activity is now reported at a higher log level for better monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->