### PR TITLE
refactor: extract translations add button into library AddButton + fix Storybook preview

### DIFF
--- a/library/.storybook/main.ts
+++ b/library/.storybook/main.ts
@@ -1,4 +1,27 @@
+import { createRequire } from 'node:module';
 import type { StorybookConfig } from '@storybook/react-vite';
+
+// The Storybook preview pulls the theme from webapp/src (see preview.tsx, issue #3326),
+// which lives in a separate node_modules with a different MUI/date-pickers/emotion set
+// than the library. Resolve the whole MUI/emotion/react stack to webapp's copies so
+// Storybook runs a single, self-consistent version set (webapp's proven combination)
+// instead of loading two conflicting ones.
+const requireFromWebapp = createRequire(
+  new URL('../../webapp/package.json', import.meta.url),
+);
+const pkgDir = (id: string) =>
+  requireFromWebapp
+    .resolve(`${id}/package.json`)
+    .replace(/\/package\.json$/, '');
+
+const SHARED_PACKAGES = [
+  '@mui/material',
+  '@mui/lab',
+  '@mui/x-date-pickers',
+  '@emotion/react',
+  '@emotion/styled',
+  'hoist-non-react-statics',
+];
 
 export default {
   stories: ['../src/**/stories.@(js|jsx|ts|tsx)', '../src/**/*.@(md|mdx)'],
@@ -15,5 +38,32 @@ export default {
   typescript: {
     check: true,
     reactDocgen: 'react-docgen-typescript',
+  },
+  async viteFinal(config) {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(config, {
+      resolve: {
+        alias: [
+          { find: /^react$/, replacement: pkgDir('react') },
+          { find: /^react-dom$/, replacement: pkgDir('react-dom') },
+          ...SHARED_PACKAGES.map((id) => ({
+            find: new RegExp(`^${id}(/.*)?$`),
+            replacement: `${pkgDir(id)}$1`,
+          })),
+        ],
+      },
+      optimizeDeps: {
+        include: [
+          '@mui/material',
+          '@mui/material/styles',
+          '@mui/lab',
+          '@mui/x-date-pickers',
+          '@mui/x-date-pickers/AdapterDateFns',
+          '@emotion/react',
+          '@emotion/styled',
+          'hoist-non-react-statics',
+        ],
+      },
+    });
   },
 } satisfies StorybookConfig;

--- a/library/src/components/AddButton/index.tsx
+++ b/library/src/components/AddButton/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+import { Plus } from '@untitled-ui/icons-react';
+import { Button } from '@mui/material';
+
+type Props = {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+  'data-cy'?: string;
+};
+
+/**
+ * AddButton is a primary call-to-action button with a plus icon. The label is
+ * supplied by the consumer, so the component stays generic and free of any
+ * translation wiring.
+ */
+export const AddButton = ({
+  children,
+  onClick,
+  disabled,
+  className,
+  ...rest
+}: Props) => {
+  return (
+    <Button
+      color="primary"
+      variant="contained"
+      startIcon={<Plus width={19} height={19} />}
+      onClick={onClick}
+      disabled={disabled}
+      className={className}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+};

--- a/library/src/components/AddButton/stories.ts
+++ b/library/src/components/AddButton/stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AddButton } from '.';
+
+const meta = {
+  component: AddButton,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Add key',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AddButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: {},
+} satisfies Story;
+
+export const Disabled = {
+  args: {
+    disabled: true,
+  },
+} satisfies Story;

--- a/webapp/src/views/projects/translations/TranslationHeader/TranslationControls.tsx
+++ b/webapp/src/views/projects/translations/TranslationHeader/TranslationControls.tsx
@@ -1,9 +1,4 @@
-import {
-  LayoutGrid02,
-  LayoutLeft,
-  Plus,
-  Trash01,
-} from '@untitled-ui/icons-react';
+import { LayoutGrid02, LayoutLeft, Trash01 } from '@untitled-ui/icons-react';
 import {
   Badge,
   Button,
@@ -13,6 +8,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
+import { AddButton } from '@tginternal/library/components/AddButton';
 
 import { LanguagesSelect } from 'tg.component/common/form/LanguagesSelect/LanguagesSelect';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
@@ -173,15 +169,12 @@ export const TranslationControls: React.FC<React.PropsWithChildren<Props>> = ({
 
           {canCreateKeys && (
             <QuickStartHighlight itemKey="add_key">
-              <Button
-                startIcon={<Plus width={19} height={19} />}
-                color="primary"
-                variant="contained"
+              <AddButton
                 onClick={handleAddTranslation}
                 data-cy="translations-add-button"
               >
                 <T keyName="key_add" />
-              </Button>
+              </AddButton>
             </QuickStartHighlight>
           )}
         </StyledSpaced>


### PR DESCRIPTION
## What

Two related changes on the library/Storybook front:

1. **Make the library Storybook preview render again** (`library/.storybook/main.ts`).
2. **Extract the translations-header add button** into a generic, reusable `AddButton` component in the library, with a Storybook story, and use it in the translations view.

## Why

### Storybook preview was broken
The preview wraps stories in `getTheme` imported from `webapp/src` (the `// TODO migrate` for #3326). That drags **webapp's MUI v5** into a Storybook running on the **library's MUI v7**, so two conflicting MUI copies load. Vite served the foreign copy raw and stories died on CJS/ESM interop (`SyntaxError: … does not provide an export named 'default' / 'darken'`) — the preview never mounted, and every story showed a blank, perpetually "preparing" canvas.

**Fix:** a `viteFinal` that resolves the whole MUI/emotion/react stack to webapp's copies (one self-consistent set — webapp's proven material-v5 + x-date-pickers-v7 combination) and pre-bundles them so the interop is clean. No component migration, no version-forcing across the v5↔v7 boundary.

### Add button → library component
Extracts the header's "add key" button into a generic `AddButton` (plus icon + MUI contained button). It's presentational: the **label is passed by the consumer** via `children`, so the library component has **no translation wiring**. The translations view keeps `<T keyName="key_add">` and passes it in as the label.

## Changes

- `library/.storybook/main.ts` — `viteFinal` alias + `optimizeDeps` so Storybook uses a single MUI stack.
- `library/src/components/AddButton/index.tsx` — new generic component.
- `library/src/components/AddButton/stories.ts` — `Default` + `Disabled` stories (text supplied via `args`, no translations).
- `webapp/.../TranslationHeader/TranslationControls.tsx` — use `<AddButton>`; drop the now-unused `Plus` import.

## Verification

- Storybook (`library/`, Node 22) boots clean; `MfaBadge`, `FlagImage`, and the new `AddButton` stories all render.
- Webapp `npm run eslint -- --fix && npm run tsc` pass (webapp `tsc` rebuilds the library types, validating the new component signature end-to-end).
- **No user-facing behavior change** in the translations view — same button, label, `data-cy`, and click handler.

## Notes for reviewer

- The MUI conflict is pre-existing and rooted in the `webapp/src` theme import (#3326); this PR works around it for Storybook rather than migrating the theme.
- Run Storybook with Node ≥ 20.16 / 22.19 / 24 (`cd library && BROWSER=none npm run storybook`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable “Add” button with plus-icon styling and support for disabled and click interactions.
  * Added Storybook examples for the default and disabled button states.

* **UI Improvements**
  * Updated the translation controls to use the new standardized “Add” button for creating keys.
  * Improved Storybook dependency resolution for more consistent component previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->