### PR TITLE
fix: hard-delete of a project with a default namespace fails on FK constraint

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -19,6 +19,7 @@ import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
 import io.tolgee.fixtures.waitFor
 import io.tolgee.model.Project
+import io.tolgee.model.key.Namespace
 import io.tolgee.service.bigMeta.BigMetaService
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewRepeatableTransaction
@@ -132,6 +133,27 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
     testDataService.saveTestData(testData.root)
     executeInNewTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+  }
+
+  @Test
+  fun `deletes project that has a default namespace`() {
+    val testData = BaseTestData()
+    val namespace = testData.projectBuilder.addNamespace { name = "homepage" }
+    testDataService.saveTestData(testData.root)
+
+    executeInNewTransaction(platformTransactionManager) {
+      val project = projectService.get(testData.projectBuilder.self.id)
+      project.defaultNamespace = entityManager.find(Namespace::class.java, namespace.self.id)
+      projectService.save(project)
+    }
+
+    executeInNewTransaction(platformTransactionManager) {
+      projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+
+    executeInNewTransaction {
+      projectService.find(testData.projectBuilder.self.id).assert.isNull()
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectHardDeletingService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectHardDeletingService.kt
@@ -92,8 +92,9 @@ class ProjectHardDeletingService(
         importService.hardDeleteImport(it)
       }
 
-      // otherwise we cannot delete the languages
+      // otherwise the project keeps referencing the language/namespace we are about to delete
       project.baseLanguage = null
+      project.defaultNamespace = null
       projectRepository.saveAndFlush(project)
 
       traceLogMeasureTime("deleteProject: delete api keys") {


### PR DESCRIPTION
## Root cause

`ProjectHardDeletingService.hardDeleteProject` nulls the project's `baseLanguage` before deleting the project's languages, but never nulls `defaultNamespace` before deleting the project's namespaces. So for any project that has a default namespace, deleting its namespaces fails:

```
ERROR: update or delete on table "namespace" violates foreign key constraint
"FK4pgl5uneh3it2odrc36nyubbx" on table "project"
  Detail: Key (id)=(...) is still referenced from table "project".
  at io.tolgee.service.key.NamespaceService.deleteAllByProject
```

## Impact

`hardDeleteProject` is used by both:
- the async `OnProjectSoftDeleted` listener (normal project deletion), and
- `DeletedOrganizationProjectPurgeScheduler` (purging projects of soft-deleted organizations, added in #3783).

The exception is caught and rethrown into the async/scheduled error handler, so it fails silently. In production the purge scheduler was running daily (visible via the "Running orphan project purge" INFO log) but always threw here before deleting anything — so projects of deleted organizations kept their `deleted_at` set and were never purged.

## Fix

Null `project.defaultNamespace` alongside `project.baseLanguage` before the flush that precedes namespace deletion.

## Test

`ProjectHardDeletingServiceTest.deletes project that has a default namespace` — reproduces the FK violation without the fix (verified: fails with `DataIntegrityViolationException`), passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hard deletion for projects that have a default namespace configured.
  * Ensures projects are fully removed without keeping stale references to related language or namespace data.
* **Tests**
  * Added a new test case covering hard-deleting a project with a default namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->