### PR TITLE
fix: purge trashed keys that have translation suggestions

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
@@ -2,18 +2,27 @@ package io.tolgee.service
 
 import io.tolgee.AbstractSpringTest
 import io.tolgee.development.testDataBuilder.data.BaseTestData
+import io.tolgee.service.key.KeyService
 import io.tolgee.service.key.KeyTrashPurgeScheduler
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import java.time.Duration
 import java.util.Date
 
 class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
   @Autowired
   lateinit var keyTrashPurgeScheduler: KeyTrashPurgeScheduler
+
+  @MockitoSpyBean
+  @Autowired
+  lateinit var keyServiceSpy: KeyService
 
   lateinit var testData: BaseTestData
 
@@ -116,6 +125,43 @@ class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
         .findOptional(keyId)
         .isPresent.assert
         .isFalse()
+    }
+  }
+
+  @Test
+  fun `keeps purging when one key cannot be hard-deleted`() {
+    val goodKeyId =
+      testData.projectBuilder.data.keys[0]
+        .self.id
+    val poisonKeyId =
+      testData.projectBuilder.data.keys[1]
+        .self.id
+
+    executeInNewTransaction {
+      keyService.softDeleteMultiple(listOf(goodKeyId, poisonKeyId), deletedBy = testData.user)
+    }
+
+    doAnswer { invocation ->
+      val ids = invocation.getArgument<Collection<Long>>(0)
+      if (poisonKeyId in ids) throw RuntimeException("cannot delete key $poisonKeyId")
+      invocation.callRealMethod()
+    }.whenever(keyServiceSpy).hardDeleteMultiple(any())
+
+    moveCurrentDate(Duration.ofDays(8))
+
+    keyTrashPurgeScheduler.purge()
+
+    executeInNewTransaction {
+      // The healthy key is purged despite sharing the failing batch.
+      keyService
+        .findOptional(goodKeyId)
+        .isPresent.assert
+        .isFalse()
+      // The un-deletable key survives and will be retried on the next run.
+      keyService
+        .findOptional(poisonKeyId)
+        .isPresent.assert
+        .isTrue()
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
@@ -125,7 +125,18 @@ class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
         .findOptional(keyId)
         .isPresent.assert
         .isFalse()
+      countSuggestionsForKey(keyId).assert.isEqualTo(0L)
     }
+  }
+
+  private fun countSuggestionsForKey(keyId: Long): Long {
+    return entityManager
+      .createQuery(
+        "select count(ts) from TranslationSuggestion ts where ts.key.id = :keyId",
+        java.lang.Long::class.java,
+      ).setParameter("keyId", keyId)
+      .singleResult
+      .toLong()
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
@@ -41,6 +41,17 @@ class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
               text = "Key 3"
             }
           }
+          addKey { name = "keyWithSuggestion" }.build {
+            addTranslation {
+              language = englishLanguage
+              text = "Key with suggestion"
+            }
+            addSuggestion {
+              language = englishLanguage
+              author = user
+              translation = "Suggested translation"
+            }
+          }
         }
       }
     executeInNewTransaction {
@@ -81,6 +92,28 @@ class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
         .isFalse()
       keyService
         .findOptional(key2Id)
+        .isPresent.assert
+        .isFalse()
+    }
+  }
+
+  @Test
+  fun `purges keys that have translation suggestions`() {
+    val keyId =
+      testData.projectBuilder.data.keys[3]
+        .self.id
+
+    executeInNewTransaction {
+      keyService.softDeleteMultiple(listOf(keyId), deletedBy = testData.user)
+    }
+
+    moveCurrentDate(Duration.ofDays(8))
+
+    keyTrashPurgeScheduler.purge()
+
+    executeInNewTransaction {
+      keyService
+        .findOptional(keyId)
         .isPresent.assert
         .isFalse()
     }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/KeyRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/KeyRepository.kt
@@ -555,11 +555,16 @@ interface KeyRepository : JpaRepository<Key, Long> {
     pageable: Pageable,
   ): Page<KeySearchResultView>
 
-  @Query("select k.id from Key k where k.deletedAt is not null and k.deletedAt < :before order by k.id")
+  @Query(
+    "select k.id from Key k " +
+      "where k.deletedAt is not null and k.deletedAt < :before and k.id > :afterId " +
+      "order by k.id",
+  )
   fun findSoftDeletedIdsBefore(
     before: Date,
+    afterId: Long,
     pageable: Pageable,
-  ): Page<Long>
+  ): List<Long>
 
   @Query(
     """

--- a/backend/data/src/main/kotlin/io/tolgee/repository/KeyRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/KeyRepository.kt
@@ -557,11 +557,11 @@ interface KeyRepository : JpaRepository<Key, Long> {
 
   @Query(
     "select k.id from Key k " +
-      "where k.deletedAt is not null and k.deletedAt < :before and k.id > :afterId " +
+      "where k.deletedAt is not null and k.deletedAt < :deletedBefore and k.id > :afterId " +
       "order by k.id",
   )
-  fun findSoftDeletedIdsBefore(
-    before: Date,
+  fun findSoftDeletedIdsDeletedBeforeAndIdAfter(
+    deletedBefore: Date,
     afterId: Long,
     pageable: Pageable,
   ): List<Long>

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -483,12 +483,12 @@ class KeyService(
     return keyRepository.findSoftDeletedByProjectId(projectId, branch, pageable)
   }
 
-  fun findSoftDeletedIdsBefore(
-    before: Date,
+  fun findSoftDeletedIdsDeletedBeforeAndIdAfter(
+    deletedBefore: Date,
     afterId: Long,
     pageable: Pageable,
   ): List<Long> {
-    return keyRepository.findSoftDeletedIdsBefore(before, afterId, pageable)
+    return keyRepository.findSoftDeletedIdsDeletedBeforeAndIdAfter(deletedBefore, afterId, pageable)
   }
 
   fun findSoftDeletedByIdsAndProjectId(

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -485,9 +485,10 @@ class KeyService(
 
   fun findSoftDeletedIdsBefore(
     before: Date,
+    afterId: Long,
     pageable: Pageable,
-  ): Page<Long> {
-    return keyRepository.findSoftDeletedIdsBefore(before, pageable)
+  ): List<Long> {
+    return keyRepository.findSoftDeletedIdsBefore(before, afterId, pageable)
   }
 
   fun findSoftDeletedByIdsAndProjectId(

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -34,6 +34,7 @@ import io.tolgee.service.key.utils.KeyInfoProvider
 import io.tolgee.service.key.utils.KeysImporter
 import io.tolgee.service.security.SecurityService
 import io.tolgee.service.translation.TranslationService
+import io.tolgee.service.translation.TranslationSuggestionService
 import io.tolgee.service.translation.applyMaxCharLimit
 import io.tolgee.service.translation.validateCharLimit
 import io.tolgee.util.Logging
@@ -75,6 +76,8 @@ class KeyService(
   private val branchMergeService: BranchMergeService,
   private val currentDateProvider: CurrentDateProvider,
   private val authenticationFacade: AuthenticationFacade,
+  @Lazy
+  private val translationSuggestionService: TranslationSuggestionService,
 ) : Logging {
   fun getAll(projectId: Long): Set<Key> {
     return keyRepository.getAllByProjectId(projectId)
@@ -356,6 +359,7 @@ class KeyService(
     screenshotService.deleteAllByKeyId(id)
     taskKeyRepository.deleteAllByKeyIdIn(listOf(id))
     branchMergeService.deleteChangesByKeyIds(listOf(id))
+    translationSuggestionService.deleteAllByKeyIds(listOf(id))
     // Flush and clear the persistence context to ensure deletions are synchronized
     // and to prevent Hibernate 6.6's CHECK_ON_FLUSH from seeing stale relationships
     entityManager.flush()
@@ -449,6 +453,8 @@ class KeyService(
     }
 
     branchMergeService.deleteChangesByKeyIds(ids)
+
+    translationSuggestionService.deleteAllByKeyIds(ids)
 
     // Flush and clear the persistence context to ensure deletions are synchronized
     // and to prevent Hibernate 6.6's CHECK_ON_FLUSH from seeing stale relationships

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.key
 
+import io.sentry.Sentry
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.LockingProvider
 import io.tolgee.component.SchedulingManager
@@ -39,25 +40,53 @@ class KeyTrashPurgeScheduler(
 
   private fun purgeExpiredKeys() {
     val cutoffDate = currentDateProvider.date.addDays(-RETENTION_DAYS)
+    var afterId = 0L
     var totalPurged = 0
 
-    do {
+    while (true) {
       val batch =
         executeInNewTransaction(transactionManager) {
-          keyService.findSoftDeletedIdsBefore(cutoffDate, PageRequest.of(0, BATCH_SIZE))
+          keyService.findSoftDeletedIdsBefore(cutoffDate, afterId, PageRequest.of(0, BATCH_SIZE))
         }
 
-      if (batch.isEmpty) break
+      if (batch.isEmpty()) break
+      // Advance past every key we attempted, deleted or not, so an un-deletable key can't
+      // wedge the run: it is skipped for the rest of this pass and retried on the next one.
+      afterId = batch.last()
 
-      executeInNewTransaction(transactionManager) {
-        keyService.hardDeleteMultiple(batch.content)
-      }
-      totalPurged += batch.numberOfElements
-      logger.info("Purged {} expired trashed keys", batch.numberOfElements)
-    } while (batch.hasNext())
+      totalPurged += purgeBatch(batch)
+
+      if (batch.size < BATCH_SIZE) break
+    }
 
     if (totalPurged > 0) {
       logger.info("Total purged {} expired trashed keys older than {}", totalPurged, cutoffDate)
+    }
+  }
+
+  private fun purgeBatch(ids: List<Long>): Int {
+    if (tryPurge(ids)) {
+      logger.info("Purged {} expired trashed keys", ids.size)
+      return ids.size
+    }
+    // A single key failing the batch delete (e.g. a dangling FK) rolls back the whole
+    // transaction, so retry each key on its own to salvage the rest of the batch.
+    logger.warn("Batch purge of {} trashed keys failed, retrying individually", ids.size)
+    return ids.count { id -> tryPurge(listOf(id)) }
+  }
+
+  private fun tryPurge(ids: List<Long>): Boolean {
+    try {
+      executeInNewTransaction(transactionManager) {
+        keyService.hardDeleteMultiple(ids)
+      }
+      return true
+    } catch (e: Exception) {
+      if (ids.size == 1) {
+        logger.error("Failed to purge trashed key {}", ids.single(), e)
+        Sentry.captureException(e)
+      }
+      return false
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
@@ -46,7 +46,7 @@ class KeyTrashPurgeScheduler(
     while (true) {
       val batch =
         executeInNewTransaction(transactionManager) {
-          keyService.findSoftDeletedIdsBefore(cutoffDate, afterId, PageRequest.of(0, BATCH_SIZE))
+          keyService.findSoftDeletedIdsDeletedBeforeAndIdAfter(cutoffDate, afterId, PageRequest.of(0, BATCH_SIZE))
         }
 
       if (batch.isEmpty()) break

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyTrashPurgeScheduler.kt
@@ -65,27 +65,27 @@ class KeyTrashPurgeScheduler(
   }
 
   private fun purgeBatch(ids: List<Long>): Int {
-    if (tryPurge(ids)) {
-      logger.info("Purged {} expired trashed keys", ids.size)
-      return ids.size
-    }
-    // A single key failing the batch delete (e.g. a dangling FK) rolls back the whole
-    // transaction, so retry each key on its own to salvage the rest of the batch.
-    logger.warn("Batch purge of {} trashed keys failed, retrying individually", ids.size)
-    return ids.count { id -> tryPurge(listOf(id)) }
-  }
-
-  private fun tryPurge(ids: List<Long>): Boolean {
     try {
       executeInNewTransaction(transactionManager) {
         keyService.hardDeleteMultiple(ids)
       }
+      logger.info("Purged {} expired trashed keys", ids.size)
+      return ids.size
+    } catch (e: Exception) {
+      logger.warn("Batch purge of {} trashed keys failed, retrying individually", ids.size, e)
+    }
+    return ids.count { purgeSingle(it) }
+  }
+
+  private fun purgeSingle(id: Long): Boolean {
+    try {
+      executeInNewTransaction(transactionManager) {
+        keyService.hardDeleteMultiple(listOf(id))
+      }
       return true
     } catch (e: Exception) {
-      if (ids.size == 1) {
-        logger.error("Failed to purge trashed key {}", ids.single(), e)
-        Sentry.captureException(e)
-      }
+      logger.error("Failed to purge trashed key {}", id, e)
+      Sentry.captureException(e)
       return false
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionService.kt
@@ -12,4 +12,6 @@ interface TranslationSuggestionService {
   fun deleteAllByLanguage(id: Long)
 
   fun deleteAllByProject(id: Long)
+
+  fun deleteAllByKeyIds(keyIds: Collection<Long>)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionServiceOssImpl.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionServiceOssImpl.kt
@@ -20,4 +20,8 @@ class TranslationSuggestionServiceOssImpl : TranslationSuggestionService {
   override fun deleteAllByProject(id: Long) {
     // doing nothing
   }
+
+  override fun deleteAllByKeyIds(keyIds: Collection<Long>) {
+    // doing nothing
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionServiceOssImpl.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationSuggestionServiceOssImpl.kt
@@ -1,10 +1,14 @@
 package io.tolgee.service.translation
 
 import io.tolgee.model.views.TranslationSuggestionView
+import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 
 @Component
-class TranslationSuggestionServiceOssImpl : TranslationSuggestionService {
+open class TranslationSuggestionServiceOssImpl(
+  protected val entityManager: EntityManager,
+) : TranslationSuggestionService {
   override fun getKeysWithSuggestions(
     projectId: Long,
     keyIds: List<Long>,
@@ -13,15 +17,34 @@ class TranslationSuggestionServiceOssImpl : TranslationSuggestionService {
     return mutableMapOf()
   }
 
+  @Transactional
   override fun deleteAllByLanguage(id: Long) {
-    // doing nothing
+    entityManager
+      .createQuery("delete from TranslationSuggestion ts where ts.language.id = :id")
+      .setParameter("id", id)
+      .executeUpdate()
   }
 
+  @Transactional
   override fun deleteAllByProject(id: Long) {
-    // doing nothing
+    entityManager
+      .createQuery("delete from TranslationSuggestion ts where ts.project.id = :id")
+      .setParameter("id", id)
+      .executeUpdate()
   }
 
+  @Transactional
   override fun deleteAllByKeyIds(keyIds: Collection<Long>) {
-    // doing nothing
+    keyIds.chunked(IN_CLAUSE_BATCH_SIZE).forEach { chunk ->
+      entityManager
+        .createQuery("delete from TranslationSuggestion ts where ts.key.id in :keyIds")
+        .setParameter("keyIds", chunk)
+        .executeUpdate()
+    }
+  }
+
+  companion object {
+    // Keep the "in :keyIds" bind list well under PostgreSQL's 65535 prepared-statement parameter limit.
+    private const val IN_CLAUSE_BATCH_SIZE = 30_000
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
@@ -117,28 +117,4 @@ interface TranslationSuggestionRepository : JpaRepository<TranslationSuggestion,
     translation: String,
     isPlural: Boolean,
   ): List<TranslationSuggestion>
-
-  @Query(
-    """
-      from TranslationSuggestion ts
-      where ts.language.id = :id
-    """,
-  )
-  fun getAllByLanguage(id: Long): List<TranslationSuggestion>
-
-  @Query(
-    """
-      from TranslationSuggestion ts
-      where ts.project.id = :id
-    """,
-  )
-  fun getAllByProject(id: Long): List<TranslationSuggestion>
-
-  @Query(
-    """
-      from TranslationSuggestion ts
-      where ts.key.id in :keyIds
-    """,
-  )
-  fun getAllByKeyIds(keyIds: Collection<Long>): List<TranslationSuggestion>
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TranslationSuggestionRepository.kt
@@ -133,4 +133,12 @@ interface TranslationSuggestionRepository : JpaRepository<TranslationSuggestion,
     """,
   )
   fun getAllByProject(id: Long): List<TranslationSuggestion>
+
+  @Query(
+    """
+      from TranslationSuggestion ts
+      where ts.key.id in :keyIds
+    """,
+  )
+  fun getAllByKeyIds(keyIds: Collection<Long>): List<TranslationSuggestion>
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
@@ -232,9 +232,21 @@ class TranslationSuggestionServiceEeImpl(
     translationSuggestionRepository.deleteAll(suggestions)
   }
 
+  override fun deleteAllByKeyIds(keyIds: Collection<Long>) {
+    keyIds.chunked(IN_CLAUSE_BATCH_SIZE).forEach { chunk ->
+      val suggestions = translationSuggestionRepository.getAllByKeyIds(chunk)
+      translationSuggestionRepository.deleteAll(suggestions)
+    }
+  }
+
   private fun checkSuggestionValid(text: String) {
     if (text.length > tolgeeProperties.maxTranslationTextLength) {
       throw BadRequestException(Message.TRANSLATION_TEXT_TOO_LONG, listOf(tolgeeProperties.maxTranslationTextLength))
     }
+  }
+
+  companion object {
+    // Keep the "in :keyIds" bind list well under PostgreSQL's 65535 prepared-statement parameter limit.
+    private const val IN_CLAUSE_BATCH_SIZE = 30_000
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/TranslationSuggestionServiceEeImpl.kt
@@ -20,7 +20,7 @@ import io.tolgee.service.key.KeyService
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.translation.SetTranslationTextUtil
 import io.tolgee.service.translation.TranslationService
-import io.tolgee.service.translation.TranslationSuggestionService
+import io.tolgee.service.translation.TranslationSuggestionServiceOssImpl
 import jakarta.persistence.EntityManager
 import org.springframework.context.annotation.Primary
 import org.springframework.data.domain.Page
@@ -34,11 +34,11 @@ class TranslationSuggestionServiceEeImpl(
   private val translationSuggestionRepository: TranslationSuggestionRepository,
   private val keyService: KeyService,
   private val languageService: LanguageService,
-  private val entityManager: EntityManager,
+  entityManager: EntityManager,
   private val authenticationFacade: AuthenticationFacade,
   private val translationService: TranslationService,
   private val tolgeeProperties: TolgeeProperties,
-) : TranslationSuggestionService {
+) : TranslationSuggestionServiceOssImpl(entityManager) {
   override fun getKeysWithSuggestions(
     projectId: Long,
     keyIds: List<Long>,
@@ -222,31 +222,9 @@ class TranslationSuggestionServiceEeImpl(
     translationSuggestionRepository.delete(suggestion)
   }
 
-  override fun deleteAllByLanguage(id: Long) {
-    val suggestions = translationSuggestionRepository.getAllByLanguage(id)
-    translationSuggestionRepository.deleteAll(suggestions)
-  }
-
-  override fun deleteAllByProject(id: Long) {
-    val suggestions = translationSuggestionRepository.getAllByProject(id)
-    translationSuggestionRepository.deleteAll(suggestions)
-  }
-
-  override fun deleteAllByKeyIds(keyIds: Collection<Long>) {
-    keyIds.chunked(IN_CLAUSE_BATCH_SIZE).forEach { chunk ->
-      val suggestions = translationSuggestionRepository.getAllByKeyIds(chunk)
-      translationSuggestionRepository.deleteAll(suggestions)
-    }
-  }
-
   private fun checkSuggestionValid(text: String) {
     if (text.length > tolgeeProperties.maxTranslationTextLength) {
       throw BadRequestException(Message.TRANSLATION_TEXT_TOO_LONG, listOf(tolgeeProperties.maxTranslationTextLength))
     }
-  }
-
-  companion object {
-    // Keep the "in :keyIds" bind list well under PostgreSQL's 65535 prepared-statement parameter limit.
-    private const val IN_CLAUSE_BATCH_SIZE = 30_000
   }
 }


### PR DESCRIPTION
Trashed keys were never permanently deleted. This PR fixes two independent causes and hardens the purge against a recurrence.

## 1. Missing suggestion cleanup (the trigger)

`KeyService.hardDeleteMultiple` / `hardDelete` deleted every child entity of a key **except** `translation_suggestion`. `TranslationSuggestion` has a non-nullable `@ManyToOne key: Key` (FK `translation_suggestion.key_id → key.id`, no cascade), so `DELETE FROM key` fails with a foreign-key violation once a key has any suggestion.

Confirmed in production Sentry (`delete from key ... violates foreign key constraint ... on table "translation_suggestion"`), 3,000+ occurrences, firing hourly: [TOLGEE-BACKEND-3TV](https://tolgee.sentry.io/issues/TOLGEE-BACKEND-3TV) / [TOLGEE-BACKEND-3TW](https://tolgee.sentry.io/issues/TOLGEE-BACKEND-3TW).

**Fix:** delete a key's translation suggestions in the hard-delete path (single + multiple), following the existing `deleteAllByProject` / `deleteAllByLanguage` pattern (OSS no-op, EE does the real delete). The EE impl chunks the id list (`IN_CLAUSE_BATCH_SIZE = 30_000`) so the `in :keyIds` bind list stays under PostgreSQL's 65535 parameter limit.

## 2. Purge wedged by one bad key (the amplifier)

`KeyTrashPurgeScheduler` deleted a batch of 100 keys in a **single transaction** and always re-fetched **page 0** (`PageRequest.of(0, BATCH_SIZE)`, ordered by `k.id`). So one key that fails to delete aborted the entire batch transaction (swallowed by `runSentryCatching`), the batch never advanced, and the purge stayed permanently stuck on the same lowest-id keys — freezing even healthy keys that shared the batch.

**Fix:**
- Page forward with an **id cursor** (`k.id > :afterId`) so every pass makes progress and terminates.
- Fall back to **per-key deletion** when a batch delete fails, so one un-deletable key can no longer block the rest. Individual failures are reported to Sentry and retried on the next run.

## Tests

`KeyTrashPurgeSchedulerTest`:
- `purges keys that have translation suggestions` — fails before fix with the exact FK `DataIntegrityViolationException`, passes after.
- `keeps purging when one key cannot be hard-deleted` — spies `KeyService` to make one key throw and asserts the healthy key in the same batch is still purged while the bad key survives (proves fix).
- The 5 existing purge tests remain green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Permanently deleting trashed keys now also deletes any linked translation suggestion records.
  - Trash cleanup is more resilient: if a batch hard-delete partially fails, healthy keys are still purged and failed ones are left for a later retry.

- **Improved Reliability**
  - Updated trash purge to use cursor-based processing to ensure all eligible items are handled consistently.

- **Monitoring**
  - Trash purge deletion errors are now reported to Sentry for easier troubleshooting.

- **Tests**
  - Added coverage for keys with suggestions and retry behavior after batch purge failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
