### PR TITLE
fix: handle Sonnet 5 adaptive thinking (safe parse + send disabled)

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/AnthropicApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/AnthropicApiService.kt
@@ -36,6 +36,7 @@ class AnthropicApiService :
         messages = messages,
         model = config.model,
         max_tokens = config.maxTokens,
+        thinking = Thinking(type = "disabled"),
         output_config =
           if (params.shouldOutputJson && config.format == "json_schema") {
             OutputConfig(format = OutputFormat())
@@ -62,8 +63,7 @@ class AnthropicApiService :
     return PromptResult(
       response.body
         ?.content
-        ?.firstOrNull()
-        ?.text
+        ?.firstNotNullOfOrNull { it.text }
         ?: throw LlmEmptyResponseException(),
       usage =
         response.body?.usage?.let {
@@ -131,8 +131,13 @@ class AnthropicApiService :
       val stream: Boolean = false,
       val messages: List<RequestMessage>,
       val model: String?,
+      val thinking: Thinking,
       @JsonInclude(JsonInclude.Include.NON_NULL)
       val output_config: OutputConfig? = null,
+    )
+
+    class Thinking(
+      val type: String,
     )
 
     class OutputConfig(
@@ -177,7 +182,8 @@ class AnthropicApiService :
     )
 
     class ResponseMessage(
-      val text: String,
+      val type: String? = null,
+      val text: String? = null,
     )
 
     class ResponseUsage(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/AnthropicApiServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/AnthropicApiServiceTest.kt
@@ -118,6 +118,39 @@ class AnthropicApiServiceTest {
   }
 
   @Test
+  fun `always sends thinking type=disabled to avoid billed adaptive thinking`() {
+    val config = createConfig(format = "json_schema")
+    val params = createParams(shouldOutputJson = true)
+    val restTemplate = createCapturingRestTemplate()
+
+    service.translate(params, config, restTemplate)
+
+    val bodyMap = objectMapper.readValue<Map<String, Any>>(capturedRequestBody!!)
+
+    @Suppress("UNCHECKED_CAST")
+    val thinking = bodyMap["thinking"] as Map<String, Any>
+    assertThat(thinking["type"]).isEqualTo("disabled")
+  }
+
+  @Test
+  fun `extracts text when response mixes thinking and text content items`() {
+    val config = createConfig(format = "json_schema")
+    val params = createParams(shouldOutputJson = true)
+    val restTemplate =
+      createCapturingRestTemplate(
+        content =
+          """[
+          {"type":"thinking","thinking":"Reasoning about the translation..."},
+          {"type":"text","text":"Ahoj svet"}
+        ]""",
+      )
+
+    val result = service.translate(params, config, restTemplate)
+
+    assertThat(result.response).isEqualTo("Ahoj svet")
+  }
+
+  @Test
   fun `omits output_config when shouldOutputJson is false`() {
     val config = createConfig(format = "json_schema")
     val params = createParams(shouldOutputJson = false)
@@ -162,10 +195,13 @@ class AnthropicApiServiceTest {
     )
   }
 
-  private fun createCapturingRestTemplate(stopReason: String = "end_turn"): RestTemplate {
+  private fun createCapturingRestTemplate(
+    stopReason: String = "end_turn",
+    content: String = """[{"type":"text","text":"result"}]""",
+  ): RestTemplate {
     val responseJson =
       """
-      {"content":[{"text":"result"}],"usage":{"input_tokens":10,"output_tokens":5},"stop_reason":"$stopReason"}
+      {"content":$content,"usage":{"input_tokens":10,"output_tokens":5},"stop_reason":"$stopReason"}
       """.trimIndent()
 
     val factory =


### PR DESCRIPTION
## Summary

Two small changes to `AnthropicApiService` needed to make the provider work correctly with Sonnet 5 (and any future Anthropic model that ships with adaptive thinking on by default):

1. **Robust response parse.** Sonnet 5's adaptive thinking can put a `{"type": "thinking", "thinking": "..."}` block ahead of the text block in the response `content` array. The previous `firstOrNull()?.text` grabbed the thinking block and Jackson threw on the missing non-null `text` in `ResponseMessage`. Change: nullable `type` + `text` on `ResponseMessage`; extraction becomes `firstNotNullOfOrNull { it.text }`. Text-only responses still work; mixed responses return the text and ignore the thinking block.

2. **Always send `thinking: {"type": "disabled"}` in requests.** Even with the parser fix, adaptive thinking still generates output tokens that Anthropic bills. Translation does not benefit from adaptive thinking for our workload, so the value is hard-coded for now — a new required field on `RequestBody`, populated once at the call site. Per Anthropic docs this is the ONE mode that both stops thinking-token generation AND avoids billing (their alternative `display: omitted` still bills for hidden thinking tokens).

## What is deliberately out of scope

- **Per-provider configurability of `thinking`.** Follow-up PR will surface it as its own field through `LlmProviderInterface` + `LlmProvider` entity + DB migration + DTO / request / response + service + assembler — around 11 touchpoints, none of which are required just to make Sonnet 5 work. Reusing OpenAI's `reasoning-effort` string field for Anthropic's binary enable/disable would be semantic pollution — better to design the right field once, in a separate change.
- **Effort tuning** (`output_config.effort: low|medium|high|xhigh|max`). Only matters when adaptive thinking is on. Follow-up if a use case ever appears.

## Test plan

- [x] `./gradlew :ee-app:ktlintCheck :ee-test:ktlintCheck` — clean.
- [x] `./gradlew :ee-test:test --tests "io.tolgee.ee.unit.AnthropicApiServiceTest"` — passes locally with two new cases: `always sends thinking type=disabled ...` verifies the request body carries the disable block, and `extracts text when response mixes thinking and text content items` verifies the parser skips a thinking block.