### PR TITLE
fix: serialize cached enums by name instead of ordinal

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/component/EnumNameKryo5Codec.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/component/EnumNameKryo5Codec.kt
@@ -1,4 +1,4 @@
-package io.tolgee.configuration
+package io.tolgee.component
 
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.EnumNameSerializer
@@ -7,10 +7,7 @@ import org.redisson.codec.Kryo5Codec
 class EnumNameKryo5Codec : Kryo5Codec {
   constructor() : super()
 
-  /**
-   * Redisson reflectively looks up a `(ClassLoader, <this exact type>)` constructor to rebind the codec to the thread
-   * context classloader (`RedisExecutor.getCodec`, enabled by default via `useThreadClassLoader`).
-   */
+  /** Redisson reflectively requires a `(ClassLoader, <this exact type>)` constructor to rebind the codec. */
   constructor(classLoader: ClassLoader?, codec: EnumNameKryo5Codec) : super(classLoader, codec)
 
   override fun createKryo(classLoader: ClassLoader?): Kryo {

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/EnumNameKryo5Codec.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/EnumNameKryo5Codec.kt
@@ -4,17 +4,13 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.EnumNameSerializer
 import org.redisson.codec.Kryo5Codec
 
-/**
- * Kryo's default enum serializer writes an enum's ordinal, so reordering or removing a constant makes
- * already-cached entries decode as a different constant, without any error. Serializing by name instead
- * keeps cached values bound to the constant they were written as.
- */
 class EnumNameKryo5Codec : Kryo5Codec {
   constructor() : super()
 
-  constructor(classLoader: ClassLoader?) : super(classLoader)
-
-  /** Invoked reflectively by `BaseCodec.copy`, which looks up a `(ClassLoader, <this exact type>)` constructor. */
+  /**
+   * Redisson reflectively looks up a `(ClassLoader, <this exact type>)` constructor to rebind the codec to the thread
+   * context classloader (`RedisExecutor.getCodec`, enabled by default via `useThreadClassLoader`).
+   */
   constructor(classLoader: ClassLoader?, codec: EnumNameKryo5Codec) : super(classLoader, codec)
 
   override fun createKryo(classLoader: ClassLoader?): Kryo {

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/EnumNameKryo5Codec.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/EnumNameKryo5Codec.kt
@@ -1,0 +1,25 @@
+package io.tolgee.configuration
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.serializers.EnumNameSerializer
+import org.redisson.codec.Kryo5Codec
+
+/**
+ * Kryo's default enum serializer writes an enum's ordinal, so reordering or removing a constant makes
+ * already-cached entries decode as a different constant, without any error. Serializing by name instead
+ * keeps cached values bound to the constant they were written as.
+ */
+class EnumNameKryo5Codec : Kryo5Codec {
+  constructor() : super()
+
+  constructor(classLoader: ClassLoader?) : super(classLoader)
+
+  /** Invoked reflectively by `BaseCodec.copy`, which looks up a `(ClassLoader, <this exact type>)` constructor. */
+  constructor(classLoader: ClassLoader?, codec: EnumNameKryo5Codec) : super(classLoader, codec)
+
+  override fun createKryo(classLoader: ClassLoader?): Kryo {
+    return super.createKryo(classLoader).apply {
+      addDefaultSerializer(Enum::class.java, EnumNameSerializer::class.java)
+    }
+  }
+}

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
@@ -26,12 +26,11 @@ class RedissonCacheConfiguration(
   private val allCachesProvider: AllCachesProvider,
 ) {
   @Bean
-  fun cacheManager(redissonClient: RedissonClient): CacheManager? {
-    val config: MutableMap<String, CacheConfig> = HashMap()
-    val caches = allCachesProvider.getAllCaches()
-    caches.forEach {
-      config[it] = CacheConfig(tolgeeProperties.cache.defaultTtl, tolgeeProperties.cache.defaultTtl)
-    }
+  fun cacheManager(redissonClient: RedissonClient): CacheManager {
+    val config =
+      allCachesProvider.getAllCaches().associateWith {
+        CacheConfig(tolgeeProperties.cache.defaultTtl, tolgeeProperties.cache.defaultTtl)
+      }
     val cacheManager = RedissonSpringCacheManager(redissonClient, config, EnumNameKryo5Codec())
     return TransactionAwareCacheManagerProxy(cacheManager)
   }

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
@@ -32,7 +32,7 @@ class RedissonCacheConfiguration(
     caches.forEach {
       config[it] = CacheConfig(tolgeeProperties.cache.defaultTtl, tolgeeProperties.cache.defaultTtl)
     }
-    val cacheManager = RedissonSpringCacheManager(redissonClient, config)
+    val cacheManager = RedissonSpringCacheManager(redissonClient, config, EnumNameKryo5Codec())
     return TransactionAwareCacheManagerProxy(cacheManager)
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/RedissonCacheConfiguration.kt
@@ -1,6 +1,7 @@
 package io.tolgee.configuration
 
 import io.tolgee.component.AllCachesProvider
+import io.tolgee.component.EnumNameKryo5Codec
 import io.tolgee.configuration.tolgee.TolgeeProperties
 import org.redisson.Redisson
 import org.redisson.api.RedissonClient
@@ -28,7 +29,7 @@ class RedissonCacheConfiguration(
   @Bean
   fun cacheManager(redissonClient: RedissonClient): CacheManager {
     val config =
-      allCachesProvider.getAllCaches().associateWith {
+      allCachesProvider.getAllCaches().associateWithTo(mutableMapOf()) {
         CacheConfig(tolgeeProperties.cache.defaultTtl, tolgeeProperties.cache.defaultTtl)
       }
     val cacheManager = RedissonSpringCacheManager(redissonClient, config, EnumNameKryo5Codec())

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
@@ -381,9 +381,7 @@ class TranslationSuggestionControllerMtTest : ProjectAuthControllerTest("/v2/pro
   @ProjectJWTAuthTestMethod
   fun `it doesn't consume when cached`() {
     saveTestData()
-    val valueWrapperMock = mock<Cache.ValueWrapper>()
-    whenever(cacheMock.get(any())).thenReturn(valueWrapperMock)
-    whenever(valueWrapperMock.get()).thenReturn(
+    whenever(cacheMock.get(any(), eq(TranslateResult::class.java))).thenReturn(
       TranslateResult(
         translatedText = "Yeey! Cached!",
         contextDescription = "context",

--- a/backend/app/src/test/kotlin/io/tolgee/cache/AbstractCacheTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/AbstractCacheTest.kt
@@ -11,9 +11,12 @@ import io.tolgee.model.Organization
 import io.tolgee.model.Permission
 import io.tolgee.model.Project
 import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.announcement.Announcement
+import io.tolgee.repository.AnnouncementRepository
 import io.tolgee.repository.PermissionRepository
 import io.tolgee.repository.ProjectRepository
 import io.tolgee.repository.UserAccountRepository
+import io.tolgee.service.AnnouncementService
 import io.tolgee.service.machineTranslation.MtServiceInfo
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.testing.assertions.Assertions
@@ -56,6 +59,13 @@ abstract class AbstractCacheTest : AbstractSpringTest() {
   lateinit var permissionRepository: PermissionRepository
 
   @Autowired
+  @MockitoBean
+  lateinit var announcementRepository: AnnouncementRepository
+
+  @Autowired
+  lateinit var announcementService: AnnouncementService
+
+  @Autowired
   @MockitoSpyBean
   lateinit var googleTranslationProvider: GoogleTranslationProvider
 
@@ -89,6 +99,8 @@ abstract class AbstractCacheTest : AbstractSpringTest() {
   @BeforeEach
   fun setup() {
     cacheManager.getCache(Caches.MACHINE_TRANSLATIONS)!!.clear()
+    cacheManager.getCache(Caches.PERMISSIONS)!!.clear()
+    cacheManager.getCache(Caches.DISMISSED_ANNOUNCEMENT)!!.clear()
     Mockito.clearInvocations(googleTranslationProvider, awsTranslationProvider)
   }
 
@@ -157,6 +169,33 @@ abstract class AbstractCacheTest : AbstractSpringTest() {
         1,
       )
   }
+
+  @Test
+  fun `caches dismissed announcement`() {
+    whenever(announcementRepository.isDismissed(1L, Announcement.FEATURE_BATCH_OPERATIONS)).then { true }
+
+    announcementService.isAnnouncementDismissed(Announcement.FEATURE_BATCH_OPERATIONS, 1)
+    announcementService.isAnnouncementDismissed(Announcement.FEATURE_BATCH_OPERATIONS, 1)
+
+    verify(announcementRepository, times(1)).isDismissed(1L, Announcement.FEATURE_BATCH_OPERATIONS)
+  }
+
+  @Test
+  fun `dismissing an announcement evicts the key it was cached under`() {
+    val user = UserAccount().apply { id = 1 }
+    whenever(userAccountRepository.findActive(1)).then { user }
+    whenever(announcementRepository.isDismissed(1L, Announcement.FEATURE_BATCH_OPERATIONS)).then { false }
+    announcementService.isAnnouncementDismissed(Announcement.FEATURE_BATCH_OPERATIONS, 1)
+    Assertions.assertThat(dismissedAnnouncementCache.get(dismissedAnnouncementKey)).isNotNull
+
+    announcementService.dismissAnnouncement(Announcement.FEATURE_BATCH_OPERATIONS, 1)
+
+    Assertions.assertThat(dismissedAnnouncementCache.get(dismissedAnnouncementKey)).isNull()
+  }
+
+  private val dismissedAnnouncementCache get() = cacheManager.getCache(Caches.DISMISSED_ANNOUNCEMENT)!!
+
+  private val dismissedAnnouncementKey get() = arrayListOf(Announcement.FEATURE_BATCH_OPERATIONS, 1L)
 
   val googleResponse = MtValueProvider.MtResult("Hello", 10)
 

--- a/backend/app/src/test/kotlin/io/tolgee/cache/CacheCodecFixtures.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/CacheCodecFixtures.kt
@@ -1,0 +1,35 @@
+package io.tolgee.cache
+
+import io.tolgee.dtos.cacheable.ApiKeyDto
+import io.tolgee.dtos.cacheable.PermissionDto
+import io.tolgee.model.enums.Scope
+
+internal val permissionDtoFixture =
+  PermissionDto(
+    id = 1,
+    userId = 2,
+    invitationId = null,
+    scopes = arrayOf(Scope.ADMIN, Scope.KEYS_EDIT),
+    projectId = 3,
+    organizationId = null,
+    type = null,
+    granular = true,
+    viewLanguageIds = null,
+    stateChangeLanguageIds = null,
+    suggestLanguageIds = null,
+    suggestManageLanguageIds = null,
+  )
+
+internal val apiKeyDtoWithoutExpiryFixture =
+  ApiKeyDto(
+    id = 1,
+    hash = "hash",
+    expiresAt = null,
+    projectId = 2,
+    userAccountId = 3,
+    scopes = setOf(Scope.ADMIN),
+  )
+
+/** Kryo terminates an ASCII string by setting the high bit on its last byte, so the name never matches verbatim. */
+internal fun ByteArray.stripKryoHighBits(): String =
+  String(map { (it.toInt() and 0x7F).toByte() }.toByteArray(), Charsets.US_ASCII)

--- a/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
@@ -1,5 +1,6 @@
 package io.tolgee.cache
 
+import io.tolgee.configuration.EnumNameKryo5Codec
 import io.tolgee.fixtures.RedisRunner
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assertions.Assertions.assertThat
@@ -47,5 +48,16 @@ class CacheWithRedisTest : AbstractCacheTest() {
   @Test
   fun `it has proper cache manager`() {
     assertThat(unwrappedCacheManager).isInstanceOf(RedissonSpringCacheManager::class.java)
+  }
+
+  @Test
+  fun `cache manager serializes enums by name`() {
+    val codec =
+      RedissonSpringCacheManager::class.java.getDeclaredField("codec").run {
+        this.isAccessible = true
+        this.get(unwrappedCacheManager)
+      }
+
+    assertThat(codec).isInstanceOf(EnumNameKryo5Codec::class.java)
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
@@ -53,10 +53,10 @@ class CacheWithRedisTest : AbstractCacheTest() {
   @Test
   fun `cache manager serializes enums by name`() {
     val codec =
-      RedissonSpringCacheManager::class.java.getDeclaredField("codec").run {
-        this.isAccessible = true
-        this.get(unwrappedCacheManager)
-      }
+      RedissonSpringCacheManager::class.java
+        .getDeclaredField("codec")
+        .apply { isAccessible = true }
+        .get(unwrappedCacheManager)
 
     assertThat(codec).isInstanceOf(EnumNameKryo5Codec::class.java)
   }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/CacheWithRedisTest.kt
@@ -1,12 +1,30 @@
 package io.tolgee.cache
 
-import io.tolgee.configuration.EnumNameKryo5Codec
+import io.netty.buffer.Unpooled
+import io.tolgee.component.EnumNameKryo5Codec
+import io.tolgee.component.ResilientCacheAccessor
+import io.tolgee.component.machineTranslation.TranslateResult
+import io.tolgee.constants.Caches
+import io.tolgee.constants.MtServiceType
+import io.tolgee.dtos.cacheable.PermissionDto
 import io.tolgee.fixtures.RedisRunner
+import io.tolgee.model.Permission
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.ByteArrayCodec
+import org.redisson.client.handler.State
+import org.redisson.codec.Kryo5Codec
+import org.redisson.spring.cache.CacheConfig
 import org.redisson.spring.cache.RedissonSpringCacheManager
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
@@ -27,6 +45,8 @@ import org.springframework.test.context.ContextConfiguration
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CacheWithRedisTest : AbstractCacheTest() {
   companion object {
+    private const val KEY = "permission-key"
+
     val redisRunner = RedisRunner()
 
     @AfterAll
@@ -45,19 +65,86 @@ class CacheWithRedisTest : AbstractCacheTest() {
     }
   }
 
+  @Autowired
+  lateinit var redissonClient: RedissonClient
+
+  @Autowired
+  lateinit var resilientCacheAccessor: ResilientCacheAccessor
+
   @Test
   fun `it has proper cache manager`() {
     assertThat(unwrappedCacheManager).isInstanceOf(RedissonSpringCacheManager::class.java)
   }
 
   @Test
-  fun `cache manager serializes enums by name`() {
-    val codec =
-      RedissonSpringCacheManager::class.java
-        .getDeclaredField("codec")
-        .apply { isAccessible = true }
-        .get(unwrappedCacheManager)
+  fun `writes enum names into redis`() {
+    permissionsCache.put(KEY, permissionDtoFixture)
 
-    assertThat(codec).isInstanceOf(EnumNameKryo5Codec::class.java)
+    val stored = rawPermissionsCache.readAllValues().map { it.stripKryoHighBits() }
+    assertThat(stored).hasSize(1)
+    assertThat(stored.single()).contains("ADMIN")
+    assertThat(permissionsCache.get(KEY)!!.get()).isEqualTo(permissionDtoFixture)
   }
+
+  @Test
+  fun `evicts and misses when ResilientCacheAccessor reads a previous-deploy entry`() {
+    previousDeployPermissionsCache.put(KEY, permissionDtoFixture)
+    assertThat(rawPermissionsCache.readAllValues()).hasSize(1)
+
+    val value = resilientCacheAccessor.get(permissionsCache, KEY, PermissionDto::class.java)
+
+    assertThat(value).isNull()
+    assertThat(rawPermissionsCache.readAllValues()).isEmpty()
+  }
+
+  @Test
+  fun `falls back to the repository when the Cacheable path reads a previous-deploy entry`() {
+    whenever(permissionRepository.findOneByProjectIdAndUserIdAndOrganizationId(3, 2)).then { Permission(id = 1) }
+    previousDeployPermissionsCache.put(arrayListOf(2L, 3L, null), permissionDtoFixture)
+    assertThat(rawPermissionsCache.readAllValues()).hasSize(1)
+
+    val found = permissionService.find(projectId = 3, userId = 2)
+
+    assertThat(found).isNotNull
+    verify(permissionRepository, times(1)).findOneByProjectIdAndUserIdAndOrganizationId(3, 2)
+    assertThat(rawPermissionsCache.readAllValues())
+      .describedAs("stale entry evicted and recomputed under the same key")
+      .hasSize(1)
+  }
+
+  @Test
+  fun `falls back to the provider when the machine translation cache holds a previous-deploy entry`() {
+    doAnswer { googleResponse }.whenever(awsTranslationProvider).translate(any())
+    mtServiceManager.translate(paramsEnAws)
+    verify(awsTranslationProvider, times(1)).translate(any())
+
+    previousDeployCache(Caches.MACHINE_TRANSLATIONS).put(
+      machineTranslationCacheKey(),
+      TranslateResult(translatedText = "Hello", usedService = MtServiceType.AWS),
+    )
+
+    mtServiceManager.translate(paramsEnAws)
+
+    verify(awsTranslationProvider, times(2)).translate(any())
+  }
+
+  private fun machineTranslationCacheKey(): String {
+    val rawKey = rawCache(Caches.MACHINE_TRANSLATIONS).readAllKeySet().single()
+    return EnumNameKryo5Codec().valueDecoder.decode(Unpooled.wrappedBuffer(rawKey), State()) as String
+  }
+
+  private val permissionsCache get() = cacheManager.getCache(Caches.PERMISSIONS)!!
+
+  private val rawPermissionsCache get() = rawCache(Caches.PERMISSIONS)
+
+  private fun rawCache(name: String) = redissonClient.getMapCache<ByteArray, ByteArray>(name, ByteArrayCodec.INSTANCE)
+
+  private val previousDeployPermissionsCache get() = previousDeployCache(Caches.PERMISSIONS)
+
+  private fun previousDeployCache(name: String) =
+    RedissonSpringCacheManager(
+      redissonClient,
+      mapOf(name to CacheConfig(tolgeeProperties.cache.defaultTtl, tolgeeProperties.cache.defaultTtl)),
+      Kryo5Codec(),
+    ).getCache(name)!!
 }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -1,0 +1,50 @@
+package io.tolgee.cache
+
+import io.netty.buffer.ByteBuf
+import io.tolgee.configuration.EnumNameKryo5Codec
+import io.tolgee.model.enums.Scope
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.redisson.client.codec.Codec
+import org.redisson.client.handler.State
+import org.redisson.codec.Kryo5Codec
+
+class EnumNameKryo5CodecTest {
+  private val codec = EnumNameKryo5Codec()
+
+  private fun Codec.encodeToBytes(value: Any): ByteArray {
+    val buffer = valueEncoder.encode(value)
+    val bytes = ByteArray(buffer.readableBytes())
+    buffer.getBytes(buffer.readerIndex(), bytes)
+    return bytes
+  }
+
+  private fun Codec.roundTrip(value: Any): Any? {
+    val buffer: ByteBuf = valueEncoder.encode(value)
+    return valueDecoder.decode(buffer, State())
+  }
+
+  /** Kryo terminates an ASCII string by setting the high bit of its last byte, so clear it before matching. */
+  private fun ByteArray.asKryoText(): String {
+    val ascii = map { (it.toInt() and 0x7F).toByte() }.toByteArray()
+    return String(ascii, Charsets.US_ASCII)
+  }
+
+  @Test
+  fun `writes enum constant name instead of ordinal`() {
+    assertThat(codec.encodeToBytes(Scope.ADMIN).asKryoText()).contains("ADMIN")
+    assertThat(Kryo5Codec().encodeToBytes(Scope.ADMIN).asKryoText()).doesNotContain("ADMIN")
+  }
+
+  @Test
+  fun `round trips enum value`() {
+    assertThat(codec.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
+  }
+
+  @Test
+  fun `round trips enums nested in collections`() {
+    val scopes = listOf(Scope.ADMIN, Scope.KEYS_EDIT)
+    assertThat(codec.roundTrip(ArrayList(scopes))).isEqualTo(scopes)
+    assertThat(codec.roundTrip(scopes.toTypedArray())).isEqualTo(scopes.toTypedArray())
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -1,7 +1,11 @@
 package io.tolgee.cache
 
+import com.esotericsoftware.kryo.KryoException
+import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
 import io.tolgee.configuration.EnumNameKryo5Codec
+import io.tolgee.dtos.cacheable.PermissionDto
+import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -13,19 +17,20 @@ import org.redisson.codec.Kryo5Codec
 
 class EnumNameKryo5CodecTest {
   private val codec = EnumNameKryo5Codec()
+  private val ordinalCodec = Kryo5Codec()
 
   @Test
   fun `writes enum constant name instead of ordinal`() {
     assertThat(codec.encodeToBytes(Scope.ADMIN).stripKryoHighBits()).contains("ADMIN")
-    assertThat(Kryo5Codec().encodeToBytes(Scope.ADMIN).stripKryoHighBits()).doesNotContain("ADMIN")
+    assertThat(ordinalCodec.encodeToBytes(Scope.ADMIN).stripKryoHighBits()).doesNotContain("ADMIN")
   }
 
   @Test
   fun `does not read entries written by the ordinal codec`() {
-    assertThatThrownBy { codec.decode(Kryo5Codec().encode(Scope.ADMIN)) }.isInstanceOf(Throwable::class.java)
+    assertThatThrownBy { codec.decode(ordinalCodec.encode(Scope.ADMIN)) }.isInstanceOf(KryoException::class.java)
     assertThatThrownBy {
-      codec.decode(Kryo5Codec().encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
-    }.isInstanceOf(Throwable::class.java)
+      codec.decode(ordinalCodec.encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
+    }.isInstanceOf(KryoException::class.java)
   }
 
   @Test
@@ -34,6 +39,30 @@ class EnumNameKryo5CodecTest {
     assertThat(codec.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
     assertThat(codec.roundTrip(ArrayList(scopes))).isEqualTo(scopes)
     assertThat(codec.roundTrip(scopes.toTypedArray())).isEqualTo(scopes.toTypedArray())
+  }
+
+  @Test
+  fun `round trips enum fields of a cached DTO, including a null enum`() {
+    val dto =
+      PermissionDto(
+        id = 1,
+        userId = 2,
+        invitationId = null,
+        scopes = arrayOf(Scope.ADMIN, Scope.KEYS_EDIT),
+        projectId = 3,
+        organizationId = null,
+        type = null,
+        granular = true,
+        viewLanguageIds = null,
+        stateChangeLanguageIds = null,
+        suggestLanguageIds = null,
+        suggestManageLanguageIds = null,
+      )
+
+    assertThat(codec.roundTrip(dto)).isEqualTo(dto)
+    assertThat(codec.roundTrip(dto.copy(type = ProjectPermissionType.MANAGE))).isEqualTo(
+      dto.copy(type = ProjectPermissionType.MANAGE),
+    )
   }
 
   @Test
@@ -48,7 +77,7 @@ class EnumNameKryo5CodecTest {
 
   private fun Codec.encode(value: Any) = valueEncoder.encode(value)
 
-  private fun Codec.decode(buffer: io.netty.buffer.ByteBuf) = valueDecoder.decode(buffer, State())
+  private fun Codec.decode(buffer: ByteBuf) = valueDecoder.decode(buffer, State())
 
   private fun Codec.encodeToBytes(value: Any): ByteArray = ByteBufUtil.getBytes(encode(value))
 

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -41,9 +41,7 @@ class EnumNameKryo5CodecTest {
 
   @Test
   fun `reverse direction fails safe on small enums but silently misreads large ones`() {
-    // Reverse of the migration: an old / rolled-back instance runs the default ordinal codec over entries the name
-    // codec wrote. For small enums the name's leading bytes decode to an out-of-range ordinal and throw, so the
-    // @Cacheable error handler / ResilientCacheAccessor evict and recompute. Every security-critical fixture is here.
+    // Kryo's ordinal enum codec throws on an out-of-range decoded ordinal but silently returns a wrong in-range one.
     assertThatThrownBy { ordinalCodec.decode(codec.encode(Scope.ADMIN)) }.isInstanceOf(KryoException::class.java)
     assertThatThrownBy {
       ordinalCodec.decode(codec.encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
@@ -56,9 +54,6 @@ class EnumNameKryo5CodecTest {
       .describedAs("no Scope constant is silently readable by the ordinal codec")
       .isEmpty()
 
-    // Large enums are the dangerous half: a short name's leading bytes read back as an IN-range ordinal, so the
-    // ordinal codec returns a WRONG constant with no exception. ActivityType (101 constants) is the worked example.
-    // This is why a rollback cannot trust old entries and must let them expire / be evicted rather than read them.
     val silentlyMisread =
       ActivityType.entries.filter {
         val decoded = runCatching { ordinalCodec.decode(codec.encode(it)) }.getOrNull()

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -1,9 +1,10 @@
 package io.tolgee.cache
 
-import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufUtil
 import io.tolgee.configuration.EnumNameKryo5Codec
 import io.tolgee.model.enums.Scope
 import io.tolgee.testing.assertions.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.redisson.client.codec.Codec
 import org.redisson.client.handler.State
@@ -12,39 +13,46 @@ import org.redisson.codec.Kryo5Codec
 class EnumNameKryo5CodecTest {
   private val codec = EnumNameKryo5Codec()
 
-  private fun Codec.encodeToBytes(value: Any): ByteArray {
-    val buffer = valueEncoder.encode(value)
-    val bytes = ByteArray(buffer.readableBytes())
-    buffer.getBytes(buffer.readerIndex(), bytes)
-    return bytes
-  }
-
-  private fun Codec.roundTrip(value: Any): Any? {
-    val buffer: ByteBuf = valueEncoder.encode(value)
-    return valueDecoder.decode(buffer, State())
-  }
-
-  /** Kryo terminates an ASCII string by setting the high bit of its last byte, so clear it before matching. */
-  private fun ByteArray.asKryoText(): String {
-    val ascii = map { (it.toInt() and 0x7F).toByte() }.toByteArray()
-    return String(ascii, Charsets.US_ASCII)
-  }
-
   @Test
   fun `writes enum constant name instead of ordinal`() {
-    assertThat(codec.encodeToBytes(Scope.ADMIN).asKryoText()).contains("ADMIN")
-    assertThat(Kryo5Codec().encodeToBytes(Scope.ADMIN).asKryoText()).doesNotContain("ADMIN")
+    assertThat(codec.encodeToBytes(Scope.ADMIN).stripKryoHighBits()).contains("ADMIN")
+    assertThat(Kryo5Codec().encodeToBytes(Scope.ADMIN).stripKryoHighBits()).doesNotContain("ADMIN")
   }
 
   @Test
-  fun `round trips enum value`() {
-    assertThat(codec.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
+  fun `does not read entries written by the ordinal codec`() {
+    assertThatThrownBy { codec.decode(Kryo5Codec().encode(Scope.ADMIN)) }.isInstanceOf(Throwable::class.java)
+    assertThatThrownBy {
+      codec.decode(Kryo5Codec().encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
+    }.isInstanceOf(Throwable::class.java)
   }
 
   @Test
-  fun `round trips enums nested in collections`() {
+  fun `round trips enums standalone and nested in collections`() {
     val scopes = listOf(Scope.ADMIN, Scope.KEYS_EDIT)
+    assertThat(codec.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
     assertThat(codec.roundTrip(ArrayList(scopes))).isEqualTo(scopes)
     assertThat(codec.roundTrip(scopes.toTypedArray())).isEqualTo(scopes.toTypedArray())
+  }
+
+  @Test
+  fun `keeps writing names when Redisson rebinds the codec to a classloader`() {
+    val rebound = EnumNameKryo5Codec(javaClass.classLoader, codec)
+
+    assertThat(rebound.encodeToBytes(Scope.ADMIN).stripKryoHighBits()).contains("ADMIN")
+    assertThat(rebound.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
+  }
+
+  private fun Codec.encode(value: Any) = valueEncoder.encode(value)
+
+  private fun Codec.decode(buffer: io.netty.buffer.ByteBuf) = valueDecoder.decode(buffer, State())
+
+  private fun Codec.encodeToBytes(value: Any): ByteArray = ByteBufUtil.getBytes(encode(value))
+
+  private fun Codec.roundTrip(value: Any): Any? = decode(encode(value))
+
+  private fun ByteArray.stripKryoHighBits(): String {
+    val ascii = map { (it.toInt() and 0x7F).toByte() }.toByteArray()
+    return String(ascii, Charsets.US_ASCII)
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.model.enums.Scope
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.redisson.client.codec.BaseCodec
 import org.redisson.client.codec.Codec
 import org.redisson.client.handler.State
 import org.redisson.codec.Kryo5Codec
@@ -37,8 +38,10 @@ class EnumNameKryo5CodecTest {
 
   @Test
   fun `keeps writing names when Redisson rebinds the codec to a classloader`() {
-    val rebound = EnumNameKryo5Codec(javaClass.classLoader, codec)
+    val rebound = BaseCodec.copy(javaClass.classLoader, codec)
 
+    assertThat(rebound).isInstanceOf(EnumNameKryo5Codec::class.java)
+    assertThat(rebound).isNotSameAs(codec)
     assertThat(rebound.encodeToBytes(Scope.ADMIN).stripKryoHighBits()).contains("ADMIN")
     assertThat(rebound.roundTrip(Scope.ADMIN)).isEqualTo(Scope.ADMIN)
   }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -3,8 +3,7 @@ package io.tolgee.cache
 import com.esotericsoftware.kryo.KryoException
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
-import io.tolgee.configuration.EnumNameKryo5Codec
-import io.tolgee.dtos.cacheable.PermissionDto
+import io.tolgee.component.EnumNameKryo5Codec
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.testing.assertions.Assertions.assertThat
@@ -31,6 +30,18 @@ class EnumNameKryo5CodecTest {
     assertThatThrownBy {
       codec.decode(ordinalCodec.encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
     }.isInstanceOf(KryoException::class.java)
+    assertThatThrownBy { codec.decode(ordinalCodec.encode(permissionDtoFixture)) }
+      .isInstanceOf(KryoException::class.java)
+    assertThatThrownBy { codec.decode(ordinalCodec.encode(apiKeyDtoWithoutExpiryFixture)) }
+      .isInstanceOf(KryoException::class.java)
+  }
+
+  @Test
+  fun `writes names into map keys too, since Redisson encodes them with the value encoder`() {
+    val key = arrayListOf(1L, Scope.ADMIN)
+
+    assertThat(codec.encodeKeyToBytes(key).stripKryoHighBits()).contains("ADMIN")
+    assertThat(ordinalCodec.encodeKeyToBytes(key).stripKryoHighBits()).doesNotContain("ADMIN")
   }
 
   @Test
@@ -43,28 +54,13 @@ class EnumNameKryo5CodecTest {
 
   @Test
   fun `round trips enum fields of a cached DTO, including a null enum`() {
-    val dto =
-      PermissionDto(
-        id = 1,
-        userId = 2,
-        invitationId = null,
-        scopes = arrayOf(Scope.ADMIN, Scope.KEYS_EDIT),
-        projectId = 3,
-        organizationId = null,
-        type = null,
-        granular = true,
-        viewLanguageIds = null,
-        stateChangeLanguageIds = null,
-        suggestLanguageIds = null,
-        suggestManageLanguageIds = null,
-      )
+    val withType = permissionDtoFixture.copy(type = ProjectPermissionType.MANAGE)
 
-    val withType = dto.copy(type = ProjectPermissionType.MANAGE)
-
-    assertThat(codec.roundTrip(dto)).isEqualTo(dto)
+    assertThat(codec.roundTrip(permissionDtoFixture)).isEqualTo(permissionDtoFixture)
     assertThat(codec.roundTrip(withType)).isEqualTo(withType)
-    assertThat(codec.encodeToBytes(dto).stripKryoHighBits()).contains("ADMIN")
-    assertThat(ordinalCodec.encodeToBytes(dto).stripKryoHighBits()).doesNotContain("ADMIN")
+    assertThat(codec.roundTrip(apiKeyDtoWithoutExpiryFixture)).isEqualTo(apiKeyDtoWithoutExpiryFixture)
+    assertThat(codec.encodeToBytes(permissionDtoFixture).stripKryoHighBits()).contains("ADMIN")
+    assertThat(ordinalCodec.encodeToBytes(permissionDtoFixture).stripKryoHighBits()).doesNotContain("ADMIN")
   }
 
   @Test
@@ -83,10 +79,7 @@ class EnumNameKryo5CodecTest {
 
   private fun Codec.encodeToBytes(value: Any): ByteArray = ByteBufUtil.getBytes(encode(value))
 
-  private fun Codec.roundTrip(value: Any): Any? = decode(encode(value))
+  private fun Codec.encodeKeyToBytes(value: Any): ByteArray = ByteBufUtil.getBytes(mapKeyEncoder.encode(value))
 
-  private fun ByteArray.stripKryoHighBits(): String {
-    val ascii = map { (it.toInt() and 0x7F).toByte() }.toByteArray()
-    return String(ascii, Charsets.US_ASCII)
-  }
+  private fun Codec.roundTrip(value: Any): Any? = decode(encode(value))
 }

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -3,7 +3,10 @@ package io.tolgee.cache
 import com.esotericsoftware.kryo.KryoException
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.component.EnumNameKryo5Codec
+import io.tolgee.component.machineTranslation.TranslateResult
+import io.tolgee.constants.MtServiceType
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.testing.assertions.Assertions.assertThat
@@ -37,6 +40,36 @@ class EnumNameKryo5CodecTest {
   }
 
   @Test
+  fun `reverse direction fails safe on small enums but silently misreads large ones`() {
+    // Reverse of the migration: an old / rolled-back instance runs the default ordinal codec over entries the name
+    // codec wrote. For small enums the name's leading bytes decode to an out-of-range ordinal and throw, so the
+    // @Cacheable error handler / ResilientCacheAccessor evict and recompute. Every security-critical fixture is here.
+    assertThatThrownBy { ordinalCodec.decode(codec.encode(Scope.ADMIN)) }.isInstanceOf(KryoException::class.java)
+    assertThatThrownBy {
+      ordinalCodec.decode(codec.encode(arrayOf(Scope.ADMIN, Scope.KEYS_EDIT)))
+    }.isInstanceOf(KryoException::class.java)
+    assertThatThrownBy { ordinalCodec.decode(codec.encode(permissionDtoFixture)) }
+      .isInstanceOf(KryoException::class.java)
+    assertThatThrownBy { ordinalCodec.decode(codec.encode(apiKeyDtoWithoutExpiryFixture)) }
+      .isInstanceOf(KryoException::class.java)
+    assertThat(Scope.entries.filter { runCatching { ordinalCodec.decode(codec.encode(it)) }.isSuccess })
+      .describedAs("no Scope constant is silently readable by the ordinal codec")
+      .isEmpty()
+
+    // Large enums are the dangerous half: a short name's leading bytes read back as an IN-range ordinal, so the
+    // ordinal codec returns a WRONG constant with no exception. ActivityType (101 constants) is the worked example.
+    // This is why a rollback cannot trust old entries and must let them expire / be evicted rather than read them.
+    val silentlyMisread =
+      ActivityType.entries.filter {
+        val decoded = runCatching { ordinalCodec.decode(codec.encode(it)) }.getOrNull()
+        decoded != null && decoded != it
+      }
+    assertThat(silentlyMisread)
+      .describedAs("large enums silently decode to a wrong constant under the ordinal codec")
+      .isNotEmpty()
+  }
+
+  @Test
   fun `writes names into map keys too, since Redisson encodes them with the value encoder`() {
     val key = arrayListOf(1L, Scope.ADMIN)
 
@@ -61,6 +94,15 @@ class EnumNameKryo5CodecTest {
     assertThat(codec.roundTrip(apiKeyDtoWithoutExpiryFixture)).isEqualTo(apiKeyDtoWithoutExpiryFixture)
     assertThat(codec.encodeToBytes(permissionDtoFixture).stripKryoHighBits()).contains("ADMIN")
     assertThat(ordinalCodec.encodeToBytes(permissionDtoFixture).stripKryoHighBits()).doesNotContain("ADMIN")
+  }
+
+  @Test
+  fun `round trips the MtServiceType field of a cached TranslateResult`() {
+    val result = TranslateResult(translatedText = "Hello", usedService = MtServiceType.AWS)
+
+    assertThat(codec.roundTrip(result)).isEqualTo(result)
+    assertThat(codec.encodeToBytes(result).stripKryoHighBits()).contains("AWS")
+    assertThat(ordinalCodec.encodeToBytes(result).stripKryoHighBits()).doesNotContain("AWS")
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/cache/EnumNameKryo5CodecTest.kt
@@ -59,10 +59,12 @@ class EnumNameKryo5CodecTest {
         suggestManageLanguageIds = null,
       )
 
+    val withType = dto.copy(type = ProjectPermissionType.MANAGE)
+
     assertThat(codec.roundTrip(dto)).isEqualTo(dto)
-    assertThat(codec.roundTrip(dto.copy(type = ProjectPermissionType.MANAGE))).isEqualTo(
-      dto.copy(type = ProjectPermissionType.MANAGE),
-    )
+    assertThat(codec.roundTrip(withType)).isEqualTo(withType)
+    assertThat(codec.encodeToBytes(dto).stripKryoHighBits()).contains("ADMIN")
+    assertThat(ordinalCodec.encodeToBytes(dto).stripKryoHighBits()).doesNotContain("ADMIN")
   }
 
   @Test

--- a/backend/data/src/main/kotlin/io/tolgee/activity/data/RevisionType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/data/RevisionType.kt
@@ -1,5 +1,6 @@
 package io.tolgee.activity.data
 
+/** Ordinal-persisted by [io.tolgee.model.activity.ActivityModifiedEntity.revisionType] — do not reorder. */
 enum class RevisionType {
   ADD,
   MOD,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
@@ -25,8 +25,8 @@ import java.util.concurrent.ConcurrentHashMap
  * The full successTargets list is persisted to the database only (via BatchJobService)
  * and is never stored in Redis.
  *
- * These maps keep the default ordinal Kryo codec: switching them to a name-based codec would change the Redis key
- * prefix and split one job's in-flight state across two hashes during a rolling deploy.
+ * These maps serialize ExecutionState (incl. its BatchJobChunkExecutionStatus enum) on the RedissonClient default
+ * ordinal codec; a codec switch or enum reorder makes pre-deploy values unreadable, with no TTL to recover.
  */
 open class RedisBatchJobStateStorage(
   private val initializer: BatchJobStateInitializer,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
@@ -25,9 +25,8 @@ import java.util.concurrent.ConcurrentHashMap
  * The full successTargets list is persisted to the database only (via BatchJobService)
  * and is never stored in Redis.
  *
- * These maps keep the Redisson client's default ordinal-based Kryo codec, unlike the Spring cache: a name-based codec
- * needs a new key prefix, which during a rolling deploy splits one job's in-flight state across two hashes while both
- * generations share the unversioned counters below.
+ * These maps keep the default ordinal Kryo codec: switching them to a name-based codec would change the Redis key
+ * prefix and split one job's in-flight state across two hashes during a rolling deploy.
  */
 open class RedisBatchJobStateStorage(
   private val initializer: BatchJobStateInitializer,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
@@ -24,6 +24,10 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * The full successTargets list is persisted to the database only (via BatchJobService)
  * and is never stored in Redis.
+ *
+ * These maps keep the Redisson client's default ordinal-based Kryo codec, unlike the Spring cache: a name-based codec
+ * needs a new key prefix, which during a rolling deploy splits one job's in-flight state across two hashes while both
+ * generations share the unversioned counters below.
  */
 open class RedisBatchJobStateStorage(
   private val initializer: BatchJobStateInitializer,

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
@@ -2,6 +2,7 @@ package io.tolgee.component.machineTranslation
 
 import io.sentry.Sentry
 import io.tolgee.Metrics
+import io.tolgee.component.ResilientCacheAccessor
 import io.tolgee.component.machineTranslation.providers.ProviderTranslateParams
 import io.tolgee.configuration.tolgee.InternalProperties
 import io.tolgee.constants.Caches
@@ -26,6 +27,7 @@ class MtServiceManager(
   private val internalProperties: InternalProperties,
   private val cacheManager: CacheManager,
   private val metrics: Metrics,
+  private val resilientCacheAccessor: ResilientCacheAccessor,
 ) {
   private val logger = LoggerFactory.getLogger(this::class.java)
 
@@ -179,11 +181,8 @@ class MtServiceManager(
   }
 
   private fun ProviderTranslateParams.findInCacheByParams(serviceType: MtServiceType): TranslateResult? {
-    return getCache()?.let { cache ->
-      val result = cache.get(this.cacheKey(serviceType.name))?.get() as? TranslateResult
-      result?.actualPrice = 0
-      return result
-    }
+    val cache = getCache() ?: return null
+    return resilientCacheAccessor.get(cache, this.cacheKey(serviceType.name), TranslateResult::class.java)
   }
 
   private fun ProviderTranslateParams.cacheResult(

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
@@ -164,7 +164,9 @@ class MtServiceManager(
     params: TranslationParams,
     e: Exception,
   ) {
-    if (params.isBatch) throw e
+    if (params.isBatch) {
+      throw e
+    }
     logger.error(
       """An exception occurred while translating
           |text "${params.text}"

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/MtServiceManager.kt
@@ -164,20 +164,16 @@ class MtServiceManager(
     params: TranslationParams,
     e: Exception,
   ) {
-    val silentFail = !params.isBatch
-    if (!silentFail) {
-      throw e
-    } else {
-      logger.error(
-        """An exception occurred while translating 
-            |text "${params.text}" 
-            |from ${params.sourceLanguageTag} 
-            |to ${params.targetLanguageTag}"
-        """.trimMargin(),
-      )
-      logger.error(e.stackTraceToString())
-      Sentry.captureException(e)
-    }
+    if (params.isBatch) throw e
+    logger.error(
+      """An exception occurred while translating
+          |text "${params.text}"
+          |from ${params.sourceLanguageTag}
+          |to ${params.targetLanguageTag}
+      """.trimMargin(),
+    )
+    logger.error(e.stackTraceToString())
+    Sentry.captureException(e)
   }
 
   private fun ProviderTranslateParams.findInCacheByParams(serviceType: MtServiceType): TranslateResult? {

--- a/backend/data/src/main/kotlin/io/tolgee/constants/MtServiceType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/MtServiceType.kt
@@ -15,6 +15,7 @@ import io.tolgee.configuration.tolgee.machineTranslation.GoogleMachineTranslatio
 import io.tolgee.configuration.tolgee.machineTranslation.LlmProperties
 import io.tolgee.configuration.tolgee.machineTranslation.MachineTranslationServiceProperties
 
+/** Ordinal-persisted by [io.tolgee.model.translation.Translation.mtProvider] — do not reorder. */
 enum class MtServiceType(
   val propertyClass: Class<out MachineTranslationServiceProperties>?,
   val providerClass: Class<out MtValueProvider>,

--- a/backend/data/src/main/kotlin/io/tolgee/formats/ExportFormat.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/ExportFormat.kt
@@ -2,6 +2,7 @@ package io.tolgee.formats
 
 import io.tolgee.service.export.ExportFilePathProvider
 
+/** Ordinal-persisted by [io.tolgee.model.contentDelivery.ContentDeliveryConfig.format] — do not reorder. */
 enum class ExportFormat(
   val extension: String,
   val mediaType: String,

--- a/backend/data/src/main/kotlin/io/tolgee/model/automations/AutomationActionType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/automations/AutomationActionType.kt
@@ -9,6 +9,7 @@ import io.tolgee.dtos.cacheable.automations.AutomationActionDto
 import io.tolgee.dtos.cacheable.automations.AutomationTriggerDto
 import kotlin.reflect.KClass
 
+/** Ordinal-persisted by [io.tolgee.model.automations.AutomationAction.type] — do not reorder. */
 enum class AutomationActionType(
   val processor: KClass<out AutomationProcessor>,
   val debouncingKeyProvider: ((BatchOperationParams, AutomationActionDto, AutomationTriggerDto) -> Any)? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJobChunkExecutionStatus.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJobChunkExecutionStatus.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.batch
 
+/** Stored by ordinal in Redis batch job state: append only — reordering silently restatuses in-flight chunks. */
 enum class BatchJobChunkExecutionStatus(
   val completed: Boolean,
 ) {

--- a/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJobChunkExecutionStatus.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/batch/BatchJobChunkExecutionStatus.kt
@@ -1,6 +1,6 @@
 package io.tolgee.model.batch
 
-/** Stored by ordinal in Redis batch job state: append only — reordering silently restatuses in-flight chunks. */
+/** Ordinal-serialized by [io.tolgee.batch.state.RedisBatchJobStateStorage] — do not reorder. */
 enum class BatchJobChunkExecutionStatus(
   val completed: Boolean,
 ) {

--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/issueTypes/FileIssueType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/issueTypes/FileIssueType.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.dataImport.issues.issueTypes
 
+/** Ordinal-persisted by [io.tolgee.model.dataImport.issues.ImportFileIssue.type] — do not reorder. */
 enum class FileIssueType {
   KEY_IS_NOT_STRING,
   MULTIPLE_VALUES_FOR_KEY_AND_LANGUAGE,

--- a/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/paramTypes/FileIssueParamType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/dataImport/issues/paramTypes/FileIssueParamType.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.dataImport.issues.paramTypes
 
+/** Ordinal-persisted by [io.tolgee.model.dataImport.issues.ImportFileIssueParam.type] — do not reorder. */
 enum class FileIssueParamType {
   KEY_NAME,
   KEY_ID,

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/OrganizationRoleType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/OrganizationRoleType.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.enums
 
+/** Ordinal-persisted by [io.tolgee.model.OrganizationRole.type] — do not reorder. */
 enum class OrganizationRoleType(
   val isReadOnly: Boolean,
 ) {

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/TranslationCommentState.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/TranslationCommentState.kt
@@ -1,5 +1,6 @@
 package io.tolgee.model.enums
 
+/** Ordinal-persisted by [io.tolgee.model.translation.TranslationComment.state] — do not reorder. */
 enum class TranslationCommentState {
   RESOLUTION_NOT_NEEDED,
   NEEDS_RESOLUTION,

--- a/backend/data/src/main/kotlin/io/tolgee/model/enums/TranslationState.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/enums/TranslationState.kt
@@ -1,5 +1,9 @@
 package io.tolgee.model.enums
 
+/**
+ * Ordinal-persisted by [io.tolgee.model.translation.Translation.state] and
+ * [io.tolgee.model.branching.snapshot.TranslationSnapshot.state] — do not reorder.
+ */
 enum class TranslationState {
   UNTRANSLATED,
   TRANSLATED,

--- a/ee/backend/tests/build.gradle
+++ b/ee/backend/tests/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation(project(":data"))
     testImplementation(project(":misc"))
     testImplementation "org.springframework.boot:spring-boot-starter-websocket"
+    testImplementation libs.hibernateTypes
     testImplementation libs.jsonUnitAssert
     testImplementation libs.mockito
     testImplementation libs.stripe

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumGuardTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumGuardTest.kt
@@ -44,13 +44,13 @@ import kotlin.reflect.KClass
 import java.lang.reflect.Type as ReflectType
 
 /**
- * Each enum below is stored by ordinal somewhere that outlives the deploy that wrote it.
- *
  * Lives in `:ee-test` so the metamodel sees every module's entities: `:server-app` pulls `:ee-app` in only
  * conditionally, so from there the EE entities would vanish from the scan while the floors below still passed.
  */
 @SpringBootTest
-class OrdinalBoundEnumOrderTest : AbstractSpringTest() {
+class OrdinalBoundEnumGuardTest : AbstractSpringTest() {
+  // Redisson structures on the default codec are not auto-discovered like JPA columns: any such structure whose
+  // value transitively holds an enum must be listed here, or that enum serializes by ordinal with no guard.
   private val nonSpringCacheOrdinalCodecRedisTypes = listOf(ExecutionState::class.java, TokenBucket::class.java)
 
   private val pinnedOrders =
@@ -134,7 +134,7 @@ class OrdinalBoundEnumOrderTest : AbstractSpringTest() {
       .withFailMessage(
         "These enums are persisted by ordinal, so their constant order is part of the schema. Pin each above " +
           "(or map the column with @Enumerated(EnumType.STRING)):\n" +
-          unpinned.map { it.name }.sorted().joinToString("\n") { "  - $it" },
+          bulletList(unpinned),
       ).isEmpty()
   }
 
@@ -166,7 +166,7 @@ class OrdinalBoundEnumOrderTest : AbstractSpringTest() {
       .withFailMessage(
         "These enums are serialized by ordinal into Redis structures that keep the default codec, where entries " +
           "have no TTL and cannot be recomputed. Pin each above:\n" +
-          unpinned.map { it.name }.sorted().joinToString("\n") { "  - $it" },
+          bulletList(unpinned),
       ).isEmpty()
     assertThat(reachable)
       .describedAs("enum fields reachable from the default-codec Redis types")
@@ -289,12 +289,15 @@ class OrdinalBoundEnumOrderTest : AbstractSpringTest() {
     return elementTypeOf(declared).takeIf { it.isEnum }
   }
 
+  private fun bulletList(types: Collection<Class<*>>) =
+    types.map { it.name }.sorted().joinToString("\n") { "  - $it" }
+
   private fun elementTypeOf(declared: Class<*>): Class<*> {
     if (declared.isArray) return declared.componentType
     return declared
   }
 
-  /** A JPA map key with no `@MapKeyEnumerated` defaults to ORDINAL, exactly as a column with no `@Enumerated` does. */
+  /** A JPA map key with no `@MapKeyEnumerated` defaults to ORDINAL. */
   private fun isOrdinalBoundMapKey(member: AnnotatedElement): Boolean =
     member.getAnnotation(MapKeyEnumerated::class.java)?.value != EnumType.STRING
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumGuardTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumGuardTest.kt
@@ -289,8 +289,7 @@ class OrdinalBoundEnumGuardTest : AbstractSpringTest() {
     return elementTypeOf(declared).takeIf { it.isEnum }
   }
 
-  private fun bulletList(types: Collection<Class<*>>) =
-    types.map { it.name }.sorted().joinToString("\n") { "  - $it" }
+  private fun bulletList(types: Collection<Class<*>>) = types.map { it.name }.sorted().joinToString("\n") { "  - $it" }
 
   private fun elementTypeOf(declared: Class<*>): Class<*> {
     if (declared.isArray) return declared.componentType

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumOrderTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/guards/OrdinalBoundEnumOrderTest.kt
@@ -1,0 +1,381 @@
+package io.tolgee.ee.guards
+
+import io.hypersistence.utils.hibernate.type.array.EnumArrayType
+import io.tolgee.AbstractSpringTest
+import io.tolgee.activity.data.RevisionType
+import io.tolgee.batch.state.ExecutionState
+import io.tolgee.component.ThirdPartyAuthTypeConverter
+import io.tolgee.component.bucket.TokenBucket
+import io.tolgee.constants.MtServiceType
+import io.tolgee.ee.model.EeSubscription
+import io.tolgee.formats.ExportFormat
+import io.tolgee.model.DismissedAnnouncementId
+import io.tolgee.model.automations.AutomationActionType
+import io.tolgee.model.batch.BatchJobChunkExecutionStatus
+import io.tolgee.model.dataImport.issues.issueTypes.FileIssueType
+import io.tolgee.model.dataImport.issues.paramTypes.FileIssueParamType
+import io.tolgee.model.enums.OrganizationRoleType
+import io.tolgee.model.enums.Scope
+import io.tolgee.model.enums.ThirdPartyAuthType
+import io.tolgee.model.enums.TranslationCommentState
+import io.tolgee.model.enums.TranslationState
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Convert
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.MapKeyEnumerated
+import jakarta.persistence.metamodel.Attribute
+import jakarta.persistence.metamodel.ManagedType
+import jakarta.persistence.metamodel.MapAttribute
+import jakarta.persistence.metamodel.PluralAttribute
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.annotations.Parameter
+import org.hibernate.annotations.Type
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Field
+import java.lang.reflect.GenericArrayType
+import java.lang.reflect.Modifier
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.WildcardType
+import kotlin.reflect.KClass
+import java.lang.reflect.Type as ReflectType
+
+/**
+ * Each enum below is stored by ordinal somewhere that outlives the deploy that wrote it.
+ *
+ * Lives in `:ee-test` so the metamodel sees every module's entities: `:server-app` pulls `:ee-app` in only
+ * conditionally, so from there the EE entities would vanish from the scan while the floors below still passed.
+ */
+@SpringBootTest
+class OrdinalBoundEnumOrderTest : AbstractSpringTest() {
+  private val nonSpringCacheOrdinalCodecRedisTypes = listOf(ExecutionState::class.java, TokenBucket::class.java)
+
+  private val pinnedOrders =
+    mapOf<Class<*>, List<String>>(
+      OrganizationRoleType::class.java to listOf("MEMBER", "OWNER", "MAINTAINER"),
+      RevisionType::class.java to listOf("ADD", "MOD", "DEL"),
+      TranslationState::class.java to listOf("UNTRANSLATED", "TRANSLATED", "REVIEWED", "DISABLED"),
+      MtServiceType::class.java to listOf("GOOGLE", "AWS", "DEEPL", "AZURE", "BAIDU", "PROMPT"),
+      TranslationCommentState::class.java to listOf("RESOLUTION_NOT_NEEDED", "NEEDS_RESOLUTION", "RESOLVED"),
+      AutomationActionType::class.java to listOf("CONTENT_DELIVERY_PUBLISH", "WEBHOOK", "SLACK_SUBSCRIPTION"),
+      ExportFormat::class.java to
+        listOf(
+          "JSON",
+          "JSON_TOLGEE",
+          "XLIFF",
+          "PO",
+          "APPLE_STRINGS_STRINGSDICT",
+          "APPLE_XLIFF",
+          "ANDROID_XML",
+          "COMPOSE_XML",
+          "FLUTTER_ARB",
+          "PROPERTIES",
+          "YAML_RUBY",
+          "YAML",
+          "JSON_I18NEXT",
+          "CSV",
+          "RESX_ICU",
+          "XLSX",
+          "APPLE_XCSTRINGS",
+          "ANDROID_SDK",
+          "APPLE_SDK",
+        ),
+      FileIssueParamType::class.java to
+        listOf(
+          "KEY_NAME",
+          "KEY_ID",
+          "LANGUAGE_ID",
+          "KEY_INDEX",
+          "VALUE",
+          "LINE",
+          "FILE_NODE_ORIGINAL",
+          "LANGUAGE_NAME",
+        ),
+      FileIssueType::class.java to
+        listOf(
+          "KEY_IS_NOT_STRING",
+          "MULTIPLE_VALUES_FOR_KEY_AND_LANGUAGE",
+          "VALUE_IS_NOT_STRING",
+          "KEY_IS_EMPTY",
+          "VALUE_IS_EMPTY",
+          "PO_MSGCTXT_NOT_SUPPORTED",
+          "ID_ATTRIBUTE_NOT_PROVIDED",
+          "TARGET_NOT_PROVIDED",
+          "TRANSLATION_TOO_LONG",
+          "KEY_IS_BLANK",
+          "TRANSLATION_DEFINED_IN_ANOTHER_FILE",
+          "INVALID_CUSTOM_VALUES",
+          "DESCRIPTION_TOO_LONG",
+          "TRANSLATION_EXCEEDS_CHAR_LIMIT",
+        ),
+      BatchJobChunkExecutionStatus::class.java to listOf("PENDING", "RUNNING", "SUCCESS", "FAILED", "CANCELLED"),
+    )
+
+  @Test
+  fun `pinned enums keep their existing constants at their existing ordinals`() {
+    pinnedOrders.forEach { (enumType, pinned) ->
+      val actual = enumType.enumConstants.map { (it as Enum<*>).name }
+      assertThat(actual)
+        .withFailMessage(
+          "${enumType.simpleName}'s constant order is part of the schema. Existing constants must keep their " +
+            "ordinals; a new one must be appended AND added to the end of the pinned list here.\n" +
+            "  pinned: $pinned\n  actual: $actual",
+        ).containsExactlyElementsOf(pinned)
+    }
+  }
+
+  @Test
+  fun `every enum a JPA column binds by ordinal is pinned above`() {
+    val unpinned = ordinalBoundJpaEnums() - pinnedOrders.keys
+    assertThat(unpinned)
+      .withFailMessage(
+        "These enums are persisted by ordinal, so their constant order is part of the schema. Pin each above " +
+          "(or map the column with @Enumerated(EnumType.STRING)):\n" +
+          unpinned.map { it.name }.sorted().joinToString("\n") { "  - $it" },
+      ).isEmpty()
+  }
+
+  @Test
+  fun `entity scan is non-trivial (a broken or empty metamodel cannot masquerade as success)`() {
+    assertThat(managedTypesOwningTheirColumns()).hasSizeGreaterThan(50)
+    assertThat(managedTypesOwningTheirColumns().map { it.javaType })
+      .describedAs("EE entities are in the metamodel — the reason this guard lives in :ee-test")
+      .contains(EeSubscription::class.java)
+    assertThat(enumAttributes()).hasSizeGreaterThan(10)
+    assertThat(ordinalBoundJpaEnums()).isNotEmpty()
+    assertThat(enumAttributes().filter { it is PluralAttribute<*, *, *> })
+      .describedAs("@ElementCollection enum columns resolve")
+      .isNotEmpty()
+    assertThat(enumAttributes().filter { (it.javaMember as? Field)?.type?.isArray == true })
+      .describedAs("enum-array columns resolve")
+      .isNotEmpty()
+    assertThat(enumAttributes().filter { it.javaMember !is Field })
+      .describedAs(
+        "enum attributes are field-access — enumTypeOf reads their real type off the Field, not the metamodel",
+      ).isEmpty()
+  }
+
+  @Test
+  fun `every enum the default-codec Redis structures serialize is pinned above`() {
+    val reachable = nonSpringCacheOrdinalCodecRedisTypes.flatMap { enumFieldsOf(it) }
+    val unpinned = reachable.toSet() - pinnedOrders.keys
+    assertThat(unpinned)
+      .withFailMessage(
+        "These enums are serialized by ordinal into Redis structures that keep the default codec, where entries " +
+          "have no TTL and cannot be recomputed. Pin each above:\n" +
+          unpinned.map { it.name }.sorted().joinToString("\n") { "  - $it" },
+      ).isEmpty()
+    assertThat(reachable)
+      .describedAs("enum fields reachable from the default-codec Redis types")
+      .isNotEmpty()
+  }
+
+  @Test
+  fun `finds each way a serialized object can hold an enum, including through a nested object`() {
+    assertThat(enumFieldsOf(RedisFixture::class.java))
+      .describedAs("a Kotlin List<out E>/Map<K, out V> field arrives as a wildcard, not a class")
+      .contains(
+        Scope::class.java,
+        TranslationState::class.java,
+        RevisionType::class.java,
+        OrganizationRoleType::class.java,
+        MtServiceType::class.java,
+        TranslationCommentState::class.java,
+        AutomationActionType::class.java,
+      )
+    assertThat(enumFieldsOf(RevisionType::class.java))
+      .describedAs("a Redis structure whose value type is itself an enum")
+      .containsExactly(RevisionType::class.java)
+  }
+
+  @Test
+  fun `scans a real Embeddable but not the IdClass mirrors Hibernate also reports as embeddables`() {
+    assertThat(ownsItsColumns(EmbeddableFixture::class.java)).isTrue()
+    assertThat(ownsItsColumns(DismissedAnnouncementId::class.java)).isFalse()
+    assertThat(entityManager.metamodel.embeddables.map { it.javaType })
+      .describedAs("an @IdClass mirror, whose fields copy the entity's @Ids without their mapping annotations")
+      .contains(DismissedAnnouncementId::class.java)
+    assertThat(managedTypesOwningTheirColumns().map { it.javaType })
+      .doesNotContain(DismissedAnnouncementId::class.java)
+  }
+
+  @Test
+  fun `classifies each way a column can bind an enum`() {
+    assertThat(isOrdinalBound(field("bare"))).describedAs("bare").isTrue()
+    assertThat(isOrdinalBound(field("ordinalArray"))).describedAs("ordinalArray").isTrue()
+    assertThat(isOrdinalBound(field("convertedToOrdinal"))).describedAs("convertedToOrdinal").isTrue()
+    assertThat(isOrdinalBound(field("stringBound"))).describedAs("stringBound").isFalse()
+    assertThat(isOrdinalBound(field("nameArray"))).describedAs("nameArray").isFalse()
+    assertThat(isOrdinalBound(field("convertedToName"))).describedAs("convertedToName").isFalse()
+    assertThat(isOrdinalBoundMapKey(field("ordinalMapKey"))).describedAs("ordinalMapKey").isTrue()
+    assertThat(isOrdinalBoundMapKey(field("nameMapKey"))).describedAs("nameMapKey").isFalse()
+  }
+
+  private fun field(name: String) = Fixture::class.java.getDeclaredField(name)
+
+  private fun enumFieldsOf(
+    type: Class<*>,
+    seen: MutableSet<Class<*>> = mutableSetOf(),
+  ): List<Class<*>> {
+    if (!seen.add(type)) return emptyList()
+    if (type.isEnum) return listOf(type)
+    return generateSequence(type) { it.superclass }
+      .takeWhile { it != Any::class.java }
+      .flatMap { it.declaredFields.asSequence() }
+      .filterNot { Modifier.isStatic(it.modifiers) }
+      .flatMap { heldTypesOf(it.genericType) }
+      .flatMap { held ->
+        when {
+          held.isEnum -> listOf(held)
+          held.name.startsWith("java.") -> emptyList()
+          else -> enumFieldsOf(held, seen)
+        }
+      }.toList()
+  }
+
+  private fun heldTypesOf(type: ReflectType): List<Class<*>> =
+    when (type) {
+      is ParameterizedType ->
+        listOfNotNull(type.rawType as? Class<*>) + type.actualTypeArguments.flatMap { heldTypesOf(it) }
+      is WildcardType -> type.upperBounds.flatMap { heldTypesOf(it) }
+      is GenericArrayType -> heldTypesOf(type.genericComponentType)
+      is Class<*> -> heldTypesOfClass(type)
+      else -> emptyList()
+    }
+
+  private fun ordinalBoundJpaEnums(): Set<Class<*>> =
+    managedTypesOwningTheirColumns()
+      .flatMap { it.attributes }
+      .flatMap { ordinalBoundEnumsOf(it) }
+      .toSet()
+
+  private fun ordinalBoundEnumsOf(attribute: Attribute<*, *>): List<Class<*>> {
+    val member = attribute.javaMember as? AnnotatedElement ?: return emptyList()
+    return listOfNotNull(
+      enumTypeOf(attribute)?.takeIf { isOrdinalBound(member) },
+      mapKeyEnumTypeOf(attribute)?.takeIf { isOrdinalBoundMapKey(member) },
+    )
+  }
+
+  private fun mapKeyEnumTypeOf(attribute: Attribute<*, *>): Class<*>? =
+    (attribute as? MapAttribute<*, *, *>)?.keyType?.javaType?.takeIf { it.isEnum }
+
+  private fun enumAttributes(): List<Attribute<*, *>> =
+    managedTypesOwningTheirColumns()
+      .flatMap { it.attributes }
+      .filter { enumTypeOf(it) != null }
+
+  private fun managedTypesOwningTheirColumns(): Collection<ManagedType<*>> =
+    entityManager.metamodel.entities +
+      entityManager.metamodel.embeddables.filter { ownsItsColumns(it.javaType) }
+
+  private fun ownsItsColumns(type: Class<*>) = type.isAnnotationPresent(Embeddable::class.java)
+
+  private fun heldTypesOfClass(type: Class<*>): List<Class<*>> {
+    if (type.isArray) return heldTypesOf(type.componentType)
+    return listOf(type)
+  }
+
+  private fun enumTypeOf(attribute: Attribute<*, *>): Class<*>? {
+    val declared =
+      when (attribute) {
+        is PluralAttribute<*, *, *> -> attribute.elementType.javaType
+        // Hibernate erases an enum-array attribute's metamodel javaType to Enum[]; the field keeps the real type.
+        else -> (attribute.javaMember as? Field)?.type ?: attribute.javaType
+      }
+    return elementTypeOf(declared).takeIf { it.isEnum }
+  }
+
+  private fun elementTypeOf(declared: Class<*>): Class<*> {
+    if (declared.isArray) return declared.componentType
+    return declared
+  }
+
+  /** A JPA map key with no `@MapKeyEnumerated` defaults to ORDINAL, exactly as a column with no `@Enumerated` does. */
+  private fun isOrdinalBoundMapKey(member: AnnotatedElement): Boolean =
+    member.getAnnotation(MapKeyEnumerated::class.java)?.value != EnumType.STRING
+
+  /** A JPA enum column with no `@Enumerated` defaults to ORDINAL. */
+  private fun isOrdinalBound(member: AnnotatedElement): Boolean {
+    member.getAnnotation(Convert::class.java)?.let { if (!it.disableConversion) return convertsToNumber(it.converter) }
+    val type = member.getAnnotation(Type::class.java)
+    if (type?.value == EnumArrayType::class) {
+      return type.parameters.none { it.name == EnumArrayType.SQL_ARRAY_TYPE && it.value == "varchar" }
+    }
+    return member.getAnnotation(Enumerated::class.java)?.value != EnumType.STRING
+  }
+
+  private fun convertsToNumber(converter: KClass<*>): Boolean {
+    val target =
+      converter.java.genericInterfaces
+        .filterIsInstance<ParameterizedType>()
+        .firstOrNull { it.rawType == AttributeConverter::class.java }
+        ?.actualTypeArguments
+        ?.getOrNull(1) as? Class<*> ?: return true
+    return Number::class.java.isAssignableFrom(target)
+  }
+
+  @Suppress("unused")
+  private class Fixture {
+    var bare: Scope? = null
+
+    @Enumerated(EnumType.STRING)
+    var stringBound: Scope? = null
+
+    @Type(EnumArrayType::class, parameters = [Parameter(name = EnumArrayType.SQL_ARRAY_TYPE, value = "varchar")])
+    var nameArray: Array<Scope>? = null
+
+    @Type(EnumArrayType::class, parameters = [Parameter(name = EnumArrayType.SQL_ARRAY_TYPE, value = "int")])
+    var ordinalArray: Array<Scope>? = null
+
+    @Convert(converter = ThirdPartyAuthTypeConverter::class)
+    var convertedToName: ThirdPartyAuthType? = null
+
+    @Convert(converter = ScopeOrdinalConverter::class)
+    var convertedToOrdinal: Scope? = null
+
+    var ordinalMapKey: MutableMap<Scope, String> = mutableMapOf()
+
+    @MapKeyEnumerated(EnumType.STRING)
+    var nameMapKey: MutableMap<Scope, String> = mutableMapOf()
+  }
+
+  @Embeddable
+  private class EmbeddableFixture
+
+  @Suppress("unused")
+  private open class RedisFixtureBase {
+    var inherited: RevisionType? = null
+  }
+
+  @Suppress("unused")
+  private class RedisFixtureNested {
+    var deep: TranslationCommentState? = null
+  }
+
+  /** Distinct from [RedisFixtureNested]: sharing a type would let `seen` mask one of the two paths into it. */
+  @Suppress("unused")
+  private class RedisFixtureNestedElement {
+    var deep: AutomationActionType? = null
+  }
+
+  @Suppress("unused")
+  private class RedisFixture : RedisFixtureBase() {
+    var direct: Scope? = null
+    var inArray: Array<TranslationState>? = null
+    var inList: List<OrganizationRoleType> = emptyList()
+    var inMap: Map<String, MtServiceType> = emptyMap()
+    var nested: RedisFixtureNested? = null
+    var nestedInList: List<RedisFixtureNestedElement> = emptyList()
+    var self: RedisFixture? = null
+  }
+
+  private class ScopeOrdinalConverter : AttributeConverter<Scope, Int> {
+    override fun convertToDatabaseColumn(attribute: Scope?) = attribute?.ordinal
+
+    override fun convertToEntityAttribute(dbData: Int?) = dbData?.let { Scope.entries[it] }
+  }
+}


### PR DESCRIPTION
## Problem

Redis caching goes through Redisson's default `Kryo5Codec` (Redisson never has `setCodec` called, and `Config` instantiates `Kryo5Codec` when the codec is null). Kryo's `EnumSerializer` writes `ordinal() + 1` and reads back `enumConstants[ordinal]`.

So every enum inside a cached value is bound to its ordinal. Reordering, inserting or removing a constant makes entries written by a previous deploy decode as a **different constant** — and because a shifted ordinal is still a valid index, this does not throw. It silently returns the wrong value.

The sharpest case is `PermissionDto.scopes` / `ApiKeyDto.scopes` (`Array<Scope>`, 38 constants): a mid-enum insert silently grants or denies the wrong permissions until the entry expires — 2 hours by default (`CacheProperties.defaultTtl`). Nothing in `Scope.kt` warns against reordering, and both the DB (`varchar[]`, `EnumType.STRING`) and the API (`@get:JsonValue`) already bind by name, so the source reads as if reordering were safe.

20 enums are reachable this way from cached values or cache keys, including `ActivityType` (101 constants, also used in the `automations` cache key), `Feature` (23, gates EE features) and `BatchJobType` (19).

Only affects deployments with `tolgee.cache.enabled=true` **and** `tolgee.cache.use-redis=true`. The Caffeine path stores live object references and never serializes.

## Change

`EnumNameKryo5Codec` overrides `Kryo5Codec.createKryo` and registers a name-based serializer for all enums:

```kotlin
addDefaultSerializer(Enum::class.java, EnumNameSerializer::class.java)
```

One line covers every enum, present and future — no per-enum annotation to remember. User-added default serializers are inserted ahead of Kryo's built-ins, so this wins over the ordinal `EnumSerializer`.

It is passed to `RedissonSpringCacheManager`'s existing `(RedissonClient, Map<String, CacheConfig>, Codec)` constructor, so the change is scoped to caches; the Redisson client's own codec is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis/resilient cache compatibility by encoding enum values by name (not ordinals), preventing incorrect decoding after codec changes.
  * Preserved cached machine-translation results via resilient cache reads and clarified fallback behavior for older entries.
  * Ensured dismissed-announcement cache entries are properly invalidated after dismissal.
* **Documentation**
  * Added/extended guidance that enums used with ordinal persistence must not be reordered.
* **Tests**
  * Expanded Redis/cache, enum codec, and resilient fallback coverage, including a new EE test to guard enum ordinal stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->