### PR TITLE
fix: keep websocket connection alive when a subscription is denied

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/websocket/WebSocketConfig.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/websocket/WebSocketConfig.kt
@@ -43,93 +43,105 @@ class WebSocketConfig(
         override fun preSend(
           message: Message<*>,
           channel: MessageChannel,
-        ): Message<*> {
+        ): Message<*>? {
           val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
 
           if (accessor?.command == StompCommand.CONNECT) {
             accessor.user = websocketAuthenticationResolver.resolve(accessor)
           }
 
-          val authentication = accessor?.user as? TolgeeAuthentication
-
-          if (accessor?.command == StompCommand.SUBSCRIBE) {
-            checkProjectPathPermissionsAuth(authentication, accessor.destination)
-            checkUserPathPermissionsAuth(authentication, accessor.destination)
+          if (accessor?.command != StompCommand.SUBSCRIBE) {
+            return message
           }
 
-          return message
+          val authentication = accessor.user as? TolgeeAuthentication
+          return when (decideSubscribe(authentication, accessor.destination)) {
+            SubscribeDecision.DENY -> null
+            // Throwing here makes Spring close the whole WebSocket, not just reject the SUBSCRIBE.
+            SubscribeDecision.UNAUTHENTICATED -> throw MessagingException("Unauthenticated")
+            SubscribeDecision.ALLOW -> message
+          }
         }
       },
     )
   }
 
-  fun checkProjectPathPermissionsAuth(
+  private enum class SubscribeDecision {
+    ALLOW,
+    DENY,
+    UNAUTHENTICATED,
+  }
+
+  private fun decideSubscribe(
     authentication: TolgeeAuthentication?,
     destination: String?,
-  ) {
-    val projectId =
-      destination?.let {
-        "/projects/([0-9]+)"
-          .toRegex()
-          .find(it)
-          ?.groupValues
-          ?.getOrNull(1)
-          ?.toLong()
-      } ?: return
-
-    if (authentication == null) {
-      throw MessagingException("Unauthenticated")
+  ): SubscribeDecision {
+    val projectId = topicId(PROJECT_TOPIC, destination)
+    if (projectId != null) {
+      val auth = authentication ?: return SubscribeDecision.UNAUTHENTICATED
+      return decision(isProjectSubscribeAllowed(auth, projectId), destination)
     }
 
-    val apiKey = authentication.credentials as? ApiKeyDto
-    val user = authentication.principal
+    val userId = topicId(USER_TOPIC, destination)
+    if (userId != null) {
+      val auth = authentication ?: return SubscribeDecision.UNAUTHENTICATED
+      return decision(isUserSubscribeAllowed(auth, userId), destination)
+    }
 
+    logger().debug("Denying websocket subscription to unrecognized destination {}", destination)
+    return SubscribeDecision.DENY
+  }
+
+  private fun topicId(
+    topic: Regex,
+    destination: String?,
+  ): Long? =
+    topic
+      .find(destination.orEmpty())
+      ?.groupValues
+      ?.get(1)
+      // toLongOrNull, not toLong: an overflow id must fall through to deny, not throw (which closes the connection).
+      ?.toLongOrNull()
+
+  private fun decision(
+    allowed: Boolean,
+    destination: String?,
+  ): SubscribeDecision {
+    if (allowed) return SubscribeDecision.ALLOW
+    logger().debug("Denying websocket subscription to {}", destination)
+    return SubscribeDecision.DENY
+  }
+
+  private fun isProjectSubscribeAllowed(
+    authentication: TolgeeAuthentication,
+    projectId: Long,
+  ): Boolean {
     try {
       securityService.checkProjectPermission(
         projectId = projectId,
         requiredPermission = Scope.KEYS_VIEW,
-        user = user,
-        apiKey = apiKey,
+        user = authentication.principal,
+        apiKey = authentication.credentials as? ApiKeyDto,
       )
     } catch (e: PermissionException) {
       logger().debug("User / API key does not have required scopes", e)
-      throwForbidden()
+      return false
     }
-
-    return
+    return true
   }
 
-  fun checkUserPathPermissionsAuth(
-    authentication: TolgeeAuthentication?,
-    destination: String?,
-  ) {
-    val userId =
-      destination?.let {
-        "/users/([0-9]+)"
-          .toRegex()
-          .find(it)
-          ?.groupValues
-          ?.getOrNull(1)
-          ?.toLong()
-      } ?: return
-
-    if (authentication == null) {
-      throw MessagingException("Unauthenticated")
+  private fun isUserSubscribeAllowed(
+    authentication: TolgeeAuthentication,
+    userId: Long,
+  ): Boolean {
+    if (authentication.credentials is ApiKeyDto) {
+      return false
     }
-
-    val creds = authentication.credentials
-    if (creds is ApiKeyDto) {
-      // API keys must not subscribe to user topics
-      throw MessagingException("Forbidden")
-    }
-
-    val user = (authentication as? TolgeeAuthentication)?.principal
-    if (user?.id != userId) {
-      throw MessagingException("Forbidden")
-    }
+    return authentication.principal.id == userId
   }
 
-  private fun throwForbidden() {
-    throw MessagingException("Forbidden")
+  private companion object {
+    val PROJECT_TOPIC = "^/projects/([0-9]+)/".toRegex()
+    val USER_TOPIC = "^/users/([0-9]+)/".toRegex()
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/AbstractWebsocketTest.kt
@@ -239,34 +239,30 @@ abstract class AbstractWebsocketTest : ProjectAuthControllerTest("/v2/projects/"
   @ProjectJWTAuthTestMethod
   fun `doesn't subscribe as another user`() {
     currentUserWebsocket.listenForNotificationsChanged()
-    val spyingUserWebsocket =
-      WebsocketTestHelper(
-        port,
-        WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(anotherUser.id)),
-        testData.projectBuilder.self.id,
-        // anotherUser trying to spy on other user's websocket
-        testData.user.id,
+    anotherUserWebsocket.listenForNotificationsChanged()
+    val spiedInbox =
+      anotherUserWebsocket.subscribeAdditional(
+        "/users/${testData.user.id}/${WebsocketEventType.NOTIFICATIONS_CHANGED.typeName}",
       )
-    try {
-      spyingUserWebsocket.listenForNotificationsChanged()
-      spyingUserWebsocket.waitForForbidden()
-      saveNotificationForCurrentUser()
 
-      assertCurrentUserReceivedMessage()
-      spyingUserWebsocket.receivedMessages.assert.isEmpty()
-    } finally {
-      spyingUserWebsocket.stop()
-    }
+    saveNotificationFor(testData.user)
+    saveNotificationFor(anotherUser)
+
+    waitFor { anotherUserWebsocket.receivedMessages.isNotEmpty() }
+    assertCurrentUserReceivedMessage()
+    spiedInbox.assert.isEmpty()
   }
 
   private fun assertCurrentUserReceivedMessage() {
     waitFor { currentUserWebsocket.receivedMessages.isNotEmpty() }
   }
 
-  private fun saveNotificationForCurrentUser(): Notification {
+  private fun saveNotificationForCurrentUser(): Notification = saveNotificationFor(testData.user)
+
+  private fun saveNotificationFor(account: UserAccount): Notification {
     val notification =
       Notification().apply {
-        user = testData.user
+        user = account
         type = NotificationType.PASSWORD_CHANGED
       }
     notificationService.notify(notification)

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketAuthenticationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketAuthenticationTest.kt
@@ -5,14 +5,20 @@ import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.dtos.request.key.CreateKeyDto
 import io.tolgee.fixtures.andIsCreated
 import io.tolgee.model.Pat
+import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.Scope
+import io.tolgee.model.notifications.Notification
+import io.tolgee.model.notifications.NotificationType
+import io.tolgee.service.notification.NotificationService
 import io.tolgee.testing.annotations.ProjectApiKeyAuthTestMethod
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import io.tolgee.testing.assert
 import io.tolgee.util.addMinutes
 import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import java.util.Date
@@ -26,6 +32,9 @@ import java.util.Date
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
   lateinit var testData: BaseTestData
+
+  @Autowired
+  lateinit var notificationService: NotificationService
 
   @LocalServerPort
   private val port: Int? = null
@@ -55,14 +64,30 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
     )
   }
 
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `unauthenticated on a user topic`() {
+    saveTestData()
+    val socket =
+      WebsocketTestHelper(
+        port,
+        WebsocketTestHelper.Auth(jwtToken = "invalid"),
+        testData.projectBuilder.self.id,
+        testData.user.id,
+      )
+    socket.listenForNotificationsChanged()
+    socket.waitForUnauthenticated()
+  }
+
   // we need at least keys.view permission when using JWT
   @Test
   @ProjectJWTAuthTestMethod
   fun `forbidden with insufficient scopes on user with JWT`() {
     val user2 = testData.root.addUserAccount { username = "user2" }
     saveTestData()
-    testItIsForbiddenWithAuth(
+    testProjectSubscribeForbidden(
       auth = WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(user2.self.id)),
+      ownUserId = user2.self.id,
     )
   }
 
@@ -107,9 +132,72 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
   @ProjectApiKeyAuthTestMethod(scopes = []) // No scopes
   fun `forbidden with insufficient scopes on PAK`() {
     saveTestData()
-    testItIsForbiddenWithAuth(
+    testProjectSubscribeForbiddenViaControlSocket(
       auth = WebsocketTestHelper.Auth(apiKey = apiKey.key),
     )
+  }
+
+  @Test
+  @ProjectApiKeyAuthTestMethod
+  fun `api key cannot subscribe to a user topic`() {
+    saveTestData()
+    val keySocket = prepareSocket(WebsocketTestHelper.Auth(apiKey = apiKey.key))
+    val ownerWitness =
+      WebsocketTestHelper(
+        port,
+        WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(testData.user.id)),
+        testData.projectBuilder.self.id,
+        testData.user.id,
+      )
+    try {
+      val deniedInbox =
+        keySocket.subscribeAdditional(
+          "/users/${testData.user.id}/${WebsocketEventType.NOTIFICATIONS_CHANGED.typeName}",
+        )
+      ownerWitness.listenForNotificationsChanged()
+      ownerWitness.assertNotified({ saveNotificationFor(testData.user) }) {
+        assertThatJson(it.poll()).node("data").isObject
+      }
+      deniedInbox.assert.isEmpty()
+    } finally {
+      keySocket.stop()
+      ownerWitness.stop()
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `denies subscription to an unrecognized destination`() {
+    saveTestData()
+    val socket = prepareSocket(WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(testData.user.id)))
+    try {
+      val wildcardInbox = socket.subscribeAdditional("/**")
+      socket.assertNotified({ createKey() }) {
+        assertThatJson(it.poll()).node("data").isObject
+      }
+      wildcardInbox.assert.isEmpty()
+    } finally {
+      socket.stop()
+    }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `denies an out-of-range project id without closing the connection`() {
+    saveTestData()
+    val socket = prepareSocket(WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(testData.user.id)))
+    try {
+      val overflowInbox =
+        socket.subscribeAdditional(
+          "/projects/99999999999999999999999/${WebsocketEventType.TRANSLATION_DATA_MODIFIED.typeName}",
+        )
+      socket.assertNotified({ createKey() }) {
+        assertThatJson(it.poll()).node("data").isObject
+      }
+      overflowInbox.assert.isEmpty()
+    } finally {
+      socket.stop()
+    }
   }
 
   @Test
@@ -151,10 +239,17 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
   @Test
   @ProjectJWTAuthTestMethod
   fun `forbidden with insufficient scopes on user with PAT`() {
-    val pat = addInsufficientPatToTestData()
+    val user2 = testData.root.addUserAccount { username = "user2" }
+    val pat =
+      user2
+        .addPat {
+          description = "Test"
+          this.expiresAt = currentDateProvider.date.addMinutes(60)
+        }.self
     saveTestData()
-    testItIsForbiddenWithAuth(
+    testProjectSubscribeForbidden(
       auth = WebsocketTestHelper.Auth(apiKey = pat.tokenWithPrefix),
+      ownUserId = user2.self.id,
     )
   }
 
@@ -162,6 +257,15 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
     testDataService.saveTestData(testData.root)
     userAccount = testData.user
     projectSupplier = { testData.projectBuilder.self }
+  }
+
+  private fun saveNotificationFor(account: UserAccount) {
+    notificationService.notify(
+      Notification().apply {
+        user = account
+        type = NotificationType.PASSWORD_CHANGED
+      },
+    )
   }
 
   fun testItWorksWithAuth(auth: WebsocketTestHelper.Auth) {
@@ -174,9 +278,41 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
     )
   }
 
-  fun testItIsForbiddenWithAuth(auth: WebsocketTestHelper.Auth) {
-    val socket = prepareSocket(auth)
-    socket.waitForForbidden()
+  fun testProjectSubscribeForbidden(
+    auth: WebsocketTestHelper.Auth,
+    ownUserId: Long,
+  ) {
+    val forbiddenSocket =
+      WebsocketTestHelper(port, auth, testData.projectBuilder.self.id, ownUserId)
+    val deliveryWitness = prepareSocket(WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(testData.user.id)))
+    try {
+      forbiddenSocket.listenForNotificationsChanged()
+      val deniedInbox =
+        forbiddenSocket.subscribeAdditional(
+          "/projects/${testData.projectBuilder.self.id}/${WebsocketEventType.TRANSLATION_DATA_MODIFIED.typeName}",
+        )
+      deliveryWitness.assertNotified({ createKey() }) {
+        assertThatJson(it.poll()).node("data").isObject
+      }
+      deniedInbox.assert.isEmpty()
+    } finally {
+      forbiddenSocket.stop()
+      deliveryWitness.stop()
+    }
+  }
+
+  fun testProjectSubscribeForbiddenViaControlSocket(auth: WebsocketTestHelper.Auth) {
+    val forbiddenSocket = prepareSocket(auth)
+    val deliveryWitness = prepareSocket(WebsocketTestHelper.Auth(jwtToken = jwtService.emitToken(testData.user.id)))
+    try {
+      deliveryWitness.assertNotified({ createKey() }) {
+        assertThatJson(it.poll()).node("data").isObject
+      }
+      forbiddenSocket.receivedMessages.assert.isEmpty()
+    } finally {
+      forbiddenSocket.stop()
+      deliveryWitness.stop()
+    }
   }
 
   fun testItIsUnauthenticatedWithAuth(auth: WebsocketTestHelper.Auth) {
@@ -207,18 +343,6 @@ class WebsocketAuthenticationTest : ProjectAuthControllerTest() {
       .addPat {
         description = "Test"
         this.expiresAt = expiresAt
-      }.self
-  }
-
-  private fun addInsufficientPatToTestData(): Pat {
-    val user =
-      testData.root.addUserAccount {
-        username = "user2"
-      }
-    return user
-      .addPat {
-        description = "Test"
-        this.expiresAt = currentDateProvider.date.addMinutes(60)
       }.self
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -82,6 +82,36 @@ class WebsocketTestHelper(
     )
   }
 
+  fun subscribeAdditional(path: String): LinkedBlockingDeque<String> {
+    val session = connection ?: error("listen() must be called before subscribeAdditional()")
+    val primary = sessionHandler ?: error("listen() must be called before subscribeAdditional()")
+    WebsocketTestSubscribeSync.awaitSubscribed(primary.subscribeCorrelationId, timeoutMs = 5000)
+
+    val inbox = LinkedBlockingDeque<String>()
+    session.subscribe(
+      StompHeaders().apply {
+        destination = path
+      },
+      MySessionHandler(path, inbox, UUID.randomUUID().toString()),
+    )
+
+    // A denied subscribe has no ack of its own; this trailing correlated subscribe is the barrier
+    // that guarantees the one above was processed before we return.
+    val barrierId = UUID.randomUUID().toString()
+    WebsocketTestSubscribeSync.register(barrierId)
+    session.subscribe(
+      StompHeaders().apply {
+        destination = primary.dest
+        add(WebsocketTestSubscribeSync.CORRELATION_HEADER, barrierId)
+      },
+      MySessionHandler(primary.dest, LinkedBlockingDeque(), barrierId),
+    )
+    WebsocketTestSubscribeSync.awaitSubscribed(barrierId, timeoutMs = 5000)
+    WebsocketTestSubscribeSync.cleanup(barrierId)
+    logger.debug("Additional SUBSCRIBE processed (sessionId={}, dest={})", session.sessionId, path)
+    return inbox
+  }
+
   private fun getAuthHeaders(): StompHeaders {
     return StompHeaders().apply {
       when {
@@ -118,29 +148,11 @@ class WebsocketTestHelper(
     Logging {
     var subscription: StompSession.Subscription? = null
 
-    // Append-only history of every status the session observed. The sequence
-    // matters because the ERROR frame and the transport close can fire in
-    // opposite orders under CI load — checking the full list (rather than
-    // just the latest value) lets a test pass when the expected rejection
-    // frame arrived at all, even if a CONNECTION_LOST was recorded first
-    // because the close fired before the frame was processed. If the list
-    // never contains the expected status, the wait fails — with the
-    // transitions logged so the failure points at the lost rejection frame.
     val statusTransitions: MutableList<AuthenticationStatus> =
       CopyOnWriteArrayList()
 
-    val authenticationStatus: AuthenticationStatus?
-      get() = statusTransitions.lastOrNull()
-
     enum class AuthenticationStatus {
       UNAUTHENTICATED,
-      FORBIDDEN,
-
-      // The transport closed before any ERROR frame was processed. NOT a
-      // valid substitute for UNAUTHENTICATED/FORBIDDEN — the wait helper
-      // fails if this is the only entry in the transitions list. Recorded
-      // so that the failure log shows what we did see when the expected
-      // rejection frame was lost in the server's flush-before-close window.
       CONNECTION_LOST,
     }
 
@@ -213,7 +225,6 @@ class WebsocketTestHelper(
         stompHeaders,
       )
 
-      handleForbidden(messageHeader)
       handleUnauthenticated(messageHeader)
 
       if (o !is ByteArray) {
@@ -225,13 +236,6 @@ class WebsocketTestHelper(
         receivedMessages.add(o.decodeToString())
       } catch (e: InterruptedException) {
         throw RuntimeException(e)
-      }
-    }
-
-    private fun handleForbidden(messageHeader: String?) {
-      if (messageHeader == "Forbidden") {
-        logger.debug("Authentication status -> FORBIDDEN (dest={})", dest)
-        recordStatus(AuthenticationStatus.FORBIDDEN)
       }
     }
 
@@ -273,15 +277,11 @@ class WebsocketTestHelper(
     stop()
   }
 
-  fun waitForForbidden() {
-    waitForAuthenticationStatus(MySessionHandler.AuthenticationStatus.FORBIDDEN)
-  }
-
   fun waitForUnauthenticated() {
     waitForAuthenticationStatus(MySessionHandler.AuthenticationStatus.UNAUTHENTICATED)
   }
 
-  fun waitForAuthenticationStatus(status: MySessionHandler.AuthenticationStatus) {
+  private fun waitForAuthenticationStatus(status: MySessionHandler.AuthenticationStatus) {
     try {
       waitFor(5000) {
         sessionHandler?.statusTransitions?.contains(status) == true


### PR DESCRIPTION
## Problem

`WebSocketConfig` rejected a STOMP SUBSCRIBE by **throwing** from the client-inbound `ChannelInterceptor`. Spring answers a throw from that interceptor by writing a STOMP ERROR frame and then closing the whole WebSocket in a `finally` — [`StompSubProtocolHandler.sendErrorMessage`](https://github.com/spring-projects/spring-framework/blob/v6.2.19/spring-websocket/src/main/java/org/springframework/web/socket/messaging/StompSubProtocolHandler.java):

```java
try   { session.sendMessage(new TextMessage(bytes)); }   // ERROR frame
finally { session.close(CloseStatus.PROTOCOL_ERROR); }   // ...then kill the socket
```

Two consequences fall out of that one `finally`:

1. **Product bug — one denied subscription kills the whole connection.** The webapp uses a single client holding an array of subscriptions with `reconnectDelay: 3000`, and `resubscribe()` re-subscribes *all* channels on reconnect — including the denied one. A user whose project permission is revoked with a tab open lands in a permanent 3-second reconnect loop that repeatedly tears down every other subscription. The CLI's `WebsocketClient.ts` has the same shape.
2. **Test flakiness.** The ERROR frame races the close, so under CI load the client sees only the close and `waitForForbidden()` times out. This is the root cause of `WebsocketWithoutRedisTest."doesn't subscribe as another user"` on the flaky-tests board. #3529 raised a timeout and #3621 rebuilt the test harness; neither touched the `finally`. #3621 predicted this recurrence and pointed here.

## Fix

`preSend` now maps a SUBSCRIBE to an explicit three-way decision instead of throwing:

- **`ALLOW`** — pass the message through.
- **`DENY`** — return `null`. `channel.send()` returns `false`, no ERROR frame is written, nothing closes, and the SUBSCRIBE never reaches the broker, so no subscription is registered. This is Spring's own sanctioned path. Used for a permission denial (valid identity, insufficient scope) and for any unrecognized destination (**fail-closed**: a new topic family is private until a branch explicitly grants it).
- **`UNAUTHENTICATED`** — still throws (ERROR + close). Reserved for a session with no usable identity, where closing is correct because the session is unusable. This is a deliberate product decision; the ERROR-vs-close race on this path is pre-existing and unchanged. Closing that race too means rejecting bad auth at CONNECT — a separate follow-up.

Denial is now silent to the client, which is correct for *Forbidden* (nothing the client can act on) and is what removes the destructive close/race. Every denial is logged at debug, matching the codebase convention.

Topic ids are parsed with anchored, precompiled regexes and `toLongOrNull()` — an out-of-range id (`/projects/<overflow>/…`) falls through to fail-closed deny rather than throwing and closing the connection.

## Verification

- All **31 tests** pass across `io.tolgee.websocket.*` (both `WithRedis` and `WithoutRedis` variants); ktlintFormat clean.
- The regression is proven by **positive delivery on a shared connection**: `doesn't subscribe as another user` and `api key cannot subscribe to a user topic` each hold an allowed *and* a denied subscription on one connection (via a new `subscribeAdditional` helper whose trailing correlated barrier makes single-connection frame ordering deterministic) and assert the allowed one keeps delivering — these fail if the connection is torn down or the denial is wrongly allowed.
- New deny-path coverage, each **mutation-verified** load-bearing (the guarded code was reverted and the test observed to fail): API-key→user-topic guard, fail-closed default-deny (`/**` wildcard), and out-of-range project id.

## Not covered here

- The `Unauthenticated` ERROR-vs-close race (reject-at-CONNECT is the follow-up).
- The CLI client: it only ever subscribes to a project topic and this server fix covers it; against older servers a client can't reliably self-fix (the ERROR frame doesn't name the rejected destination and is often lost in the very race being fixed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket subscription authorization for project and user destinations.
  * Unauthorized subscriptions are rejected without disconnecting the WebSocket session.
  * Prevented API-key credentials from subscribing to user-specific destinations.
  * Blocked subscriptions to unrecognized or invalid project destinations.
  * Unauthenticated access to recognized user destinations now returns an authentication error.

* **Tests**
  * Added coverage for unauthorized, invalid, and unauthenticated subscription scenarios.
  * Verified authorized connections remain active when a subscription is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->