### PR TITLE
fix: recompute importable keys when import file namespace changes

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerManipulationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerManipulationTest.kt
@@ -1,6 +1,7 @@
 package io.tolgee.api.v2.controllers.v2ImportController
 
 import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.development.testDataBuilder.data.dataImport.ImportNamespaceSelectionTestData
 import io.tolgee.development.testDataBuilder.data.dataImport.ImportNamespacesTestData
 import io.tolgee.development.testDataBuilder.data.dataImport.ImportTestData
 import io.tolgee.fixtures.andAssertThatJson
@@ -150,6 +151,46 @@ class V2ImportControllerManipulationTest : ProjectAuthControllerTest("/v2/projec
           .find { it.name == "de" }!!
       importLanguage.translations
         .any { it.conflict != null }
+        .assert
+        .isEqualTo(false)
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it marks keys existing in selected namespace as importable when createNewKeys is disabled`() {
+    val testData = ImportNamespaceSelectionTestData()
+    testDataService.saveTestData(testData.root)
+    projectSupplier = { testData.project }
+    userAccount = testData.userAccount
+    val path = "import/result/files/${testData.flatFile.id}/select-namespace"
+    performProjectAuthPut(path, mapOf("namespace" to "web")).andIsOk
+
+    executeInNewTransaction {
+      val file =
+        importService.findFile(projectId = project.id, authorId = userAccount!!.id, testData.flatFile.id)!!
+      file.keys
+        .all { it.shouldBeImported }
+        .assert
+        .isEqualTo(true)
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it marks keys missing in selected namespace as not importable when createNewKeys is disabled`() {
+    val testData = ImportNamespaceSelectionTestData()
+    testDataService.saveTestData(testData.root)
+    projectSupplier = { testData.project }
+    userAccount = testData.userAccount
+    val path = "import/result/files/${testData.webFile.id}/select-namespace"
+    performProjectAuthPut(path, mapOf("namespace" to null)).andIsOk
+
+    executeInNewTransaction {
+      val file =
+        importService.findFile(projectId = project.id, authorId = userAccount!!.id, testData.webFile.id)!!
+      file.keys
+        .any { it.shouldBeImported }
         .assert
         .isEqualTo(false)
     }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportNamespaceSelectionTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/ImportNamespaceSelectionTestData.kt
@@ -1,0 +1,90 @@
+package io.tolgee.development.testDataBuilder.data.dataImport
+
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.model.Language
+import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
+import io.tolgee.model.dataImport.ImportFile
+import io.tolgee.model.enums.ProjectPermissionType
+
+class ImportNamespaceSelectionTestData {
+  lateinit var project: Project
+  var userAccount: UserAccount
+  lateinit var german: Language
+  lateinit var flatFile: ImportFile
+  lateinit var webFile: ImportFile
+
+  val root: TestDataBuilder =
+    TestDataBuilder().apply {
+      userAccount =
+        addUserAccount {
+          username = "franta"
+          name = "Frantisek Dobrota"
+        }.self
+      addProject {
+        name = "test"
+        useNamespaces = true
+        project = this
+      }.build project@{
+        addPermission {
+          project = this@project.self
+          user = this@ImportNamespaceSelectionTestData.userAccount
+          type = ProjectPermissionType.MANAGE
+        }
+        addEnglish()
+        german = addGerman().self
+        addKey {
+          name = "existing key"
+        }.setNamespace("web")
+        setImportSettings {
+          userAccount = this@ImportNamespaceSelectionTestData.userAccount
+          createNewKeys = false
+        }
+        addImport {
+          author = userAccount
+        }.build {
+          addImportFile {
+            name = "flat.xlsx"
+            flatFile = this
+          }.build {
+            val importGerman =
+              addImportLanguage {
+                name = "de"
+                existingLanguage = german
+              }.self
+            addImportKey {
+              name = "existing key"
+              shouldBeImported = false
+            }.build key@{
+              addImportTranslation {
+                text = "Hallo"
+                language = importGerman
+                key = this@key.self
+              }
+            }
+          }
+          addImportFile {
+            name = "web.xlsx"
+            namespace = "web"
+            webFile = this
+          }.build {
+            val importGerman =
+              addImportLanguage {
+                name = "de"
+                existingLanguage = german
+              }.self
+            addImportKey {
+              name = "existing key"
+              shouldBeImported = true
+            }.build key@{
+              addImportTranslation {
+                text = "Hallo"
+                language = importGerman
+                key = this@key.self
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
@@ -197,6 +197,8 @@ class ImportService(
     val dataManager = ImportDataManager(applicationContext, import)
     file.namespace = getSafeNamespace(namespace)
     importFileRepository.save(file)
+    val settings = importSettingsService.get(import.author, projectId)
+    dataManager.applyKeyCreateChange(settings.createNewKeys)
     file.languages.forEach {
       dataManager.resetLanguage(it)
       dataManager.resetCollisionsBetweenFiles(it, null)


### PR DESCRIPTION
## Problem

Reported by a customer: when importing a file to add translations to **existing keys** with "Create new keys" unchecked, the translation count in the import dialog doesn't register the translations. Checking "Create new keys" updates the count, and unchecking it again keeps the value — making the checkbox look required even when no new keys are wanted.

## Cause

The import result's translation count only includes translations whose key has `shouldBeImported = true`. That flag is computed at upload time against the file's detected namespace. When the user then selects a different namespace in the import dialog, `ImportService.selectNamespace` saved the namespace and reset conflicts, but never recomputed `shouldBeImported` — so keys that exist in the newly selected namespace stayed excluded (and vice versa). The only code path recomputing the flag was the `createNewKeys` settings change, which explains the checkbox-toggle "workaround" the customer discovered.

## Fix

`selectNamespace` now recomputes `shouldBeImported` for the import's keys against the stored `createNewKeys` setting (same recompute as the settings change), right after the namespace is saved.

## Tests

Two new application tests in `V2ImportControllerManipulationTest` with a new `ImportNamespaceSelectionTestData`, covering both directions with `createNewKeys` disabled:
- selecting a namespace where the keys exist marks them importable
- selecting a namespace where they don't exist marks them not importable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import namespace selection so keys are marked as importable or not importable based on the selected namespace and current import settings.
  * When new keys are not allowed, files in the chosen namespace now correctly reflect which entries can be imported, including cases with no namespace selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->