### PR TITLE
fix: webhooks - don't encode URLs that already contain "%"

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -31,13 +31,13 @@ class WebhookExecutor(
     headers.contentType = MediaType.APPLICATION_JSON
 
     val request = HttpEntity(stringData, headers)
-    
+
     // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
     val fullyEncoded =
       config.url.contains("%") &&
         Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
     val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
-    
+
     try {
       val responseEntity: ResponseEntity<String> =
         restTemplate.exchange(uri, HttpMethod.POST, request, String::class.java)

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -32,13 +32,13 @@ class WebhookExecutor(
 
     val request = HttpEntity(stringData, headers)
 
-    // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
-    val fullyEncoded =
-      config.url.contains("%") &&
-        Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
-    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
-
     try {
+      // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
+      val fullyEncoded =
+        config.url.contains("%") &&
+          Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
+      val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
+
       val responseEntity: ResponseEntity<String> =
         restTemplate.exchange(uri, HttpMethod.POST, request, String::class.java)
       if (!responseEntity.statusCode.is2xxSuccessful) {

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
 
 @Component
 class WebhookExecutor(
@@ -30,10 +31,13 @@ class WebhookExecutor(
     headers.contentType = MediaType.APPLICATION_JSON
 
     val request = HttpEntity(stringData, headers)
-
+    
+    // If the webhook URL already contains a % it likely already properly escaped its parameters
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(config.url.contains("%"))
+    
     try {
       val responseEntity: ResponseEntity<String> =
-        restTemplate.exchange(config.url, HttpMethod.POST, request, String::class.java)
+        restTemplate.exchange(uri, HttpMethod.POST, request, String::class.java)
       if (!responseEntity.statusCode.is2xxSuccessful) {
         throw WebhookRespondedWithNon200Status(responseEntity.statusCode, responseEntity.body)
       }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -32,8 +32,11 @@ class WebhookExecutor(
 
     val request = HttpEntity(stringData, headers)
     
-    // If the webhook URL already contains a % it likely already properly escaped its parameters
-    val uri = UriComponentsBuilder.fromUriString(config.url).build(config.url.contains("%"))
+    // Treat as already-encoded only when every '%' starts a valid percent-encoded triplet.
+    val fullyEncoded =
+      config.url.contains("%") &&
+        Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded)
     
     try {
       val responseEntity: ResponseEntity<String> =

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -36,7 +36,7 @@ class WebhookExecutor(
     val fullyEncoded =
       config.url.contains("%") &&
         Regex("%(?![0-9A-Fa-f]{2})").find(config.url) == null
-    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded)
+    val uri = UriComponentsBuilder.fromUriString(config.url).build(fullyEncoded).toUri()
     
     try {
       val responseEntity: ResponseEntity<String> =

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
@@ -27,6 +27,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.web.client.RestTemplate
+import java.net.URI
 import java.util.UUID
 
 @SpringBootTest
@@ -105,7 +106,7 @@ class WebhookAutomationTest : ProjectAuthControllerTest("/v2/projects/") {
       ResponseEntity.status(httpStatus).build<Any>()
     }.whenever(webhookRestTemplate)
       .exchange(
-        any<String>(),
+        any<URI>(),
         any<HttpMethod>(),
         any<HttpEntity<*>>(),
         any<Class<*>>(),
@@ -144,6 +145,7 @@ class WebhookAutomationTest : ProjectAuthControllerTest("/v2/projects/") {
           .last()
           .arguments
       callArguments[0]
+        .toString()
         .assert
         .isEqualTo(testData.webhookConfig.self.url)
       val httpEntity = callArguments[2] as HttpEntity<String>


### PR DESCRIPTION
Builds on #3709 (webhook URL double-encoding fix by @jdimeo). This branch cherry-picks that PR's commits unchanged and adds two things on top:

### 1. Fix the failing `WebhookAutomationTest`
#3709 switches `WebhookExecutor` from the `String` overload of `restTemplate.exchange(...)` to the `URI` overload. That broke the test in two ways:
- `mockWebhookResponse` stubbed `exchange(any<String>(), …)`, so the new `URI`-overload call never matched the stub and the mock returned `null` → NPE on `responseEntity.statusCode`.
- `verifyWebhookExecuted` asserted `callArguments[0].isEqualTo(url)`, comparing the recorded arg (now a `URI`) against a `String`.

Fixed by matching `any<URI>()` and asserting on `callArguments[0].toString()`.

### 2. Wrap the URI construction in the existing `try/catch`
In #3709 the `UriComponentsBuilder.fromUriString(...).build(...).toUri()` call sits **outside** the `try`, so a malformed/edge-case URL throws a raw `IllegalArgumentException`/`IllegalStateException` instead of `WebhookExecutionFailed`. That wrapper matters:
- the "test webhook" endpoint (`WebhookConfigService.test`) only catches `WebhookException`, so a bad URL would return HTTP 500 instead of `success = false`;
- `WebhookExecutionFailed : ExpectedUserError`, so batch/automation error classification would mis-label a user error as an internal one.

Moving the URI build inside the `try` restores both behaviors.

## Remaining concern for the maintainers (not fixed here — needs a decision)
The `fullyEncoded` heuristic can't distinguish an **intentional percent-encoded triplet** from a **literal `%` that happens to be followed by two hex digits** — the two are textually identical, so no regex can resolve it.

Example that regresses vs. `main`:
```
https://hooks.example.com/t/order%b5c9
```
`%b5` is a valid triplet → `fullyEncoded = true` → passed through untouched → the receiver percent-decodes `%b5` into byte `0xB5`, so it gets a garbled path instead of the literal `order%b5c9`. Before the change, `%` was encoded to `%25` and the literal string arrived intact.

The only robust fix is a contract decision rather than a smarter heuristic: require the stored webhook URL to always be a fully-encoded RFC-3986 URI (always `build(true)`, validate/normalize at save time, document that a literal `%` must be written `%25`). Flagging for discussion; happy to implement whichever direction the maintainers prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook request URL handling by validating webhook target URLs before dispatch.
  * Correctly constructs the outbound dispatch URI (including proper handling of percent-encoded characters) to ensure requests are sent to the intended endpoint.
  * Updated webhook execution verification to align with URI-based request handling while keeping existing signing and error-handling behavior.
* **Tests**
  * Adjusted webhook REST call mocking and assertions to use URI arguments consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->