### PR TITLE
fix: don't fail whole machine translation job on unparseable LLM response

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtTranslatePartialFailureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/batch/BatchMtTranslatePartialFailureTest.kt
@@ -1,0 +1,163 @@
+package io.tolgee.api.v2.controllers.batch
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.component.machineTranslation.MtValueProvider
+import io.tolgee.component.machineTranslation.providers.GoogleTranslationProvider
+import io.tolgee.component.machineTranslation.providers.ProviderTranslateParams
+import io.tolgee.config.BatchJobBaseConfiguration
+import io.tolgee.constants.Message
+import io.tolgee.exceptions.LlmProviderNotReturnedJsonException
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.waitForNotThrowing
+import io.tolgee.model.batch.BatchJob
+import io.tolgee.model.batch.BatchJobChunkExecution
+import io.tolgee.model.batch.BatchJobChunkExecutionStatus
+import io.tolgee.model.batch.BatchJobStatus
+import io.tolgee.model.translation.Translation
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+
+@Import(BatchJobBaseConfiguration::class)
+class BatchMtTranslatePartialFailureTest : ProjectAuthControllerTest("/v2/projects/") {
+  companion object {
+    private const val FAILING_KEY_NAME = "key2"
+  }
+
+  @Autowired
+  lateinit var batchJobTestBase: BatchJobTestBase
+
+  @Autowired
+  @MockitoSpyBean
+  lateinit var googleTranslationProvider: GoogleTranslationProvider
+
+  val testData
+    get() = batchJobTestBase.testData
+
+  @BeforeEach
+  fun setup() {
+    batchJobTestBase.setup()
+    whenever(internalProperties.fakeMtProviders).thenReturn(false)
+    doAnswer { invocation ->
+      val params = invocation.arguments[0] as ProviderTranslateParams
+      if (params.keyName == FAILING_KEY_NAME) {
+        throw LlmProviderNotReturnedJsonException()
+      }
+      MtValueProvider.MtResult(
+        translated =
+          "${params.text} translated with GOOGLE " +
+            "from ${params.sourceLanguageTag} to ${params.targetLanguageTag}",
+        price = 100,
+      )
+    }.whenever(googleTranslationProvider).translate(any())
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `keeps translations of other keys when llm response is unparseable for one key`() {
+    val keys = testData.addTranslationOperationData(12)
+    batchJobTestBase.saveAndPrepare(this)
+    val keyIds = keys.map { it.id }
+
+    performProjectAuthPost(
+      "start-batch-job/machine-translate",
+      mapOf(
+        "keyIds" to keyIds,
+        "targetLanguageIds" to
+          listOf(
+            testData.projectBuilder
+              .getLanguageByTag("cs")!!
+              .self.id,
+          ),
+      ),
+    ).andIsOk
+
+    waitForJobFailed()
+
+    assertOnlyFailingKeyNotTranslated(keys.map { it.name })
+    assertFailedChunkStoredSuccessfulTargetsAndOtherChunksSucceeded()
+    assertNoKeyTranslatedTwice()
+  }
+
+  private fun waitForJobFailed() {
+    waitForNotThrowing(pollTime = 500, timeout = 30000) {
+      getSingleJob().status.assert.isEqualTo(BatchJobStatus.FAILED)
+    }
+  }
+
+  private fun assertOnlyFailingKeyNotTranslated(allKeyNames: List<String>) {
+    executeInNewTransaction {
+      val translations =
+        entityManager
+          .createQuery(
+            """from Translation t where t.key.name in :keyNames and t.language.tag = 'cs'""",
+            Translation::class.java,
+          ).setParameter("keyNames", allKeyNames)
+          .resultList
+
+      val translated = translations.filter { !it.text.isNullOrEmpty() }
+      translated.map { it.key.name }.assert.containsExactlyInAnyOrderElementsOf(allKeyNames - FAILING_KEY_NAME)
+      translated.forEach {
+        it.text.assert.contains("translated with GOOGLE from en to cs")
+      }
+    }
+  }
+
+  private fun assertFailedChunkStoredSuccessfulTargetsAndOtherChunksSucceeded() {
+    executeInNewTransaction {
+      val executions =
+        entityManager
+          .createQuery(
+            """from BatchJobChunkExecution e where e.batchJob.id = :jobId""",
+            BatchJobChunkExecution::class.java,
+          ).setParameter("jobId", getSingleJob().id)
+          .resultList
+
+      val failed = executions.filter { it.status == BatchJobChunkExecutionStatus.FAILED }
+      failed.assert.hasSize(1)
+      failed
+        .single()
+        .errorMessage.assert
+        .isEqualTo(Message.LLM_PROVIDER_NOT_RETURNED_JSON)
+      failed
+        .single()
+        .retry.assert
+        .isFalse()
+      // the 4 other items of the failing chunk were translated and stored
+      failed
+        .single()
+        .successTargets.assert
+        .hasSize(4)
+
+      executions.count { it.status == BatchJobChunkExecutionStatus.SUCCESS }.assert.isEqualTo(2)
+    }
+  }
+
+  private fun assertNoKeyTranslatedTwice() {
+    verify(googleTranslationProvider, times(1)).translate(argThat { keyName == FAILING_KEY_NAME })
+    verify(googleTranslationProvider, times(12)).translate(any())
+  }
+
+  private fun getSingleJob(): BatchJob =
+    executeInNewTransaction {
+      entityManager
+        .createQuery("""from BatchJob""", BatchJob::class.java)
+        .singleResult
+    }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
@@ -38,9 +38,15 @@ class MtProviderCatching(
       } catch (e: LlmContentFilterException) {
         throw FailedDontRequeueException(Message.LLM_CONTENT_FILTER, successfulTargets, e)
       } catch (e: LlmEmptyResponseException) {
-        throw FailedDontRequeueException(Message.LLM_PROVIDER_EMPTY_RESPONSE, successfulTargets, e)
+        // maxRetries = 0: malformed responses are consistent for the same input, retrying doesn't
+        // help — but the remaining items of the chunk must still be processed
+        exceptions.add(
+          RequeueWithDelayException(Message.LLM_PROVIDER_EMPTY_RESPONSE, successfulTargets, e, maxRetries = 0),
+        )
       } catch (e: LlmProviderNotReturnedJsonException) {
-        throw FailedDontRequeueException(Message.LLM_PROVIDER_NOT_RETURNED_JSON, successfulTargets, e)
+        exceptions.add(
+          RequeueWithDelayException(Message.LLM_PROVIDER_NOT_RETURNED_JSON, successfulTargets, e, maxRetries = 0),
+        )
       } catch (e: LlmRateLimitedException) {
         exceptions.add(
           RequeueWithDelayException(

--- a/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/machineTranslation/MtService.kt
@@ -8,7 +8,13 @@ import org.springframework.transaction.annotation.Transactional
 class MtService(
   private val applicationContext: ApplicationContext,
 ) {
-  @Transactional
+  /**
+   * noRollbackFor: batch chunk processing catches provider exceptions and commits the chunk
+   * transaction with the successfully translated items. Without it, an exception passing
+   * through this boundary marks the shared transaction rollback-only, and the whole chunk
+   * (including already translated items) gets rolled back to the savepoint.
+   */
+  @Transactional(noRollbackFor = [Exception::class])
   fun getMachineTranslations(
     projectId: Long,
     isBatch: Boolean,
@@ -19,7 +25,7 @@ class MtService(
     return getMachineTranslations(projectId, isBatch, params)
   }
 
-  @Transactional
+  @Transactional(noRollbackFor = [Exception::class])
   fun getMachineTranslations(
     projectId: Long,
     isBatch: Boolean,

--- a/backend/data/src/test/kotlin/io/tolgee/batch/MtProviderCatchingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/batch/MtProviderCatchingTest.kt
@@ -1,0 +1,96 @@
+package io.tolgee.batch
+
+import io.tolgee.batch.data.BatchTranslationTargetItem
+import io.tolgee.constants.Message
+import io.tolgee.exceptions.LlmEmptyResponseException
+import io.tolgee.exceptions.LlmProviderNotReturnedJsonException
+import io.tolgee.exceptions.OutOfCreditsException
+import io.tolgee.testing.assert
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import kotlin.coroutines.EmptyCoroutineContext
+
+class MtProviderCatchingTest {
+  private val mtProviderCatching = MtProviderCatching(currentDateProvider = mock())
+
+  private val chunk = (1L..3L).map { BatchTranslationTargetItem(keyId = it, languageId = 1L) }
+
+  @Test
+  fun `continues with other items when llm does not return json and does not retry the failed one`() {
+    val processed = mutableListOf<BatchTranslationTargetItem>()
+
+    val thrown =
+      catchThrowable {
+        mtProviderCatching.iterateCatching(chunk, EmptyCoroutineContext) { item ->
+          processed.add(item)
+          if (item.keyId == 2L) throw LlmProviderNotReturnedJsonException()
+        }
+      }
+
+    processed.assert.isEqualTo(chunk)
+    thrown.assert.isInstanceOf(RequeueWithDelayException::class.java)
+    thrown as RequeueWithDelayException
+    thrown.tolgeeMessage.assert.isEqualTo(Message.LLM_PROVIDER_NOT_RETURNED_JSON)
+    thrown.successfulTargets.assert.containsExactly(chunk[0], chunk[2])
+    thrown.maxRetries.assert.isEqualTo(0)
+  }
+
+  @Test
+  fun `continues with other items when llm returns empty response and does not retry the failed one`() {
+    val processed = mutableListOf<BatchTranslationTargetItem>()
+
+    val thrown =
+      catchThrowable {
+        mtProviderCatching.iterateCatching(chunk, EmptyCoroutineContext) { item ->
+          processed.add(item)
+          if (item.keyId == 2L) throw LlmEmptyResponseException()
+        }
+      }
+
+    processed.assert.isEqualTo(chunk)
+    thrown.assert.isInstanceOf(RequeueWithDelayException::class.java)
+    thrown as RequeueWithDelayException
+    thrown.tolgeeMessage.assert.isEqualTo(Message.LLM_PROVIDER_EMPTY_RESPONSE)
+    thrown.successfulTargets.assert.containsExactly(chunk[0], chunk[2])
+    thrown.maxRetries.assert.isEqualTo(0)
+  }
+
+  @Test
+  fun `aggregates multiple llm response failures and processes all items`() {
+    val processed = mutableListOf<BatchTranslationTargetItem>()
+
+    val thrown =
+      catchThrowable {
+        mtProviderCatching.iterateCatching(chunk, EmptyCoroutineContext) { item ->
+          processed.add(item)
+          if (item.keyId == 1L) throw LlmProviderNotReturnedJsonException()
+          if (item.keyId == 2L) throw LlmEmptyResponseException()
+        }
+      }
+
+    processed.assert.isEqualTo(chunk)
+    thrown.assert.isInstanceOf(MultipleItemsFailedException::class.java)
+    thrown as MultipleItemsFailedException
+    thrown.exceptions.assert.hasSize(2)
+    thrown.successfulTargets.assert.containsExactly(chunk[2])
+  }
+
+  @Test
+  fun `stops iteration and does not requeue when out of credits`() {
+    val processed = mutableListOf<BatchTranslationTargetItem>()
+
+    val thrown =
+      catchThrowable {
+        mtProviderCatching.iterateCatching(chunk, EmptyCoroutineContext) { item ->
+          processed.add(item)
+          if (item.keyId == 2L) throw OutOfCreditsException(OutOfCreditsException.Reason.OUT_OF_CREDITS)
+        }
+      }
+
+    processed.assert.isEqualTo(chunk.take(2))
+    thrown.assert.isInstanceOf(FailedDontRequeueException::class.java)
+    thrown as FailedDontRequeueException
+    thrown.successfulTargets.assert.containsExactly(chunk[0])
+  }
+}


### PR DESCRIPTION
## The problem

When the LLM returned a response without valid JSON for a single key during a batch machine translation, the whole job died with nothing saved:

1. `LlmProviderNotReturnedJsonException` was classified as `FailedDontRequeueException`, which stops iterating the chunk at the failing key.
2. Worse, the exception propagates through the `@Transactional` boundary of `MtService.getMachineTranslations`, marking the chunk transaction rollback-only. `BatchJobActionService` then rolls back to the savepoint and wipes `successTargets` — so even the items that were successfully translated (and paid for) before the failure were discarded. This partial-success persistence has been broken since #2092 introduced `@Transactional` on that method (the batch machinery was designed to store successful targets in #1793 and did so correctly before that).

## The fix

- **`MtProviderCatching`**: collect `LlmProviderNotReturnedJsonException` / `LlmEmptyResponseException` per item instead of failing fast, so the remaining items of the chunk (and the other chunks) still get translated. `maxRetries = 0` because these failures are consistent for the same input — retrying doesn't help, it just costs money and delays the failure.
- **`MtService.getMachineTranslations`**: `noRollbackFor = [Exception::class]`, so a provider failure caught by the batch chunk processing no longer poisons the shared transaction. Successful items and their `successTargets` commit; the job still ends as FAILED with the proper error message. This also restores partial-success persistence for all other MT failure types (rate limits, generic errors) and makes the pre-existing `noRollbackFor = [OutOfCreditsException]` in `MtCreditBucketService` effective again.

## Tests

- `MtProviderCatchingTest` (unit): iteration continues past LLM response failures, aggregation of multiple failures, out-of-credits still fails fast.
- `BatchMtTranslatePartialFailureTest` (integration): 12 keys, provider consistently fails with not-returned-JSON for one key → job FAILED with `LLM_PROVIDER_NOT_RETURNED_JSON`, the other 11 keys' translations are persisted, the failed execution stores its successful targets, sibling chunks succeed, each key hit the provider exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch machine translation now continues processing other items when one translation response is invalid or empty, instead of failing the whole chunk.
  * Successful translations are now saved even if one item in the batch fails.
  * Failed items are marked clearly, with retry behavior adjusted to avoid unnecessary reprocessing.
* **Tests**
  * Added coverage for partial batch failures, aggregated item failures, and out-of-credits handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->