### PR TITLE
chore: classify billing entities as IGNORED for project export/import

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ExportImportPolicy.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ExportImportPolicy.kt
@@ -5,6 +5,7 @@ package io.tolgee.service.projectExportImport
  *
  * Every entity in the application must map to exactly one policy; a new unclassified entity fails
  * the build-gate guard (see `ProjectExportImportPolicyGuardTest`) until a developer assigns it one.
+ * See [ProjectExportImportPolicyRegistry.policyOf] for the one exception, the billing package.
  */
 enum class ExportImportPolicy {
   /** Project content that must round-trip: serialized on export, recreated on import. */
@@ -28,9 +29,22 @@ enum class ExportImportPolicy {
   ;
 
   /**
-   * True for policies the generic entity graph does not carry: a reference from an OWNED entity to such a
-   * target is dropped (nulled) on import, so a non-nullable FK to one is a build-gate violation.
+   * True for policies the generic entity graph does not carry.
    */
   val isNotGraphCarried: Boolean
-    get() = this == IGNORED || this == SIDE_CHANNEL
+    get() =
+      when (this) {
+        IGNORED, SIDE_CHANNEL -> true
+        OWNED, USER_REF, PROJECT_ROOT -> false
+      }
+
+  /**
+   * True for policies for which import may delete rows of.
+   */
+  val mayBeDeletedByImport: Boolean
+    get() =
+      when (this) {
+        OWNED, SIDE_CHANNEL, IGNORED -> true
+        USER_REF, PROJECT_ROOT -> false
+      }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistry.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistry.kt
@@ -195,23 +195,42 @@ object ProjectExportImportPolicyRegistry {
       )
     }
 
-  private fun MutableMap<String, ExportImportPolicy>.owned(vararg classes: KClass<*>) =
-    classes.forEach { classify(it, ExportImportPolicy.OWNED) }
+  /**
+   * Exporting a billing entity would break importing the project onto an instance of another edition
+   * (self-hosted -> cloud), so they all need to be IGNORED.
+   */
+  fun policyOf(entityClassName: String): ExportImportPolicy? {
+    if (isBillingEntity(entityClassName)) return ExportImportPolicy.IGNORED
+    return policies[entityClassName]
+  }
 
-  private fun MutableMap<String, ExportImportPolicy>.ignored(vararg classes: KClass<*>) =
-    classes.forEach { classify(it, ExportImportPolicy.IGNORED) }
+  fun isBillingEntity(entityClassName: String): Boolean {
+    return entityClassName.startsWith(BILLING_ENTITY_PACKAGE_PREFIX)
+  }
 
-  private fun MutableMap<String, ExportImportPolicy>.ignoredByName(vararg classNames: String) =
-    classNames.forEach { classifyUnique(it, ExportImportPolicy.IGNORED) }
+  private fun MutableMap<String, ExportImportPolicy>.owned(vararg classes: KClass<*>) {
+    return classes.forEach { classify(it, ExportImportPolicy.OWNED) }
+  }
+
+  private fun MutableMap<String, ExportImportPolicy>.ignored(vararg classes: KClass<*>) {
+    return classes.forEach { classify(it, ExportImportPolicy.IGNORED) }
+  }
+
+  private fun MutableMap<String, ExportImportPolicy>.ignoredByName(vararg classNames: String) {
+    return classNames.forEach { classifyUnique(it, ExportImportPolicy.IGNORED) }
+  }
 
   private fun MutableMap<String, ExportImportPolicy>.classify(
     klass: KClass<*>,
     policy: ExportImportPolicy,
+  ) {
     // Key by the JVM binary name (java.name) to match every lookup, which uses EntityType.javaType.name
     // — qualifiedName differs for a nested @Entity (`Outer.Inner` vs `Outer$Inner`).
-  ) = classifyUnique(klass.java.name, policy)
+    return classifyUnique(klass.java.name, policy)
+  }
 
-  fun policyOf(entityClassName: String): ExportImportPolicy? = policies[entityClassName]
+  val listedClassNames: Set<String>
+    get() = policies.keys
 
   val ownedClassNames: Set<String>
     get() = policies.filterValues { it == ExportImportPolicy.OWNED }.keys
@@ -219,9 +238,13 @@ object ProjectExportImportPolicyRegistry {
   val sideChannelClassNames: Set<String>
     get() = policies.filterValues { it == ExportImportPolicy.SIDE_CHANNEL }.keys
 
-  fun unclassified(managedEntityClassNames: Set<String>): Set<String> = managedEntityClassNames - policies.keys
+  fun unclassified(managedEntityClassNames: Set<String>): Set<String> {
+    return managedEntityClassNames.filterTo(mutableSetOf()) { policyOf(it) == null }
+  }
 
-  fun staleEntries(managedEntityClassNames: Set<String>): Set<String> = policies.keys - managedEntityClassNames
+  fun staleEntries(managedEntityClassNames: Set<String>): Set<String> {
+    return policies.keys - managedEntityClassNames
+  }
 
   /**
    * Validate one association of an OWNED entity pointing at [targetClassName]. [droppable] is true
@@ -238,6 +261,8 @@ object ProjectExportImportPolicyRegistry {
     }
     return null
   }
+
+  private const val BILLING_ENTITY_PACKAGE_PREFIX = "io.tolgee.billing."
 }
 
 internal fun MutableMap<String, ExportImportPolicy>.classifyUnique(

--- a/backend/data/src/test/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistryTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistryTest.kt
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Test
  */
 class ProjectExportImportPolicyRegistryTest {
   private val fake = "io.tolgee.model.DefinitelyNotAnEntity"
+  private val billingPrefix = "io.tolgee.billing."
+  private val billingEntity = "${billingPrefix}data.model.Invoice"
 
   @Test
   fun `classifies the load-bearing entities as expected`() {
@@ -34,6 +36,21 @@ class ProjectExportImportPolicyRegistryTest {
   }
 
   @Test
+  fun `classifies every billing entity as IGNORED without listing it`() {
+    assertThat(ProjectExportImportPolicyRegistry.policyOf(billingEntity))
+      .isEqualTo(ExportImportPolicy.IGNORED)
+    assertThat(ProjectExportImportPolicyRegistry.policyOf("${billingPrefix}data.model.NotYetWrittenEntity"))
+      .isEqualTo(ExportImportPolicy.IGNORED)
+    assertThat(ProjectExportImportPolicyRegistry.unclassified(setOf(billingEntity, fake)))
+      .containsExactly(fake)
+  }
+
+  @Test
+  fun `the billing prefix does not classify a same-prefixed platform entity`() {
+    assertThat(ProjectExportImportPolicyRegistry.policyOf("io.tolgee.billingsomething.Foo")).isNull()
+  }
+
+  @Test
   fun `staleEntries flags classified names absent from the managed set`() {
     assertThat(ProjectExportImportPolicyRegistry.staleEntries(emptySet()))
       .isNotEmpty
@@ -41,9 +58,40 @@ class ProjectExportImportPolicyRegistryTest {
   }
 
   @Test
+  fun `mayBeDeletedByImport is pinned (only the billing repo reads it, so platform CI cannot see a wrong value)`() {
+    assertThat(ExportImportPolicy.entries.filterNot { it.mayBeDeletedByImport })
+      .containsExactlyInAnyOrder(ExportImportPolicy.USER_REF, ExportImportPolicy.PROJECT_ROOT)
+  }
+
+  @Test
+  fun `isNotGraphCarried is pinned (OWNED is its only divergence from mayBeDeletedByImport)`() {
+    assertThat(ExportImportPolicy.entries.filter { it.isNotGraphCarried })
+      .containsExactlyInAnyOrder(ExportImportPolicy.IGNORED, ExportImportPolicy.SIDE_CHANNEL)
+  }
+
+  @Test
+  fun `no billing entity is listed in the registry (a listed name would be stale on every platform-only build)`() {
+    val listedBillingNames =
+      ProjectExportImportPolicyRegistry.listedClassNames.filter { it.startsWith(billingPrefix) }
+    assertThat(listedBillingNames)
+      .withFailMessage(
+        "Billing entities must not be listed here. Remove: %s",
+        listedBillingNames,
+      ).isEmpty()
+  }
+
+  @Test
   fun `associationViolation rejects an unclassified target regardless of droppability`() {
     assertThat(ProjectExportImportPolicyRegistry.associationViolation(fake, droppable = true)).isNotNull()
     assertThat(ProjectExportImportPolicyRegistry.associationViolation(fake, droppable = false)).isNotNull()
+  }
+
+  @Test
+  fun `associationViolation treats a billing target as IGNORED rather than unclassified`() {
+    assertThat(ProjectExportImportPolicyRegistry.associationViolation(billingEntity, droppable = false))
+      .isNotNull()
+    assertThat(ProjectExportImportPolicyRegistry.associationViolation(billingEntity, droppable = true))
+      .isNull()
   }
 
   @Test


### PR DESCRIPTION
## What

Fixes the billing repo's backend CI, which #3764 broke.

`ProjectExportImportPolicyGuardTest` asserts every JPA entity in the metamodel is classified in `ProjectExportImportPolicyRegistry`. Billing's 18 entities were not, so `every managed entity is classified()` failed in billing CI listing all of them.

## The fix

`policyOf` classifies anything under `io.tolgee.billing.` as `IGNORED`.

Billing data is organization-scoped and must never travel with a project: exporting from a self-hosted instance and importing onto cloud is a main use case for the feature, and the two editions do not agree on which billing tables exist. So this is a property of the design, not a per-entity judgement.

## Verification

- `:ee-test:test ProjectExportImportPolicyGuardTest` **with billing on the classpath**: 11/11 pass (previously red, listing exactly the 18 billing entities).
- `:ee-test:test io.tolgee.ee.projectExportImport.*`: 72 tests, 0 failures.
- `:data:test ProjectExportImportPolicyRegistryTest`: 14/14.
- ktlint clean.

## Known limits

Billing links to other modules by raw id column, and no metamodel walk can distinguish such a column from any other number — the platform pins its own soft FKs (`KeysDistance.key1Id`, `Translation.promptId`) by hand for the same reason. A raw id into project content is not detectable by any guard and needs review by eye.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export and import handling for billing-related entities by consistently excluding them from graph processing.
  * Corrected classification of billing entities so they are not reported as unclassified.
  * Clarified which data can be removed during imports.
  * Preserved accurate handling of non-graph-carried data and association validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
