### PR TITLE
fix: prevent long language names from shrinking dashboard progress bars

### DIFF
--- a/webapp/src/views/projects/dashboard/LanguageStats/LanguageStats.tsx
+++ b/webapp/src/views/projects/dashboard/LanguageStats/LanguageStats.tsx
@@ -30,7 +30,7 @@ import { TooltipCard } from 'tg.component/common/TooltipCard';
 
 const StyledContainer = styled('div')`
   display: grid;
-  grid-template-columns: auto auto auto 10fr auto auto;
+  grid-template-columns: fit-content(40%) auto auto minmax(120px, 1fr) auto auto;
   margin: ${({ theme }) => theme.spacing(1, 0, 2, 0)};
 `;
 
@@ -51,6 +51,8 @@ const StyledRow = styled('div')`
 `;
 
 const StyledInfo = styled(Box)`
+  min-width: 0;
+  overflow: hidden;
   display: grid;
   grid-template-columns: auto auto 1fr;
   grid-template-areas:
@@ -58,6 +60,24 @@ const StyledInfo = styled(Box)`
     'flag tag  base';
   gap: 5px 10px;
   padding-left: ${({ theme }) => theme.spacing(1)};
+`;
+
+const StyledLanguageName = styled('div')`
+  grid-area: name;
+  justify-self: start;
+  max-width: 100%;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const StyledTag = styled('div')`
+  grid-area: tag;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const StyledTooltip = styled(Tooltip)`
@@ -162,6 +182,12 @@ export const LanguageStats: FC<React.PropsWithChildren<Props>> = ({
           'translations.view',
           language.id
         );
+        const languageDisplayName =
+          item.languageName +
+          (item.languageOriginalName &&
+          item.languageOriginalName !== item.languageName
+            ? ' | ' + item.languageOriginalName
+            : '');
 
         return (
           <React.Fragment key={item.languageId}>
@@ -172,22 +198,18 @@ export const LanguageStats: FC<React.PropsWithChildren<Props>> = ({
               }
             >
               <StyledInfo>
-                <Box gridArea="name">
-                  {item.languageName +
-                    (item.languageOriginalName &&
-                    item.languageOriginalName !== item.languageName
-                      ? ' | ' + item.languageOriginalName
-                      : '')}
-                </Box>
+                <Tooltip title={languageDisplayName} disableInteractive>
+                  <StyledLanguageName>{languageDisplayName}</StyledLanguageName>
+                </Tooltip>
                 <Box gridArea="flag">
                   <CircledLanguageIcon
                     size={20}
                     flag={item.languageFlagEmoji || ''}
                   />
                 </Box>
-                <Box gridArea="tag">{item.languageTag}</Box>
+                <StyledTag>{item.languageTag}</StyledTag>
                 <Box gridArea="base">
-                  {language?.base && (
+                  {language.base && (
                     <Chip size="small" label={t('global_language_base')} />
                   )}
                 </Box>
@@ -198,7 +220,6 @@ export const LanguageStats: FC<React.PropsWithChildren<Props>> = ({
                   componentsProps={{
                     tooltip: { style: { maxWidth: '100vw' } },
                   }}
-                  className="test"
                   title={<LanguageLabels data={item} />}
                 >
                   <Box>
@@ -242,7 +263,7 @@ export const LanguageStats: FC<React.PropsWithChildren<Props>> = ({
                   </Tooltip>
                 )}
               <StyledActions>
-                <LanguageMenu language={language!} />
+                <LanguageMenu language={language} />
               </StyledActions>
             </StyledRow>
             {i + 1 < languageStats.length && <StyledSeparator />}


### PR DESCRIPTION
## Problem

On the project dashboard, a language with a long name (e.g. "Arabic (Palestinian Territories) | العربية (الأراضي الفلسطينية)") shrinks the translation status progress bar to a sliver — for **every** language row, since all rows share one grid.

## Cause

`LanguageStats` lays rows out with:

```css
grid-template-columns: auto auto auto 10fr auto auto;
```

The `auto` name column grows to the name's full single-line (max-content) width — the text never wraps — and the `10fr` bar column only receives leftover space, which can drop to zero.

## Fix

```css
grid-template-columns: fit-content(40%) auto auto minmax(120px, 1fr) auto auto;
```

- short names keep hugging their content, so the bar keeps nearly all its current width in the common case
- long names cap at 40% of the container and truncate with an ellipsis; the full name is shown in a tooltip on hover (same pattern as #3657 uses for the `LanguagesSelect` dropdown), keeping every row single-line
- the bar column has a 120px floor and — because grid tracks are shared across rows — all bars stay equal width and aligned, so they remain visually comparable
- language tags get the same ellipsis treatment, so an overlong custom tag cannot clip the Base chip or bleed under the bar
- drive-by: removed a stray debug `className="test"` and redundant null-handling on the already-asserted `language`

## Verification

Measured a standalone replica of the grid in a headless browser at 700px and 450px container widths, covering short-names-only, mixed long/short names, and an overlong unbreakable custom tag: bars are equal width across rows in all cases, names/tags truncate on a single line, nothing overlaps the bar, no horizontal overflow.

Related: #3657 addresses long language names in the `LanguagesSelect` dropdown — different component, same truncation pattern.