### PR TITLE
fix: let users without an organization open public projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ e2e/cypress/integration/examples/
 /webapp/.DS_Store
 /webapp/.env.local
 /webapp/.env.development.local
+/webapp/.env.e2e
 /webapp/.env.test.local
 /webapp/.env.production.local
 /webapp/src/eeSetup/eeModule.current.tsx

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/BusinessEventController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/BusinessEventController.kt
@@ -6,9 +6,10 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.component.reporting.BusinessEventPublisher
 import io.tolgee.dtos.request.BusinessEventReportRequest
 import io.tolgee.dtos.request.IdentifyRequest
-import io.tolgee.exceptions.AuthenticationException
 import io.tolgee.openApiDocs.OpenApiHideFromPublicDocs
+import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.organization.OrganizationRoleService
+import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.SecurityService
 import io.tolgee.util.Logging
 import io.tolgee.util.logger
@@ -27,6 +28,8 @@ class BusinessEventController(
   private val businessEventPublisher: BusinessEventPublisher,
   private val securityService: SecurityService,
   private val organizationRoleService: OrganizationRoleService,
+  private val projectService: ProjectService,
+  private val authenticationFacade: AuthenticationFacade,
 ) : Logging {
   @PostMapping("/report")
   @Operation(summary = "Reports business event")
@@ -34,13 +37,16 @@ class BusinessEventController(
     @RequestBody eventData: BusinessEventReportRequest,
   ) {
     try {
-      eventData.projectId?.let { securityService.checkAnyProjectPermission(it) }
-      eventData.organizationId?.let { organizationRoleService.checkUserCanView(it) }
-      businessEventPublisher.publish(eventData)
+      val projectId = eventData.projectId?.takeIf { securityService.hasAnyProjectPermission(it) }
+      val owningOrganizationId = projectId?.let { owningOrganizationId(it) }
+      val organizationId =
+        eventData.organizationId
+          ?.takeIf { canReportOrganization(it) }
+          ?.takeIf { agreesWithReportedProject(it, owningOrganizationId) }
+      val backedClaims = eventData.copy(projectId = projectId, organizationId = organizationId)
+      logDroppedClaims(eventData, projectId, organizationId)
+      businessEventPublisher.publish(backedClaims)
     } catch (e: Throwable) {
-      if (e is AuthenticationException) {
-        return
-      }
       logger.error("Error storing event", e)
       Sentry.captureException(e)
     }
@@ -57,5 +63,36 @@ class BusinessEventController(
       logger.error("Error storing event", e)
       Sentry.captureException(e)
     }
+  }
+
+  private fun owningOrganizationId(projectId: Long): Long? = projectService.findDto(projectId)?.organizationOwnerId
+
+  private fun canReportOrganization(organizationId: Long): Boolean {
+    val user = authenticationFacade.authenticatedUserOrNull ?: return false
+    return organizationRoleService.canUserView(user, organizationId)
+  }
+
+  private fun agreesWithReportedProject(
+    organizationId: Long,
+    owningOrganizationId: Long?,
+  ): Boolean = owningOrganizationId == null || organizationId == owningOrganizationId
+
+  private fun logDroppedClaims(
+    eventData: BusinessEventReportRequest,
+    backedProjectId: Long?,
+    backedOrganizationId: Long?,
+  ) {
+    if (backedProjectId == eventData.projectId && backedOrganizationId == eventData.organizationId) {
+      return
+    }
+    logger.debug(
+      "Dropped unbacked claim(s) from business event {}; claimed project {}, organization {}; " +
+        "backed project {}, organization {}",
+      eventData.eventName,
+      eventData.projectId,
+      eventData.organizationId,
+      backedProjectId,
+      backedOrganizationId,
+    )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/InitialDataController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/InitialDataController.kt
@@ -3,7 +3,7 @@ package io.tolgee.api.v2.controllers
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.api.EeSubscriptionProvider
-import io.tolgee.component.PreferredOrganizationFacade
+import io.tolgee.facade.PrivateOrganizationModelFacade
 import io.tolgee.hateoas.auth.AuthInfoModelAssembler
 import io.tolgee.hateoas.initialData.InitialDataEeSubscriptionModel
 import io.tolgee.hateoas.initialData.InitialDataModel
@@ -33,7 +33,7 @@ class InitialDataController(
   private val configurationController: ConfigurationController,
   private val authenticationFacade: AuthenticationFacade,
   private val userPreferencesService: UserPreferencesService,
-  private val preferredOrganizationFacade: PreferredOrganizationFacade,
+  private val privateOrganizationModelFacade: PrivateOrganizationModelFacade,
   private val announcementController: AnnouncementController,
   private val tenantService: TenantService,
   private val authInfoModelAssembler: AuthInfoModelAssembler,
@@ -59,7 +59,7 @@ class InitialDataController(
       data.authInfo = authInfoModelAssembler.toModel(authenticationFacade.authentication)
       data.userInfo = privateUserAccountModelAssembler.toModel(userAccountView)
       data.ssoInfo = tenant?.let { publicSsoTenantModelAssembler.toModel(it) }
-      data.preferredOrganization = preferredOrganizationFacade.getPreferred()
+      data.preferredOrganization = privateOrganizationModelFacade.getPreferred()
       data.languageTag = userPreferencesService.find(userAccount.id)?.language
       data.announcement = announcementController.getLatest()
       data.eeSubscription = getEeSubscriptionModel()

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationController.kt
@@ -6,9 +6,9 @@ package io.tolgee.api.v2.controllers
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import io.tolgee.component.PreferredOrganizationFacade
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.PermissionException
+import io.tolgee.facade.PrivateOrganizationModelFacade
 import io.tolgee.hateoas.organization.PrivateOrganizationModel
 import io.tolgee.openApiDocs.OpenApiHideFromPublicDocs
 import org.springframework.web.bind.annotation.CrossOrigin
@@ -21,18 +21,17 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(value = ["/v2/preferred-organization"])
 @Tag(name = "Preferred organization")
 class PreferredOrganizationController(
-  private val preferredOrganizationFacade: PreferredOrganizationFacade,
+  private val privateOrganizationModelFacade: PrivateOrganizationModelFacade,
 ) {
   @GetMapping("")
   @Operation(
     summary = "Get preferred organization",
     description =
-      "Returns preferred organization. " +
-        "If server allows users to create organization, preferred organization is automatically created " +
-        "if user doesn't have access to any organization.",
+      "Returns the preferred organization, or 403 when the user has none they can view.",
   )
   @OpenApiHideFromPublicDocs
   fun getPreferred(): PrivateOrganizationModel {
-    return preferredOrganizationFacade.getPreferred() ?: throw PermissionException(Message.CANNOT_CREATE_ORGANIZATION)
+    return privateOrganizationModelFacade.getPreferred()
+      ?: throw PermissionException(Message.CANNOT_CREATE_ORGANIZATION)
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/UserPreferencesController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/UserPreferencesController.kt
@@ -7,6 +7,9 @@ package io.tolgee.api.v2.controllers
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.dtos.request.UserStorageResponse
+import io.tolgee.exceptions.NotFoundException
+import io.tolgee.facade.PrivateOrganizationModelFacade
+import io.tolgee.hateoas.organization.PrivateOrganizationModel
 import io.tolgee.hateoas.userPreferences.UserPreferencesModel
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.security.authentication.BypassEmailVerification
@@ -14,6 +17,7 @@ import io.tolgee.security.authentication.BypassForcedSsoAuthentication
 import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.security.UserPreferencesService
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -31,6 +35,7 @@ class UserPreferencesController(
   private val authenticationFacade: AuthenticationFacade,
   private val organizationRoleService: OrganizationRoleService,
   private val organizationService: OrganizationService,
+  private val privateOrganizationModelFacade: PrivateOrganizationModelFacade,
 ) {
   @GetMapping("")
   @Operation(summary = "Get user's preferences")
@@ -54,12 +59,15 @@ class UserPreferencesController(
 
   @PutMapping("/set-preferred-organization/{organizationId}")
   @Operation(summary = "Set user preferred organization")
+  @Transactional
   fun setPreferredOrganization(
     @PathVariable organizationId: Long,
-  ) {
+  ): PrivateOrganizationModel {
     val organization = organizationService.get(organizationId)
-    organizationRoleService.checkUserCanViewOrPublic(organization.id)
+    organizationRoleService.checkUserCanViewOrPublic(organizationId)
     userPreferencesService.setPreferredOrganization(organization, authenticationFacade.authenticatedUserEntity)
+    return privateOrganizationModelFacade.getPrivateModelWithoutAuthorization(organizationId)
+      ?: throw NotFoundException()
   }
 
   @GetMapping("/storage/{fieldName}")

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2UserController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/V2UserController.kt
@@ -7,12 +7,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.activity.ActivityHolder
 import io.tolgee.api.isMfaEnabled
-import io.tolgee.component.PreferredOrganizationFacade
 import io.tolgee.constants.Message
 import io.tolgee.dtos.request.SuperTokenRequest
 import io.tolgee.dtos.request.UserUpdatePasswordRequestDto
 import io.tolgee.dtos.request.UserUpdateRequestDto
 import io.tolgee.exceptions.AuthenticationException
+import io.tolgee.facade.PrivateOrganizationModelFacade
 import io.tolgee.hateoas.organization.PrivateOrganizationModel
 import io.tolgee.hateoas.organization.SimpleOrganizationModel
 import io.tolgee.hateoas.organization.SimpleOrganizationModelAssembler
@@ -66,7 +66,7 @@ class V2UserController(
   private val publicSsoTenantModelAssembler: PublicSsoTenantModelAssembler,
   private val imageUploadService: ImageUploadService,
   private val organizationService: OrganizationService,
-  private val preferredOrganizationFacade: PreferredOrganizationFacade,
+  private val privateOrganizationModelFacade: PrivateOrganizationModelFacade,
   private val organizationRoleService: OrganizationRoleService,
   private val tenantService: TenantService,
   private val simpleOrganizationModelAssembler: SimpleOrganizationModelAssembler,
@@ -245,7 +245,7 @@ class V2UserController(
     val userAccount = authenticationFacade.authenticatedUser
     val org = organizationRoleService.getManagedBy(userId = userAccount.id) ?: return ResponseEntity.noContent().build()
     val model =
-      preferredOrganizationFacade.getPrivateModel(org.id)
+      privateOrganizationModelFacade.getPrivateModelWithoutAuthorization(org.id)
         ?: return ResponseEntity.noContent().build()
     return ResponseEntity.ok(model)
   }

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationController.kt
@@ -8,9 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.component.mtBucketSizeProvider.PayAsYouGoCreditsProvider
 import io.tolgee.component.translationsLimitProvider.LimitsProvider
-import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.constants.Message
-import io.tolgee.dtos.cacheable.isAdmin
 import io.tolgee.dtos.queryResults.organization.OrganizationView
 import io.tolgee.dtos.request.organization.OrganizationDto
 import io.tolgee.dtos.request.organization.OrganizationRequestParamsDto
@@ -18,7 +16,6 @@ import io.tolgee.dtos.request.organization.SetOrganizationRoleDto
 import io.tolgee.dtos.request.validators.exceptions.ValidationException
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
-import io.tolgee.exceptions.PermissionException
 import io.tolgee.hateoas.organization.OrganizationModel
 import io.tolgee.hateoas.organization.OrganizationModelAssembler
 import io.tolgee.hateoas.organization.PublicUsageModel
@@ -27,7 +24,6 @@ import io.tolgee.hateoas.organization.UserAccountWithOrganizationRoleModelAssemb
 import io.tolgee.model.Project
 import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.ProjectPermissionType
-import io.tolgee.model.enums.ThirdPartyAuthType
 import io.tolgee.model.views.UserAccountWithOrganizationRoleView
 import io.tolgee.openApiDocs.OpenApiOrderExtension
 import io.tolgee.security.OrganizationHolder
@@ -83,7 +79,6 @@ class OrganizationController(
   >,
   private val organizationModelAssembler: OrganizationModelAssembler,
   private val userAccountWithOrganizationRoleModelAssembler: UserAccountWithOrganizationRoleModelAssembler,
-  private val tolgeeProperties: TolgeeProperties,
   private val authenticationFacade: AuthenticationFacade,
   private val organizationRoleService: OrganizationRoleService,
   private val userAccountService: UserAccountService,
@@ -105,22 +100,11 @@ class OrganizationController(
     @RequestBody @Valid
     dto: OrganizationDto,
   ): ResponseEntity<OrganizationModel> {
-    if (!this.tolgeeProperties.authentication.userCanCreateOrganizations &&
-      !authenticationFacade.authenticatedUser.isAdmin()
-    ) {
-      throw PermissionException()
-    }
-    if (authenticationFacade.authenticatedUserEntity.thirdPartyAuthType === ThirdPartyAuthType.SSO &&
-      !authenticationFacade.authenticatedUser.isAdmin()
-    ) {
-      throw PermissionException(Message.SSO_USER_CANNOT_CREATE_ORGANIZATION)
-    }
-    this.organizationService.create(dto).let {
-      return ResponseEntity(
-        organizationModelAssembler.toModel(OrganizationView.of(it, OrganizationRoleType.OWNER)),
-        HttpStatus.CREATED,
-      )
-    }
+    val organization = organizationService.createAsCurrentUser(dto)
+    return ResponseEntity(
+      organizationModelAssembler.toModel(OrganizationView.of(organization, OrganizationRoleType.OWNER)),
+      HttpStatus.CREATED,
+    )
   }
 
   @GetMapping("/{id:[0-9]+}")
@@ -230,12 +214,12 @@ class OrganizationController(
   fun leaveOrganization(
     @PathVariable("id") id: Long,
   ) {
-    organizationService.find(id)?.let {
-      if (!organizationService.isThereAnotherOwner(id)) {
-        throw ValidationException(Message.ORGANIZATION_HAS_NO_OTHER_OWNER)
-      }
-      organizationRoleService.leave(id)
-    } ?: throw NotFoundException()
+    organizationService.find(id) ?: throw NotFoundException()
+    val isOwner = organizationRoleService.isUserOwner(authenticationFacade.authenticatedUser.id, id)
+    if (isOwner && !organizationService.isThereAnotherOwner(id)) {
+      throw ValidationException(Message.ORGANIZATION_HAS_NO_OTHER_OWNER)
+    }
+    organizationRoleService.leave(id)
   }
 
   @PutMapping("/{organizationId:[0-9]+}/users/{userId:[0-9]+}/set-role")

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
@@ -15,6 +15,7 @@ import io.tolgee.dtos.request.project.ProjectFilters
 import io.tolgee.dtos.request.project.SetPermissionLanguageParams
 import io.tolgee.dtos.request.task.UserAccountFilters
 import io.tolgee.exceptions.BadRequestException
+import io.tolgee.facade.ProjectCreationFacade
 import io.tolgee.facade.ProjectPermissionFacade
 import io.tolgee.facade.ProjectWithStatsFacade
 import io.tolgee.hateoas.project.ProjectModel
@@ -22,7 +23,6 @@ import io.tolgee.hateoas.project.ProjectModelAssembler
 import io.tolgee.hateoas.project.ProjectWithStatsModel
 import io.tolgee.hateoas.userAccount.UserAccountInProjectModel
 import io.tolgee.hateoas.userAccount.UserAccountInProjectModelAssembler
-import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
 import io.tolgee.model.views.ExtendedUserAccountInProject
@@ -37,8 +37,6 @@ import io.tolgee.security.authorization.IsGlobalRoute
 import io.tolgee.security.authorization.RequiresProjectPermissions
 import io.tolgee.security.authorization.UseDefaultPermissions
 import io.tolgee.service.ImageUploadService
-import io.tolgee.service.organization.OrganizationRoleService
-import io.tolgee.service.project.ProjectCreationService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.PermissionService
 import io.tolgee.service.security.UserAccountService
@@ -79,11 +77,10 @@ class ProjectsController(
   private val userAccountService: UserAccountService,
   private val permissionService: PermissionService,
   private val authenticationFacade: AuthenticationFacade,
-  private val organizationRoleService: OrganizationRoleService,
   private val imageUploadService: ImageUploadService,
   private val projectPermissionFacade: ProjectPermissionFacade,
   private val projectWithStatsFacade: ProjectWithStatsFacade,
-  private val projectCreationService: ProjectCreationService,
+  private val projectCreationFacade: ProjectCreationFacade,
 ) {
   @PostMapping(value = [""])
   @Operation(summary = "Create project", description = "Creates a new project with languages and initial settings.")
@@ -95,12 +92,7 @@ class ProjectsController(
     @RequestBody @Valid
     dto: CreateProjectRequest,
   ): ProjectModel {
-    organizationRoleService.checkUserCanCreateProject(dto.organizationId)
-    val project = projectCreationService.createProject(dto)
-    if (organizationRoleService.findType(dto.organizationId) == OrganizationRoleType.MAINTAINER) {
-      // Maintainers get full access to projects they create
-      permissionService.grantFullAccessToProject(authenticationFacade.authenticatedUserEntity, project)
-    }
+    val project = projectCreationFacade.createProjectAsCurrentUser(dto)
     return projectModelAssembler.toModel(projectService.getView(project.id))
   }
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectsController.kt
@@ -97,7 +97,7 @@ class ProjectsController(
   ): ProjectModel {
     organizationRoleService.checkUserCanCreateProject(dto.organizationId)
     val project = projectCreationService.createProject(dto)
-    if (organizationRoleService.getType(dto.organizationId) == OrganizationRoleType.MAINTAINER) {
+    if (organizationRoleService.findType(dto.organizationId) == OrganizationRoleType.MAINTAINER) {
       // Maintainers get full access to projects they create
       permissionService.grantFullAccessToProject(authenticationFacade.authenticatedUserEntity, project)
     }

--- a/backend/api/src/main/kotlin/io/tolgee/facade/PrivateOrganizationModelFacade.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/facade/PrivateOrganizationModelFacade.kt
@@ -1,7 +1,6 @@
-package io.tolgee.component
+package io.tolgee.facade
 
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
-import io.tolgee.dtos.cacheable.isSupporterOrAdmin
 import io.tolgee.hateoas.organization.PrivateOrganizationModel
 import io.tolgee.hateoas.organization.PrivateOrganizationModelAssembler
 import io.tolgee.security.authentication.AuthenticationFacade
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Component
 
 @Suppress("SpringJavaInjectionPointsAutowiringInspection")
 @Component
-class PreferredOrganizationFacade(
+class PrivateOrganizationModelFacade(
   private val authenticationFacade: AuthenticationFacade,
   private val userPreferencesService: UserPreferencesService,
   private val privateOrganizationModelAssembler: PrivateOrganizationModelAssembler,
@@ -23,20 +22,20 @@ class PreferredOrganizationFacade(
   fun getPreferred(): PrivateOrganizationModel? {
     val user = authenticationFacade.authenticatedUser
     val preferences = userPreferencesService.findOrCreate(user.id)
-    var preferred = preferences.preferredOrganization
-    if (preferred == null || !organizationRoleService.canUserViewOrPublic(user, preferred.id)) {
-      preferred = userPreferencesService.refreshPreferredOrganization(user.id) ?: return null
-    }
+    val preferred = preferences.preferredOrganization ?: return null
+    val accessible =
+      preferred.takeIf { organizationRoleService.canUserViewOrPublic(user, it.id) }
+        ?: userPreferencesService.refreshPreferredOrganization(user.id)
+        ?: return null
 
-    return getPrivateModel(preferred.id)
+    return getPrivateModelWithoutAuthorization(accessible.id)
   }
 
-  fun getPrivateModel(organizationId: Long): PrivateOrganizationModel? {
+  fun getPrivateModelWithoutAuthorization(organizationId: Long): PrivateOrganizationModel? {
     val user = authenticationFacade.authenticatedUser
     val view = organizationService.findPrivateView(organizationId, user.id) ?: return null
-    val isAtLeastMember = organizationRoleService.canUserViewAtLeastMember(user, organizationId)
-    val limitedView =
-      !user.isSupporterOrAdmin() && !organizationRoleService.canUserViewStrict(user.id, organizationId)
+    val isAtLeastMember = organizationRoleService.hasAnyOrganizationRole(user.id, organizationId)
+    val limitedView = !organizationRoleService.canUserView(user, organizationId)
     return privateOrganizationModelAssembler.toModel(
       view,
       enabledFeaturesProvider.get(view.organization.id),

--- a/backend/api/src/main/kotlin/io/tolgee/facade/ProjectCreationFacade.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/facade/ProjectCreationFacade.kt
@@ -1,0 +1,29 @@
+package io.tolgee.facade
+
+import io.tolgee.dtos.request.project.CreateProjectRequest
+import io.tolgee.model.Project
+import io.tolgee.model.enums.OrganizationRoleType
+import io.tolgee.security.authentication.AuthenticationFacade
+import io.tolgee.service.organization.OrganizationRoleService
+import io.tolgee.service.project.ProjectCreationService
+import io.tolgee.service.security.PermissionService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ProjectCreationFacade(
+  private val projectCreationService: ProjectCreationService,
+  private val organizationRoleService: OrganizationRoleService,
+  private val permissionService: PermissionService,
+  private val authenticationFacade: AuthenticationFacade,
+) {
+  @Transactional
+  fun createProjectAsCurrentUser(dto: CreateProjectRequest): Project {
+    organizationRoleService.checkUserCanCreateProject(dto.organizationId)
+    val project = projectCreationService.createProjectWithoutAuthorization(dto)
+    if (organizationRoleService.findType(dto.organizationId) == OrganizationRoleType.MAINTAINER) {
+      permissionService.grantFullAccessToProject(authenticationFacade.authenticatedUserEntity, project)
+    }
+    return project
+  }
+}

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/PrivateOrganizationModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/PrivateOrganizationModel.kt
@@ -19,7 +19,7 @@ open class PrivateOrganizationModel(
   val activeCloudSubscription: PublicCloudSubscriptionModel?,
   @get:Schema(
     example = "false",
-    description = "Whether the user views the organization purely via public-project access",
+    description = "True when the viewer reaches this organization only through its public projects",
   )
   val limitedView: Boolean,
 ) : RepresentationModel<PrivateOrganizationModel>(),

--- a/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/InitialUserCreatorCommandLineRunner.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/commandLineRunners/InitialUserCreatorCommandLineRunner.kt
@@ -72,10 +72,8 @@ class InitialUserCreatorCommandLineRunner(
     userAccountService.createUser(userAccount = user)
     userAccountService.transferLegacyNoAuthUser()
 
-    // If the user was already existing, it may already have assigned orgs.
-    // To avoid conflicts, we only create the org if the user doesn't have any.
     val organization =
-      organizationService.create(
+      organizationService.createWithoutAuthorization(
         OrganizationDto(
           properties.authentication.initialUsername,
         ),

--- a/backend/app/src/main/kotlin/io/tolgee/mcp/tools/ProjectMcpTools.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/mcp/tools/ProjectMcpTools.kt
@@ -5,14 +5,13 @@ import io.tolgee.api.v2.controllers.ProjectStatsController
 import io.tolgee.api.v2.controllers.project.ProjectsController
 import io.tolgee.dtos.request.LanguageRequest
 import io.tolgee.dtos.request.project.CreateProjectRequest
+import io.tolgee.facade.ProjectCreationFacade
 import io.tolgee.mcp.McpRequestContext
 import io.tolgee.mcp.McpToolsProvider
 import io.tolgee.mcp.buildSpec
 import io.tolgee.security.ProjectHolder
 import io.tolgee.service.language.LanguageService
-import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.project.LanguageStatsService
-import io.tolgee.service.project.ProjectCreationService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.util.executeInNewTransaction
 import org.springframework.data.domain.PageRequest
@@ -24,10 +23,9 @@ import tools.jackson.databind.ObjectMapper
 class ProjectMcpTools(
   private val mcpRequestContext: McpRequestContext,
   private val projectService: ProjectService,
-  private val projectCreationService: ProjectCreationService,
+  private val projectCreationFacade: ProjectCreationFacade,
   private val languageStatsService: LanguageStatsService,
   private val languageService: LanguageService,
-  private val organizationRoleService: OrganizationRoleService,
   private val projectHolder: ProjectHolder,
   private val objectMapper: ObjectMapper,
   private val transactionManager: PlatformTransactionManager,
@@ -105,8 +103,7 @@ class ProjectMcpTools(
           )
 
         executeInNewTransaction(transactionManager) {
-          organizationRoleService.checkUserCanCreateProject(dto.organizationId)
-          val project = projectCreationService.createProject(dto)
+          val project = projectCreationFacade.createProjectAsCurrentUser(dto)
           val result =
             mapOf(
               "id" to project.id,

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/BusinessEventControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/BusinessEventControllerTest.kt
@@ -2,29 +2,43 @@ package io.tolgee.api.v2.controllers
 
 import com.posthog.server.PostHog
 import io.tolgee.ProjectAuthControllerTest
-import io.tolgee.development.testDataBuilder.data.BaseTestData
+import io.tolgee.development.testDataBuilder.data.BusinessEventTestData
 import io.tolgee.fixtures.AuthorizedRequestFactory
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.assertPostHogEventReported
+import io.tolgee.model.UserAccount
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 
 class BusinessEventControllerTest : ProjectAuthControllerTest("/v2/projects/") {
-  private lateinit var testData: BaseTestData
+  private lateinit var testData: BusinessEventTestData
 
   @Autowired
   lateinit var postHog: PostHog
 
+  private val foreignOrganizationBuilder get() = testData.foreignOrganizationBuilder
+  private val memberOrganizationBuilder get() = testData.memberOrganizationBuilder
+  private val outsider get() = testData.outsider
+  private val admin get() = testData.admin
+  private val supporter get() = testData.supporter
+  private val softDeletedProject get() = testData.softDeletedProject
+
   @BeforeEach
   fun setup() {
-    testData = BaseTestData()
+    testData = BusinessEventTestData()
     testDataService.saveTestData(testData.root)
     projectSupplier = { testData.projectBuilder.self }
     userAccount = testData.user
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test
@@ -38,9 +52,7 @@ class BusinessEventControllerTest : ProjectAuthControllerTest("/v2/projects/") {
         "projectId" to testData.projectBuilder.self.id,
         "data" to mapOf("test" to "test"),
       ),
-      HttpHeaders().also {
-        it["Authorization"] = AuthorizedRequestFactory.getBearerTokenString(generateJwtToken(userAccount!!.id))
-      },
+      bearerHeadersFor(userAccount!!),
     ).andIsOk
 
     val params = assertPostHogEventReported(postHog, "TEST_EVENT")
@@ -48,4 +60,421 @@ class BusinessEventControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     params["organizationName"].assert.isEqualTo("test_username")
     params["test"].assert.isEqualTo("test")
   }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops an organization claim the reporter cannot back`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "OUTSIDER_EVENT",
+        "organizationId" to testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "OUTSIDER_EVENT")
+    params["organizationId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it derives attribution from the project the event was fired in, dropping a foreign claim`() {
+    val foreignOrg = foreignOrganizationBuilder.self
+    executeInNewTransaction {
+      projectService.get(testData.projectBuilder.self.id).public = true
+    }
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "PUBLIC_PROJECT_EVENT",
+        "organizationId" to foreignOrg.id,
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "PUBLIC_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isEqualTo(testData.projectBuilder.self.id)
+    params["projectId"].assert.isEqualTo(testData.projectBuilder.self.id)
+    params["organizationId"].assert.isEqualTo(
+      testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
+    )
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it keeps a claim the reporter is a member of`() {
+    val owner = testData.userAccountBuilder.self
+    val ownOrg = testData.userAccountBuilder.defaultOrganizationBuilder.self
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "MEMBER_EVENT",
+        "organizationId" to ownOrg.id,
+      ),
+      bearerHeadersFor(owner),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "MEMBER_EVENT")
+    params["organizationId"].assert.isEqualTo(ownOrg.id)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it keeps a private project claim from someone with access to that project`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "OWN_PRIVATE_PROJECT_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+      bearerHeadersFor(testData.user),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "OWN_PRIVATE_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isEqualTo(testData.projectBuilder.self.id)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a project claim the reporter cannot back but keeps the event`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "PRIVATE_PROJECT_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "PRIVATE_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isNull()
+    params["organizationId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a claim for a project that no longer exists but keeps the event`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "DELETED_PROJECT_EVENT",
+        "projectId" to Long.MAX_VALUE,
+      ),
+      bearerHeadersFor(testData.user),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "DELETED_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a bare organization claim backed only by that organization having public projects`() {
+    val publicOrg = testData.userAccountBuilder.defaultOrganizationBuilder.self
+    executeInNewTransaction {
+      projectService.get(testData.projectBuilder.self.id).public = true
+    }
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "UNADOPTED_EVENT",
+        "organizationId" to publicOrg.id,
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "UNADOPTED_EVENT")
+    params["organizationId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it marks a kept claim from a member as a member claim`() {
+    val ownOrg = testData.userAccountBuilder.defaultOrganizationBuilder.self
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "MEMBER_MARKED_EVENT",
+        "organizationId" to ownOrg.id,
+      ),
+      bearerHeadersFor(testData.userAccountBuilder.self),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "MEMBER_MARKED_EVENT")
+    params["organizationMember"].assert.isEqualTo(true)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it answers membership for an organization derived from the reported project`() {
+    executeInNewTransaction {
+      projectService.get(testData.projectBuilder.self.id).public = true
+    }
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "DERIVED_ORG_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "DERIVED_ORG_EVENT")
+    params.postHogGroupedProjectId().assert.isEqualTo(testData.projectBuilder.self.id)
+    params["organizationMember"].assert.isEqualTo(false)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it does not count staff browsing a customer organization as its members`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_MEMBERSHIP_EVENT",
+        "organizationId" to foreignOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+    assertPostHogEventReported(postHog, "ADMIN_MEMBERSHIP_EVENT")["organizationMember"]
+      .assert
+      .isEqualTo(false)
+
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "SUPPORTER_MEMBERSHIP_EVENT",
+        "organizationId" to foreignOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(supporter),
+    ).andIsOk
+    assertPostHogEventReported(postHog, "SUPPORTER_MEMBERSHIP_EVENT")["organizationMember"]
+      .assert
+      .isEqualTo(false)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a project claim from an anonymous reporter but keeps the event`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ANONYMOUS_PROJECT_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ANONYMOUS_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops an admin claim for an organization that does not exist`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_EVENT",
+        "organizationId" to Long.MAX_VALUE,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ADMIN_EVENT")
+    params["organizationId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it keeps an admin claim for an organization the admin does not belong to`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_VIEW_EVENT",
+        "organizationId" to foreignOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ADMIN_VIEW_EVENT")
+    params["organizationId"].assert.isEqualTo(foreignOrganizationBuilder.self.id)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it does not let the free-form data map overwrite the authorized attribution`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "DATA_MAP_EVENT",
+        "organizationId" to testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
+        "data" to
+          mapOf(
+            "organizationId" to 999999,
+            "organizationName" to "Acme",
+            "projectId" to 999999,
+          ),
+      ),
+      bearerHeadersFor(outsider),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "DATA_MAP_EVENT")
+    params["organizationId"].assert.isNull()
+    params["organizationName"].assert.isNull()
+    params["projectId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it keeps a supporter claim for an organization the supporter does not belong to`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "SUPPORTER_VIEW_EVENT",
+        "organizationId" to foreignOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(supporter),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "SUPPORTER_VIEW_EVENT")
+    params["organizationId"].assert.isEqualTo(foreignOrganizationBuilder.self.id)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops an organization claim that does not own the reported project`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "CROSS_ATTRIBUTION_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+        "organizationId" to memberOrganizationBuilder.self.id,
+      ),
+      bearerHeadersFor(testData.user),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "CROSS_ATTRIBUTION_EVENT")
+    params.postHogGroupedProjectId().assert.isEqualTo(testData.projectBuilder.self.id)
+    params["organizationId"].assert.isEqualTo(
+      testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
+    )
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it still identifies the person it reports for`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf("eventName" to "IDENTIFIED_EVENT"),
+      bearerHeadersFor(testData.user),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "IDENTIFIED_EVENT")
+    val setEntry = params["\u0024set"] as Map<*, *>
+    setEntry["email"].assert.isEqualTo(testData.user.username)
+    setEntry["name"].assert.isEqualTo(testData.user.name)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it keeps a staff claim for a project the staff user holds no permission in`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_PROJECT_EVENT",
+        "projectId" to testData.projectBuilder.self.id,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ADMIN_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isEqualTo(testData.projectBuilder.self.id)
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a staff claim for a project that does not exist`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_DELETED_PROJECT_EVENT",
+        "projectId" to Long.MAX_VALUE,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ADMIN_DELETED_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops a staff claim for a soft-deleted project, along with the organization it would attribute`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ADMIN_SOFT_DELETED_PROJECT_EVENT",
+        "projectId" to softDeletedProject.id,
+      ),
+      bearerHeadersFor(admin),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ADMIN_SOFT_DELETED_PROJECT_EVENT")
+    params.postHogGroupedProjectId().assert.isNull()
+    params["organizationId"].assert.isNull()
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it refuses to let an anonymous report write PostHog person state`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "PERSON_STATE_EVENT",
+        "anonymousUserId" to "anonymous-attacker",
+        "data" to
+          mapOf(
+            "\u0024set" to mapOf("email" to "attacker@example.com"),
+            "\u0024set_once" to mapOf("name" to "Attacker"),
+            "\u0024unset" to listOf("email"),
+            "harmless" to "kept",
+          ),
+      ),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "PERSON_STATE_EVENT")
+    params["\u0024set"].assert.isNull()
+    params["\u0024set_once"].assert.isNull()
+    params["\u0024unset"].assert.isNull()
+    params["harmless"].assert.isEqualTo("kept")
+    params["\u0024anon_distinct_id"].assert.isEqualTo("anonymous-attacker")
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `it drops an anonymous organization claim`() {
+    performPost(
+      "/v2/public/business-events/report",
+      mapOf(
+        "eventName" to "ANONYMOUS_EVENT",
+        "organizationId" to testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
+      ),
+    ).andIsOk
+
+    val params = assertPostHogEventReported(postHog, "ANONYMOUS_EVENT")
+    params["organizationId"].assert.isNull()
+  }
+
+  private fun Map<*, *>.postHogGroupedProjectId(): Any? = (this["\u0024groups"] as? Map<*, *>)?.get("project")
+
+  private fun bearerHeadersFor(user: UserAccount): HttpHeaders =
+    HttpHeaders().also {
+      it["Authorization"] = AuthorizedRequestFactory.getBearerTokenString(generateJwtToken(user.id))
+    }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/OrganizationCreationRestrictionsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/OrganizationCreationRestrictionsTest.kt
@@ -1,0 +1,125 @@
+package io.tolgee.api.v2.controllers
+
+import io.tolgee.constants.Message
+import io.tolgee.development.testDataBuilder.data.PublicProjectsControllerTestData
+import io.tolgee.exceptions.PermissionException
+import io.tolgee.fixtures.andHasErrorMessage
+import io.tolgee.fixtures.andIsCreated
+import io.tolgee.fixtures.andIsForbidden
+import io.tolgee.model.UserAccount
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.properties.Delegates
+
+class OrganizationCreationRestrictionsTest : AuthorizedControllerTest() {
+  lateinit var testData: PublicProjectsControllerTestData
+
+  private var originalUserCanCreateOrganizations by Delegates.notNull<Boolean>()
+  private var originalSsoBypass: Boolean? = null
+
+  @BeforeEach
+  fun setup() {
+    originalUserCanCreateOrganizations = tolgeeProperties.authentication.userCanCreateOrganizations
+    originalSsoBypass = tolgeeProperties.internal.verifySsoAccountAvailableBypass
+    testData = PublicProjectsControllerTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @AfterEach
+  fun clean() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = originalUserCanCreateOrganizations
+    tolgeeProperties.internal.verifySsoAccountAvailableBypass = originalSsoBypass
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `an SSO user is refused organization creation even where the server allows it`() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = true
+    val ssoUser = userEntity(testData.ssoOrgLessUser)
+
+    assertThat(organizationService.canUserCreateOrganization(ssoUser)).isEqualTo(false)
+
+    val refusal =
+      assertThrows<PermissionException> { organizationService.checkUserCanCreateOrganization(ssoUser) }
+    assertThat(refusal.tolgeeMessage).isEqualTo(Message.SSO_USER_CANNOT_CREATE_ORGANIZATION)
+  }
+
+  @Test
+  fun `the server property refusal wins over the SSO refusal`() {
+    refuseOrganizationCreation()
+    val ssoUser = userEntity(testData.ssoOrgLessUser)
+
+    val refusal =
+      assertThrows<PermissionException> { organizationService.checkUserCanCreateOrganization(ssoUser) }
+    assertThat(refusal.tolgeeMessage).isEqualTo(Message.OPERATION_NOT_PERMITTED)
+  }
+
+  @Test
+  fun `a server admin creates organizations even while creation is refused to everyone else`() {
+    refuseOrganizationCreation()
+    val admin = userEntity(testData.serverAdmin)
+
+    assertThat(organizationService.canUserCreateOrganization(admin)).isEqualTo(true)
+
+    userAccount = testData.serverAdmin
+    performAuthPost(
+      "/v2/organizations",
+      mapOf("name" to ADMIN_CREATED_ORGANIZATION),
+    ).andIsCreated
+  }
+
+  @Test
+  fun `the create endpoint refuses an SSO user`() {
+    tolgeeProperties.internal.verifySsoAccountAvailableBypass = true
+    userAccount = testData.ssoOrgLessUser
+
+    performAuthPost(
+      "/v2/organizations",
+      mapOf("name" to "Attempted organization"),
+    ).andIsForbidden.andHasErrorMessage(Message.SSO_USER_CANNOT_CREATE_ORGANIZATION)
+
+    assertThat(organizationService.findPreferred(testData.ssoOrgLessUser.id)).isNull()
+  }
+
+  @Test
+  fun `server-wide SSO restricts authentication only, so its users create organizations like anyone else`() {
+    assertThat(
+      organizationService.canUserCreateOrganization(userEntity(testData.ssoGlobalOrgLessUser)),
+    ).isEqualTo(true)
+  }
+
+  @Test
+  fun `a server admin creates organizations even through SSO`() {
+    refuseOrganizationCreation()
+
+    assertThat(organizationService.canUserCreateOrganization(userEntity(testData.ssoServerAdmin))).isEqualTo(true)
+  }
+
+  @Test
+  fun `a server supporter is refused organization creation like everyone else`() {
+    refuseOrganizationCreation()
+    val supporter = userEntity(testData.serverSupporter)
+
+    assertThat(organizationService.canUserCreateOrganization(supporter)).isEqualTo(false)
+
+    userAccount = testData.serverSupporter
+    performAuthPost(
+      "/v2/organizations",
+      mapOf("name" to "Supporter organization"),
+    ).andIsForbidden
+  }
+
+  private fun userEntity(user: UserAccount): UserAccount = executeInNewTransaction { userAccountService.get(user.id) }
+
+  private fun refuseOrganizationCreation() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = false
+  }
+
+  companion object {
+    private const val ADMIN_CREATED_ORGANIZATION = "Admin organization"
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/OrganizationEntitlementVisibilityTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/OrganizationEntitlementVisibilityTest.kt
@@ -1,0 +1,136 @@
+package io.tolgee.api.v2.controllers
+
+import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
+import io.tolgee.constants.Feature
+import io.tolgee.development.testDataBuilder.data.PublicProjectsControllerTestData
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.testing.AuthorizedControllerTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+
+class OrganizationEntitlementVisibilityTest : AuthorizedControllerTest() {
+  lateinit var testData: PublicProjectsControllerTestData
+
+  @MockitoBean
+  @Autowired
+  lateinit var enabledFeaturesProvider: EnabledFeaturesProvider
+
+  @BeforeEach
+  fun setup() {
+    testData = PublicProjectsControllerTestData()
+    testDataService.saveTestData(testData.root)
+    doReturn(emptyArray<Feature>()).whenever(enabledFeaturesProvider).get(any())
+    doReturn(arrayOf(Feature.PREMIUM_SUPPORT)).whenever(enabledFeaturesProvider).get(testData.otherOrg.id)
+  }
+
+  @AfterEach
+  fun clean() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `a member reads the organization's paid entitlements`() {
+    userAccount = testData.otherOrgMember
+
+    adoptOtherOrg()
+
+    performAuthGet(PREFERRED_ORGANIZATION_URL).andIsOk.andAssertThatJson {
+      node("enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `a non-member reaching the organization through its public projects reads its entitlements`() {
+    userAccount = testData.nonMember
+
+    adoptOtherOrg()
+
+    // A project inherits the features of its own organization, whoever is looking at it.
+    performAuthGet(PREFERRED_ORGANIZATION_URL).andIsOk.andAssertThatJson {
+      node("limitedView").isEqualTo(true)
+      node("enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `a server admin reads the entitlements of an organization they hold no role in`() {
+    userAccount = testData.serverAdmin
+
+    adoptOtherOrg()
+
+    performAuthGet(PREFERRED_ORGANIZATION_URL).andIsOk.andAssertThatJson {
+      node("limitedView").isEqualTo(false)
+      node("enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `a server supporter reads the entitlements of an organization they hold no role in`() {
+    userAccount = testData.serverSupporter
+
+    adoptOtherOrg()
+
+    performAuthGet(PREFERRED_ORGANIZATION_URL).andIsOk.andAssertThatJson {
+      node("limitedView").isEqualTo(false)
+      node("enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `a direct project permission user reads the entitlements without a role`() {
+    userAccount = testData.directPermissionUser
+
+    adoptOtherOrg()
+
+    performAuthGet(PREFERRED_ORGANIZATION_URL).andIsOk.andAssertThatJson {
+      node("currentUserRole").isEqualTo(null)
+      node("limitedView").isEqualTo(false)
+      node("enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `initial data carries the entitlements of an organization reached through its public projects`() {
+    userAccount = testData.nonMember
+
+    adoptOtherOrg()
+
+    performAuthGet(INITIAL_DATA_URL).andIsOk.andAssertThatJson {
+      node("preferredOrganization.limitedView").isEqualTo(true)
+      node("preferredOrganization.enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  @Test
+  fun `initial data carries the entitlements of an organization the viewer belongs to`() {
+    userAccount = testData.otherOrgMember
+
+    adoptOtherOrg()
+
+    performAuthGet(INITIAL_DATA_URL).andIsOk.andAssertThatJson {
+      node("preferredOrganization.limitedView").isEqualTo(false)
+      node("preferredOrganization.enabledFeatures").isEqualTo(listOf("PREMIUM_SUPPORT"))
+    }
+  }
+
+  private fun adoptOtherOrg() {
+    executeInNewTransaction {
+      userPreferencesService.setPreferredOrganization(
+        organizationService.get(testData.otherOrg.id),
+        userAccountService.get(userAccount!!.id),
+      )
+    }
+  }
+
+  companion object {
+    private const val PREFERRED_ORGANIZATION_URL = "/v2/preferred-organization"
+    private const val INITIAL_DATA_URL = "/v2/public/initial-data"
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationCommunityTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationCommunityTest.kt
@@ -2,6 +2,7 @@ package io.tolgee.api.v2.controllers
 
 import io.tolgee.development.testDataBuilder.data.PublicProjectsControllerTestData
 import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.model.UserAccount
 import io.tolgee.testing.AuthorizedControllerTest
@@ -9,18 +10,23 @@ import io.tolgee.testing.assertions.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.properties.Delegates
 
 class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
   lateinit var testData: PublicProjectsControllerTestData
 
+  private var originalUserCanCreateOrganizations by Delegates.notNull<Boolean>()
+
   @BeforeEach
   fun setup() {
+    originalUserCanCreateOrganizations = tolgeeProperties.authentication.userCanCreateOrganizations
     testData = PublicProjectsControllerTestData()
     testDataService.saveTestData(testData.root)
   }
 
   @AfterEach
   fun clean() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = originalUserCanCreateOrganizations
     testDataService.cleanTestData(testData.root)
   }
 
@@ -94,6 +100,50 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
     }
   }
 
+  @Test
+  fun `org-less user has no preferred organization until it adopts one with public projects`() {
+    disableOrganizationCreation()
+    loginAsOrgLessUser()
+
+    performAuthGet("/v2/preferred-organization").andIsForbidden
+    performAuthGet("/v2/public/initial-data").andIsOk.andAssertThatJson {
+      node("preferredOrganization").isEqualTo(null)
+    }
+
+    performAuthPut(
+      "/v2/user-preferences/set-preferred-organization/${testData.otherOrg.id}",
+      null,
+    ).andIsOk
+
+    assertStoredPreference(testData.orgLessCommunityUser.id, testData.otherOrg.id)
+    performAuthGet("/v2/preferred-organization").andIsOk.andAssertThatJson {
+      node("name").isEqualTo("Vibrant translators")
+      node("currentUserRole").isEqualTo(null)
+      node("limitedView").isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun `org-less user cannot adopt an organization without public projects`() {
+    disableOrganizationCreation()
+    loginAsOrgLessUser()
+
+    performAuthPut(
+      "/v2/user-preferences/set-preferred-organization/${testData.noPublicOrg.id}",
+      null,
+    ).andIsForbidden
+    performAuthGet("/v2/preferred-organization").andIsForbidden
+    assertNoStoredPreference(testData.orgLessCommunityUser.id)
+  }
+
+  private fun loginAsOrgLessUser() {
+    userAccount = testData.orgLessCommunityUser
+  }
+
+  private fun disableOrganizationCreation() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = false
+  }
+
   private fun setPreferred(
     user: UserAccount,
     organizationId: Long,
@@ -109,6 +159,12 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
   private fun unpublishOtherOrgProject() {
     executeInNewTransaction {
       projectService.get(testData.otherOrgPublicProject.id).public = false
+    }
+  }
+
+  private fun assertNoStoredPreference(userId: Long) {
+    executeInNewTransaction {
+      assertThat(userPreferencesService.find(userId)?.preferredOrganization).isNull()
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationCommunityTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PreferredOrganizationCommunityTest.kt
@@ -5,6 +5,7 @@ import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assertions.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -39,7 +40,6 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
       node("currentUserRole").isEqualTo(null)
       node("limitedView").isEqualTo(true)
       node("basePermissions").isNotNull
-      node("activeCloudSubscription").isEqualTo(null)
     }
   }
 
@@ -62,7 +62,6 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
       node("name").isEqualTo("Vibrant translators")
       node("currentUserRole").isEqualTo(null)
       node("limitedView").isEqualTo(false)
-      node("activeCloudSubscription").isEqualTo(null)
     }
   }
 
@@ -102,8 +101,8 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
 
   @Test
   fun `org-less user has no preferred organization until it adopts one with public projects`() {
-    disableOrganizationCreation()
-    loginAsOrgLessUser()
+    refuseOrganizationCreation()
+    userAccount = testData.orgLessCommunityUser
 
     performAuthGet("/v2/preferred-organization").andIsForbidden
     performAuthGet("/v2/public/initial-data").andIsOk.andAssertThatJson {
@@ -125,8 +124,8 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
 
   @Test
   fun `org-less user cannot adopt an organization without public projects`() {
-    disableOrganizationCreation()
-    loginAsOrgLessUser()
+    refuseOrganizationCreation()
+    userAccount = testData.orgLessCommunityUser
 
     performAuthPut(
       "/v2/user-preferences/set-preferred-organization/${testData.noPublicOrg.id}",
@@ -136,11 +135,191 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
     assertNoStoredPreference(testData.orgLessCommunityUser.id)
   }
 
-  private fun loginAsOrgLessUser() {
+  @Test
+  fun `the implicit personal organization follows the same refusal rule as explicit creation`() {
+    refuseOrganizationCreation()
     userAccount = testData.orgLessCommunityUser
+
+    performAuthPost(
+      "/v2/organizations",
+      mapOf("name" to "Attempted organization"),
+    ).andIsForbidden
+    performAuthGet("/v2/preferred-organization").andIsForbidden
+    assertNoStoredPreference(testData.orgLessCommunityUser.id)
+
+    tolgeeProperties.authentication.userCanCreateOrganizations = true
+
+    performAuthGet("/v2/preferred-organization").andIsOk.andAssertThatJson {
+      node("currentUserRole").isEqualTo("OWNER")
+    }
   }
 
-  private fun disableOrganizationCreation() {
+  @Test
+  fun `an org-less user whose stored preference is null adopts an organization they are added to`() {
+    userAccount = testData.orgLessCommunityUser
+    refuseOrganizationCreation()
+
+    performAuthGet("/v2/preferred-organization").andIsForbidden
+    assertNoStoredPreference(testData.orgLessCommunityUser.id)
+
+    executeInNewTransaction {
+      organizationRoleService.grantRoleToUser(
+        userAccountService.get(testData.orgLessCommunityUser.id),
+        organizationService.get(testData.otherOrg.id),
+        OrganizationRoleType.MEMBER,
+      )
+    }
+
+    performAuthGet("/v2/preferred-organization").andIsOk.andAssertThatJson {
+      node("id").isEqualTo(testData.otherOrg.id)
+      node("currentUserRole").isEqualTo("MEMBER")
+    }
+    assertStoredPreference(testData.orgLessCommunityUser.id, testData.otherOrg.id)
+  }
+
+  @Test
+  fun `an SSO user gets no implicit personal organization`() {
+    tolgeeProperties.authentication.userCanCreateOrganizations = true
+    val ssoUser = userEntity(testData.ssoOrgLessUser)
+
+    assertThat(executeInNewTransaction { organizationService.findOrCreatePreferred(ssoUser) }).isNull()
+  }
+
+  @Test
+  fun `a stale preference heals to nothing while organization creation is refused`() {
+    setPreferred(testData.orgLessCommunityUser, testData.otherOrg.id)
+    unpublishOtherOrgProject()
+    refuseOrganizationCreation()
+    userAccount = testData.orgLessCommunityUser
+
+    performAuthGet("/v2/public/initial-data").andIsOk.andAssertThatJson {
+      node("preferredOrganization").isEqualTo(null)
+    }
+    performAuthGet("/v2/preferred-organization").andIsForbidden
+    assertNoStoredPreference(testData.orgLessCommunityUser.id)
+  }
+
+  @Test
+  fun `the implicit personal organization keeps a short name and pads it`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "李明")
+      }
+
+    assertThat(organization.name).isEqualTo("李明 Organization")
+    assertThat(organization.slug).isNotEmpty()
+  }
+
+  @Test
+  fun `the implicit personal organization truncates a name the entity would reject`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "N".repeat(120))
+      }
+
+    assertThat(organization.name).isEqualTo("N".repeat(50))
+  }
+
+  @Test
+  fun `the implicit personal organization never truncates onto a lone surrogate`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "N".repeat(49) + "\uD83D\uDE00".repeat(5))
+      }
+
+    assertThat(organization.name).isEqualTo("N".repeat(49))
+    assertThat(organization.name.none { it.isSurrogate() }).isTrue()
+  }
+
+  @Test
+  fun `the implicit personal organization keeps a surrogate pair that ends exactly at the limit`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "N".repeat(48) + "\uD83D\uDE00".repeat(5))
+      }
+
+    assertThat(organization.name).isEqualTo("N".repeat(48) + "\uD83D\uDE00")
+    assertThat(organization.name.length).isEqualTo(50)
+  }
+
+  @Test
+  fun `the implicit personal organization falls back to the username when there is no name`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "")
+      }
+
+    assertThat(organization.name).isEqualTo("org Organization")
+  }
+
+  @Test
+  fun `the username fallback drops a surrogate pair whole rather than cutting it`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        withUsernameRestoredBeforeCommit(user, "ab\uD83D\uDE00@example.com") {
+          organizationService.createPreferredWithoutAuthorization(user, "")
+        }
+      }
+
+    assertThat(organization.name).isEqualTo("ab Organization")
+  }
+
+  @Test
+  fun `the implicit personal organization keeps a name the DTO accepts`() {
+    val organization =
+      executeInNewTransaction {
+        val user = userAccountService.get(testData.orgLessCommunityUser.id)
+        organizationService.createPreferredWithoutAuthorization(user, "Joe")
+      }
+
+    assertThat(organization.name).isEqualTo("Joe")
+  }
+
+  @Test
+  fun `a server admin still gets an implicit personal organization while creation is refused`() {
+    refuseOrganizationCreation()
+
+    val created =
+      executeInNewTransaction {
+        val admin = userAccountService.get(testData.ssoServerAdmin.id)
+        organizationService.findOrCreatePreferred(admin)
+      }
+
+    assertThat(created).isNotNull
+    assertThat(organizationService.findPreferred(testData.ssoServerAdmin.id)).isNotNull
+  }
+
+  @Test
+  fun `server admin viewing an organization they hold no role in is not limited`() {
+    setPreferred(testData.serverAdmin, testData.otherOrg.id)
+    userAccount = testData.serverAdmin
+
+    performAuthGet("/v2/preferred-organization").andIsOk.andAssertThatJson {
+      node("currentUserRole").isEqualTo(null)
+      node("limitedView").isEqualTo(false)
+    }
+  }
+
+  @Test
+  fun `server supporter viewing an organization they hold no role in is not limited`() {
+    setPreferred(testData.serverSupporter, testData.otherOrg.id)
+    userAccount = testData.serverSupporter
+
+    performAuthGet("/v2/preferred-organization").andIsOk.andAssertThatJson {
+      node("currentUserRole").isEqualTo(null)
+      node("limitedView").isEqualTo(false)
+    }
+  }
+
+  private fun userEntity(user: UserAccount): UserAccount = executeInNewTransaction { userAccountService.get(user.id) }
+
+  private fun refuseOrganizationCreation() {
     tolgeeProperties.authentication.userCanCreateOrganizations = false
   }
 
@@ -159,6 +338,24 @@ class PreferredOrganizationCommunityTest : AuthorizedControllerTest() {
   private fun unpublishOtherOrgProject() {
     executeInNewTransaction {
       projectService.get(testData.otherOrgPublicProject.id).public = false
+    }
+  }
+
+  /**
+   * `cleanTestData` looks users up by the username their builder gave them, so a rename that
+   * reaches the database would strand this user and everything created under it.
+   */
+  private fun <T> withUsernameRestoredBeforeCommit(
+    user: UserAccount,
+    username: String,
+    body: () -> T,
+  ): T {
+    val original = user.username
+    user.username = username
+    try {
+      return body()
+    } finally {
+      user.username = original
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserPreferencesSetPreferredOrganizationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/UserPreferencesSetPreferredOrganizationTest.kt
@@ -1,6 +1,7 @@
 package io.tolgee.api.v2.controllers
 
 import io.tolgee.development.testDataBuilder.data.PublicProjectsControllerTestData
+import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.testing.AuthorizedControllerTest
@@ -28,6 +29,30 @@ class UserPreferencesSetPreferredOrganizationTest : AuthorizedControllerTest() {
     userAccount = testData.nonMember
     performAuthPut("/v2/user-preferences/set-preferred-organization/${testData.otherOrg.id}", null).andIsOk
     assertPreferredOrganization(testData.nonMember.id, testData.otherOrg.id)
+  }
+
+  @Test
+  fun `the write answers with the organization it stored, so no follow-up read is needed`() {
+    userAccount = testData.nonMember
+    performAuthPut("/v2/user-preferences/set-preferred-organization/${testData.otherOrg.id}", null)
+      .andIsOk
+      .andAssertThatJson {
+        node("id").isEqualTo(testData.otherOrg.id)
+        node("name").isEqualTo("Vibrant translators")
+        node("currentUserRole").isEqualTo(null)
+        node("limitedView").isEqualTo(true)
+      }
+  }
+
+  @Test
+  fun `the write answers with the full model for a member`() {
+    userAccount = testData.otherOrgMember
+    performAuthPut("/v2/user-preferences/set-preferred-organization/${testData.otherOrg.id}", null)
+      .andIsOk
+      .andAssertThatJson {
+        node("currentUserRole").isEqualTo("MEMBER")
+        node("limitedView").isEqualTo(false)
+      }
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2UserControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/V2UserControllerTest.kt
@@ -1,6 +1,7 @@
 package io.tolgee.api.v2.controllers
 
 import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.development.testDataBuilder.data.ManagingOrganizationTestData
 import io.tolgee.development.testDataBuilder.data.SensitiveOperationProtectionTestData
 import io.tolgee.development.testDataBuilder.data.UserDeletionTestData
 import io.tolgee.dtos.request.UserUpdatePasswordRequestDto
@@ -307,6 +308,22 @@ class V2UserControllerTest : AuthorizedControllerTest() {
   fun `it returns no content for managed by`() {
     // EE dependant endpoint - without EE always returns no content
     performAuthGet("/v2/user/managed-by").andIsNoContent
+  }
+
+  @Test
+  fun `it returns the managing organization when there is one`() {
+    val managing = ManagingOrganizationTestData()
+    testDataService.saveTestData(managing.root)
+    try {
+      loginAsUser(managing.managedUser)
+
+      performAuthGet("/v2/user/managed-by").andIsOk.andAssertThatJson {
+        node("id").isEqualTo(managing.managingOrganization.id)
+        node("name").isEqualTo("Managing org")
+      }
+    } finally {
+      testDataService.cleanTestData(managing.root)
+    }
   }
 
   private fun assertSingleOwned(

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/BaseOrganizationControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/BaseOrganizationControllerTest.kt
@@ -36,7 +36,7 @@ class BaseOrganizationControllerTest : AuthorizedControllerTest() {
   protected fun withOwnerInOrganization(
     fn: (organization: Organization, owner: UserAccount, ownerRole: OrganizationRole) -> Unit,
   ) {
-    executeInNewTransaction { this.organizationService.create(dummyDto, userAccount!!) }
+    executeInNewTransaction { this.organizationService.createWithoutAuthorization(dummyDto, userAccount!!) }
       .let { organization ->
         dbPopulator.createUserIfNotExists("superuser").let { createdUser ->
           OrganizationRole(

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerInvitingTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerInvitingTest.kt
@@ -54,7 +54,7 @@ class OrganizationControllerInvitingTest : AuthorizedControllerTest() {
   fun testGetAllInvitations() {
     val helloUser = dbPopulator.createUserIfNotExists("hellouser")
 
-    this.organizationService.create(dummyDto, helloUser).let { organization ->
+    this.organizationService.createWithoutAuthorization(dummyDto, helloUser).let { organization ->
       val invitation =
         invitationService.create(
           CreateOrganizationInvitationParams(
@@ -79,7 +79,7 @@ class OrganizationControllerInvitingTest : AuthorizedControllerTest() {
     val helloUser = dbPopulator.createUserIfNotExists("hellouser")
     loginAsUser(helloUser.username)
 
-    this.organizationService.create(dummyDto, helloUser).let { organization ->
+    this.organizationService.createWithoutAuthorization(dummyDto, helloUser).let { organization ->
       val body = OrganizationInviteUserDto(roleType = OrganizationRoleType.MEMBER)
       performAuthPut("/v2/organizations/${organization.id}/invite", body).andPrettyPrint.andAssertThatJson {
         node("code").isString.hasSize(50).satisfies {
@@ -94,7 +94,7 @@ class OrganizationControllerInvitingTest : AuthorizedControllerTest() {
   fun testAcceptInvitation() {
     val helloUser = dbPopulator.createUserIfNotExists("hellouser")
 
-    this.organizationService.create(dummyDto, helloUser).let { organization ->
+    this.organizationService.createWithoutAuthorization(dummyDto, helloUser).let { organization ->
       val invitation =
         invitationService.create(
           CreateOrganizationInvitationParams(
@@ -117,7 +117,7 @@ class OrganizationControllerInvitingTest : AuthorizedControllerTest() {
   fun `it prevents accepting invitation again already a member`() {
     val helloUser = dbPopulator.createUserIfNotExists("hellouser")
 
-    this.organizationService.create(dummyDto, helloUser).let { organization ->
+    this.organizationService.createWithoutAuthorization(dummyDto, helloUser).let { organization ->
       val invitation =
         invitationService.create(
           CreateOrganizationInvitationParams(
@@ -150,7 +150,7 @@ class OrganizationControllerInvitingTest : AuthorizedControllerTest() {
 
   private fun prepareTestOrganization(): Organization {
     val helloUser = dbPopulator.createUserIfNotExists(TEST_USERNAME)
-    val organization = organizationService.create(dummyDto, helloUser)
+    val organization = organizationService.createWithoutAuthorization(dummyDto, helloUser)
     loginAsUser(helloUser.username)
     return organization
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerLeavingTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerLeavingTest.kt
@@ -1,13 +1,18 @@
 package io.tolgee.api.v2.controllers.organizationController
 
 import io.tolgee.development.testDataBuilder.data.OrganizationTestData
+import io.tolgee.development.testDataBuilder.data.OwnerlessOrganizationTestData
 import io.tolgee.development.testDataBuilder.data.PermissionsTestData
 import io.tolgee.fixtures.andAssertError
+import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsBadRequest
+import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.testing.assert
 import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
@@ -18,7 +23,8 @@ import org.springframework.data.domain.PageRequest
 class OrganizationControllerLeavingTest : BaseOrganizationControllerTest() {
   @Test
   fun testLeaveOrganization() {
-    val testOrg = executeInNewTransaction { this.organizationService.create(dummyDto, userAccount!!) }
+    val testOrg =
+      executeInNewTransaction { this.organizationService.createWithoutAuthorization(dummyDto, userAccount!!) }
     organizationRoleService.grantOwnerRoleToUser(dbPopulator.createUserIfNotExists("secondOwner"), testOrg)
     assertThat(getPermittedOrgs().find { testOrg.id == it.id }).isNotNull
     performAuthPut("/v2/organizations/${testOrg.id}/leave", null).andIsOk
@@ -68,9 +74,49 @@ class OrganizationControllerLeavingTest : BaseOrganizationControllerTest() {
       .isNull()
   }
 
+  private var ownerlessTestData: OwnerlessOrganizationTestData? = null
+
+  @AfterEach
+  fun cleanOwnerlessTestData() {
+    ownerlessTestData?.let { testDataService.cleanTestData(it.root) }
+    ownerlessTestData = null
+  }
+
+  private fun saveOwnerless(): OwnerlessOrganizationTestData {
+    val data = OwnerlessOrganizationTestData()
+    ownerlessTestData = data
+    testDataService.saveTestData(data.root)
+    return data
+  }
+
+  @Test
+  fun `a member of an ownerless organization can leave it`() {
+    val ownerless = saveOwnerless()
+
+    userAccount = ownerless.member
+    performAuthPut("/v2/organizations/${ownerless.withMember.id}/leave", null).andIsOk
+    assertThat(
+      organizationRepository.findAllPermitted(ownerless.member.id, PageRequest.of(0, 20)).content.find {
+        ownerless.withMember.id == it.id
+      },
+    ).isNull()
+  }
+
+  @Test
+  fun `leaving an organization with no owners reports not-a-member, not the owner count`() {
+    val ownerless = saveOwnerless()
+
+    performAuthPut("/v2/organizations/${ownerless.withPublicProject.id}/leave", null)
+      .andIsNotFound
+      .andAssertThatJson {
+        node("code").isEqualTo("user_is_not_member_of_organization")
+      }
+  }
+
   @Test
   fun testLeaveOrganizationNoOtherOwner() {
-    val organization = executeInNewTransaction { this.organizationService.create(dummyDto, userAccount!!) }
+    val organization =
+      executeInNewTransaction { this.organizationService.createWithoutAuthorization(dummyDto, userAccount!!) }
     organizationRepository.findAllPermitted(userAccount!!.id, PageRequest.of(0, 20)).content.let {
       assertThat(it).isNotEmpty
     }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationControllerTest.kt
@@ -257,7 +257,7 @@ class OrganizationControllerTest : BaseOrganizationControllerTest() {
   @Test
   fun testEdit() {
     executeInNewTransaction {
-      this.organizationService.create(dummyDto, userAccount!!).let {
+      this.organizationService.createWithoutAuthorization(dummyDto, userAccount!!).let {
         performAuthPut(
           "/v2/organizations/${it.id}",
           dummyDto.also { organization ->
@@ -302,7 +302,7 @@ class OrganizationControllerTest : BaseOrganizationControllerTest() {
 
   private fun createOrganization(organizationDto: OrganizationDto) =
     executeInNewTransaction {
-      organizationService.create(
+      organizationService.createWithoutAuthorization(
         organizationDto,
         userAccount!!,
       )

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationFloorAccessTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationFloorAccessTest.kt
@@ -250,6 +250,55 @@ class OrganizationFloorAccessTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `a NONE-only permission holder can still leave, a pure floor viewer cannot`() {
+    userAccount = testData.noneOnlyUser
+    performAuthPut("/v2/organizations/${testData.otherOrg.id}/leave", null).andIsOk
+
+    userAccount = testData.nonMember
+    performAuthPut("/v2/organizations/${testData.otherOrg.id}/leave", null)
+      .andIsNotFound
+      .andAssertThatJson {
+        node("code").isEqualTo("user_is_not_member_of_organization")
+      }
+  }
+
+  @Test
+  fun `a direct-permission collaborator can shed it even when the org has a sole owner`() {
+    userAccount = testData.guestWithPermission
+    performAuthPut("/v2/organizations/${testData.otherOrg.id}/leave", null).andIsOk
+    performAuthGet("/v2/projects/${testData.otherOrgPrivateProject.id}").andIsNotFound
+  }
+
+  @Test
+  fun `a permission in another organization is not something to leave this one with`() {
+    userAccount = testData.revokedOnlyUser
+    performAuthPut("/v2/organizations/${testData.otherOrg.id}/leave", null)
+      .andIsNotFound
+      .andAssertThatJson {
+        node("code").isEqualTo("user_is_not_member_of_organization")
+      }
+  }
+
+  @Test
+  fun `staff cannot view a soft-deleted organization`() {
+    executeInNewTransaction {
+      val admin = userAccountService.getDto(testData.serverAdmin.id)
+      organizationRoleService
+        .canUserView(admin, testData.softDeletedOrg.id)
+        .assert
+        .isFalse()
+      organizationRoleService
+        .canUserViewOrPublic(admin, testData.softDeletedOrg.id)
+        .assert
+        .isFalse()
+      organizationRoleService
+        .canUserViewAtLeastMember(admin, testData.softDeletedOrg.id)
+        .assert
+        .isFalse()
+    }
+  }
+
+  @Test
   fun `a NONE-only permission on a private-only org grants no org access`() {
     userAccount = testData.revokedOnlyUser
     performAuthGet("/v2/organizations/${testData.noPublicOrg.id}").andIsNotFound

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
@@ -14,6 +14,7 @@ import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
 import io.tolgee.fixtures.satisfies
 import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
 import io.tolgee.model.branching.Branch
 import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.ProjectPermissionType
@@ -158,6 +159,29 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
           assertThat(
             permissionService.getUserProjectPermission(it.id, maintainerAccount.id)?.type,
           ).isEqualTo(ProjectPermissionType.MANAGE)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `creates project for server admin who is not a member of the organization`() {
+    val owner = dbPopulator.createUserIfNotExists("outsiderOrgOwner")
+    val organization = dbPopulator.createOrganization("Outsider Organization", owner)
+    val adminAccount = dbPopulator.createUserIfNotExists("serverAdminUser")
+    adminAccount.role = UserAccount.Role.ADMIN
+    userAccountService.save(adminAccount)
+    loginAsUser("serverAdminUser")
+
+    val request =
+      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
+      node("id").asNumber().satisfies {
+        projectService.get(it.toLong()).let { project ->
+          assertThat(project.organizationOwner.id).isEqualTo(organization.id)
+          assertThat(
+            permissionService.getUserProjectPermission(project.id, adminAccount.id),
+          ).isNull()
         }
       }
     }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
@@ -130,8 +130,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
     val userAccount = dbPopulator.createUserIfNotExists("testuser")
     val organization = dbPopulator.createOrganization("Test Organization", userAccount)
     loginAsUser("testuser")
-    val request =
-      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    val request = createProjectRequest(organization.id)
     performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
       node("icuPlaceholders").isBoolean.isTrue
       node("id").asNumber().satisfies {
@@ -149,8 +148,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
     val maintainerAccount = dbPopulator.createUserIfNotExists("maintainerUser")
     organizationRoleService.grantRoleToUser(maintainerAccount, organization, OrganizationRoleType.MAINTAINER)
     loginAsUser("maintainerUser")
-    val request =
-      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    val request = createProjectRequest(organization.id)
     performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
       node("icuPlaceholders").isBoolean.isTrue
       node("id").asNumber().satisfies {
@@ -165,16 +163,66 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `grants an owner no explicit project permission - the organization role carries it`() {
+    val owner = dbPopulator.createUserIfNotExists("ownerCreatingUser")
+    val organization = dbPopulator.createOrganization("Owner Organization", owner)
+    loginAsUser("ownerCreatingUser")
+
+    performAuthPost("/v2/projects", createProjectRequest(organization.id)).andIsOk.andAssertThatJson {
+      node("id").asNumber().satisfies {
+        assertThat(permissionService.getUserProjectPermission(it.toLong(), owner.id)).isNull()
+      }
+    }
+  }
+
+  @Test
+  fun `refuses project creation for a plain member of the organization`() {
+    val owner = dbPopulator.createUserIfNotExists("memberOrgOwner")
+    val organization = dbPopulator.createOrganization("Member Organization", owner)
+    val memberAccount = dbPopulator.createUserIfNotExists("plainMemberUser")
+    organizationRoleService.grantRoleToUser(memberAccount, organization, OrganizationRoleType.MEMBER)
+    loginAsUser("plainMemberUser")
+
+    val request = createProjectRequest(organization.id)
+    performAuthPost("/v2/projects", request).andIsForbidden
+
+    assertThat(projectService.findAllInOrganization(organization.id)).isEmpty()
+  }
+
+  @Test
+  fun `refuses project creation for a user with no role in the organization`() {
+    val owner = dbPopulator.createUserIfNotExists("nonMemberOrgOwner")
+    val organization = dbPopulator.createOrganization("Non Member Organization", owner)
+    dbPopulator.createUserIfNotExists("nonMemberUser")
+    loginAsUser("nonMemberUser")
+
+    val request = createProjectRequest(organization.id)
+    performAuthPost("/v2/projects", request).andIsForbidden
+
+    assertThat(projectService.findAllInOrganization(organization.id)).isEmpty()
+  }
+
+  @Test
+  fun `refuses project creation for a server supporter who is not a member`() {
+    val owner = dbPopulator.createUserIfNotExists("supporterOrgOwner")
+    val organization = dbPopulator.createOrganization("Supporter Organization", owner)
+    dbPopulator.createUserIfNotExists("serverSupporterUser", role = UserAccount.Role.SUPPORTER)
+    loginAsUser("serverSupporterUser")
+
+    val request = createProjectRequest(organization.id)
+    performAuthPost("/v2/projects", request).andIsForbidden
+
+    assertThat(projectService.findAllInOrganization(organization.id)).isEmpty()
+  }
+
+  @Test
   fun `creates project for server admin who is not a member of the organization`() {
     val owner = dbPopulator.createUserIfNotExists("outsiderOrgOwner")
     val organization = dbPopulator.createOrganization("Outsider Organization", owner)
-    val adminAccount = dbPopulator.createUserIfNotExists("serverAdminUser")
-    adminAccount.role = UserAccount.Role.ADMIN
-    userAccountService.save(adminAccount)
+    val adminAccount = dbPopulator.createUserIfNotExists("serverAdminUser", role = UserAccount.Role.ADMIN)
     loginAsUser("serverAdminUser")
 
-    val request =
-      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    val request = createProjectRequest(organization.id)
     performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
       node("id").asNumber().satisfies {
         projectService.get(it.toLong()).let { project ->
@@ -194,8 +242,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
     val maintainerAccount = dbPopulator.createUserIfNotExists("maintainerUser")
     organizationRoleService.grantRoleToUser(maintainerAccount, organization, OrganizationRoleType.MAINTAINER)
     loginAsUser("testuser")
-    val request =
-      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    val request = createProjectRequest(organization.id)
     var project: Project? = null
     performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
       node("id").asNumber().satisfies {
@@ -312,4 +359,7 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
     performAuthPost("/v2/projects", createForLanguagesDto.apply { this.baseLanguageTag = "not_exists" })
       .andIsBadRequest
   }
+
+  private fun createProjectRequest(organizationId: Long) =
+    CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organizationId, icuPlaceholders = true)
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerCreateTest.kt
@@ -13,6 +13,7 @@ import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.andPrettyPrint
 import io.tolgee.fixtures.satisfies
 import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
 import io.tolgee.model.branching.Branch
 import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.ProjectPermissionType
@@ -158,6 +159,29 @@ class ProjectsControllerCreateTest : AuthorizedControllerTest() {
           assertThat(
             permissionService.getUserProjectPermission(it.id, maintainerAccount.id)?.type,
           ).isEqualTo(ProjectPermissionType.MANAGE)
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `creates project for server admin who is not a member of the organization`() {
+    val owner = dbPopulator.createUserIfNotExists("outsiderOrgOwner")
+    val organization = dbPopulator.createOrganization("Outsider Organization", owner)
+    val adminAccount = dbPopulator.createUserIfNotExists("serverAdminUser")
+    adminAccount.role = UserAccount.Role.ADMIN
+    userAccountService.save(adminAccount)
+    loginAsUser("serverAdminUser")
+
+    val request =
+      CreateProjectRequest("aaa", listOf(languageDTO), organizationId = organization.id, icuPlaceholders = true)
+    performAuthPost("/v2/projects", request).andIsOk.andAssertThatJson {
+      node("id").asNumber().satisfies {
+        projectService.get(it.toLong()).let { project ->
+          assertThat(project.organizationOwner.id).isEqualTo(organization.id)
+          assertThat(
+            permissionService.getUserProjectPermission(project.id, adminAccount.id),
+          ).isNull()
         }
       }
     }

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpProjectToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpProjectToolsTest.kt
@@ -2,7 +2,12 @@ package io.tolgee.mcp.tools
 
 import io.modelcontextprotocol.client.McpSyncClient
 import io.tolgee.AbstractMcpTest
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.model.Pat
+import io.tolgee.model.enums.OrganizationRoleType
+import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -10,10 +15,21 @@ class McpProjectToolsTest : AbstractMcpTest() {
   lateinit var data: McpPatTestData
   lateinit var client: McpSyncClient
 
+  private val extraTestDataRoots = mutableListOf<TestDataBuilder>()
+
   @BeforeEach
   fun setup() {
     data = createTestDataWithPat()
     client = createMcpClientWithPat(data.pat.token!!)
+  }
+
+  @AfterEach
+  fun cleanTestData() {
+    extraTestDataRoots.forEach { testDataService.cleanTestData(it) }
+    extraTestDataRoots.clear()
+    if (this::data.isInitialized) {
+      testDataService.cleanTestData(data.testData.root)
+    }
   }
 
   @Test
@@ -42,17 +58,52 @@ class McpProjectToolsTest : AbstractMcpTest() {
       callToolAndGetJson(
         client,
         "create_project",
-        mapOf(
-          "name" to "New MCP Project",
-          "organizationId" to data.organizationId,
-          "languages" to
-            listOf(
-              mapOf("name" to "English", "tag" to "en"),
-            ),
-        ),
+        createProjectArguments("New MCP Project"),
       )
     assertThat(json["id"]).isNotNull()
     assertThat(json["name"].asText()).isEqualTo("New MCP Project")
+  }
+
+  @Test
+  fun `create_project grants the maintainer full access to the project it created`() {
+    val maintainer = createUserWithPat("mcp_project_maintainer")
+    executeInNewTransaction {
+      organizationRoleService.grantRoleToUser(
+        userAccountService.get(maintainer.userId),
+        organizationService.get(data.organizationId),
+        OrganizationRoleType.MAINTAINER,
+      )
+    }
+
+    val json =
+      callToolAndGetJson(
+        createMcpClientWithPat(maintainer.token),
+        "create_project",
+        createProjectArguments("Maintainer MCP Project"),
+      )
+
+    val projectId = json["id"].asLong()
+    executeInNewTransaction {
+      assertThat(permissionService.getUserProjectPermission(projectId, maintainer.userId)?.type)
+        .isEqualTo(ProjectPermissionType.MANAGE)
+    }
+  }
+
+  @Test
+  fun `create_project refuses a user with no role in the organization`() {
+    val outsider = createUserWithPat("mcp_project_outsider")
+
+    assertToolFails(
+      createMcpClientWithPat(outsider.token),
+      "create_project",
+      createProjectArguments("Outsider MCP Project"),
+      expectedError = "user_is_not_owner_or_maintainer_of_organization",
+    )
+
+    executeInNewTransaction {
+      assertThat(projectService.findAllInOrganization(data.organizationId).map { it.name })
+        .doesNotContain("Outsider MCP Project")
+    }
   }
 
   @Test
@@ -74,6 +125,7 @@ class McpProjectToolsTest : AbstractMcpTest() {
   @Test
   fun `get_project_language_statistics auto-resolves projectId from PAK`() {
     val pakData = createTestDataWithPak()
+    extraTestDataRoots.add(pakData.testData.root)
     val pakClient = createMcpClientWithPak(pakData.apiKey.encodedKey!!)
 
     val json = callToolAndGetJson(pakClient, "get_project_language_statistics")
@@ -81,4 +133,34 @@ class McpProjectToolsTest : AbstractMcpTest() {
     assertThat(json.size()).isGreaterThan(0)
     assertThat(json[0].has("languageTag")).isTrue()
   }
+
+  private fun createUserWithPat(username: String): PatUser {
+    var pat: Pat? = null
+    val root = TestDataBuilder()
+    val userBuilder = root.addUserAccount { this.username = username }
+    userBuilder.build {
+      addPat {
+        description = "MCP test PAT"
+        pat = this
+      }
+    }
+    testDataService.saveTestData(root)
+    extraTestDataRoots.add(root)
+    return PatUser(userId = userBuilder.self.id, token = pat!!.token!!)
+  }
+
+  private data class PatUser(
+    val userId: Long,
+    val token: String,
+  )
+
+  private fun createProjectArguments(name: String) =
+    mapOf(
+      "name" to name,
+      "organizationId" to data.organizationId,
+      "languages" to
+        listOf(
+          mapOf("name" to "English", "tag" to "en"),
+        ),
+    )
 }

--- a/backend/app/src/test/kotlin/io/tolgee/service/translationMemory/TranslationMemoryServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/translationMemory/TranslationMemoryServiceTest.kt
@@ -59,7 +59,7 @@ class TranslationMemoryServiceTest : AbstractSpringTest() {
     val orgId = testData.projectWithoutTm.organizationOwner.id
 
     val project =
-      projectCreationService.createProject(
+      projectCreationService.createProjectWithoutAuthorization(
         CreateProjectRequest(
           name = "New TM Project",
           languages = listOf(LanguageRequest(name = "English", originalName = "English", tag = "en")),

--- a/backend/app/src/test/kotlin/io/tolgee/unit/PostHogBusinessEventReporterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/PostHogBusinessEventReporterTest.kt
@@ -1,0 +1,121 @@
+package io.tolgee.unit
+
+import com.posthog.server.PostHog
+import io.tolgee.component.reporting.OnBusinessEventToCaptureEvent
+import io.tolgee.component.reporting.PostHogBusinessEventReporter
+import io.tolgee.dtos.cacheable.UserAccountDto
+import io.tolgee.model.Organization
+import io.tolgee.service.organization.OrganizationRoleService
+import io.tolgee.service.organization.OrganizationService
+import io.tolgee.service.project.ProjectService
+import io.tolgee.service.security.UserAccountService
+import io.tolgee.testing.assert
+import jakarta.persistence.EntityManager
+import jakarta.persistence.TypedQuery
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+class PostHogBusinessEventReporterTest {
+  private val postHog = Mockito.mock(PostHog::class.java)
+  private val organizationService = Mockito.mock(OrganizationService::class.java)
+  private val userAccountService = Mockito.mock(UserAccountService::class.java)
+  private val entityManager = Mockito.mock(EntityManager::class.java)
+  private val organizationRoleService = Mockito.mock(OrganizationRoleService::class.java)
+
+  private val reporter =
+    PostHogBusinessEventReporter(
+      postHog = postHog,
+      projectService = Mockito.mock(ProjectService::class.java),
+      organizationService = organizationService,
+      userAccountService = userAccountService,
+      entityManager = entityManager,
+      postHogGroupIdentifier = null,
+      organizationRoleService = organizationRoleService,
+    )
+
+  private fun capturedProperties(): Map<*, *> =
+    Mockito
+      .mockingDetails(postHog)
+      .invocations
+      .first { it.method.name == "capture" }
+      .getArgument(2)
+
+  private fun captureInvocationCount() =
+    Mockito
+      .mockingDetails(postHog)
+      .invocations
+      .count { it.method.name == "capture" }
+
+  @Test
+  fun `it refuses a reserved event name outright`() {
+    reporter.captureAsync(
+      OnBusinessEventToCaptureEvent(
+        eventName = "${'$'}create_alias",
+        anonymousUserId = "anonymous-attacker",
+      ),
+    )
+
+    captureInvocationCount().assert.isEqualTo(0)
+  }
+
+  @Test
+  fun `it omits organizationMember when the publisher named no user`() {
+    val ownerId = 42L
+    val organization = Mockito.mock(Organization::class.java)
+    Mockito.`when`(organization.name).thenReturn("Owner Org")
+    Mockito.`when`(organizationService.get(7L)).thenReturn(organization)
+
+    @Suppress("UNCHECKED_CAST")
+    val query = Mockito.mock(TypedQuery::class.java) as TypedQuery<Long>
+    Mockito
+      .`when`(entityManager.createQuery(Mockito.anyString(), Mockito.eq(Long::class.java)))
+      .thenReturn(query)
+    Mockito.`when`(query.setParameter(Mockito.anyString(), Mockito.any())).thenReturn(query)
+    Mockito.`when`(query.resultList).thenReturn(listOf(ownerId))
+    // The owner really resolves: without this the substitution never materialises and the test
+    // would pass whichever event the actor is read from.
+    Mockito.`when`(userAccountService.findDto(ownerId)).thenReturn(
+      UserAccountDto(
+        name = "Owner",
+        username = "owner@example.com",
+        domain = null,
+        role = null,
+        id = ownerId,
+        needsSuperJwt = false,
+        avatarHash = null,
+        deleted = false,
+        tokensValidNotBefore = null,
+        emailVerified = true,
+        thirdPartyAuth = null,
+        ssoRefreshToken = null,
+        ssoSessionExpiry = null,
+      ),
+    )
+
+    reporter.captureAsync(
+      OnBusinessEventToCaptureEvent(
+        eventName = "SERVER_INITIATED_EVENT",
+        organizationId = 7L,
+      ),
+    )
+
+    // fillOtherData substitutes the organization OWNER as the attribution account, so reading the
+    // actor from the filled copy would report that owner's membership as the actor's.
+    capturedProperties().containsKey("organizationMember").assert.isEqualTo(false)
+    Mockito
+      .verify(organizationRoleService, Mockito.never())
+      .hasAnyOrganizationRole(Mockito.anyLong(), Mockito.anyLong())
+  }
+
+  @Test
+  fun `it reports an ordinary event name`() {
+    reporter.captureAsync(
+      OnBusinessEventToCaptureEvent(
+        eventName = "ORDINARY_EVENT",
+        anonymousUserId = "anonymous-visitor",
+      ),
+    )
+
+    captureInvocationCount().assert.isEqualTo(1)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/unit/PrivateOrganizationModelAssemblerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/PrivateOrganizationModelAssemblerTest.kt
@@ -2,10 +2,12 @@ package io.tolgee.unit
 
 import io.tolgee.constants.Feature
 import io.tolgee.dtos.queryResults.organization.PrivateOrganizationView
+import io.tolgee.dtos.queryResults.organization.QuickStartView
 import io.tolgee.hateoas.organization.OrganizationModel
 import io.tolgee.hateoas.organization.OrganizationModelAssembler
 import io.tolgee.hateoas.organization.PrivateOrganizationModelAssembler
 import io.tolgee.hateoas.permission.PermissionModel
+import io.tolgee.hateoas.quickStart.QuickStartModel
 import io.tolgee.hateoas.quickStart.QuickStartModelAssembler
 import io.tolgee.publicBilling.CloudSubscriptionModelProvider
 import io.tolgee.publicBilling.PublicCloudSubscriptionModel
@@ -52,7 +54,7 @@ class PrivateOrganizationModelAssemblerTest {
   }
 
   @Test
-  fun `a below-member reader gets no subscription and maps the passed limitedView`() {
+  fun `a limited reader sees the organization's entitlements but not its subscription`() {
     setup()
 
     val model =
@@ -74,7 +76,7 @@ class PrivateOrganizationModelAssemblerTest {
   }
 
   @Test
-  fun `a below-member with standing gets no subscription but a non-limited view`() {
+  fun `a below-member with standing gets the entitlements but no subscription`() {
     setup()
 
     val model =
@@ -85,9 +87,32 @@ class PrivateOrganizationModelAssemblerTest {
         limitedView = false,
       )
 
+    model.enabledFeatures
+      .toSet()
+      .assert
+      .isEqualTo(setOf(Feature.GLOSSARY))
     model.limitedView.assert.isEqualTo(false)
     model.activeCloudSubscription.assert.isNull()
     verify(cloudSubscriptionModelProvider, never()).provide(any())
+  }
+
+  @Test
+  fun `it carries the viewer's quick start for the organization`() {
+    setup()
+    val quickStart = Mockito.mock(QuickStartView::class.java)
+    val quickStartModel = Mockito.mock(QuickStartModel::class.java)
+    whenever(view.quickStart).thenReturn(quickStart)
+    whenever(quickStartModelAssembler.toModel(quickStart)).thenReturn(quickStartModel)
+
+    val model =
+      underTest.toModel(
+        view,
+        arrayOf(Feature.GLOSSARY),
+        isAtLeastMember = true,
+        limitedView = false,
+      )
+
+    model.quickStart.assert.isEqualTo(quickStartModel)
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/unit/SurrogateSafeEndTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/SurrogateSafeEndTest.kt
@@ -1,0 +1,30 @@
+package io.tolgee.unit
+
+import io.tolgee.testing.assert
+import io.tolgee.util.surrogateSafeEnd
+import org.junit.jupiter.api.Test
+
+class SurrogateSafeEndTest {
+  @Test
+  fun `it steps back off a lone high surrogate`() {
+    surrogateSafeEnd("ab😀", 3).assert.isEqualTo(2)
+  }
+
+  @Test
+  fun `it leaves a cut that lands between characters alone`() {
+    surrogateSafeEnd("abcd", 3).assert.isEqualTo(3)
+  }
+
+  @Test
+  fun `it keeps a whole surrogate pair when the cut falls after it`() {
+    surrogateSafeEnd("a😀b", 3).assert.isEqualTo(3)
+  }
+
+  @Test
+  fun `it never returns an index outside the name`() {
+    surrogateSafeEnd("ab", 3).assert.isEqualTo(2)
+    surrogateSafeEnd("", 3).assert.isEqualTo(0)
+    surrogateSafeEnd("abc", 0).assert.isEqualTo(0)
+    surrogateSafeEnd("abc", -1).assert.isEqualTo(0)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/component/reporting/PostHogBusinessEventReporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/reporting/PostHogBusinessEventReporter.kt
@@ -3,10 +3,13 @@ package io.tolgee.component.reporting
 import com.posthog.server.PostHog
 import io.tolgee.component.reporting.PostHogGroupIdentifier.Companion.GROUP_TYPE
 import io.tolgee.dtos.cacheable.UserAccountDto
+import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.organization.OrganizationService
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.security.UserAccountService
+import io.tolgee.util.Logging
 import io.tolgee.util.filterValueNotNull
+import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Lazy
@@ -22,15 +25,16 @@ class PostHogBusinessEventReporter(
   private val userAccountService: UserAccountService,
   private val entityManager: EntityManager,
   private var postHogGroupIdentifier: PostHogGroupIdentifier?,
-) {
+  private val organizationRoleService: OrganizationRoleService,
+) : Logging {
   @Lazy
   @Autowired
   private lateinit var selfProxied: PostHogBusinessEventReporter
 
   @Async
-  fun captureAsync(data: OnBusinessEventToCaptureEvent) {
-    val filledData = fillOtherData(data)
-    captureWithPostHog(filledData)
+  fun captureAsync(published: OnBusinessEventToCaptureEvent) {
+    val filled = fillOtherData(published)
+    captureWithPostHog(filled, organizationMember(published.actorId(), filled.organizationId))
   }
 
   @EventListener
@@ -51,21 +55,32 @@ class PostHogBusinessEventReporter(
     )
   }
 
-  private fun captureWithPostHog(data: OnBusinessEventToCaptureEvent) {
+  private fun captureWithPostHog(
+    data: OnBusinessEventToCaptureEvent,
+    organizationMember: Boolean?,
+  ) {
+    if (isReservedEventName(data.eventName)) {
+      logger.warn("Refusing to report business event with a reserved name: {}", data.eventName)
+      return
+    }
+
     val id = data.userAccountDto?.id ?: data.instanceId ?: data.anonymousUserId
     val setEntry = getIdentificationMapForPostHog(data)
-
-    val map =
+    val clientSupplied = withoutReservedProperties((data.utmData ?: emptyMap()) + (data.data ?: emptyMap()))
+    val authorizedAttribution =
       mapOf(
         "${'$'}groups" to
           mapOf(
             "project" to data.projectDto?.id,
             GROUP_TYPE to data.organizationId,
           ),
+        "projectId" to data.projectDto?.id,
         "organizationId" to data.organizationId,
         "organizationName" to data.organizationName,
+        "organizationMember" to organizationMember,
         "glossaryId" to data.glossaryId,
-      ) + (data.utmData ?: emptyMap()) + (data.data ?: emptyMap()) + setEntry
+      )
+    val map = clientSupplied + authorizedAttribution + setEntry
 
     postHog?.capture(
       id.toString(),
@@ -75,6 +90,11 @@ class PostHogBusinessEventReporter(
 
     postHogGroupIdentifier?.identifyOrganization(organizationId = data.organizationId ?: return)
   }
+
+  private fun isReservedEventName(eventName: String) = eventName.startsWith(RESERVED_PREFIX)
+
+  private fun withoutReservedProperties(properties: Map<String, Any?>) =
+    properties.filterKeys { !it.startsWith(RESERVED_PREFIX) }
 
   /**
    * PostHog accepts user information in $set property.
@@ -130,6 +150,16 @@ class PostHogBusinessEventReporter(
     )
   }
 
+  private fun OnBusinessEventToCaptureEvent.actorId(): Long? = userAccountId ?: userAccountDto?.id
+
+  private fun organizationMember(
+    actorId: Long?,
+    organizationId: Long?,
+  ): Boolean? {
+    if (actorId == null || organizationId == null) return null
+    return organizationRoleService.hasAnyOrganizationRole(actorId, organizationId)
+  }
+
   private fun findOwnerUserByOrganizationId(organizationId: Long?): Long? {
     organizationId ?: return null
     return entityManager
@@ -145,5 +175,9 @@ class PostHogBusinessEventReporter(
       ).setParameter("organizationId", organizationId)
       .resultList
       .firstOrNull()
+  }
+
+  companion object {
+    private const val RESERVED_PREFIX = '$'
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/DbPopulatorReal.kt
@@ -63,20 +63,26 @@ class DbPopulatorReal(
     username: String,
     password: String? = null,
     name: String? = null,
+    role: UserAccount.Role? = null,
   ): UserAccount {
-    return userAccountService.findActive(username) ?: let {
-      val rawPassword =
-        password
-          ?: initialPasswordManager.initialPassword
-
-      userAccountService.createUser(
-        UserAccount(
-          name = name ?: username,
-          username = username,
-          password = passwordEncoder.encode(rawPassword),
-        ),
-      )
+    val existing = userAccountService.findActive(username)
+    if (existing != null) {
+      require(role == null || existing.role == role) {
+        "User $username already exists with role ${existing.role}, but role $role was requested"
+      }
+      return existing
     }
+
+    val rawPassword = password ?: initialPasswordManager.initialPassword
+
+    return userAccountService.createUser(
+      UserAccount(
+        name = name ?: username,
+        username = username,
+        password = passwordEncoder.encode(rawPassword),
+        role = role ?: UserAccount.Role.USER,
+      ),
+    )
   }
 
   fun createOrganization(
@@ -84,7 +90,7 @@ class DbPopulatorReal(
     userAccount: UserAccount,
   ): Organization {
     val slug = slugGenerator.generate(name, 3, 100) { true }
-    return organizationService.create(OrganizationDto(name, slug), userAccount)
+    return organizationService.createWithoutAuthorization(OrganizationDto(name, slug), userAccount)
   }
 
   @Transactional
@@ -166,7 +172,7 @@ class DbPopulatorReal(
     userAccount: UserAccount,
   ): Organization {
     return organizationService.find(name) ?: let {
-      organizationService.create(OrganizationDto(name, slug = slug), userAccount)
+      organizationService.createWithoutAuthorization(OrganizationDto(name, slug = slug), userAccount)
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/ProjectBuilder.kt
@@ -293,12 +293,7 @@ class ProjectBuilder(
       ?.self
   }
 
-  /**
-   * Declares a PROJECT-type TM for this project on its parent organization. Mirrors what
-   * `ProjectCreationService.createProject` does in production. The TM is added to the
-   * organization's TM list and is persisted alongside any explicitly-declared shared TMs by
-   * the regular TM persistence pass.
-   */
+  /** Mirrors `TranslationMemoryManagementService.createProjectTm`. */
   fun addProjectTm(ft: FT<TranslationMemory> = {}): TranslationMemoryBuilder {
     val org =
       testDataBuilder.data.organizations

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BusinessEventTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BusinessEventTestData.kt
@@ -1,0 +1,52 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
+
+class BusinessEventTestData : BaseTestData() {
+  val foreignOrganizationBuilder =
+    root.addOrganization {
+      name = "Business Event Foreign Org"
+    }
+
+  val memberOrganizationBuilder =
+    root.addOrganization {
+      name = "Business Event Member Org"
+    }
+
+  val softDeletedProject: Project
+
+  val outsider: UserAccount
+  val admin: UserAccount
+  val supporter: UserAccount
+
+  init {
+    memberOrganizationBuilder.addRole {
+      user = this@BusinessEventTestData.user
+      type = OrganizationRoleType.MEMBER
+    }
+
+    softDeletedProject =
+      root
+        .addProject(organizationOwner = foreignOrganizationBuilder.self) {
+          name = "Business Event Soft Deleted Project"
+        }.build {
+          setDeletedAt()
+        }.self
+
+    outsider = reporter("business_event_outsider")
+    admin = reporter("business_event_admin", UserAccount.Role.ADMIN)
+    supporter = reporter("business_event_supporter", UserAccount.Role.SUPPORTER)
+  }
+
+  private fun reporter(
+    username: String,
+    role: UserAccount.Role = UserAccount.Role.USER,
+  ): UserAccount =
+    root
+      .addUserAccount {
+        this.username = username
+        this.role = role
+      }.self
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ManagingOrganizationTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ManagingOrganizationTestData.kt
@@ -1,0 +1,29 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.Organization
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
+
+class ManagingOrganizationTestData : BaseTestData() {
+  val managedUser: UserAccount
+  val managingOrganization: Organization
+
+  init {
+    val managedUserBuilder =
+      root.addUserAccount {
+        username = "managed_user@test.com"
+      }
+    managedUser = managedUserBuilder.self
+
+    val organizationBuilder =
+      root.addOrganization {
+        name = "Managing org"
+      }
+    organizationBuilder.addRole {
+      user = managedUser
+      type = OrganizationRoleType.MEMBER
+      managed = true
+    }
+    managingOrganization = organizationBuilder.self
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OwnerlessOrganizationTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OwnerlessOrganizationTestData.kt
@@ -1,0 +1,47 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.model.Organization
+import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
+
+class OwnerlessOrganizationTestData {
+  val root: TestDataBuilder = TestDataBuilder()
+
+  val member: UserAccount
+  val withMember: Organization
+  val withPublicProject: Organization
+  val publicProject: Project
+
+  init {
+    val memberBuilder =
+      root.addUserAccount {
+        username = "ownerless_org_member@test.com"
+      }
+    member = memberBuilder.self
+
+    val withMemberBuilder =
+      root.addOrganization {
+        name = "Ownerless With Member"
+      }
+    withMemberBuilder.addRole {
+      user = member
+      type = OrganizationRoleType.MEMBER
+    }
+    withMember = withMemberBuilder.self
+
+    val withPublicProjectBuilder =
+      root.addOrganization {
+        name = "Ownerless With Public Project"
+      }
+    withPublicProject = withPublicProjectBuilder.self
+
+    publicProject =
+      root
+        .addProject(organizationOwner = withPublicProject) {
+          name = "Ownerless public project"
+          public = true
+        }.self
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
@@ -50,6 +50,7 @@ class PublicProjectsControllerTestData : BaseTestData() {
   lateinit var softDeletedOrg: Organization
   lateinit var softDeletedOrgPublicProject: Project
   lateinit var softDeletedOrgMember: UserAccount
+  lateinit var orgLessCommunityUser: UserAccount
 
   init {
     root.apply {
@@ -60,6 +61,12 @@ class PublicProjectsControllerTestData : BaseTestData() {
         }
       nonMember = nonMemberBuilder.self
       nonMemberPersonalOrg = nonMemberBuilder.defaultOrganizationBuilder.self
+
+      orgLessCommunityUser =
+        addUserAccountWithoutOrganization {
+          username = "org_less_community_user"
+          name = "Org Less Community User"
+        }.self
 
       directPermissionUser =
         addUserAccount {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
@@ -8,6 +8,7 @@ import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.model.enums.ProjectPermissionType
 import io.tolgee.model.enums.Scope
+import io.tolgee.model.enums.ThirdPartyAuthType
 
 class PublicProjectsControllerTestData : BaseTestData() {
   val privateProject: Project get() = project
@@ -30,6 +31,7 @@ class PublicProjectsControllerTestData : BaseTestData() {
   lateinit var storedGuest: UserAccount
   lateinit var otherOrgPrivateProject: Project
   lateinit var serverAdmin: UserAccount
+  lateinit var serverSupporter: UserAccount
 
   lateinit var guestWithPermission: UserAccount
   lateinit var granularPermissionUser: UserAccount
@@ -51,6 +53,9 @@ class PublicProjectsControllerTestData : BaseTestData() {
   lateinit var softDeletedOrgPublicProject: Project
   lateinit var softDeletedOrgMember: UserAccount
   lateinit var orgLessCommunityUser: UserAccount
+  lateinit var ssoOrgLessUser: UserAccount
+  lateinit var ssoServerAdmin: UserAccount
+  lateinit var ssoGlobalOrgLessUser: UserAccount
 
   init {
     root.apply {
@@ -66,6 +71,28 @@ class PublicProjectsControllerTestData : BaseTestData() {
         addUserAccountWithoutOrganization {
           username = "org_less_community_user"
           name = "Org Less Community User"
+        }.self
+
+      ssoOrgLessUser =
+        addUserAccountWithoutOrganization {
+          username = "sso_org_less_user"
+          name = "Sso Org Less User"
+          thirdPartyAuthType = ThirdPartyAuthType.SSO
+        }.self
+
+      ssoGlobalOrgLessUser =
+        addUserAccountWithoutOrganization {
+          username = "sso_global_org_less_user"
+          name = "Sso Global Org Less User"
+          thirdPartyAuthType = ThirdPartyAuthType.SSO_GLOBAL
+        }.self
+
+      ssoServerAdmin =
+        addUserAccountWithoutOrganization {
+          username = "sso_server_admin"
+          name = "Sso Server Admin"
+          thirdPartyAuthType = ThirdPartyAuthType.SSO
+          role = UserAccount.Role.ADMIN
         }.self
 
       directPermissionUser =
@@ -124,6 +151,13 @@ class PublicProjectsControllerTestData : BaseTestData() {
           username = "server_admin"
           name = "Server Admin"
           role = UserAccount.Role.ADMIN
+        }.self
+
+      serverSupporter =
+        addUserAccount {
+          username = "server_supporter"
+          name = "Server Supporter"
+          role = UserAccount.Role.SUPPORTER
         }.self
 
       otherOrg =

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -14,6 +14,11 @@ class PublicProjectsE2eData(
           name = "Community User"
         }
 
+      addUserAccountWithoutOrganization {
+        username = "orgLessCommunityUser"
+        name = "Org Less Community User"
+      }
+
       if (includeForeignOrgProject) {
         addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
           name = "Community Outsider"

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -1,11 +1,20 @@
 package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
 
 class PublicProjectsE2eData(
   count: Int = 6,
-  includeForeignOrgProject: Boolean = true,
+  scenario: Scenario = Scenario.FULL,
 ) : BaseTestData("publicProjectsUser", "Private project") {
+  enum class Scenario {
+    FULL,
+
+    /** Omits the extra personas and the foreign-organization project. */
+    MINIMAL,
+  }
+
   init {
     root.apply {
       val communityUserBuilder =
@@ -19,7 +28,38 @@ class PublicProjectsE2eData(
         name = "Org Less Community User"
       }
 
-      if (includeForeignOrgProject) {
+      if (scenario == Scenario.FULL) {
+        val supporterBuilder =
+          addUserAccountWithoutOrganization {
+            username = "supporterCommunityUser"
+            name = "Supporter Community User"
+            role = UserAccount.Role.SUPPORTER
+          }
+
+        val dualOrgBuilder =
+          addUserAccount {
+            username = "dualOrgCommunityUser"
+            name = "Dual Org Member"
+          }
+
+        // Without this the server picks the organization this user only belongs to.
+        dualOrgBuilder.build {
+          setUserPreferences {
+            preferredOrganization = dualOrgBuilder.defaultOrganizationBuilder.self
+          }
+        }
+
+        communityUserBuilder.defaultOrganizationBuilder.build {
+          addRole {
+            user = supporterBuilder.self
+            type = OrganizationRoleType.MEMBER
+          }
+          addRole {
+            user = dualOrgBuilder.self
+            type = OrganizationRoleType.MEMBER
+          }
+        }
+
         addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
           name = "Community Outsider"
           public = true

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -1,11 +1,20 @@
 package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.OrganizationRoleType
 
 class PublicProjectsE2eData(
   count: Int = 6,
-  includeForeignOrgProject: Boolean = true,
+  scenario: Scenario = Scenario.FULL,
 ) : BaseTestData("publicProjectsUser", "Private project") {
+  enum class Scenario {
+    FULL,
+
+    /** Omits the extra personas and the foreign-organization project. */
+    MINIMAL,
+  }
+
   init {
     root.apply {
       val communityUserBuilder =
@@ -14,7 +23,43 @@ class PublicProjectsE2eData(
           name = "Community User"
         }
 
-      if (includeForeignOrgProject) {
+      addUserAccountWithoutOrganization {
+        username = "orgLessCommunityUser"
+        name = "Org Less Community User"
+      }
+
+      if (scenario == Scenario.FULL) {
+        val supporterBuilder =
+          addUserAccountWithoutOrganization {
+            username = "supporterCommunityUser"
+            name = "Supporter Community User"
+            role = UserAccount.Role.SUPPORTER
+          }
+
+        val dualOrgBuilder =
+          addUserAccount {
+            username = "dualOrgCommunityUser"
+            name = "Dual Org Member"
+          }
+
+        // Without this the server picks the organization this user only belongs to.
+        dualOrgBuilder.build {
+          setUserPreferences {
+            preferredOrganization = dualOrgBuilder.defaultOrganizationBuilder.self
+          }
+        }
+
+        communityUserBuilder.defaultOrganizationBuilder.build {
+          addRole {
+            user = supporterBuilder.self
+            type = OrganizationRoleType.MEMBER
+          }
+          addRole {
+            user = dualOrgBuilder.self
+            type = OrganizationRoleType.MEMBER
+          }
+        }
+
         addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
           name = "Community Outsider"
           public = true

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -1,20 +1,16 @@
 package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.development.testDataBuilder.builders.UserAccountBuilder
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.OrganizationRoleType
 
 class PublicProjectsE2eData(
   count: Int = 6,
-  scenario: Scenario = Scenario.FULL,
+  withCommunityPersonas: Boolean = true,
+  withForeignOrgProject: Boolean = true,
 ) : BaseTestData("publicProjectsUser", "Private project") {
-  enum class Scenario {
-    FULL,
-
-    /** Omits the extra personas and the foreign-organization project. */
-    MINIMAL,
-  }
-
   init {
     root.apply {
       val communityUserBuilder =
@@ -23,43 +19,11 @@ class PublicProjectsE2eData(
           name = "Community User"
         }
 
-      addUserAccountWithoutOrganization {
-        username = "orgLessCommunityUser"
-        name = "Org Less Community User"
+      if (withCommunityPersonas) {
+        addCommunityPersonas(communityUserBuilder)
       }
 
-      if (scenario == Scenario.FULL) {
-        val supporterBuilder =
-          addUserAccountWithoutOrganization {
-            username = "supporterCommunityUser"
-            name = "Supporter Community User"
-            role = UserAccount.Role.SUPPORTER
-          }
-
-        val dualOrgBuilder =
-          addUserAccount {
-            username = "dualOrgCommunityUser"
-            name = "Dual Org Member"
-          }
-
-        // Without this the server picks the organization this user only belongs to.
-        dualOrgBuilder.build {
-          setUserPreferences {
-            preferredOrganization = dualOrgBuilder.defaultOrganizationBuilder.self
-          }
-        }
-
-        communityUserBuilder.defaultOrganizationBuilder.build {
-          addRole {
-            user = supporterBuilder.self
-            type = OrganizationRoleType.MEMBER
-          }
-          addRole {
-            user = dualOrgBuilder.self
-            type = OrganizationRoleType.MEMBER
-          }
-        }
-
+      if (withForeignOrgProject) {
         addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
           name = "Community Outsider"
           public = true
@@ -76,6 +40,66 @@ class PublicProjectsE2eData(
         }.build {
           addBaseLanguage()
         }
+      }
+    }
+  }
+
+  private fun TestDataBuilder.addCommunityPersonas(communityUserBuilder: UserAccountBuilder) {
+    addUserAccountWithoutOrganization {
+      username = "orgLessCommunityUser"
+      name = "Org Less Community User"
+    }
+
+    val membersOnlyBuilder =
+      addUserAccountWithoutOrganization {
+        username = "membersOnlyUser"
+        name = "Members Only User"
+      }
+
+    val membersOnlyOrganization =
+      addOrganization {
+        name = "Members Only Outfit"
+      }.build {
+        addRole {
+          user = membersOnlyBuilder.self
+          type = OrganizationRoleType.OWNER
+        }
+      }
+
+    addProject(organizationOwner = membersOnlyOrganization.self) {
+      name = "Members only private project"
+      public = false
+    }.build {
+      addBaseLanguage()
+    }
+
+    val supporterBuilder =
+      addUserAccountWithoutOrganization {
+        username = "supporterCommunityUser"
+        name = "Supporter Community User"
+        role = UserAccount.Role.SUPPORTER
+      }
+
+    val dualOrgBuilder =
+      addUserAccount {
+        username = "dualOrgCommunityUser"
+        name = "Dual Org Member"
+      }
+
+    dualOrgBuilder.build {
+      setUserPreferences {
+        preferredOrganization = dualOrgBuilder.defaultOrganizationBuilder.self
+      }
+    }
+
+    communityUserBuilder.defaultOrganizationBuilder.build {
+      addRole {
+        user = supporterBuilder.self
+        type = OrganizationRoleType.MEMBER
+      }
+      addRole {
+        user = dualOrgBuilder.self
+        type = OrganizationRoleType.MEMBER
       }
     }
   }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/organization/OrganizationDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/organization/OrganizationDto.kt
@@ -1,13 +1,14 @@
 package io.tolgee.dtos.request.organization
 
 import io.swagger.v3.oas.annotations.media.Schema
+import io.tolgee.model.Organization
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class OrganizationDto(
   @field:NotBlank
-  @field:Size(min = 3, max = 50)
+  @field:Size(min = 3, max = Organization.NAME_MAX_LENGTH)
   @Schema(example = "Beautiful organization")
   var name: String = "",
   @Schema(example = "This is a beautiful organization full of beautiful and clever people")

--- a/backend/data/src/main/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobConfiguration.kt
@@ -1,6 +1,5 @@
 package io.tolgee.jobs.migration.allOrganizationOwner
 
-import io.tolgee.dtos.request.organization.OrganizationDto
 import io.tolgee.model.Project
 import io.tolgee.model.UserAccount
 import io.tolgee.repository.OrganizationRepository
@@ -77,14 +76,7 @@ class AllOrganizationOwnerJobConfiguration {
       items.forEach { project ->
         val organization =
           organizationRepository.findUsersDefaultOrganization(project.userOwner!!)
-            ?: let {
-              val ownerName = project.userOwner!!.name
-              val ownerNameSafe = if (ownerName.length >= 3) ownerName else "$ownerName Organization"
-              organizationService.create(
-                OrganizationDto(name = ownerNameSafe),
-                project.userOwner!!,
-              )
-            }
+            ?: organizationService.createPreferredWithoutAuthorization(project.userOwner!!)
 
         val permission =
           permissionService.find(
@@ -117,7 +109,7 @@ class AllOrganizationOwnerJobConfiguration {
   val noRoleUserWriter: ItemWriter<UserAccount> =
     ItemWriter { items ->
       items.forEach { userAccount ->
-        organizationService.create(OrganizationDto(name = userAccount.name), userAccount)
+        organizationService.createPreferredWithoutAuthorization(userAccount)
       }
     }
 

--- a/backend/data/src/main/kotlin/io/tolgee/model/Organization.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Organization.kt
@@ -32,7 +32,7 @@ class Organization(
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   override var id: Long = 0,
   @field:NotBlank
-  @field:Size(min = 1, max = 50) var name: String = "",
+  @field:Size(min = 1, max = NAME_MAX_LENGTH) var name: String = "",
   var description: String? = null,
   @Column(name = "address_part")
   @field:NotBlank
@@ -80,4 +80,8 @@ class Organization(
 
   @Transient
   override var disableActivityLogging: Boolean = false
+
+  companion object {
+    const val NAME_MAX_LENGTH = 50
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/StartupImportService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/StartupImportService.kt
@@ -151,7 +151,7 @@ class StartupImportService(
         .toList()
 
     val project =
-      projectCreationService.createProject(
+      projectCreationService.createProjectWithoutAuthorization(
         CreateProjectRequest(
           name = projectName,
           languages = languages,

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationRoleService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationRoleService.kt
@@ -47,16 +47,16 @@ class OrganizationRoleService(
   private val self: OrganizationRoleService,
   private val cacheManager: CacheManager,
 ) {
-  fun canUserViewStrict(
-    userId: Long,
-    organizationId: Long,
-  ) = this.organizationRepository.canUserView(userId, organizationId)
-
   fun checkUserCanViewOrPublic(organizationId: Long) {
-    if (canUserViewOrPublic(authenticationFacade.authenticatedUser, organizationId)) {
-      return
+    if (!canUserViewOrPublic(authenticationFacade.authenticatedUser, organizationId)) {
+      throw PermissionException(Message.USER_CANNOT_VIEW_THIS_ORGANIZATION)
     }
-    throw PermissionException(Message.USER_CANNOT_VIEW_THIS_ORGANIZATION)
+  }
+
+  fun checkUserCanView(organizationId: Long) {
+    if (!canUserView(authenticationFacade.authenticatedUser, organizationId)) {
+      throw PermissionException(Message.USER_CANNOT_VIEW_THIS_ORGANIZATION)
+    }
   }
 
   fun canUserViewOrPublic(
@@ -72,41 +72,42 @@ class OrganizationRoleService(
     organizationId: Long,
   ): Boolean {
     if (user.isSupporterOrAdmin()) {
-      return organizationRepository.find(organizationId) != null
+      return staffCanReach(organizationId)
     }
     return canUserViewStrictOrPublic(user.id, organizationId)
+  }
+
+  fun canUserView(
+    user: UserAccountDto,
+    organizationId: Long,
+  ): Boolean {
+    if (user.isSupporterOrAdmin()) {
+      return staffCanReach(organizationId)
+    }
+    return canUserViewStrict(user.id, organizationId)
   }
 
   fun canUserViewAtLeastMember(
     user: UserAccountDto,
     organizationId: Long,
-  ): Boolean = user.isSupporterOrAdmin() || hasAnyOrganizationRole(user.id, organizationId)
+  ): Boolean {
+    if (user.isSupporterOrAdmin()) {
+      return staffCanReach(organizationId)
+    }
+    return hasAnyOrganizationRole(user.id, organizationId)
+  }
+
+  private fun staffCanReach(organizationId: Long) = organizationRepository.find(organizationId) != null
 
   fun canUserViewStrictOrPublic(
     userId: Long,
     organizationId: Long,
   ): Boolean = canUserViewStrict(userId, organizationId) || projectService.hasPublicProjects(organizationId)
 
-  fun checkUserCanView(organizationId: Long) {
-    checkUserCanView(
-      authenticationFacade.authenticatedUser,
-      organizationId,
-    )
-  }
-
-  private fun checkUserCanView(
-    user: UserAccountDto,
+  private fun canUserViewStrict(
+    userId: Long,
     organizationId: Long,
-  ) {
-    if (!user.isSupporterOrAdmin() &&
-      !canUserViewStrict(
-        user.id,
-        organizationId,
-      )
-    ) {
-      throw PermissionException(Message.USER_CANNOT_VIEW_THIS_ORGANIZATION)
-    }
-  }
+  ) = this.organizationRepository.canUserView(userId, organizationId)
 
   /**
    * Verifies the user has a role equal or higher than a given role.

--- a/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/organization/OrganizationService.kt
@@ -11,6 +11,7 @@ import io.tolgee.dtos.request.organization.OrganizationRequestParamsDto
 import io.tolgee.dtos.request.validators.exceptions.ValidationException
 import io.tolgee.events.BeforeOrganizationDeleteEvent
 import io.tolgee.exceptions.NotFoundException
+import io.tolgee.exceptions.PermissionException
 import io.tolgee.model.Organization
 import io.tolgee.model.Permission
 import io.tolgee.model.UserAccount
@@ -29,6 +30,8 @@ import io.tolgee.service.security.PermissionService
 import io.tolgee.service.security.UserPreferencesService
 import io.tolgee.util.Logging
 import io.tolgee.util.SlugGenerator
+import io.tolgee.util.logger
+import io.tolgee.util.surrogateSafeEnd
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cache.Cache
 import org.springframework.cache.CacheManager
@@ -71,12 +74,14 @@ class OrganizationService(
   lateinit var projectService: ProjectService
 
   @Transactional
-  fun create(createDto: OrganizationDto): Organization {
-    return create(createDto, authenticationFacade.authenticatedUserEntity)
+  fun createAsCurrentUser(createDto: OrganizationDto): Organization {
+    val userAccount = authenticationFacade.authenticatedUserEntity
+    checkUserCanCreateOrganization(userAccount)
+    return createWithoutAuthorization(createDto, userAccount)
   }
 
   @Transactional
-  fun create(
+  fun createWithoutAuthorization(
     createDto: OrganizationDto,
     userAccount: UserAccount,
   ): Organization {
@@ -84,9 +89,11 @@ class OrganizationService(
       throw ValidationException(Message.SLUG_NOT_UNIQUE)
     }
 
+    val name = boundedOrganizationName(createDto.name)
+
     val slug =
       createDto.slug
-        ?: generateSlug(createDto.name)
+        ?: generateSlug(name)
 
     val basePermission =
       Permission(
@@ -95,7 +102,7 @@ class OrganizationService(
 
     val organization =
       Organization(
-        name = createDto.name,
+        name = name,
         description = createDto.description,
         slug = slug,
       )
@@ -110,17 +117,33 @@ class OrganizationService(
     return organization
   }
 
-  fun createPreferred(
+  fun createPreferredWithoutAuthorization(
     userAccount: UserAccount,
     name: String = userAccount.name,
   ): Organization {
-    val safeName =
-      if (name.isNotEmpty() || name.length >= 3) {
-        name
-      } else {
-        "${userAccount.username.take(3)} Organization"
-      }
-    return this.create(OrganizationDto(name = safeName), userAccount = userAccount)
+    val safeName = organizationNameFor(name, userAccount)
+    return this.createWithoutAuthorization(OrganizationDto(name = safeName), userAccount = userAccount)
+  }
+
+  private fun organizationNameFor(
+    name: String,
+    userAccount: UserAccount,
+  ): String {
+    if (name.length >= 3) {
+      return name
+    }
+    val username = userAccount.username
+    val prefix = name.ifEmpty { username.take(surrogateSafeEnd(username, 3)) }
+    return "$prefix Organization"
+  }
+
+  private fun boundedOrganizationName(name: String): String {
+    if (name.length <= Organization.NAME_MAX_LENGTH) {
+      return name
+    }
+    val end = surrogateSafeEnd(name, Organization.NAME_MAX_LENGTH)
+    logger.info("Truncating organization name of length ${name.length} to $end characters")
+    return name.substring(0, end)
   }
 
   private fun generateSlug(name: String) =
@@ -128,9 +151,6 @@ class OrganizationService(
       this.validateSlugUniqueness(it)
     }
 
-  /**
-   * Returns any organizations accessible by user.
-   */
   @Transactional(readOnly = true)
   fun findPreferred(
     userAccountId: Long,
@@ -145,23 +165,37 @@ class OrganizationService(
       .firstOrNull()
   }
 
-  /**
-   * Returns existing or created organization which seems to be potentially preferred.
-   */
   fun findOrCreatePreferred(
     userAccount: UserAccount,
     exceptOrganizationId: Long = 0,
   ): Organization? {
-    return findPreferred(userAccount.id, exceptOrganizationId) ?: let {
-      val canCreateOrganizations =
-        tolgeeProperties.authentication.userCanCreateOrganizations &&
-          userAccount.thirdPartyAuthType !== ThirdPartyAuthType.SSO
-
-      if (canCreateOrganizations || userAccount.isAdmin()) {
-        return@let createPreferred(userAccount)
-      }
-      null
+    findPreferred(userAccount.id, exceptOrganizationId)?.let { return it }
+    if (!canUserCreateOrganization(userAccount)) {
+      return null
     }
+    return createPreferredWithoutAuthorization(userAccount)
+  }
+
+  fun checkUserCanCreateOrganization(userAccount: UserAccount) {
+    organizationCreationRefusal(userAccount)?.let { throw PermissionException(it) }
+  }
+
+  fun canUserCreateOrganization(userAccount: UserAccount): Boolean = organizationCreationRefusal(userAccount) == null
+
+  private fun organizationCreationRefusal(userAccount: UserAccount): Message? {
+    if (userAccount.isAdmin()) {
+      return null
+    }
+
+    if (!tolgeeProperties.authentication.userCanCreateOrganizations) {
+      return Message.OPERATION_NOT_PERMITTED
+    }
+
+    if (userAccount.thirdPartyAuthType == ThirdPartyAuthType.SSO) {
+      return Message.SSO_USER_CANNOT_CREATE_ORGANIZATION
+    }
+
+    return null
   }
 
   @Transactional(readOnly = true)

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectCreationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectCreationService.kt
@@ -23,7 +23,7 @@ class ProjectCreationService(
 ) {
   @Transactional
   @CacheEvict(cacheNames = [Caches.PROJECTS], key = "#result.id")
-  fun createProject(dto: CreateProjectRequest): Project {
+  fun createProjectWithoutAuthorization(dto: CreateProjectRequest): Project {
     val project = Project()
     project.name = dto.name
     project.icuPlaceholders = dto.icuPlaceholders

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SecurityService.kt
@@ -27,7 +27,6 @@ import io.tolgee.service.label.LabelService
 import io.tolgee.service.language.LanguageService
 import io.tolgee.service.organization.OrganizationRoleService
 import io.tolgee.service.project.ProjectFeatureGuard
-import io.tolgee.service.project.ProjectFeatureRegistry
 import io.tolgee.service.project.ProjectService
 import io.tolgee.service.task.ITaskService
 import org.springframework.beans.factory.annotation.Autowired
@@ -84,13 +83,16 @@ class SecurityService(
     return requestedProjectIds.filter { it in accessibleSet }
   }
 
-  fun checkAnyProjectPermission(projectId: Long) {
-    if (
-      getProjectPermissionScopesNoApiKey(projectId).isNullOrEmpty() &&
-      !activeUser.isSupporterOrAdmin()
-    ) {
-      throw PermissionException(Message.USER_HAS_NO_PROJECT_ACCESS)
+  fun hasAnyProjectPermission(projectId: Long): Boolean {
+    val user = authenticationFacade.authenticatedUserOrNull ?: return false
+    // Before the staff bypass, which would otherwise answer true for a project that does not exist.
+    if (projectService.findDto(projectId) == null) {
+      return false
     }
+    if (user.isSupporterOrAdmin()) {
+      return true
+    }
+    return !getProjectPermissionScopesNoApiKey(projectId).isNullOrEmpty()
   }
 
   fun currentPermittedScopesContain(scope: Scope): Boolean {

--- a/backend/data/src/main/kotlin/io/tolgee/service/security/SignUpProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/security/SignUpProcessor.kt
@@ -78,7 +78,7 @@ class SignUpProcessor(
       return
     }
 
-    val organization = organizationService.createPreferred(user, organizationName)
+    val organization = organizationService.createPreferredWithoutAuthorization(user, organizationName)
     quickStartService.create(user, organization)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/util/surrogateSafeEnd.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/surrogateSafeEnd.kt
@@ -1,0 +1,16 @@
+package io.tolgee.util
+
+/**
+ * The index to cut [value] at so the result never ends in a lone high surrogate - pgjdbc rejects
+ * one, where `@Size` would accept it.
+ */
+fun surrogateSafeEnd(
+  value: String,
+  end: Int,
+): Int {
+  val bounded = end.coerceIn(0, value.length)
+  if (bounded > 0 && value[bounded - 1].isHighSurrogate()) {
+    return bounded - 1
+  }
+  return bounded
+}

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/NewOrganizationE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/NewOrganizationE2eDataController.kt
@@ -3,17 +3,9 @@ package io.tolgee.controllers.internal.e2eData
 import io.tolgee.controllers.internal.InternalController
 import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
 import io.tolgee.development.testDataBuilder.data.OrganizationTestData
-import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.bind.annotation.GetMapping
 
 @InternalController(["internal/e2e-data/organization-new"])
 class NewOrganizationE2eDataController : AbstractE2eDataController() {
-  @GetMapping(value = ["/generate"])
-  @Transactional
-  fun generateBasicTestData() {
-    testDataService.saveTestData(testData)
-  }
-
   override val testData: TestDataBuilder
     get() = OrganizationTestData().root
 }

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/OrganizationE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/OrganizationE2eDataController.kt
@@ -27,7 +27,7 @@ class OrganizationE2eDataController(
   fun createOrganizations(): Map<String, Map<String, String>> {
     val organizations =
       data.map {
-        organizationService.create(
+        organizationService.createWithoutAuthorization(
           it.dto,
           this.dbPopulatorReal.createUserIfNotExists(it.owner.email, null, it.owner.name),
         )

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
@@ -21,7 +21,8 @@ class PublicProjectsE2eDataController(
     return generatingService.generate(
       PublicProjectsE2eData(
         count = 5,
-        scenario = PublicProjectsE2eData.Scenario.MINIMAL,
+        withCommunityPersonas = false,
+        withForeignOrgProject = false,
       ).root,
     )
   }

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
@@ -18,6 +18,11 @@ class PublicProjectsE2eDataController(
   @GetMapping(value = ["/generate-few"])
   @Transactional
   fun generateFew(): StandardTestDataResult {
-    return generatingService.generate(PublicProjectsE2eData(count = 5, includeForeignOrgProject = false).root)
+    return generatingService.generate(
+      PublicProjectsE2eData(
+        count = 5,
+        scenario = PublicProjectsE2eData.Scenario.MINIMAL,
+      ).root,
+    )
   }
 }

--- a/e2e/cypress.config.ts
+++ b/e2e/cypress.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   viewportHeight: 1080,
   viewportWidth: 1440,
   defaultCommandTimeout: 20000,
+  // cy.wait('@alias.request') is governed by requestTimeout, not defaultCommandTimeout.
+  requestTimeout: 20000,
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.

--- a/e2e/cypress/common/apiCalls/common.ts
+++ b/e2e/cypress/common/apiCalls/common.ts
@@ -211,6 +211,9 @@ export const enableOrganizationsSsoProvider = () =>
 export const disableOrganizationsSsoProvider = () =>
   setProperty('authentication.ssoOrganizations.enabled', false);
 
+export const setOrganizationCreationAllowed = (allowed: boolean) =>
+  setProperty('authentication.userCanCreateOrganizations', allowed);
+
 export const enableGlobalSsoProvider = () =>
   setProperty('authentication.ssoGlobal.enabled', true);
 

--- a/e2e/cypress/common/communityProjects.ts
+++ b/e2e/cypress/common/communityProjects.ts
@@ -1,0 +1,129 @@
+import { HOST } from './constants';
+import { publicProjectsData } from './apiCalls/testData/testData';
+import { gcyAdvanced } from './shared';
+import { waitForGlobalLoading } from './loading';
+import { setOrganizationCreationAllowed } from './apiCalls/common';
+
+export const PUBLIC_PROJECT_NAME = 'Community Alpha';
+
+export const SET_PREFERRED_ORG =
+  '**/v2/user-preferences/set-preferred-organization/*';
+
+const COMMUNITY_ORGANIZATION_NAMES = [
+  'publicProjectsUser',
+  'Community User',
+  'Dual Org Member',
+  'Members Only Outfit',
+] as const;
+
+type CommunityOrganizationName = typeof COMMUNITY_ORGANIZATION_NAMES[number];
+
+export type CommunityProjectsFixture = {
+  organizations: Record<
+    CommunityOrganizationName,
+    { slug: string; id: number }
+  >;
+  privateProjectId: number;
+  publicProjectId: number;
+};
+
+export const communityProjectsFixture = (): CommunityProjectsFixture => {
+  const emptyOrganizations = () =>
+    ({} as CommunityProjectsFixture['organizations']);
+
+  const fixture: CommunityProjectsFixture = {
+    organizations: emptyOrganizations(),
+    privateProjectId: 0,
+    publicProjectId: 0,
+  };
+
+  beforeEach(() => {
+    publicProjectsData.clean();
+    publicProjectsData.generateStandard().then((res) => {
+      const organizations = emptyOrganizations();
+      res.body.organizations.forEach((org) => {
+        organizations[org.name as CommunityOrganizationName] = org;
+      });
+      COMMUNITY_ORGANIZATION_NAMES.forEach((name) => {
+        if (!organizations[name]) {
+          throw new Error(
+            `PublicProjectsE2eData no longer creates an organization named "${name}"`
+          );
+        }
+      });
+      fixture.organizations = organizations;
+      fixture.privateProjectId = res.body.projects.find(
+        (project) => project.name === 'Private project'
+      ).id;
+      fixture.publicProjectId = res.body.projects.find(
+        (project) => project.name === PUBLIC_PROJECT_NAME
+      ).id;
+    });
+  });
+
+  afterEach(() => {
+    publicProjectsData.clean();
+  });
+
+  return fixture;
+};
+
+const DEFAULT_HOLD_MS = 2000;
+export const HELD_REQUEST_MS = 6000;
+
+/** Mirrors ORGANIZATION_SWITCH_DEADLINE_MS in webapp/src/globalContext/organizationSwitchSequencer.ts. */
+export const SWITCH_DEADLINE_MS = 8000;
+
+/** Long enough that the switch deadline fires while the write is still held. */
+export const PAST_SWITCH_DEADLINE_MS = SWITCH_DEADLINE_MS + 4000;
+
+/**
+ * Register before any retrying assertion in an `afterEach`: `userCanCreateOrganizations` is
+ * server-wide, and a hook that times out aborts the ones registered after it.
+ */
+export const restoreOrganizationCreation = () => {
+  afterEach(() => {
+    setOrganizationCreationAllowed(true);
+  });
+};
+
+export const keepPersonasOrganizationLess = () => {
+  restoreOrganizationCreation();
+
+  beforeEach(() => {
+    setOrganizationCreationAllowed(false);
+  });
+};
+
+export const interceptPreferredOrgDelayed = (
+  alias: string,
+  delayMs: number = DEFAULT_HOLD_MS,
+  onlyForId?: () => number
+) =>
+  cy
+    .intercept('PUT', SET_PREFERRED_ORG, (req) =>
+      req.continue((res) => {
+        if (!onlyForId || req.url.endsWith(`/${onlyForId()}`)) {
+          res.setDelay(delayMs);
+        }
+      })
+    )
+    .as(alias);
+
+export const interceptPreferredOrgForbidden = () =>
+  cy.intercept('PUT', SET_PREFERRED_ORG, {
+    statusCode: 403,
+    body: { code: 'operation_not_permitted' },
+  });
+
+/** Enters through /community-projects — the surface this feature builds, not the anonymous list. */
+export const openPublicProject = () => {
+  cy.visit(`${HOST}/community-projects`);
+  waitForGlobalLoading();
+  gcyAdvanced({
+    value: 'dashboard-projects-list-item',
+    name: PUBLIC_PROJECT_NAME,
+  }).click();
+  cy.url().should('match', /\/projects\/[0-9]+/);
+  waitForGlobalLoading();
+};

--- a/e2e/cypress/common/forms.ts
+++ b/e2e/cypress/common/forms.ts
@@ -1,0 +1,6 @@
+import { gcy } from './shared';
+
+export const submitFormDirectly = () =>
+  gcy('standard-form')
+    .should('have.length', 1)
+    .then(($form) => ($form[0] as HTMLFormElement).requestSubmit());

--- a/e2e/cypress/common/organizationSettingsMenu.ts
+++ b/e2e/cypress/common/organizationSettingsMenu.ts
@@ -1,0 +1,14 @@
+import { gcyAdvanced } from './shared';
+
+export type OrganizationSettingsMenuItem =
+  | 'profile'
+  | 'members'
+  | 'member-privileges'
+  | 'glossaries'
+  | 'translation-memories'
+  | 'apps';
+
+export const organizationSettingsMenuItem = (
+  item: OrganizationSettingsMenuItem,
+  options?: Parameters<typeof gcyAdvanced>[1]
+) => gcyAdvanced({ value: 'settings-menu-item', item }, options);

--- a/e2e/cypress/common/shared.ts
+++ b/e2e/cypress/common/shared.ts
@@ -164,7 +164,7 @@ export const getTextAreaByName = (name: string): Chainable => {
 };
 
 export const switchToOrganizationWithSearch = (name: string): Chainable => {
-  cy.gcy('organization-switch').click();
+  openOrganizationSwitch();
   cy.gcy('switch-popover-search').type(name);
   cy.waitForDom();
 
@@ -181,10 +181,14 @@ export const switchToOrganization = (name: string): Chainable => {
   return assertSwitchedToOrganization(name);
 };
 
-export const selectOrganizationInSwitch = (name: string): Chainable => {
+export const openOrganizationSwitch = () => {
   cy.waitForDom();
   cy.gcy('organization-switch').click();
   cy.waitForDom();
+};
+
+export const selectOrganizationInSwitch = (name: string): Chainable => {
+  openOrganizationSwitch();
   return cy.gcy('switch-popover-item').contains(name).scrollIntoView().click();
 };
 
@@ -223,6 +227,11 @@ export const visitProjectDeveloperStorage = (projectId: number) => {
 
 export const visitProjectDeveloperHooks = (projectId: number) => {
   return cy.visit(`${HOST}/projects/${projectId}/developer/webhooks`);
+};
+
+export const visitRootAndSettle = () => {
+  cy.visit(HOST);
+  waitForGlobalLoading();
 };
 
 export const dismissMenu = () => {

--- a/e2e/cypress/common/shared.ts
+++ b/e2e/cypress/common/shared.ts
@@ -177,11 +177,15 @@ export const switchToOrganizationWithSearch = (name: string): Chainable => {
 };
 
 export const switchToOrganization = (name: string): Chainable => {
+  selectOrganizationInSwitch(name);
+  return assertSwitchedToOrganization(name);
+};
+
+export const selectOrganizationInSwitch = (name: string): Chainable => {
   cy.waitForDom();
   cy.gcy('organization-switch').click();
   cy.waitForDom();
-  cy.gcy('switch-popover-item').contains(name).scrollIntoView().click();
-  return assertSwitchedToOrganization(name);
+  return cy.gcy('switch-popover-item').contains(name).scrollIntoView().click();
 };
 
 export const assertSwitchedToOrganization = (name: string) => {

--- a/e2e/cypress/e2e/organizations/organizationsSettings.cy.ts
+++ b/e2e/cypress/e2e/organizations/organizationsSettings.cy.ts
@@ -9,6 +9,7 @@ import {
 } from '../../common/shared';
 import { login, setBypassSeatCountCheck } from '../../common/apiCalls/common';
 import { organizationTestData } from '../../common/apiCalls/testData/testData';
+import { organizationSettingsMenuItem } from '../../common/organizationSettingsMenu';
 
 describe('Organization Settings', () => {
   let organizationData: Record<string, { slug: string }>;
@@ -70,16 +71,10 @@ describe('Organization Settings', () => {
       .click();
     cy.waitForDom();
     cy.gcy('global-form-save-button').should('be.disabled');
-    cy.gcy('organization-profile-delete-button').should('be.disabled');
-    cy.gcy('settings-menu-item')
-      .contains('Organization profile')
-      .should('be.visible');
-    cy.gcy('settings-menu-item')
-      .contains('Organization members')
-      .should('not.exist');
-    cy.gcy('settings-menu-item')
-      .contains('Member permissions')
-      .should('not.exist');
+    cy.gcy('organization-profile-delete-button').should('not.exist');
+    organizationSettingsMenuItem('profile').should('be.visible');
+    organizationSettingsMenuItem('members').should('not.exist');
+    organizationSettingsMenuItem('member-privileges').should('not.exist');
   });
 
   it('deletes organization', () => {

--- a/e2e/cypress/e2e/organizations/organizationsSwitching.cy.ts
+++ b/e2e/cypress/e2e/organizations/organizationsSwitching.cy.ts
@@ -7,6 +7,7 @@ import {
   switchToOrganization,
   switchToOrganizationWithSearch,
 } from '../../common/shared';
+import { organizationSettingsMenuItem } from '../../common/organizationSettingsMenu';
 
 describe('Organization switching', () => {
   let organizationData: Record<string, { slug: string }>;
@@ -51,13 +52,12 @@ describe('Organization switching', () => {
     assertOrganizationIsPreferred('Tolgee');
   });
 
-  it('switches correctly when in organization settings', () => {
+  it('adopts the newly routed organization while staying inside organization settings', () => {
     visitMembers();
     switchToOrganization('Microsoft');
     cy.waitForDom();
-    gcy('settings-menu-item')
-      .contains('Organization profile')
-      .should('have.class', 'selected');
+    organizationSettingsMenuItem('profile').should('have.class', 'selected');
+    assertOrganizationIsPreferred('Microsoft');
   });
 
   it('switches organization correctly from user menu', () => {

--- a/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
+++ b/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
@@ -1,5 +1,5 @@
 import { HOST } from '../../common/constants';
-import { login } from '../../common/apiCalls/common';
+import { login, logout, setProperty } from '../../common/apiCalls/common';
 import { publicProjectsData } from '../../common/apiCalls/testData/testData';
 import {
   assertSwitchedToOrganization,
@@ -9,8 +9,12 @@ import {
 } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
 
+const SET_PREFERRED_ORG = '**/v2/user-preferences/set-preferred-organization/*';
+
 describe('Community preferred organization', () => {
   let organizations: Record<string, { slug: string }>;
+  let privateProjectId: number;
+  let publicProjectId: number;
 
   beforeEach(() => {
     publicProjectsData.clean();
@@ -19,13 +23,24 @@ describe('Community preferred organization', () => {
       res.body.organizations.forEach((org) => {
         organizations[org.name] = org;
       });
+      privateProjectId = res.body.projects.find(
+        (project) => project.name === 'Private project'
+      ).id;
+      publicProjectId = res.body.projects.find(
+        (project) => project.name === 'Community Alpha'
+      ).id;
     });
-    login('communityUser');
   });
 
   afterEach(() => {
     publicProjectsData.clean();
   });
+
+  const interceptPreferredOrgForbidden = () =>
+    cy.intercept('PUT', SET_PREFERRED_ORG, {
+      statusCode: 403,
+      body: { code: 'operation_not_permitted' },
+    });
 
   const openPublicProject = () => {
     cy.visit(`${HOST}/public-projects`);
@@ -35,59 +50,217 @@ describe('Community preferred organization', () => {
     waitForGlobalLoading();
   };
 
-  it('switches a guest to the owning organization and shows its public projects', () => {
-    openPublicProject();
-    gcy('notistack-snackbar').should('not.exist');
-    assertSwitchedToOrganization('publicProjectsUser');
+  it('hides the help menu from a signed-out visitor on an unmatched route', () => {
+    logout();
 
-    cy.visit(`${HOST}/`);
+    cy.visit(`${HOST}/definitely-not-a-route`, { failOnStatusCode: false });
     waitForGlobalLoading();
-    gcy('dashboard-projects-list-item').should('have.length', 6);
-    cy.contains('Community Outsider').should('not.exist');
-    cy.contains('Private project').should('not.exist');
-    gcy('global-plus-button').should('not.exist');
-    gcy('project-list-more-button').should('not.exist');
+    gcy('help-menu-button').should('not.exist');
   });
 
-  it('restores the full member experience after switching back to the own organization', () => {
-    openPublicProject();
-    assertSwitchedToOrganization('publicProjectsUser');
-
-    cy.visit(`${HOST}/`);
-    waitForGlobalLoading();
-    switchToOrganization('Community User');
-    waitForGlobalLoading();
-    gcy('global-plus-button').should('exist');
-    gcy('dashboard-projects-list-item').should('have.length', 1);
-    gcy('project-list-more-button').should('exist');
-  });
-
-  it('keeps the project page usable when the preferred-organization switch fails', () => {
-    cy.intercept('PUT', '**/v2/user-preferences/set-preferred-organization/*', {
-      statusCode: 403,
-      body: { code: 'operation_not_permitted' },
+  describe('user with an organization', () => {
+    beforeEach(() => {
+      login('communityUser');
     });
-    openPublicProject();
-    cy.url().should('match', /\/projects\/[0-9]+/);
-    gcy('global-base-view-content').should('exist');
+
+    it('switches a guest to the owning organization and shows its public projects', () => {
+      openPublicProject();
+      gcy('notistack-snackbar').should('not.exist');
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/`);
+      waitForGlobalLoading();
+      gcy('dashboard-projects-list-item').should('have.length', 6);
+      cy.contains('Community Outsider').should('not.exist');
+      cy.contains('Private project').should('not.exist');
+      gcy('global-plus-button').should('not.exist');
+      gcy('project-list-more-button').should('not.exist');
+    });
+
+    it('restores the full member experience after switching back to the own organization', () => {
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/`);
+      waitForGlobalLoading();
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-plus-button').should('exist');
+      gcy('dashboard-projects-list-item').should('have.length', 1);
+      gcy('project-list-more-button').should('exist');
+    });
+
+    it('keeps the project page usable when the preferred-organization switch fails', () => {
+      interceptPreferredOrgForbidden();
+      openPublicProject();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      gcy('global-base-view-content').should('exist');
+    });
+
+    it('shows glossaries but hides translation memories in the foreign org settings', () => {
+      openPublicProject();
+      cy.visit(
+        `${HOST}/organizations/${organizations['publicProjectsUser'].slug}/profile`
+      );
+      waitForGlobalLoading();
+      gcyAdvanced({ value: 'settings-menu-item', item: 'profile' }).should(
+        'be.visible'
+      );
+      gcyAdvanced({ value: 'settings-menu-item', item: 'glossaries' }).should(
+        'be.visible'
+      );
+      gcyAdvanced({
+        value: 'settings-menu-item',
+        item: 'translation-memories',
+      }).should('not.exist');
+      gcy('organization-profile-leave-button').should('be.disabled');
+    });
   });
 
-  it('shows glossaries but hides translation memories in the foreign org settings', () => {
-    openPublicProject();
-    cy.visit(
-      `${HOST}/organizations/${organizations['publicProjectsUser'].slug}/profile`
-    );
-    waitForGlobalLoading();
-    gcyAdvanced({ value: 'settings-menu-item', item: 'profile' }).should(
-      'be.visible'
-    );
-    gcyAdvanced({ value: 'settings-menu-item', item: 'glossaries' }).should(
-      'be.visible'
-    );
-    gcyAdvanced({
-      value: 'settings-menu-item',
-      item: 'translation-memories',
-    }).should('not.exist');
-    gcy('organization-profile-leave-button').should('be.disabled');
+  describe('user without any organization', () => {
+    beforeEach(() => {
+      setProperty('authentication.userCanCreateOrganizations', false);
+      login('orgLessCommunityUser');
+    });
+
+    afterEach(() => {
+      setProperty('authentication.userCanCreateOrganizations', true);
+    });
+
+    const visitRootAndExpectNoOrganization = () => {
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('be.visible');
+    };
+
+    it('opens a public project and adopts the owning organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('notistack-snackbar').should('not.exist');
+    });
+
+    it('keeps the organization after a reload', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('dashboard-projects-list-item').should('have.length', 6);
+      gcy('dashboard-projects-list-item')
+        .contains('Private project')
+        .should('not.exist');
+      gcy('dashboard-projects-list-item')
+        .contains('Community Outsider')
+        .should('not.exist');
+      gcy('no-permissions-message').should('not.exist');
+    });
+
+    it('still requires an organization to create a project', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      cy.url().should('include', '/projects/add');
+      gcy('no-permissions-message').should('be.visible');
+    });
+
+    it('offers the help menu even without an organization', () => {
+      visitRootAndExpectNoOrganization();
+      gcy('help-menu-button').should('be.visible');
+
+      openPublicProject();
+      gcy('help-menu-button').should('be.visible');
+    });
+
+    it('adopts the organization on a cold deep-link to a public project', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${publicProjectId}`);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('notistack-snackbar').should('not.exist');
+    });
+
+    it('keeps the project usable when the organization switch fails', () => {
+      interceptPreferredOrgForbidden();
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${publicProjectId}`);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      gcy('global-base-view-content').should('exist');
+      gcy('organization-switch').should('not.exist');
+      gcy('navigation-item').first().should('contain', 'Community Alpha');
+
+      visitRootAndExpectNoOrganization();
+    });
+
+    it('does not adopt an organization from a project it cannot view', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+      cy.intercept('GET', `**/v2/projects/${privateProjectId}`).as(
+        'privateProjectDetail'
+      );
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${privateProjectId}`);
+      cy.wait('@privateProjectDetail')
+        .its('response.statusCode')
+        .should('be.oneOf', [403, 404]);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('be.visible');
+      gcy('global-base-view-content').should('not.exist');
+      cy.get('@setPreferred.all').should('have.length', 0);
+
+      visitRootAndExpectNoOrganization();
+    });
+
+    it('still requires an organization to create an organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/organizations/add`);
+      waitForGlobalLoading();
+      cy.url().should('include', '/organizations/add');
+      gcy('no-permissions-message').should('be.visible');
+    });
+
+    it('lists community projects without an organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/community-projects`);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('not.exist');
+      gcy('dashboard-projects-list-item').should('have.length', 7);
+      gcy('dashboard-projects-list-item')
+        .contains('Private project')
+        .should('not.exist');
+      gcy('community-translation-item').should('be.visible');
+      gcy('organization-switch').should('not.exist');
+    });
+
+    it('does not re-issue the switch when the project is reopened', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+      cy.intercept('GET', `**/v2/projects/${publicProjectId}`).as(
+        'projectDetail'
+      );
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      cy.wait('@setPreferred');
+
+      cy.get('@projectDetail.all').then((beforeReload) => {
+        cy.reload();
+        cy.get('@projectDetail.all').should(
+          'have.length.at.least',
+          beforeReload.length + 1
+        );
+      });
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('publicProjectsUser');
+      cy.get('@setPreferred.all').should('have.length', 1);
+    });
   });
 });

--- a/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
+++ b/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
@@ -1,16 +1,24 @@
 import { HOST } from '../../common/constants';
-import { login } from '../../common/apiCalls/common';
+import { login, logout, setProperty } from '../../common/apiCalls/common';
 import { publicProjectsData } from '../../common/apiCalls/testData/testData';
 import {
   assertSwitchedToOrganization,
   gcy,
   gcyAdvanced,
+  selectOrganizationInSwitch,
   switchToOrganization,
 } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
 
+const SET_PREFERRED_ORG = '**/v2/user-preferences/set-preferred-organization/*';
+
+const SWITCH_RESPONSE_DELAY = 4000;
+const WHILE_SWITCH_IN_FLIGHT = 1500;
+
 describe('Community preferred organization', () => {
   let organizations: Record<string, { slug: string }>;
+  let privateProjectId: number;
+  let publicProjectId: number;
 
   beforeEach(() => {
     publicProjectsData.clean();
@@ -19,13 +27,24 @@ describe('Community preferred organization', () => {
       res.body.organizations.forEach((org) => {
         organizations[org.name] = org;
       });
+      privateProjectId = res.body.projects.find(
+        (project) => project.name === 'Private project'
+      ).id;
+      publicProjectId = res.body.projects.find(
+        (project) => project.name === 'Community Alpha'
+      ).id;
     });
-    login('communityUser');
   });
 
   afterEach(() => {
     publicProjectsData.clean();
   });
+
+  const interceptPreferredOrgForbidden = () =>
+    cy.intercept('PUT', SET_PREFERRED_ORG, {
+      statusCode: 403,
+      body: { code: 'operation_not_permitted' },
+    });
 
   const openPublicProject = () => {
     cy.visit(`${HOST}/public-projects`);
@@ -35,59 +54,333 @@ describe('Community preferred organization', () => {
     waitForGlobalLoading();
   };
 
-  it('switches a guest to the owning organization and shows its public projects', () => {
-    openPublicProject();
-    gcy('notistack-snackbar').should('not.exist');
-    assertSwitchedToOrganization('publicProjectsUser');
+  it('hides the help menu from a signed-out visitor on an unmatched route', () => {
+    logout();
 
-    cy.visit(`${HOST}/`);
+    cy.visit(`${HOST}/definitely-not-a-route`, { failOnStatusCode: false });
     waitForGlobalLoading();
-    gcy('dashboard-projects-list-item').should('have.length', 6);
-    cy.contains('Community Outsider').should('not.exist');
-    cy.contains('Private project').should('not.exist');
-    gcy('global-plus-button').should('not.exist');
-    gcy('project-list-more-button').should('not.exist');
+    gcy('help-menu-button').should('not.exist');
   });
 
-  it('restores the full member experience after switching back to the own organization', () => {
-    openPublicProject();
-    assertSwitchedToOrganization('publicProjectsUser');
-
-    cy.visit(`${HOST}/`);
-    waitForGlobalLoading();
-    switchToOrganization('Community User');
-    waitForGlobalLoading();
-    gcy('global-plus-button').should('exist');
-    gcy('dashboard-projects-list-item').should('have.length', 1);
-    gcy('project-list-more-button').should('exist');
-  });
-
-  it('keeps the project page usable when the preferred-organization switch fails', () => {
-    cy.intercept('PUT', '**/v2/user-preferences/set-preferred-organization/*', {
-      statusCode: 403,
-      body: { code: 'operation_not_permitted' },
+  describe('user with an organization', () => {
+    beforeEach(() => {
+      login('communityUser');
     });
-    openPublicProject();
-    cy.url().should('match', /\/projects\/[0-9]+/);
-    gcy('global-base-view-content').should('exist');
+
+    it('switches a guest to the owning organization and shows its public projects', () => {
+      openPublicProject();
+      gcy('notistack-snackbar').should('not.exist');
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/`);
+      waitForGlobalLoading();
+      gcy('dashboard-projects-list-item').should('have.length', 6);
+      cy.contains('Community Outsider').should('not.exist');
+      cy.contains('Private project').should('not.exist');
+      gcy('global-plus-button').should('not.exist');
+      gcy('project-list-more-button').should('not.exist');
+    });
+
+    it('restores the full member experience after switching back to the own organization', () => {
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/`);
+      waitForGlobalLoading();
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-plus-button').should('exist');
+      gcy('dashboard-projects-list-item').should('have.length', 1);
+      gcy('project-list-more-button').should('exist');
+    });
+
+    it('keeps the project page usable when the preferred-organization switch fails', () => {
+      interceptPreferredOrgForbidden();
+      openPublicProject();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      gcy('global-base-view-content').should('exist');
+    });
+
+    it('disables the create submit on a foreign organization and creates in the switched-to one', () => {
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      gcy('project-name-field').find('input').type('Switched org project');
+
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+      gcy('project-name-field')
+        .find('input')
+        .should('have.value', 'Switched org project');
+
+      gcy('global-form-save-button').click();
+      cy.wait('@createProject').its('response.statusCode').should('eq', 200);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('Community User');
+      gcy('dashboard-projects-list-item')
+        .contains('Switched org project')
+        .should('be.visible');
+    });
+
+    it('shows glossaries but hides translation memories in the foreign org settings', () => {
+      openPublicProject();
+      cy.visit(
+        `${HOST}/organizations/${organizations['publicProjectsUser'].slug}/profile`
+      );
+      waitForGlobalLoading();
+      gcyAdvanced({ value: 'settings-menu-item', item: 'profile' }).should(
+        'be.visible'
+      );
+      gcyAdvanced({ value: 'settings-menu-item', item: 'glossaries' }).should(
+        'be.visible'
+      );
+      gcyAdvanced({
+        value: 'settings-menu-item',
+        item: 'translation-memories',
+      }).should('not.exist');
+      gcy('organization-profile-leave-button').should('be.disabled');
+    });
   });
 
-  it('shows glossaries but hides translation memories in the foreign org settings', () => {
-    openPublicProject();
-    cy.visit(
-      `${HOST}/organizations/${organizations['publicProjectsUser'].slug}/profile`
-    );
-    waitForGlobalLoading();
-    gcyAdvanced({ value: 'settings-menu-item', item: 'profile' }).should(
-      'be.visible'
-    );
-    gcyAdvanced({ value: 'settings-menu-item', item: 'glossaries' }).should(
-      'be.visible'
-    );
-    gcyAdvanced({
-      value: 'settings-menu-item',
-      item: 'translation-memories',
-    }).should('not.exist');
-    gcy('organization-profile-leave-button').should('be.disabled');
+  describe('user who owns one organization and belongs to another', () => {
+    beforeEach(() => {
+      login('dualOrgCommunityUser');
+    });
+
+    it('blocks the submit while switching into an organization it cannot create in', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG, (req) => {
+        req.on('response', (res) => {
+          res.setDelay(SWITCH_RESPONSE_DELAY);
+        });
+      }).as('slowSwitch');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+
+      selectOrganizationInSwitch('Community User');
+
+      gcy('global-form-save-button', {
+        timeout: WHILE_SWITCH_IN_FLIGHT,
+      }).should('be.disabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+
+      cy.wait('@slowSwitch');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+    });
+  });
+
+  describe('supporter who owns no organization', () => {
+    beforeEach(() => {
+      login('supporterCommunityUser');
+    });
+
+    it('offers no project creation in organizations it only supports or belongs to', () => {
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      gcy('global-plus-button').should('not.exist');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+    });
+  });
+
+  describe('user without any organization', () => {
+    beforeEach(() => {
+      setProperty('authentication.userCanCreateOrganizations', false);
+      login('orgLessCommunityUser');
+    });
+
+    afterEach(() => {
+      setProperty('authentication.userCanCreateOrganizations', true);
+    });
+
+    const visitRootAndExpectNoOrganization = () => {
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('be.visible');
+    };
+
+    it('opens a public project and adopts the owning organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('notistack-snackbar').should('not.exist');
+    });
+
+    it('keeps the organization after a reload', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('dashboard-projects-list-item').should('have.length', 6);
+      gcy('dashboard-projects-list-item')
+        .contains('Private project')
+        .should('not.exist');
+      gcy('dashboard-projects-list-item')
+        .contains('Community Outsider')
+        .should('not.exist');
+      gcy('no-permissions-message').should('not.exist');
+    });
+
+    it('disables the create submit after adopting a foreign organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('not.exist');
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+      gcy('project-name-field').find('input').type('Not allowed{enter}');
+
+      // A full page load after the submit attempt, so a POST that did fire
+      // would already have been recorded by the time the count is asserted.
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      cy.get('@createProject.all').should('have.length', 0);
+    });
+
+    it('still requires an organization to create a project', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      cy.url().should('include', '/projects/add');
+      gcy('no-permissions-message').should('be.visible');
+    });
+
+    it('offers the help menu even without an organization', () => {
+      visitRootAndExpectNoOrganization();
+      gcy('help-menu-button').should('be.visible');
+
+      openPublicProject();
+      gcy('help-menu-button').should('be.visible');
+    });
+
+    it('adopts the organization on a cold deep-link to a public project', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${publicProjectId}`);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      assertSwitchedToOrganization('publicProjectsUser');
+      gcy('notistack-snackbar').should('not.exist');
+    });
+
+    it('keeps the project usable when the organization switch fails', () => {
+      interceptPreferredOrgForbidden();
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${publicProjectId}`);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+      gcy('global-base-view-content').should('exist');
+      gcy('organization-switch').should('not.exist');
+      gcy('navigation-item').first().should('contain', 'Community Alpha');
+
+      visitRootAndExpectNoOrganization();
+    });
+
+    it('does not adopt an organization from a project it cannot view', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+      cy.intercept('GET', `**/v2/projects/${privateProjectId}`).as(
+        'privateProjectDetail'
+      );
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/projects/${privateProjectId}`);
+      cy.wait('@privateProjectDetail')
+        .its('response.statusCode')
+        .should('be.oneOf', [403, 404]);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('be.visible');
+      gcy('global-base-view-content').should('not.exist');
+      cy.get('@setPreferred.all').should('have.length', 0);
+
+      visitRootAndExpectNoOrganization();
+    });
+
+    it('still requires an organization to create an organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/organizations/add`);
+      waitForGlobalLoading();
+      cy.url().should('include', '/organizations/add');
+      gcy('no-permissions-message').should('be.visible');
+    });
+
+    it('lists community projects without an organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      cy.visit(`${HOST}/community-projects`);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('not.exist');
+      gcy('dashboard-projects-list-item').should('have.length', 7);
+      gcy('dashboard-projects-list-item')
+        .contains('Private project')
+        .should('not.exist');
+      gcy('community-translation-item').should('be.visible');
+      gcy('organization-switch').should('not.exist');
+    });
+
+    it('does not re-issue the switch when the project is reopened', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+      cy.intercept('GET', `**/v2/projects/${publicProjectId}`).as(
+        'projectDetail'
+      );
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      cy.wait('@setPreferred');
+
+      cy.get('@projectDetail.all').then((beforeReload) => {
+        cy.reload();
+        cy.get('@projectDetail.all').should(
+          'have.length.at.least',
+          beforeReload.length + 1
+        );
+      });
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('publicProjectsUser');
+      cy.get('@setPreferred.all').should('have.length', 1);
+    });
   });
 });

--- a/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
+++ b/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
@@ -1,70 +1,46 @@
 import { HOST } from '../../common/constants';
-import { login, logout, setProperty } from '../../common/apiCalls/common';
-import { publicProjectsData } from '../../common/apiCalls/testData/testData';
+import {
+  login,
+  setOrganizationCreationAllowed,
+} from '../../common/apiCalls/common';
 import {
   assertSwitchedToOrganization,
   gcy,
   gcyAdvanced,
   selectOrganizationInSwitch,
+  openOrganizationSwitch,
   switchToOrganization,
+  visitRootAndSettle,
 } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
+import {
+  PUBLIC_PROJECT_NAME,
+  HELD_REQUEST_MS,
+  SET_PREFERRED_ORG,
+  interceptPreferredOrgDelayed,
+  interceptPreferredOrgForbidden,
+  openPublicProject,
+  communityProjectsFixture,
+  restoreOrganizationCreation,
+} from '../../common/communityProjects';
+import { submitFormDirectly } from '../../common/forms';
+import { organizationSettingsMenuItem } from '../../common/organizationSettingsMenu';
 
-const SET_PREFERRED_ORG = '**/v2/user-preferences/set-preferred-organization/*';
-
-const SWITCH_RESPONSE_DELAY = 4000;
-const WHILE_SWITCH_IN_FLIGHT = 1500;
+const WITHIN_HOLD_MS = HELD_REQUEST_MS / 3;
 
 describe('Community preferred organization', () => {
-  let organizations: Record<string, { slug: string }>;
-  let privateProjectId: number;
-  let publicProjectId: number;
-
-  beforeEach(() => {
-    publicProjectsData.clean();
-    publicProjectsData.generateStandard().then((res) => {
-      organizations = {};
-      res.body.organizations.forEach((org) => {
-        organizations[org.name] = org;
-      });
-      privateProjectId = res.body.projects.find(
-        (project) => project.name === 'Private project'
-      ).id;
-      publicProjectId = res.body.projects.find(
-        (project) => project.name === 'Community Alpha'
-      ).id;
-    });
-  });
-
-  afterEach(() => {
-    publicProjectsData.clean();
-  });
-
-  const interceptPreferredOrgForbidden = () =>
-    cy.intercept('PUT', SET_PREFERRED_ORG, {
-      statusCode: 403,
-      body: { code: 'operation_not_permitted' },
-    });
-
-  const openPublicProject = () => {
-    cy.visit(`${HOST}/public-projects`);
-    waitForGlobalLoading();
-    gcy('dashboard-projects-list-item').contains('Community Alpha').click();
-    cy.url().should('match', /\/projects\/[0-9]+/);
-    waitForGlobalLoading();
-  };
-
-  it('hides the help menu from a signed-out visitor on an unmatched route', () => {
-    logout();
-
-    cy.visit(`${HOST}/definitely-not-a-route`, { failOnStatusCode: false });
-    waitForGlobalLoading();
-    gcy('help-menu-button').should('not.exist');
-  });
+  const fixture = communityProjectsFixture();
 
   describe('user with an organization', () => {
     beforeEach(() => {
       login('communityUser');
+    });
+
+    restoreOrganizationCreation();
+
+    afterEach(() => {
+      // An unsettled adoption write bleeds a 'resolving' preferred organization into the next test.
+      waitForGlobalLoading();
     });
 
     it('switches a guest to the owning organization and shows its public projects', () => {
@@ -75,8 +51,14 @@ describe('Community preferred organization', () => {
       cy.visit(`${HOST}/`);
       waitForGlobalLoading();
       gcy('dashboard-projects-list-item').should('have.length', 6);
-      cy.contains('Community Outsider').should('not.exist');
-      cy.contains('Private project').should('not.exist');
+      gcyAdvanced({
+        value: 'dashboard-projects-list-item',
+        name: 'Community Outsider',
+      }).should('not.exist');
+      gcyAdvanced({
+        value: 'dashboard-projects-list-item',
+        name: 'Private project',
+      }).should('not.exist');
       gcy('global-plus-button').should('not.exist');
       gcy('project-list-more-button').should('not.exist');
     });
@@ -94,11 +76,61 @@ describe('Community preferred organization', () => {
       gcy('project-list-more-button').should('exist');
     });
 
+    it('renders a public project while its adoption write is still in flight', () => {
+      interceptPreferredOrgDelayed('heldCrossOrgAdoption', HELD_REQUEST_MS);
+
+      cy.visit(`${HOST}/community-projects`);
+      waitForGlobalLoading();
+      gcyAdvanced({
+        value: 'dashboard-projects-list-item',
+        name: PUBLIC_PROJECT_NAME,
+      }).click();
+
+      cy.wait('@heldCrossOrgAdoption.request');
+      cy.url({ timeout: WITHIN_HOLD_MS }).should('match', /\/projects\/[0-9]+/);
+      gcy('project-menu-items', { timeout: WITHIN_HOLD_MS }).should(
+        'be.visible'
+      );
+    });
+
+    it('waits for the adoption write before rendering an organization page it adopts', () => {
+      interceptPreferredOrgDelayed('heldOrgPageAdoption', HELD_REQUEST_MS);
+
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/profile`
+      );
+      cy.wait('@heldOrgPageAdoption.request');
+
+      // The chrome above the page names the active organization, so it must not render this
+      // organization's settings under the previous one's name.
+      organizationSettingsMenuItem('profile', {
+        timeout: WITHIN_HOLD_MS,
+      }).should('not.exist');
+
+      waitForGlobalLoading();
+      organizationSettingsMenuItem('profile').should('be.visible');
+      assertSwitchedToOrganization('publicProjectsUser');
+    });
+
     it('keeps the project page usable when the preferred-organization switch fails', () => {
       interceptPreferredOrgForbidden();
       openPublicProject();
       cy.url().should('match', /\/projects\/[0-9]+/);
       gcy('global-base-view-content').should('exist');
+    });
+
+    it('keeps the EE menu of the own organization when the switch back to it fails', () => {
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      interceptPreferredOrgForbidden();
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['Community User'].slug}/profile`
+      );
+      waitForGlobalLoading();
+
+      organizationSettingsMenuItem('glossaries').should('be.visible');
+      organizationSettingsMenuItem('translation-memories').should('be.visible');
     });
 
     it('disables the create submit on a foreign organization and creates in the switched-to one', () => {
@@ -132,31 +164,185 @@ describe('Community preferred organization', () => {
       waitForGlobalLoading();
       cy.url().should('match', /\/projects\/[0-9]+/);
 
-      cy.visit(HOST);
-      waitForGlobalLoading();
+      visitRootAndSettle();
       assertSwitchedToOrganization('Community User');
-      gcy('dashboard-projects-list-item')
-        .contains('Switched org project')
-        .should('be.visible');
+      gcyAdvanced({
+        value: 'dashboard-projects-list-item',
+        name: 'Switched org project',
+      }).should('be.visible');
+    });
+
+    it('offers no organization creation in the switcher while the server refuses it', () => {
+      visitRootAndSettle();
+      openOrganizationSwitch();
+      gcy('switch-popover-new').should('be.visible');
+
+      setOrganizationCreationAllowed(false);
+      visitRootAndSettle();
+      openOrganizationSwitch();
+      gcy('switch-popover-new').should('not.exist');
+    });
+
+    it('follows the preferred-organization link, with and without a path suffix', () => {
+      cy.visit(`${HOST}/preferred-organization`);
+      waitForGlobalLoading();
+      cy.url().should(
+        'match',
+        new RegExp(
+          `/organizations/${fixture.organizations['Community User'].slug}/profile$`
+        )
+      );
+      organizationSettingsMenuItem('profile').should('be.visible');
+
+      cy.visit(`${HOST}/preferred-organization?path=members`);
+      waitForGlobalLoading();
+      cy.url().should(
+        'include',
+        `/organizations/${fixture.organizations['Community User'].slug}/members`
+      );
+    });
+
+    it('opens the glossaries of an adopted foreign organization', () => {
+      openPublicProject();
+
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/glossaries`
+      );
+      waitForGlobalLoading();
+
+      organizationSettingsMenuItem('glossaries').should('be.visible');
+      gcy('global-user-menu-button').should('be.visible');
+    });
+
+    it('offers the organization entries in the user menu when there is a preferred organization', () => {
+      visitRootAndSettle();
+
+      gcy('global-user-menu-button').click();
+      cy.waitForDom();
+      gcy('user-menu-organization-switch').should('be.visible');
+      gcy('user-menu-organization-settings').should('be.visible');
+    });
+
+    it('adopts a foreign organization it opens without granting it any manage entry', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/profile`
+      );
+      waitForGlobalLoading();
+
+      assertSwitchedToOrganization('publicProjectsUser');
+      organizationSettingsMenuItem('profile').should('be.visible');
+      organizationSettingsMenuItem('translation-memories').should('not.exist');
+    });
+
+    it('sends a deep link to a manage-only page back to the profile it can see', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/apps`
+      );
+      waitForGlobalLoading();
+
+      cy.url().should('include', '/profile');
+      cy.url().should('not.include', '/apps');
+      assertSwitchedToOrganization('publicProjectsUser');
+    });
+
+    it('sends deep links to the other restricted pages back to the profile too', () => {
+      const slug = fixture.organizations['publicProjectsUser'].slug;
+
+      ['members', 'member-privileges', 'sso', 'translation-memories'].forEach(
+        (page) => {
+          cy.visit(`${HOST}/organizations/${slug}/${page}`);
+          waitForGlobalLoading();
+
+          cy.url().should('include', '/profile');
+          cy.url().should('not.include', `/${page}`);
+          organizationSettingsMenuItem('profile').should('be.visible');
+        }
+      );
     });
 
     it('shows glossaries but hides translation memories in the foreign org settings', () => {
       openPublicProject();
       cy.visit(
-        `${HOST}/organizations/${organizations['publicProjectsUser'].slug}/profile`
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/profile`
       );
       waitForGlobalLoading();
-      gcyAdvanced({ value: 'settings-menu-item', item: 'profile' }).should(
-        'be.visible'
-      );
-      gcyAdvanced({ value: 'settings-menu-item', item: 'glossaries' }).should(
-        'be.visible'
-      );
-      gcyAdvanced({
-        value: 'settings-menu-item',
-        item: 'translation-memories',
-      }).should('not.exist');
+      organizationSettingsMenuItem('profile').should('be.visible');
+      organizationSettingsMenuItem('glossaries').should('be.visible');
+      organizationSettingsMenuItem('translation-memories').should('not.exist');
       gcy('organization-profile-leave-button').should('be.disabled');
+      gcy('organization-profile-delete-button').should('not.exist');
+    });
+
+    it('creates a project when the form is submitted directly (positive control for the refusal specs)', () => {
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('project-name-field').find('input').type('Directly submitted');
+      submitFormDirectly();
+
+      cy.wait('@createProject').its('response.statusCode').should('eq', 200);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+    });
+
+    it('issues one create even when the form is submitted twice while the first is in flight', () => {
+      cy.intercept('POST', '**/v2/projects', (req) =>
+        req.continue((res) => {
+          res.setDelay(HELD_REQUEST_MS);
+        })
+      ).as('createProject');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('project-name-field').find('input').type('Submitted twice');
+
+      submitFormDirectly();
+      cy.wait('@createProject.request');
+      submitFormDirectly();
+
+      waitForGlobalLoading();
+      cy.get('@createProject.all').should('have.length', 1);
+    });
+
+    it('creates one organization even when the form is submitted twice after the create lands', () => {
+      interceptPreferredOrgDelayed('heldAdoptionAfterCreate', HELD_REQUEST_MS);
+      cy.intercept('POST', '**/v2/organizations').as('createOrganization');
+
+      cy.visit(`${HOST}/organizations/add`);
+      waitForGlobalLoading();
+      gcy('organization-name-field').find('input').type('Submitted twice');
+
+      // The slug is not required client-side, so the save button enables before it is filled.
+      gcy('organization-address-part-field')
+        .find('input')
+        .should('not.have.value', '');
+      gcy('global-form-save-button').should('not.be.disabled').click();
+      cy.wait('@createOrganization');
+      submitFormDirectly();
+
+      cy.wait('@heldAdoptionAfterCreate');
+      waitForGlobalLoading();
+      cy.get('@createOrganization.all').should('have.length', 1);
+    });
+
+    it('surfaces a server refusal of the create request', () => {
+      cy.intercept('POST', '**/v2/projects', {
+        statusCode: 403,
+        body: { code: 'user_is_not_owner_or_maintainer_of_organization' },
+      }).as('createProject');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('error-message').should('not.exist');
+      gcy('project-name-field').find('input').type('Refused by server');
+      gcy('global-form-save-button').click();
+
+      cy.wait('@createProject');
+      waitForGlobalLoading();
+      cy.url().should('include', '/projects/add');
+      gcy('error-message').should('be.visible');
+      gcy('global-form-save-button').should('be.enabled');
     });
   });
 
@@ -166,41 +352,177 @@ describe('Community preferred organization', () => {
     });
 
     it('blocks the submit while switching into an organization it cannot create in', () => {
-      cy.intercept('PUT', SET_PREFERRED_ORG, (req) => {
-        req.on('response', (res) => {
-          res.setDelay(SWITCH_RESPONSE_DELAY);
-        });
-      }).as('slowSwitch');
+      interceptPreferredOrgDelayed('heldSwitch', HELD_REQUEST_MS);
+      cy.intercept('POST', '**/v2/projects').as('createProject');
 
       cy.visit(`${HOST}/projects/add`);
       waitForGlobalLoading();
       gcy('global-form-save-button').should('be.enabled');
+      gcy('project-name-field').find('input').type('Submitted mid-switch');
 
       selectOrganizationInSwitch('Community User');
 
-      gcy('global-form-save-button', {
-        timeout: WHILE_SWITCH_IN_FLIGHT,
-      }).should('be.disabled');
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-switching-message').should('be.visible');
       gcy('project-create-no-permission-message').should('not.exist');
+      submitFormDirectly();
+      waitForGlobalLoading();
+      cy.get('@createProject.all').should('have.length', 0);
 
-      cy.wait('@slowSwitch');
+      cy.wait('@heldSwitch');
       waitForGlobalLoading();
       gcy('global-form-save-button').should('be.disabled');
       gcy('project-create-no-permission-message').should('be.visible');
+      cy.get('@createProject.all').should('have.length', 0);
+    });
+
+    it('keeps the newest selection when an earlier switch resolves after it', () => {
+      interceptPreferredOrgDelayed(
+        'overlappingSwitches',
+        HELD_REQUEST_MS,
+        () => fixture.organizations['Community User'].id
+      );
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+
+      selectOrganizationInSwitch('Community User');
+      selectOrganizationInSwitch('Dual Org Member');
+
+      cy.wait('@overlappingSwitches');
+      cy.wait('@overlappingSwitches');
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('Dual Org Member');
+
+      visitRootAndSettle();
+      assertSwitchedToOrganization('Dual Org Member');
+    });
+
+    it('stays put when the switcher selection is refused, and switches on a later try', () => {
+      interceptPreferredOrgForbidden();
+
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['Dual Org Member'].slug}/profile`
+      );
+      waitForGlobalLoading();
+
+      selectOrganizationInSwitch('Community User');
+      waitForGlobalLoading();
+
+      cy.url().should('include', fixture.organizations['Dual Org Member'].slug);
+      assertSwitchedToOrganization('Dual Org Member');
+
+      // Cypress has no intercept removal, and a spy-only intercept would not shadow the 403 above.
+      cy.intercept('PUT', SET_PREFERRED_ORG, (req) => req.continue()).as(
+        'freshSwitch'
+      );
+      selectOrganizationInSwitch('Community User');
+      cy.wait('@freshSwitch');
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('Community User');
     });
   });
 
-  describe('supporter who owns no organization', () => {
+  describe('server admin', () => {
+    beforeEach(() => {
+      login('admin', 'admin');
+    });
+
+    it('offers the manage and EE menu entries on a foreign organization', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['Members Only Outfit'].slug}/profile`
+      );
+      waitForGlobalLoading();
+
+      organizationSettingsMenuItem('glossaries').should('be.visible');
+      organizationSettingsMenuItem('translation-memories').should('be.visible');
+      organizationSettingsMenuItem('profile').should('be.visible');
+    });
+
+    it('creates a project in a foreign organization it is not a member of', () => {
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('project-create-no-permission-message').should('not.exist');
+      gcy('global-form-save-button').should('be.enabled');
+
+      gcy('project-name-field').find('input').type('Admin created project');
+      gcy('global-form-save-button').click();
+
+      cy.wait('@createProject').then(({ response }) => {
+        expect(response?.statusCode).to.eq(200);
+        expect(response?.body.organizationOwner.slug).to.eq(
+          fixture.organizations['publicProjectsUser'].slug
+        );
+      });
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+    });
+
+    it('adopts a customer organization when it opens one of its EE pages', () => {
+      visitRootAndSettle();
+
+      const customer = fixture.organizations['publicProjectsUser'];
+      cy.intercept('PUT', SET_PREFERRED_ORG).as('adoption');
+      cy.visit(`${HOST}/organizations/${customer.slug}/glossaries`);
+      waitForGlobalLoading();
+
+      cy.url().should('include', '/glossaries');
+      cy.wait('@adoption')
+        .its('request.url')
+        .should('include', `/set-preferred-organization/${customer.id}`);
+    });
+
+    it('adopts a foreign organization it opens and keeps its admin access to it', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/profile`
+      );
+      waitForGlobalLoading();
+      organizationSettingsMenuItem('profile').should('be.visible');
+      gcy('organization-profile-delete-button').should('be.visible');
+
+      visitRootAndSettle();
+      assertSwitchedToOrganization('publicProjectsUser');
+    });
+  });
+
+  describe('supporter who owns no organization of its own', () => {
     beforeEach(() => {
       login('supporterCommunityUser');
+    });
+
+    it('manages a foreign organization but cannot edit its profile', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['Members Only Outfit'].slug}/profile`
+      );
+      waitForGlobalLoading();
+
+      organizationSettingsMenuItem('members').should('be.visible');
+      organizationSettingsMenuItem('apps').should('be.visible');
+
+      gcy('organization-profile-delete-button').should('not.exist');
+      gcy('global-form-save-button').should('be.disabled');
+    });
+
+    it('reads the apps page of a foreign organization, as the read-only bypass allows', () => {
+      cy.visit(
+        `${HOST}/organizations/${fixture.organizations['Members Only Outfit'].slug}/apps`
+      );
+      waitForGlobalLoading();
+
+      cy.url().should('include', '/apps');
+      cy.url().should('not.include', '/profile');
     });
 
     it('offers no project creation in organizations it only supports or belongs to', () => {
       openPublicProject();
       assertSwitchedToOrganization('publicProjectsUser');
 
-      cy.visit(HOST);
-      waitForGlobalLoading();
+      visitRootAndSettle();
       gcy('global-plus-button').should('not.exist');
 
       cy.visit(`${HOST}/projects/add`);
@@ -212,175 +534,6 @@ describe('Community preferred organization', () => {
       waitForGlobalLoading();
       gcy('global-form-save-button').should('be.disabled');
       gcy('project-create-no-permission-message').should('be.visible');
-    });
-  });
-
-  describe('user without any organization', () => {
-    beforeEach(() => {
-      setProperty('authentication.userCanCreateOrganizations', false);
-      login('orgLessCommunityUser');
-    });
-
-    afterEach(() => {
-      setProperty('authentication.userCanCreateOrganizations', true);
-    });
-
-    const visitRootAndExpectNoOrganization = () => {
-      cy.visit(HOST);
-      waitForGlobalLoading();
-      gcy('no-permissions-message').should('be.visible');
-    };
-
-    it('opens a public project and adopts the owning organization', () => {
-      visitRootAndExpectNoOrganization();
-
-      openPublicProject();
-      assertSwitchedToOrganization('publicProjectsUser');
-      gcy('notistack-snackbar').should('not.exist');
-    });
-
-    it('keeps the organization after a reload', () => {
-      visitRootAndExpectNoOrganization();
-
-      openPublicProject();
-      cy.visit(HOST);
-      waitForGlobalLoading();
-      assertSwitchedToOrganization('publicProjectsUser');
-      gcy('dashboard-projects-list-item').should('have.length', 6);
-      gcy('dashboard-projects-list-item')
-        .contains('Private project')
-        .should('not.exist');
-      gcy('dashboard-projects-list-item')
-        .contains('Community Outsider')
-        .should('not.exist');
-      gcy('no-permissions-message').should('not.exist');
-    });
-
-    it('disables the create submit after adopting a foreign organization', () => {
-      visitRootAndExpectNoOrganization();
-
-      openPublicProject();
-      assertSwitchedToOrganization('publicProjectsUser');
-
-      cy.visit(`${HOST}/projects/add`);
-      waitForGlobalLoading();
-      gcy('no-permissions-message').should('not.exist');
-      gcy('global-form-save-button').should('be.disabled');
-      gcy('project-create-no-permission-message').should('be.visible');
-
-      cy.intercept('POST', '**/v2/projects').as('createProject');
-      gcy('project-name-field').find('input').type('Not allowed{enter}');
-
-      // A full page load after the submit attempt, so a POST that did fire
-      // would already have been recorded by the time the count is asserted.
-      cy.visit(HOST);
-      waitForGlobalLoading();
-      cy.get('@createProject.all').should('have.length', 0);
-    });
-
-    it('still requires an organization to create a project', () => {
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/projects/add`);
-      waitForGlobalLoading();
-      cy.url().should('include', '/projects/add');
-      gcy('no-permissions-message').should('be.visible');
-    });
-
-    it('offers the help menu even without an organization', () => {
-      visitRootAndExpectNoOrganization();
-      gcy('help-menu-button').should('be.visible');
-
-      openPublicProject();
-      gcy('help-menu-button').should('be.visible');
-    });
-
-    it('adopts the organization on a cold deep-link to a public project', () => {
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/projects/${publicProjectId}`);
-      waitForGlobalLoading();
-      cy.url().should('match', /\/projects\/[0-9]+/);
-      assertSwitchedToOrganization('publicProjectsUser');
-      gcy('notistack-snackbar').should('not.exist');
-    });
-
-    it('keeps the project usable when the organization switch fails', () => {
-      interceptPreferredOrgForbidden();
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/projects/${publicProjectId}`);
-      waitForGlobalLoading();
-      cy.url().should('match', /\/projects\/[0-9]+/);
-      gcy('global-base-view-content').should('exist');
-      gcy('organization-switch').should('not.exist');
-      gcy('navigation-item').first().should('contain', 'Community Alpha');
-
-      visitRootAndExpectNoOrganization();
-    });
-
-    it('does not adopt an organization from a project it cannot view', () => {
-      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
-      cy.intercept('GET', `**/v2/projects/${privateProjectId}`).as(
-        'privateProjectDetail'
-      );
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/projects/${privateProjectId}`);
-      cy.wait('@privateProjectDetail')
-        .its('response.statusCode')
-        .should('be.oneOf', [403, 404]);
-      waitForGlobalLoading();
-      gcy('no-permissions-message').should('be.visible');
-      gcy('global-base-view-content').should('not.exist');
-      cy.get('@setPreferred.all').should('have.length', 0);
-
-      visitRootAndExpectNoOrganization();
-    });
-
-    it('still requires an organization to create an organization', () => {
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/organizations/add`);
-      waitForGlobalLoading();
-      cy.url().should('include', '/organizations/add');
-      gcy('no-permissions-message').should('be.visible');
-    });
-
-    it('lists community projects without an organization', () => {
-      visitRootAndExpectNoOrganization();
-
-      cy.visit(`${HOST}/community-projects`);
-      waitForGlobalLoading();
-      gcy('no-permissions-message').should('not.exist');
-      gcy('dashboard-projects-list-item').should('have.length', 7);
-      gcy('dashboard-projects-list-item')
-        .contains('Private project')
-        .should('not.exist');
-      gcy('community-translation-item').should('be.visible');
-      gcy('organization-switch').should('not.exist');
-    });
-
-    it('does not re-issue the switch when the project is reopened', () => {
-      cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
-      cy.intercept('GET', `**/v2/projects/${publicProjectId}`).as(
-        'projectDetail'
-      );
-      visitRootAndExpectNoOrganization();
-
-      openPublicProject();
-      cy.wait('@setPreferred');
-
-      cy.get('@projectDetail.all').then((beforeReload) => {
-        cy.reload();
-        cy.get('@projectDetail.all').should(
-          'have.length.at.least',
-          beforeReload.length + 1
-        );
-      });
-      waitForGlobalLoading();
-      assertSwitchedToOrganization('publicProjectsUser');
-      cy.get('@setPreferred.all').should('have.length', 1);
     });
   });
 });

--- a/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
+++ b/e2e/cypress/e2e/projects/communityPreferredOrganization.cy.ts
@@ -5,11 +5,15 @@ import {
   assertSwitchedToOrganization,
   gcy,
   gcyAdvanced,
+  selectOrganizationInSwitch,
   switchToOrganization,
 } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
 
 const SET_PREFERRED_ORG = '**/v2/user-preferences/set-preferred-organization/*';
+
+const SWITCH_RESPONSE_DELAY = 4000;
+const WHILE_SWITCH_IN_FLIGHT = 1500;
 
 describe('Community preferred organization', () => {
   let organizations: Record<string, { slug: string }>;
@@ -97,6 +101,45 @@ describe('Community preferred organization', () => {
       gcy('global-base-view-content').should('exist');
     });
 
+    it('disables the create submit on a foreign organization and creates in the switched-to one', () => {
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      gcy('project-name-field').find('input').type('Switched org project');
+
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+      gcy('project-name-field')
+        .find('input')
+        .should('have.value', 'Switched org project');
+
+      gcy('global-form-save-button').click();
+      cy.wait('@createProject').its('response.statusCode').should('eq', 200);
+      waitForGlobalLoading();
+      cy.url().should('match', /\/projects\/[0-9]+/);
+
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      assertSwitchedToOrganization('Community User');
+      gcy('dashboard-projects-list-item')
+        .contains('Switched org project')
+        .should('be.visible');
+    });
+
     it('shows glossaries but hides translation memories in the foreign org settings', () => {
       openPublicProject();
       cy.visit(
@@ -114,6 +157,61 @@ describe('Community preferred organization', () => {
         item: 'translation-memories',
       }).should('not.exist');
       gcy('organization-profile-leave-button').should('be.disabled');
+    });
+  });
+
+  describe('user who owns one organization and belongs to another', () => {
+    beforeEach(() => {
+      login('dualOrgCommunityUser');
+    });
+
+    it('blocks the submit while switching into an organization it cannot create in', () => {
+      cy.intercept('PUT', SET_PREFERRED_ORG, (req) => {
+        req.on('response', (res) => {
+          res.setDelay(SWITCH_RESPONSE_DELAY);
+        });
+      }).as('slowSwitch');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.enabled');
+
+      selectOrganizationInSwitch('Community User');
+
+      gcy('global-form-save-button', {
+        timeout: WHILE_SWITCH_IN_FLIGHT,
+      }).should('be.disabled');
+      gcy('project-create-no-permission-message').should('not.exist');
+
+      cy.wait('@slowSwitch');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+    });
+  });
+
+  describe('supporter who owns no organization', () => {
+    beforeEach(() => {
+      login('supporterCommunityUser');
+    });
+
+    it('offers no project creation in organizations it only supports or belongs to', () => {
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      gcy('global-plus-button').should('not.exist');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      switchToOrganization('Community User');
+      waitForGlobalLoading();
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
     });
   });
 
@@ -156,6 +254,28 @@ describe('Community preferred organization', () => {
         .contains('Community Outsider')
         .should('not.exist');
       gcy('no-permissions-message').should('not.exist');
+    });
+
+    it('disables the create submit after adopting a foreign organization', () => {
+      visitRootAndExpectNoOrganization();
+
+      openPublicProject();
+      assertSwitchedToOrganization('publicProjectsUser');
+
+      cy.visit(`${HOST}/projects/add`);
+      waitForGlobalLoading();
+      gcy('no-permissions-message').should('not.exist');
+      gcy('global-form-save-button').should('be.disabled');
+      gcy('project-create-no-permission-message').should('be.visible');
+
+      cy.intercept('POST', '**/v2/projects').as('createProject');
+      gcy('project-name-field').find('input').type('Not allowed{enter}');
+
+      // A full page load after the submit attempt, so a POST that did fire
+      // would already have been recorded by the time the count is asserted.
+      cy.visit(HOST);
+      waitForGlobalLoading();
+      cy.get('@createProject.all').should('have.length', 0);
     });
 
     it('still requires an organization to create a project', () => {

--- a/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
+++ b/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
@@ -14,12 +14,25 @@ import {
   organizationTestData,
   publicProjectsData,
 } from '../../common/apiCalls/testData/testData';
-import { gcy, gcyAdvanced, switchToOrganization } from '../../common/shared';
+import {
+  gcy,
+  gcyAdvanced,
+  switchToOrganization,
+  openOrganizationSwitch,
+  visitRootAndSettle,
+} from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
 
 const disableMyContributions = () => {
-  gcy('community-my-contributions-toggle').click();
-  waitForGlobalLoading();
+  gcy('community-my-contributions-toggle').then(($toggle) => {
+    if ($toggle.find('input:checked').length) {
+      cy.wrap($toggle).click();
+      waitForGlobalLoading();
+    }
+  });
+  gcy('community-my-contributions-toggle')
+    .find('input')
+    .should('not.be.checked');
 };
 
 describe('Community projects navigation', () => {
@@ -48,19 +61,13 @@ describe('Community projects navigation', () => {
     cy.waitForDom();
   };
 
-  const openSwitch = () => {
-    cy.waitForDom();
-    gcy('organization-switch').click();
-    cy.waitForDom();
-  };
-
   const visitCommunity = () => {
     cy.visit(`${HOST}/community-projects`);
     cy.waitForDom();
   };
 
   it('navigates to the community page via the dropdown entry (mouse)', () => {
-    openSwitch();
+    openOrganizationSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
       action: 'organization-switch-community',
@@ -69,7 +76,7 @@ describe('Community projects navigation', () => {
   });
 
   it('navigates to the community page via the dropdown entry (keyboard)', () => {
-    openSwitch();
+    openOrganizationSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
       action: 'organization-switch-community',
@@ -121,7 +128,7 @@ describe('Community projects navigation', () => {
 
   it('highlights no org row while on the community page but still offers the community entry', () => {
     visitCommunity();
-    openSwitch();
+    openOrganizationSwitch();
     gcy('switch-popover-item').should('exist');
     gcy('switch-popover-item').filter('.Mui-selected').should('not.exist');
     gcyAdvanced({
@@ -134,7 +141,7 @@ describe('Community projects navigation', () => {
     cy.visit(
       `${HOST}/organizations/${organizationData['Tolgee'].slug}/members`
     );
-    openSwitch();
+    openOrganizationSwitch();
     gcy('switch-popover-item').should('exist');
     gcyAdvanced({
       value: 'switch-popover-footer-action',
@@ -145,7 +152,7 @@ describe('Community projects navigation', () => {
   it('does not offer the community entry for a user with no contributions', () => {
     communityContributionData.clean();
     visitProjects();
-    openSwitch();
+    openOrganizationSwitch();
     gcy('switch-popover-item').should('exist');
     gcyAdvanced({
       value: 'switch-popover-footer-action',
@@ -165,7 +172,7 @@ describe('Community projects navigation', () => {
   });
 
   it('closes the popover on Escape from the footer entry', () => {
-    openSwitch();
+    openOrganizationSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
       action: 'organization-switch-community',
@@ -206,6 +213,12 @@ describe('Community projects email-verification gate', () => {
     deleteUserSql(changedEmail);
     deleteAllEmails();
     disableEmailVerification();
+  });
+
+  it('keeps an unverified user on the root rather than sending them to the community projects', () => {
+    visitRootAndSettle();
+    cy.url().should('not.include', '/community-projects');
+    gcy('resend-email-button').should('be.visible');
   });
 
   it('shows EmailNotVerifiedView instead of the switcher for unverified users', () => {

--- a/e2e/cypress/e2e/projects/orgLessCommunityUser.cy.ts
+++ b/e2e/cypress/e2e/projects/orgLessCommunityUser.cy.ts
@@ -1,0 +1,381 @@
+import { HOST } from '../../common/constants';
+import { login } from '../../common/apiCalls/common';
+import {
+  assertSwitchedToOrganization,
+  gcy,
+  gcyAdvanced,
+  openOrganizationSwitch,
+  visitRootAndSettle,
+} from '../../common/shared';
+import { waitForGlobalLoading } from '../../common/loading';
+import {
+  PAST_SWITCH_DEADLINE_MS,
+  PUBLIC_PROJECT_NAME,
+  SET_PREFERRED_ORG,
+  SWITCH_DEADLINE_MS,
+  communityProjectsFixture,
+  interceptPreferredOrgDelayed,
+  interceptPreferredOrgForbidden,
+  keepPersonasOrganizationLess,
+  openPublicProject,
+} from '../../common/communityProjects';
+import { submitFormDirectly } from '../../common/forms';
+import { organizationSettingsMenuItem } from '../../common/organizationSettingsMenu';
+
+describe('Org-less community user', () => {
+  const customerOrganizationProfile = () =>
+    `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/profile`;
+
+  keepPersonasOrganizationLess();
+
+  const fixture = communityProjectsFixture();
+
+  beforeEach(() => {
+    login('orgLessCommunityUser');
+  });
+
+  const assertRootLandsOnCommunityProjects = () => {
+    visitRootAndSettle();
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+    gcy('no-permissions-message').should('not.exist');
+  };
+
+  it('adopts the owning organization from the community projects list', () => {
+    assertRootLandsOnCommunityProjects();
+
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: PUBLIC_PROJECT_NAME,
+    }).click();
+    cy.url().should('match', /\/projects\/[0-9]+/);
+    waitForGlobalLoading();
+    assertSwitchedToOrganization('publicProjectsUser');
+  });
+
+  it('opens a public project and adopts the owning organization', () => {
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    assertSwitchedToOrganization('publicProjectsUser');
+    gcy('notistack-snackbar').should('not.exist');
+  });
+
+  it("re-adopts when moving in-app from one organization's project to another's", () => {
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    assertSwitchedToOrganization('publicProjectsUser');
+
+    openOrganizationSwitch();
+    gcyAdvanced({
+      value: 'switch-popover-footer-action',
+      action: 'organization-switch-community',
+    }).click();
+    waitForGlobalLoading();
+
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: 'Community Outsider',
+    }).click();
+    cy.url().should('match', /\/projects\/[0-9]+/);
+    waitForGlobalLoading();
+
+    assertSwitchedToOrganization('Community User');
+  });
+
+  it('offers a way back to the community projects after adopting', () => {
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    assertSwitchedToOrganization('publicProjectsUser');
+
+    openOrganizationSwitch();
+    gcyAdvanced({
+      value: 'switch-popover-footer-action',
+      action: 'organization-switch-community',
+    }).click();
+
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+  });
+
+  it('keeps the organization after a reload', () => {
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    visitRootAndSettle();
+    assertSwitchedToOrganization('publicProjectsUser');
+    gcy('dashboard-projects-list-item').should('have.length', 6);
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: 'Private project',
+    }).should('not.exist');
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: 'Community Outsider',
+    }).should('not.exist');
+    gcy('no-permissions-message').should('not.exist');
+  });
+
+  it('disables the create submit after adopting a foreign organization', () => {
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    assertSwitchedToOrganization('publicProjectsUser');
+
+    cy.visit(`${HOST}/projects/add`);
+    waitForGlobalLoading();
+    gcy('no-permissions-message').should('not.exist');
+    gcy('global-form-save-button').should('be.disabled');
+    gcy('project-create-no-permission-message').should('be.visible');
+
+    cy.intercept('POST', '**/v2/projects').as('createProject');
+    gcy('project-name-field').find('input').type('Not allowed');
+    submitFormDirectly();
+
+    visitRootAndSettle();
+    cy.get('@createProject.all').should('have.length', 0);
+  });
+
+  it('refuses the project form without an organization', () => {
+    assertRootLandsOnCommunityProjects();
+
+    cy.visit(`${HOST}/projects/add`);
+    waitForGlobalLoading();
+    cy.url().should('include', '/projects/add');
+    gcyAdvanced({
+      value: 'no-permissions-message',
+      reason: 'no-organization',
+    }).should('be.visible');
+    gcy('global-form-save-button').should('not.exist');
+    gcy('project-name-field').should('not.exist');
+  });
+
+  it('redirects the projects route to the community projects', () => {
+    cy.visit(`${HOST}/projects`);
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+  });
+
+  it('adopts an organization it may view from a direct link', () => {
+    cy.visit(customerOrganizationProfile());
+    waitForGlobalLoading();
+    gcy('no-permissions-message').should('not.exist');
+    organizationSettingsMenuItem('profile').should('be.visible');
+    assertSwitchedToOrganization('publicProjectsUser');
+  });
+
+  it('holds the project page until the adoption write settles', () => {
+    interceptPreferredOrgDelayed('heldAdoption');
+
+    cy.visit(`${HOST}/projects/${fixture.publicProjectId}`);
+    cy.wait('@heldAdoption.request');
+    gcy('project-menu-items').should('not.exist');
+
+    waitForGlobalLoading();
+    gcy('project-menu-items').should('be.visible');
+  });
+
+  it('holds the organization page until the adoption write settles', () => {
+    interceptPreferredOrgDelayed('heldAdoption');
+
+    cy.visit(customerOrganizationProfile());
+    cy.wait('@heldAdoption.request');
+    organizationSettingsMenuItem('profile').should('not.exist');
+
+    waitForGlobalLoading();
+    organizationSettingsMenuItem('profile').should('be.visible');
+  });
+
+  it('renders the organization page when the adoption write is refused', () => {
+    interceptPreferredOrgForbidden();
+
+    cy.visit(customerOrganizationProfile());
+    waitForGlobalLoading();
+    organizationSettingsMenuItem('profile').should('be.visible');
+    gcy('no-permissions-message').should('not.exist');
+  });
+
+  it('keeps an EE route usable when the adoption write is refused', () => {
+    interceptPreferredOrgForbidden();
+
+    cy.visit(
+      `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/glossaries`
+    );
+    waitForGlobalLoading();
+
+    cy.url().should('include', '/glossaries');
+    organizationSettingsMenuItem('profile').should('be.visible');
+  });
+
+  it('adopts the organization behind an EE route it deep-links into', () => {
+    cy.visit(
+      `${HOST}/organizations/${fixture.organizations['publicProjectsUser'].slug}/glossaries`
+    );
+    waitForGlobalLoading();
+
+    cy.url().should('include', '/glossaries');
+    assertSwitchedToOrganization('publicProjectsUser');
+    organizationSettingsMenuItem('glossaries').should('be.visible');
+  });
+
+  it('keeps the project usable when an adoption write never answers', () => {
+    interceptPreferredOrgDelayed('stalledAdoption', PAST_SWITCH_DEADLINE_MS);
+
+    cy.visit(`${HOST}/community-projects`);
+    waitForGlobalLoading();
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: PUBLIC_PROJECT_NAME,
+    }).click();
+    cy.wait('@stalledAdoption.request');
+
+    // Past the sequencer deadline the abandoned switch must stop blocking the UI, so the viewer
+    // reaches a usable page instead of a permanent loader.
+    cy.url({ timeout: SWITCH_DEADLINE_MS + 15000 }).should(
+      'match',
+      /\/projects\/[0-9]+/
+    );
+    gcy('global-base-view-content', {
+      timeout: SWITCH_DEADLINE_MS + 15000,
+    }).should('be.visible');
+  });
+
+  it('is sent to the community projects by the preferred-organization link', () => {
+    cy.visit(`${HOST}/preferred-organization`);
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+  });
+
+  it('is sent to the community projects by the billing link on a server without billing', () => {
+    cy.visit(`${HOST}/billing`);
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+  });
+
+  it('is told why an organization page cannot be loaded', () => {
+    cy.intercept('GET', '**/v2/organizations/*', { statusCode: 500 }).as(
+      'orgFailed'
+    );
+
+    cy.visit(customerOrganizationProfile());
+    waitForGlobalLoading();
+    gcy('organization-load-failed-message').should('be.visible');
+  });
+
+  it('is sent back to the community projects by an organization it may not view', () => {
+    cy.visit(
+      `${HOST}/organizations/${fixture.organizations['Members Only Outfit'].slug}/profile`
+    );
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+    organizationSettingsMenuItem('profile').should('not.exist');
+  });
+
+  it('offers a user menu without any organization entries', () => {
+    assertRootLandsOnCommunityProjects();
+
+    gcy('global-user-menu-button').click();
+    cy.waitForDom();
+    gcy('user-menu-organization-settings').should('not.exist');
+    gcy('user-menu-organization-switch').should('not.exist');
+    gcy('user-menu-user-settings').should('be.visible');
+  });
+
+  it('offers the help menu even without an organization', () => {
+    assertRootLandsOnCommunityProjects();
+    gcy('help-menu-button').should('be.visible');
+
+    openPublicProject();
+    gcy('help-menu-button').should('be.visible');
+  });
+
+  it('adopts the organization on a cold deep-link to a public project', () => {
+    assertRootLandsOnCommunityProjects();
+
+    cy.visit(`${HOST}/projects/${fixture.publicProjectId}`);
+    waitForGlobalLoading();
+    cy.url().should('match', /\/projects\/[0-9]+/);
+    assertSwitchedToOrganization('publicProjectsUser');
+    gcy('notistack-snackbar').should('not.exist');
+  });
+
+  it('keeps the project usable when the organization switch fails', () => {
+    interceptPreferredOrgForbidden();
+    assertRootLandsOnCommunityProjects();
+
+    cy.visit(`${HOST}/projects/${fixture.publicProjectId}`);
+    waitForGlobalLoading();
+    cy.url().should('match', /\/projects\/[0-9]+/);
+    gcy('global-base-view-content').should('exist');
+    gcy('organization-switch').should('not.exist');
+    gcy('navigation-item').first().should('contain', PUBLIC_PROJECT_NAME);
+
+    cy.visit(`${HOST}/projects/${fixture.publicProjectId}/translations`);
+    waitForGlobalLoading();
+    gcy('translations-view-list-button').should('be.visible');
+    gcy('organization-switch').should('not.exist');
+
+    assertRootLandsOnCommunityProjects();
+  });
+
+  it('does not adopt an organization from a project it cannot view', () => {
+    cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+    cy.intercept('GET', `**/v2/projects/${fixture.privateProjectId}`).as(
+      'privateProjectDetail'
+    );
+    assertRootLandsOnCommunityProjects();
+
+    cy.visit(`${HOST}/projects/${fixture.privateProjectId}`);
+    cy.wait('@privateProjectDetail')
+      .its('response.statusCode')
+      .should('be.oneOf', [403, 404]);
+    waitForGlobalLoading();
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+    cy.get('@setPreferred.all').should('have.length', 0);
+
+    assertRootLandsOnCommunityProjects();
+  });
+
+  it('lists community projects without an organization', () => {
+    assertRootLandsOnCommunityProjects();
+
+    cy.visit(`${HOST}/community-projects`);
+    waitForGlobalLoading();
+    gcy('no-permissions-message').should('not.exist');
+    gcy('dashboard-projects-list-item').should('have.length', 7);
+    gcyAdvanced({
+      value: 'dashboard-projects-list-item',
+      name: 'Private project',
+    }).should('not.exist');
+    gcy('community-translation-item').should('be.visible');
+    gcy('organization-switch').should('not.exist');
+  });
+
+  it('does not re-issue the switch when the project is reopened', () => {
+    cy.intercept('PUT', SET_PREFERRED_ORG).as('setPreferred');
+    cy.intercept('GET', `**/v2/projects/${fixture.publicProjectId}`).as(
+      'projectDetail'
+    );
+    assertRootLandsOnCommunityProjects();
+
+    openPublicProject();
+    cy.wait('@setPreferred');
+
+    cy.get('@projectDetail.all').then((beforeReload) => {
+      cy.reload();
+      cy.get('@projectDetail.all').should(
+        'have.length.at.least',
+        beforeReload.length + 1
+      );
+    });
+    waitForGlobalLoading();
+    assertSwitchedToOrganization('publicProjectsUser');
+    cy.get('@setPreferred.all').should('have.length', 1);
+  });
+});

--- a/e2e/cypress/e2e/security/noPermission.cy.ts
+++ b/e2e/cypress/e2e/security/noPermission.cy.ts
@@ -1,29 +1,89 @@
 /// <reference types="cypress" />
 import { HOST } from '../../common/constants';
 import { organizationNewTestData } from '../../common/apiCalls/testData/testData';
-import { login, setProperty } from '../../common/apiCalls/common';
-import { gcy } from '../../common/shared';
+import {
+  login,
+  setOrganizationCreationAllowed,
+} from '../../common/apiCalls/common';
+import {
+  assertSwitchedToOrganization,
+  gcy,
+  gcyAdvanced,
+} from '../../common/shared';
+import { waitForGlobalLoading } from '../../common/loading';
 
 context('No permission', () => {
   beforeEach(() => {
     organizationNewTestData.clean();
-    organizationNewTestData.generate();
-    setProperty('authentication.userCanCreateOrganizations', false);
+    organizationNewTestData.generateStandard();
+    setOrganizationCreationAllowed(false);
     login('milan');
   });
 
   afterEach(() => {
+    setOrganizationCreationAllowed(true);
     organizationNewTestData.clean();
   });
 
-  it('shows the no permission screen', () => {
+  it('sends a user without an organization to the community projects', () => {
     cy.visit(HOST);
-    cy.contains('No permission').should('be.visible');
+    cy.url().should('include', '/community-projects');
+    gcy('community-projects-view').should('be.visible');
+  });
+
+  it('shows the no permission screen where creating an organization is refused', () => {
+    cy.visit(`${HOST}/organizations/add`);
+    gcyAdvanced({
+      value: 'no-permissions-message',
+      reason: 'server-disallows',
+    }).should('be.visible');
   });
 
   it('creates the organization when property changes', () => {
-    setProperty('authentication.userCanCreateOrganizations', true);
+    setOrganizationCreationAllowed(true);
     cy.visit(HOST);
-    gcy('organization-switch').should('exist').should('contain', 'Milan');
+    assertSwitchedToOrganization('Milan');
+  });
+
+  it('offers the organization form where creating an organization is allowed', () => {
+    setOrganizationCreationAllowed(true);
+    cy.visit(HOST);
+    waitForGlobalLoading();
+
+    cy.visit(`${HOST}/organizations/add`);
+    waitForGlobalLoading();
+    gcy('no-permissions-message').should('not.exist');
+    gcy('global-form-save-button').should('be.visible');
+  });
+
+  it('creates an organization through the relocated route', () => {
+    setOrganizationCreationAllowed(true);
+
+    cy.visit(`${HOST}/organizations/add`);
+    waitForGlobalLoading();
+    gcy('organization-name-field').find('input').type('Milan Organization');
+    gcy('organization-address-part-field')
+      .find('input')
+      .should('not.have.value', '');
+
+    gcy('global-form-save-button').click();
+    waitForGlobalLoading();
+    assertSwitchedToOrganization('Milan Organization');
+  });
+
+  it('refuses the organization form to a member once creation is turned off', () => {
+    setOrganizationCreationAllowed(true);
+    cy.visit(HOST);
+    waitForGlobalLoading();
+    gcy('organization-switch').should('exist');
+
+    setOrganizationCreationAllowed(false);
+    cy.visit(`${HOST}/organizations/add`);
+    waitForGlobalLoading();
+    gcyAdvanced({
+      value: 'no-permissions-message',
+      reason: 'server-disallows',
+    }).should('be.visible');
+    gcy('global-form-save-button').should('not.exist');
   });
 });

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -298,6 +298,7 @@ declare namespace DataCy {
         "handlebars-editor": true;
         "handlebars-tooltip": true;
         "handlebars-tooltip-helper-description": true;
+        "help-menu-button": true;
         "import-conflict-resolution-dialog": true;
         "import-conflicts-not-resolved-dialog": true;
         "import-conflicts-not-resolved-dialog-cancel-button": true;
@@ -484,6 +485,7 @@ declare namespace DataCy {
         "namespaces-select-text-field": true;
         "namespaces-selector": true;
         "navigation-item": true;
+        "no-permissions-message": true;
         "notifications-button": true;
         "notifications-count": true;
         "notifications-empty-message": true;

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -254,7 +254,6 @@ declare namespace DataCy {
         "global-search-field": true;
         "global-search-field-clear": true;
         "global-user-menu-button": true;
-        "glossaries": true;
         "glossaries-empty-add-button": true;
         "glossaries-list-more-button": true;
         "glossary-batch-delete-button": true;
@@ -501,10 +500,12 @@ declare namespace DataCy {
         "order-translation-sharing-details-consent-checkbox": true;
         "order-translation-submit": true;
         "organization-address-part-field": true;
+        "organization-create-switching-message": true;
         "organization-description-field": true;
         "organization-invitation-cancel-button": true;
         "organization-invitation-copy-button": true;
         "organization-invitation-item": true;
+        "organization-load-failed-message": true;
         "organization-member-item": true;
         "organization-member-leave-button": true;
         "organization-members-remove-user-button": true;
@@ -542,7 +543,6 @@ declare namespace DataCy {
         "plan-limit-dialog-close": true;
         "plan-limit-exceeded-popover": true;
         "plan_seat_limit_exceeded_while_accepting_invitation_message": true;
-        "profile": true;
         "project-ai-prompt-dialog-description-input": true;
         "project-ai-prompt-dialog-save": true;
         "project-base-language-tm-conflict-confirm": true;
@@ -559,8 +559,8 @@ declare namespace DataCy {
         "project-contributor-item": true;
         "project-contributor-item-first-contribution": true;
         "project-contributor-item-last-contribution": true;
-        "project-create-no-organization-message": true;
         "project-create-no-permission-message": true;
+        "project-create-switching-message": true;
         "project-dashboard-activity-chart": true;
         "project-dashboard-activity-list": true;
         "project-dashboard-base-word-count": true;
@@ -733,6 +733,7 @@ declare namespace DataCy {
         "spending-limit-dialog-close": true;
         "spending-limit-exceeded-popover": true;
         "sso-migration-info-text": true;
+        "standard-form": true;
         "storage-add-item-button": true;
         "storage-form-azure-connection-string": true;
         "storage-form-azure-container-name": true;
@@ -883,7 +884,6 @@ declare namespace DataCy {
         "translation-label-add": true;
         "translation-label-control": true;
         "translation-label-delete": true;
-        "translation-memories": true;
         "translation-memories-empty-add-button": true;
         "translation-memories-list-more-button": true;
         "translation-memory-delete-button": true;

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -299,6 +299,7 @@ declare namespace DataCy {
         "handlebars-editor": true;
         "handlebars-tooltip": true;
         "handlebars-tooltip-helper-description": true;
+        "help-menu-button": true;
         "import-conflict-resolution-dialog": true;
         "import-conflicts-not-resolved-dialog": true;
         "import-conflicts-not-resolved-dialog-cancel-button": true;
@@ -485,6 +486,7 @@ declare namespace DataCy {
         "namespaces-select-text-field": true;
         "namespaces-selector": true;
         "navigation-item": true;
+        "no-permissions-message": true;
         "notifications-button": true;
         "notifications-count": true;
         "notifications-empty-message": true;
@@ -557,6 +559,8 @@ declare namespace DataCy {
         "project-contributor-item": true;
         "project-contributor-item-first-contribution": true;
         "project-contributor-item-last-contribution": true;
+        "project-create-no-organization-message": true;
+        "project-create-no-permission-message": true;
         "project-dashboard-activity-chart": true;
         "project-dashboard-activity-list": true;
         "project-dashboard-base-word-count": true;

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -553,6 +553,8 @@ declare namespace DataCy {
         "project-branch-merge-change": true;
         "project-branch-merge-delete-branch-checkbox": true;
         "project-branch-merge-detail": true;
+        "project-create-no-organization-message": true;
+        "project-create-no-permission-message": true;
         "project-dashboard-activity-chart": true;
         "project-dashboard-activity-list": true;
         "project-dashboard-base-word-count": true;

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/service/qa/QaEventListenerTest.kt
@@ -172,7 +172,7 @@ class QaEventListenerTest : AuthorizedControllerTest() {
   fun `auto-enables QA on project creation when org has feature`() {
     val project =
       executeInNewTransaction(platformTransactionManager) {
-        projectCreationService.createProject(
+        projectCreationService.createProjectWithoutAuthorization(
           CreateProjectRequest(
             name = "qa-auto-enable-test",
             organizationId = testData.userAccountBuilder.defaultOrganizationBuilder.self.id,
@@ -206,7 +206,7 @@ class QaEventListenerTest : AuthorizedControllerTest() {
 
     val project =
       executeInNewTransaction(platformTransactionManager) {
-        projectCreationService.createProject(
+        projectCreationService.createProjectWithoutAuthorization(
           CreateProjectRequest(
             name = "qa-no-auto-enable-test",
             organizationId = testData.userAccountBuilder.defaultOrganizationBuilder.self.id,

--- a/webapp/src/component/DashboardRouter.tsx
+++ b/webapp/src/component/DashboardRouter.tsx
@@ -1,0 +1,46 @@
+import { Redirect, Route, Switch } from 'react-router-dom';
+
+import { LINKS } from 'tg.constants/links';
+import { ProjectsRouter } from 'tg.views/projects/ProjectsRouter';
+import { CommunityProjectsView } from 'tg.views/projects/CommunityProjectsView';
+import { OrganizationsRouter } from 'tg.views/organizations/OrganizationsRouter';
+import { RootView } from 'tg.views/RootView';
+
+import { PrivateRoute } from './common/PrivateRoute';
+import { RequirePreferredOrganization } from './common/RequirePreferredOrganization';
+import { HelpMenu } from './HelpMenu';
+
+export const DashboardRouter = () => {
+  return (
+    <>
+      <Switch>
+        {/* Must stay above the gate: these are what a user with no preference
+            can reach, and ProjectContext is what then adopts one. */}
+        <PrivateRoute exact path={LINKS.PROJECTS.template}>
+          <Redirect to={LINKS.ROOT.template} />
+        </PrivateRoute>
+        <PrivateRoute path={LINKS.PROJECTS.template}>
+          <ProjectsRouter />
+        </PrivateRoute>
+        <PrivateRoute exact path={LINKS.COMMUNITY_PROJECTS.template}>
+          <CommunityProjectsView />
+        </PrivateRoute>
+
+        <Route>
+          <RequirePreferredOrganization>
+            <Switch>
+              <PrivateRoute exact path={LINKS.ROOT.template}>
+                <RootView />
+              </PrivateRoute>
+              <PrivateRoute path={LINKS.ORGANIZATIONS.template}>
+                <OrganizationsRouter />
+              </PrivateRoute>
+            </Switch>
+          </RequirePreferredOrganization>
+        </Route>
+      </Switch>
+
+      <HelpMenu />
+    </>
+  );
+};

--- a/webapp/src/component/DashboardRouter.tsx
+++ b/webapp/src/component/DashboardRouter.tsx
@@ -1,4 +1,4 @@
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Switch } from 'react-router-dom';
 
 import { LINKS } from 'tg.constants/links';
 import { ProjectsRouter } from 'tg.views/projects/ProjectsRouter';
@@ -6,18 +6,19 @@ import { CommunityProjectsView } from 'tg.views/projects/CommunityProjectsView';
 import { OrganizationsRouter } from 'tg.views/organizations/OrganizationsRouter';
 import { RootView } from 'tg.views/RootView';
 
-import { PrivateRoute } from './common/PrivateRoute';
-import { RequirePreferredOrganization } from './common/RequirePreferredOrganization';
-import { HelpMenu } from './HelpMenu';
+import { PrivateRoute } from 'tg.component/common/PrivateRoute';
+import { RequirePreferredOrganization } from 'tg.component/common/RequirePreferredOrganization';
+import { HelpMenu } from 'tg.component/HelpMenu';
+import { useIsEmailVerified } from 'tg.globalContext/helpers';
 
 export const DashboardRouter = () => {
+  const isEmailVerified = useIsEmailVerified();
+
   return (
     <>
       <Switch>
-        {/* Must stay above the gate: these are what a user with no preference
-            can reach, and ProjectContext is what then adopts one. */}
         <PrivateRoute exact path={LINKS.PROJECTS.template}>
-          <Redirect to={LINKS.ROOT.template} />
+          <Redirect to={LINKS.ROOT.build()} />
         </PrivateRoute>
         <PrivateRoute path={LINKS.PROJECTS.template}>
           <ProjectsRouter />
@@ -25,19 +26,20 @@ export const DashboardRouter = () => {
         <PrivateRoute exact path={LINKS.COMMUNITY_PROJECTS.template}>
           <CommunityProjectsView />
         </PrivateRoute>
-
-        <Route>
-          <RequirePreferredOrganization>
-            <Switch>
-              <PrivateRoute exact path={LINKS.ROOT.template}>
-                <RootView />
-              </PrivateRoute>
-              <PrivateRoute path={LINKS.ORGANIZATIONS.template}>
-                <OrganizationsRouter />
-              </PrivateRoute>
-            </Switch>
-          </RequirePreferredOrganization>
-        </Route>
+        <PrivateRoute exact path={LINKS.ROOT.template}>
+          {isEmailVerified ? (
+            <RequirePreferredOrganization
+              fallback={<Redirect to={LINKS.COMMUNITY_PROJECTS.build()} />}
+            >
+              <RootView />
+            </RequirePreferredOrganization>
+          ) : (
+            <RootView />
+          )}
+        </PrivateRoute>
+        <PrivateRoute path={LINKS.ORGANIZATIONS.template}>
+          <OrganizationsRouter />
+        </PrivateRoute>
       </Switch>
 
       <HelpMenu />

--- a/webapp/src/component/GoToBilling.tsx
+++ b/webapp/src/component/GoToBilling.tsx
@@ -1,5 +1,5 @@
 import { LINKS } from 'tg.constants/links';
-import { useGlobalContext } from 'tg.globalContext/GlobalContext';
+import { useBillingRefusal } from 'tg.globalContext/helpers';
 
 type Props = {
   render: (props: {
@@ -7,13 +7,19 @@ type Props = {
     rel: string;
     target: string;
   }) => React.ReactElement;
+  /** Rendered for a viewer who has an organization but may not act on its billing. */
+  fallback?: React.ReactNode;
 };
 
-export const GoToBilling = ({ render }: Props) => {
-  const billingEnabled = useGlobalContext(
-    (c) => c.initialData.serverConfiguration.billing.enabled
-  );
-  if (!billingEnabled) {
+export const GoToBilling = ({ render, fallback }: Props) => {
+  const refusal = useBillingRefusal();
+
+  if (refusal === 'billing-not-an-owner') {
+    return <>{fallback ?? null}</>;
+  }
+
+  // Anything else — billing off, or no organization at all — has nothing to say to this viewer.
+  if (refusal) {
     return null;
   }
   return render({

--- a/webapp/src/component/HelpMenu.tsx
+++ b/webapp/src/component/HelpMenu.tsx
@@ -25,7 +25,8 @@ import {
 } from '@untitled-ui/icons-react';
 import { T, useTranslate } from '@tolgee/react';
 
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import { useUser } from 'tg.globalContext/helpers';
+
 import { GitHub, Slack } from './CustomIcons';
 import { TranslationsShortcuts } from './shortcuts/TranslationsShortcuts';
 import { useChatwoot } from 'tg.hooks/useChatwoot';
@@ -41,7 +42,7 @@ const StyledHelpButton = styled('div')`
 
 export const HelpMenu = () => {
   const { t } = useTranslate();
-  const { preferredOrganization } = usePreferredOrganization();
+  const user = useUser();
   const { chatwootAvailable, openChatwoot } = useChatwoot();
   const { intercomAvailable, openIntercom } = useIntercom();
 
@@ -72,7 +73,7 @@ export const HelpMenu = () => {
     return { href: url, target: 'blank', rel: 'noreferrer noopener' };
   }
 
-  if (!preferredOrganization) {
+  if (!user) {
     return null;
   }
 
@@ -82,7 +83,11 @@ export const HelpMenu = () => {
         title={t('help_menu_tooltip')}
         PopperProps={{ placement: 'right' }}
       >
-        <StyledHelpButton onClick={handleOpen} id="help-button">
+        <StyledHelpButton
+          onClick={handleOpen}
+          id="help-button"
+          data-cy="help-menu-button"
+        >
           <Fab color="primary" size="small">
             <HelpCircle />
           </Fab>

--- a/webapp/src/component/MandatoryDataProvider.tsx
+++ b/webapp/src/component/MandatoryDataProvider.tsx
@@ -1,10 +1,13 @@
-import { useGlobalContext } from 'tg.globalContext/GlobalContext';
 import { useEffect, useSyncExternalStore } from 'react';
 import * as Sentry from '@sentry/react';
 import { useGlobalLoading } from './GlobalLoading';
 import { useIdentify } from 'tg.hooks/useIdentify';
 import { useQueryClient } from 'react-query';
-import { useConfig, useUser } from 'tg.globalContext/helpers';
+import {
+  useConfig,
+  useIsSwitchingOrganization,
+  useUser,
+} from 'tg.globalContext/helpers';
 import { usePosthogInit } from 'tg.hooks/usePosthog';
 import { usePlausible } from 'tg.hooks/plausible';
 import { CustomOptions } from 'tg.service/http/useQueryApi';
@@ -14,7 +17,7 @@ export const MandatoryDataProvider = (props: any) => {
   const config = useConfig();
 
   const queryClient = useQueryClient();
-  const isFetching = useGlobalContext((c) => c.initialData.isFetching);
+  const isSwitchingOrganization = useIsSwitchingOrganization();
 
   const isGloballyFetching = useSyncExternalStore(
     (onChange) => queryClient.getQueryCache().subscribe(onChange),
@@ -37,7 +40,7 @@ export const MandatoryDataProvider = (props: any) => {
   );
 
   useGlobalLoading(
-    Boolean(isGloballyFetching || isGloballyMutating || isFetching)
+    Boolean(isGloballyFetching || isGloballyMutating || isSwitchingOrganization)
   );
 
   useIdentify(userData?.id);

--- a/webapp/src/component/RootRouter.tsx
+++ b/webapp/src/component/RootRouter.tsx
@@ -1,19 +1,14 @@
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 
 import { LINKS } from 'tg.constants/links';
-import { ProjectsRouter } from 'tg.views/projects/ProjectsRouter';
-import { CommunityProjectsView } from 'tg.views/projects/CommunityProjectsView';
 import { UserSettingsRouter } from 'tg.views/userSettings/UserSettingsRouter';
-import { OrganizationsRouter } from 'tg.views/organizations/OrganizationsRouter';
 import { AdministrationView } from 'tg.views/administration/AdministrationView';
-import { RootView } from 'tg.views/RootView';
 import { routes } from 'tg.ee';
 
 import { PrivateRoute } from './common/PrivateRoute';
+import { DashboardRouter } from './DashboardRouter';
 import { OrganizationBillingRedirect } from './security/OrganizationBillingRedirect';
-import { RequirePreferredOrganization } from '../RequirePreferredOrganization';
-import { HelpMenu } from './HelpMenu';
 import { PublicOnlyRoute } from './common/PublicOnlyRoute';
 import { PreferredOrganizationRedirect } from './security/PreferredOrganizationRedirect';
 import { RecaptchaProvider } from 'tg.component/common/RecaptchaProvider';
@@ -96,30 +91,13 @@ export const RootRouter = () => {
         <PrivateRoute path={LINKS.USER_SETTINGS.template}>
           <UserSettingsRouter />
         </PrivateRoute>
-        <PrivateRoute path={`${LINKS.ADMINISTRATION.template}`}>
+        <PrivateRoute path={LINKS.ADMINISTRATION.template}>
           <AdministrationView />
         </PrivateRoute>
 
-        <RequirePreferredOrganization>
-          <Switch>
-            <PrivateRoute exact path={LINKS.ROOT.template}>
-              <RootView />
-            </PrivateRoute>
-            <PrivateRoute exact path={LINKS.PROJECTS.template}>
-              <Redirect to={LINKS.ROOT.template} />
-            </PrivateRoute>
-            <PrivateRoute path={LINKS.PROJECTS.template}>
-              <ProjectsRouter />
-            </PrivateRoute>
-            <PrivateRoute exact path={LINKS.COMMUNITY_PROJECTS.template}>
-              <CommunityProjectsView />
-            </PrivateRoute>
-            <PrivateRoute path={`${LINKS.ORGANIZATIONS.template}`}>
-              <OrganizationsRouter />
-            </PrivateRoute>
-          </Switch>
-          <HelpMenu />
-        </RequirePreferredOrganization>
+        <Route>
+          <DashboardRouter />
+        </Route>
       </Switch>
 
       <routes.Root />

--- a/webapp/src/component/RootRouter.tsx
+++ b/webapp/src/component/RootRouter.tsx
@@ -7,7 +7,7 @@ import { AdministrationView } from 'tg.views/administration/AdministrationView';
 import { routes } from 'tg.ee';
 
 import { PrivateRoute } from './common/PrivateRoute';
-import { DashboardRouter } from './DashboardRouter';
+import { DashboardRouter } from 'tg.component/DashboardRouter';
 import { OrganizationBillingRedirect } from './security/OrganizationBillingRedirect';
 import { PublicOnlyRoute } from './common/PublicOnlyRoute';
 import { PreferredOrganizationRedirect } from './security/PreferredOrganizationRedirect';

--- a/webapp/src/component/common/NoPermissionsView.tsx
+++ b/webapp/src/component/common/NoPermissionsView.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from 'react';
+import { Box } from '@mui/material';
+import { T, useTranslate } from '@tolgee/react';
+
+import { CompactView } from 'tg.component/layout/CompactView';
+import { TranslatedError } from 'tg.translationTools/TranslatedError';
+import { DashboardPage } from 'tg.component/layout/DashboardPage';
+import { DisplayedRefusal } from 'tg.fixtures/refusal';
+
+const MESSAGES: Record<DisplayedRefusal, ReactNode> = {
+  'no-organization': (
+    <T
+      keyName="no_organization_message"
+      defaultValue="You are not a member of any organization."
+    />
+  ),
+  'server-disallows': (
+    <T
+      keyName="organization_create_disallowed_message"
+      defaultValue="This server doesn't allow users to create organizations."
+    />
+  ),
+  sso: <TranslatedError code="sso_user_cannot_create_organization" />,
+  'billing-not-an-owner': (
+    <T
+      keyName="billing_requires_organization_owner"
+      defaultValue="Billing is only available to owners of the organization."
+    />
+  ),
+};
+
+type Props = {
+  reason: DisplayedRefusal;
+};
+
+export const NoPermissionsView = ({ reason }: Props) => {
+  const { t } = useTranslate();
+
+  return (
+    <DashboardPage>
+      <CompactView
+        primaryContent={
+          <Box data-cy="no-permissions-message" data-cy-reason={reason}>
+            {MESSAGES[reason]}
+          </Box>
+        }
+        title={
+          <T keyName="no-permissions-title" defaultValue="No permission" />
+        }
+        windowTitle={t('no-permissions-title', 'No permission')}
+      />
+    </DashboardPage>
+  );
+};

--- a/webapp/src/component/common/OrganizationLoadFailedView.tsx
+++ b/webapp/src/component/common/OrganizationLoadFailedView.tsx
@@ -1,0 +1,34 @@
+import { Box } from '@mui/material';
+import { T, useTranslate } from '@tolgee/react';
+
+import { CompactView } from 'tg.component/layout/CompactView';
+import { DashboardPage } from 'tg.component/layout/DashboardPage';
+
+export const OrganizationLoadFailedView = () => {
+  const { t } = useTranslate();
+
+  return (
+    <DashboardPage>
+      <CompactView
+        primaryContent={
+          <Box data-cy="organization-load-failed-message">
+            <T
+              keyName="organization_load_failed_message"
+              defaultValue="This organization could not be loaded. Please refresh the page to try again."
+            />
+          </Box>
+        }
+        title={
+          <T
+            keyName="organization_load_failed_title"
+            defaultValue="Could not load organization"
+          />
+        }
+        windowTitle={t(
+          'organization_load_failed_title',
+          'Could not load organization'
+        )}
+      />
+    </DashboardPage>
+  );
+};

--- a/webapp/src/component/common/RequireOrganizationAccess.tsx
+++ b/webapp/src/component/common/RequireOrganizationAccess.tsx
@@ -1,0 +1,44 @@
+import { Redirect } from 'react-router-dom';
+
+import { LINKS, PARAMS } from 'tg.constants/links';
+import {
+  canManageOrganization,
+  canViewOrganization,
+} from 'tg.fixtures/organizationRole';
+import { useIsAdminOrSupporter } from 'tg.globalContext/helpers';
+import { useOrganization } from 'tg.views/organizations/useOrganization';
+
+type Level = 'member' | 'manage';
+
+type Props = {
+  level: Level;
+};
+
+export const RequireOrganizationAccess: React.FC<
+  React.PropsWithChildren<Props>
+> = ({ level, children }) => {
+  const organization = useOrganization();
+  const isAdminOrSupporter = useIsAdminOrSupporter();
+
+  if (!organization) {
+    return null;
+  }
+
+  const role = organization.currentUserRole;
+  const permitted =
+    level === 'manage'
+      ? canManageOrganization(role, isAdminOrSupporter)
+      : canViewOrganization(role, isAdminOrSupporter);
+
+  if (!permitted) {
+    return (
+      <Redirect
+        to={LINKS.ORGANIZATION_PROFILE.build({
+          [PARAMS.ORGANIZATION_SLUG]: organization.slug,
+        })}
+      />
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/webapp/src/component/common/RequirePreferredOrganization.tsx
+++ b/webapp/src/component/common/RequirePreferredOrganization.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Box } from '@mui/material';
 import {
   useIsEmailVerified,
   usePreferredOrganization,
@@ -21,18 +22,21 @@ export const RequirePreferredOrganization: FC<
   if (!isEmailVerified) {
     return <>{props.children}</>;
   }
-  if (allowPrivate && !preferredOrganization && isFetching) {
-    return null;
-  }
+  const hasPrivateAccessWithoutOrganization =
+    allowPrivate && !preferredOrganization;
 
-  if (allowPrivate && !preferredOrganization && !isFetching) {
+  if (hasPrivateAccessWithoutOrganization) {
+    if (isFetching) {
+      return null;
+    }
+
     return (
       <DashboardPage>
         <CompactView
           primaryContent={
-            <>
+            <Box data-cy="no-permissions-message">
               <T keyName={'no-permissions-on-the-server'} />
-            </>
+            </Box>
           }
           title={<T keyName={'no-permissions-title'} />}
           windowTitle={t('no-permissions-title')}

--- a/webapp/src/component/common/RequirePreferredOrganization.tsx
+++ b/webapp/src/component/common/RequirePreferredOrganization.tsx
@@ -1,49 +1,24 @@
-import { FC } from 'react';
-import { Box } from '@mui/material';
-import {
-  useIsEmailVerified,
-  usePreferredOrganization,
-} from 'tg.globalContext/helpers';
-import { DashboardPage } from 'tg.component/layout/DashboardPage';
-import { CompactView } from 'tg.component/layout/CompactView';
-import { T, useTranslate } from '@tolgee/react';
-import { useGlobalContext } from 'tg.globalContext/GlobalContext';
+import { FC, ReactNode } from 'react';
+
+import { FullPageLoading } from 'tg.component/common/FullPageLoading';
+import { usePreferredOrganizationResolution } from 'tg.globalContext/helpers';
+
+type Props = {
+  fallback: ReactNode;
+};
 
 export const RequirePreferredOrganization: FC<
-  React.PropsWithChildren<unknown>
+  React.PropsWithChildren<Props>
 > = (props) => {
-  const allowPrivate = useGlobalContext((c) => c.auth.allowPrivate);
+  const resolution = usePreferredOrganizationResolution();
 
-  const { t } = useTranslate();
-
-  const { preferredOrganization, isFetching } = usePreferredOrganization();
-
-  const isEmailVerified = useIsEmailVerified();
-  if (!isEmailVerified) {
+  if (resolution.status === 'resolved') {
     return <>{props.children}</>;
   }
-  const hasPrivateAccessWithoutOrganization =
-    allowPrivate && !preferredOrganization;
 
-  if (hasPrivateAccessWithoutOrganization) {
-    if (isFetching) {
-      return null;
-    }
-
-    return (
-      <DashboardPage>
-        <CompactView
-          primaryContent={
-            <Box data-cy="no-permissions-message">
-              <T keyName={'no-permissions-on-the-server'} />
-            </Box>
-          }
-          title={<T keyName={'no-permissions-title'} />}
-          windowTitle={t('no-permissions-title')}
-        />
-      </DashboardPage>
-    );
+  if (resolution.status === 'resolving') {
+    return <FullPageLoading />;
   }
 
-  return <>{props.children}</>;
+  return <>{props.fallback}</>;
 };

--- a/webapp/src/component/common/form/StandardForm.tsx
+++ b/webapp/src/component/common/form/StandardForm.tsx
@@ -1,4 +1,4 @@
-import { default as React, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Box, Button, SxProps } from '@mui/material';
 import { SpinnerProgress } from 'tg.component/SpinnerProgress';
 import { T } from '@tolgee/react';
@@ -17,6 +17,25 @@ export interface LoadableType {
   error?: ApiError | null;
 }
 
+type BuiltInFooter = {
+  submitButtons?: undefined;
+  submitButtonInner?: ReactNode;
+  customActions?: ReactNode;
+  hideCancel?: boolean;
+};
+
+type FooterExclusivity =
+  | (BuiltInFooter & { submitDisabledReason?: ReactNode; disabled?: never })
+  | (BuiltInFooter & { submitDisabledReason?: never; disabled?: boolean })
+  | {
+      submitButtons: ReactNode;
+      submitDisabledReason?: never;
+      submitButtonInner?: never;
+      customActions?: never;
+      hideCancel?: never;
+      disabled?: never;
+    };
+
 interface FormPropsBase<T> {
   initialValues: T;
   onSubmit: (values: T, formikHelpers: FormikHelpers<T>) => void | Promise<any>;
@@ -30,25 +49,7 @@ interface FormPropsBase<T> {
   formId?: string;
 }
 
-type FooterProps =
-  | {
-      submitButtons?: undefined;
-      submitDisabledReason?: ReactNode;
-      submitButtonInner?: ReactNode;
-      customActions?: ReactNode;
-      hideCancel?: boolean;
-      disabled?: boolean;
-    }
-  | {
-      submitButtons: ReactNode;
-      submitDisabledReason?: never;
-      submitButtonInner?: never;
-      customActions?: never;
-      hideCancel?: never;
-      disabled?: never;
-    };
-
-type FormProps<T> = FormPropsBase<T> & FooterProps;
+type FormProps<T> = FormPropsBase<T> & FooterExclusivity;
 
 export function StandardForm<T extends FormikValues>({
   initialValues,
@@ -67,7 +68,7 @@ export function StandardForm<T extends FormikValues>({
     props.saveActionLoadable?.isLoading || props.saveActionLoadable?.loading;
 
   const submitBlocked = Boolean(
-    props.loading || disabled || submitDisabledReason
+    actionLoading || props.loading || disabled || submitDisabledReason
   );
 
   return (
@@ -81,6 +82,7 @@ export function StandardForm<T extends FormikValues>({
       <Formik
         initialValues={initialValues}
         onSubmit={(values, helpers) => {
+          // Enter and requestSubmit() submit without going through the disabled button
           if (submitBlocked) {
             helpers.setSubmitting(false);
             return;
@@ -97,7 +99,7 @@ export function StandardForm<T extends FormikValues>({
               : history.goBack();
 
           return (
-            <Form id={formId}>
+            <Form id={formId} data-cy="standard-form">
               {typeof props.children === 'function'
                 ? !props.loading && props.children(formikProps)
                 : props.children}
@@ -108,39 +110,37 @@ export function StandardForm<T extends FormikValues>({
               )}
               {props.submitButtons || (
                 <Box display="flex" justifyContent="flex-end" sx={rootSx}>
-                  <React.Fragment>
-                    {props.customActions && (
-                      <Box flexGrow={1}>{props.customActions}</Box>
+                  {props.customActions && (
+                    <Box flexGrow={1}>{props.customActions}</Box>
+                  )}
+                  <Box display="flex" alignItems="flex-end">
+                    {!hideCancel && (
+                      <Button
+                        data-cy="global-form-cancel-button"
+                        onClick={onCancel}
+                      >
+                        <T keyName="global_form_cancel" />
+                      </Button>
                     )}
-                    <Box display="flex" alignItems="flex-end">
-                      {!hideCancel && (
-                        <Button
-                          data-cy="global-form-cancel-button"
-                          onClick={onCancel}
-                        >
-                          <T keyName="global_form_cancel" />
-                        </Button>
-                      )}
-                      <Box ml={1}>
-                        <LoadingButton
-                          data-cy="global-form-save-button"
-                          loading={actionLoading}
-                          color="primary"
-                          variant="contained"
-                          disabled={submitBlocked}
-                          type="submit"
-                        >
-                          {props.submitButtonInner || (
-                            <T keyName="global_form_save" />
-                          )}
-                        </LoadingButton>
-                      </Box>
+                    <Box ml={1}>
+                      <LoadingButton
+                        data-cy="global-form-save-button"
+                        loading={actionLoading}
+                        color="primary"
+                        variant="contained"
+                        disabled={submitBlocked}
+                        type="submit"
+                      >
+                        {props.submitButtonInner || (
+                          <T keyName="global_form_save" />
+                        )}
+                      </LoadingButton>
                     </Box>
-                  </React.Fragment>
+                  </Box>
                 </Box>
               )}
               {props.loading && (
-                <Box justifyContent="cetner">
+                <Box display="flex" justifyContent="center">
                   <SpinnerProgress />
                 </Box>
               )}

--- a/webapp/src/component/common/form/StandardForm.tsx
+++ b/webapp/src/component/common/form/StandardForm.tsx
@@ -17,28 +17,44 @@ export interface LoadableType {
   error?: ApiError | null;
 }
 
-interface FormProps<T> {
+interface FormPropsBase<T> {
   initialValues: T;
   onSubmit: (values: T, formikHelpers: FormikHelpers<T>) => void | Promise<any>;
   onCancel?: (formikHelpers: FormikProps<T>) => void;
   loading?: boolean;
   validationSchema?: ObjectSchema<any>;
-  submitButtons?: ReactNode;
-  customActions?: ReactNode;
-  submitButtonInner?: ReactNode;
   saveActionLoadable?: LoadableType;
-  disabled?: boolean;
   children: ReactNode | ((formikProps: FormikProps<T>) => ReactNode);
   rootSx?: SxProps;
-  hideCancel?: boolean;
   showResourceError?: boolean;
   formId?: string;
 }
+
+type FooterProps =
+  | {
+      submitButtons?: undefined;
+      submitDisabledReason?: ReactNode;
+      submitButtonInner?: ReactNode;
+      customActions?: ReactNode;
+      hideCancel?: boolean;
+      disabled?: boolean;
+    }
+  | {
+      submitButtons: ReactNode;
+      submitDisabledReason?: never;
+      submitButtonInner?: never;
+      customActions?: never;
+      hideCancel?: never;
+      disabled?: never;
+    };
+
+type FormProps<T> = FormPropsBase<T> & FooterProps;
 
 export function StandardForm<T extends FormikValues>({
   initialValues,
   validationSchema,
   disabled,
+  submitDisabledReason,
   rootSx = { mb: 2 },
   hideCancel,
   showResourceError = true,
@@ -50,6 +66,10 @@ export function StandardForm<T extends FormikValues>({
   const actionLoading =
     props.saveActionLoadable?.isLoading || props.saveActionLoadable?.loading;
 
+  const submitBlocked = Boolean(
+    props.loading || disabled || submitDisabledReason
+  );
+
   return (
     <>
       {showResourceError &&
@@ -60,7 +80,13 @@ export function StandardForm<T extends FormikValues>({
 
       <Formik
         initialValues={initialValues}
-        onSubmit={props.onSubmit}
+        onSubmit={(values, helpers) => {
+          if (submitBlocked) {
+            helpers.setSubmitting(false);
+            return;
+          }
+          return props.onSubmit(values, helpers);
+        }}
         validationSchema={validationSchema}
         enableReinitialize
       >
@@ -75,6 +101,11 @@ export function StandardForm<T extends FormikValues>({
               {typeof props.children === 'function'
                 ? !props.loading && props.children(formikProps)
                 : props.children}
+              {submitDisabledReason && (
+                <Box display="flex" justifyContent="flex-end" sx={{ mb: 1 }}>
+                  {submitDisabledReason}
+                </Box>
+              )}
               {props.submitButtons || (
                 <Box display="flex" justifyContent="flex-end" sx={rootSx}>
                   <React.Fragment>
@@ -96,7 +127,7 @@ export function StandardForm<T extends FormikValues>({
                           loading={actionLoading}
                           color="primary"
                           variant="contained"
-                          disabled={props.loading || disabled}
+                          disabled={submitBlocked}
                           type="submit"
                         >
                           {props.submitButtonInner || (

--- a/webapp/src/component/common/useFeatureMissingExplanation.tsx
+++ b/webapp/src/component/common/useFeatureMissingExplanation.tsx
@@ -1,65 +1,50 @@
 import { useTranslate } from '@tolgee/react';
 import { LINKS } from 'tg.constants/links';
 import { useGlobalContext } from 'tg.globalContext/GlobalContext';
-import { useIsAdmin } from 'tg.globalContext/helpers';
+import {
+  useCanSeeBilling,
+  useIsAdmin,
+  useIsBillingEnabled,
+} from 'tg.globalContext/helpers';
 
 export function useFeatureMissingExplanation() {
   const subscription = useGlobalContext((c) => c.initialData.eeSubscription);
   const isAdmin = useIsAdmin();
-  const billingEnabled = useGlobalContext(
-    (c) => c.initialData.serverConfiguration.billing.enabled
-  );
-  const isOrganizationOwner = useGlobalContext(
-    (c) => c.initialData.preferredOrganization?.currentUserRole === 'OWNER'
-  );
+  const billingEnabled = useIsBillingEnabled();
+  const canSeeBilling = useCanSeeBilling();
 
   const { t } = useTranslate();
 
-  function ifAdmin<T>(value: T) {
-    if (isAdmin) {
-      return value;
-    } else {
-      return undefined;
-    }
-  }
+  const ifAdmin = <T,>(value: T) => (isAdmin ? value : undefined);
 
-  function ifOrgOwner<T>(value: T) {
-    if (isOrganizationOwner) {
-      return value;
-    } else {
-      return undefined;
-    }
-  }
+  const ifCanSeeBilling = <T,>(value: T) => (canSeeBilling ? value : undefined);
 
   if (billingEnabled) {
     return {
       message: t('feature-explanation-plan-not-sufficient'),
-      actionTitle: ifOrgOwner(t('feature-explanation-upgrade-subscription')),
-      link: ifOrgOwner(LINKS.GO_TO_CLOUD_BILLING.build()),
+      actionTitle: ifCanSeeBilling(
+        t('feature-explanation-upgrade-subscription')
+      ),
+      link: ifCanSeeBilling(LINKS.GO_TO_CLOUD_BILLING.build()),
     };
   }
 
-  if (subscription && subscription.status === 'ACTIVE') {
+  if (subscription) {
     return {
-      message: t('feature-explanation-license-not-sufficient'),
+      message:
+        subscription.status === 'ACTIVE'
+          ? t('feature-explanation-license-not-sufficient')
+          : t('feature-explanation-license-not-active'),
       actionTitle: ifAdmin(t('feature-explanation-check-license-action')),
       link: ifAdmin(LINKS.ADMINISTRATION_EE_LICENSE.build()),
     };
   }
 
-  if (subscription && subscription.status !== 'ACTIVE') {
-    return {
-      message: t('feature-explanation-license-not-active'),
-      actionTitle: ifAdmin(t('feature-explanation-check-license-action')),
-      link: ifAdmin(LINKS.ADMINISTRATION_EE_LICENSE.build()),
-    };
-  }
-
-  if (!subscription && isAdmin) {
+  if (isAdmin) {
     return {
       message: t('feature-explanation-no-license'),
-      actionTitle: ifAdmin(t('feature-explanation-setup-license')),
-      link: ifAdmin(LINKS.ADMINISTRATION_EE_LICENSE.build()),
+      actionTitle: t('feature-explanation-setup-license'),
+      link: LINKS.ADMINISTRATION_EE_LICENSE.build(),
     };
   }
 

--- a/webapp/src/component/layout/BaseFormView.tsx
+++ b/webapp/src/component/layout/BaseFormView.tsx
@@ -7,8 +7,6 @@ import { LoadableType, StandardForm } from '../common/form/StandardForm';
 import { BaseView, BaseViewProps } from './BaseView';
 
 interface BaseFormViewProps {
-  onInit?: () => Record<string, unknown>;
-  saving?: boolean;
   initialValues: Record<string, unknown>;
   onSubmit: (v: any) => void;
   onCancel?: () => void;
@@ -16,8 +14,9 @@ interface BaseFormViewProps {
   saveActionLoadable?: LoadableType;
   redirectAfter?: Link;
   customActions?: ReactNode;
-  submitButtons?: ReactNode;
   submitButtonInner?: ReactNode;
+  submitDisabledReason?: ReactNode;
+  disabled?: boolean;
   children?: ReactNode | ((formikProps: FormikProps<any>) => ReactNode);
 }
 
@@ -32,9 +31,10 @@ export const BaseFormView: FunctionComponent<
         onCancel={props.onCancel}
         validationSchema={props.validationSchema}
         customActions={props.customActions}
-        submitButtons={props.submitButtons}
         submitButtonInner={props.submitButtonInner}
         saveActionLoadable={props.saveActionLoadable}
+        submitDisabledReason={props.submitDisabledReason}
+        disabled={props.disabled}
       >
         {props.children}
       </StandardForm>

--- a/webapp/src/component/layout/BaseFormView.tsx
+++ b/webapp/src/component/layout/BaseFormView.tsx
@@ -2,27 +2,31 @@ import { FunctionComponent, ReactNode } from 'react';
 import { FormikProps } from 'formik';
 import { ObjectSchema } from 'yup';
 
-import { Link } from 'tg.constants/links';
 import { LoadableType, StandardForm } from '../common/form/StandardForm';
 import { BaseView, BaseViewProps } from './BaseView';
 
-interface BaseFormViewProps {
+type BaseFormViewProps = {
   initialValues: Record<string, unknown>;
   onSubmit: (v: any) => void;
   onCancel?: () => void;
   validationSchema: ObjectSchema<any>;
   saveActionLoadable?: LoadableType;
-  redirectAfter?: Link;
   customActions?: ReactNode;
   submitButtonInner?: ReactNode;
-  submitDisabledReason?: ReactNode;
-  disabled?: boolean;
   children?: ReactNode | ((formikProps: FormikProps<any>) => ReactNode);
-}
+} & (
+  | { submitDisabledReason?: ReactNode; disabled?: never }
+  | { submitDisabledReason?: never; disabled?: boolean }
+);
 
 export const BaseFormView: FunctionComponent<
   BaseFormViewProps & Omit<BaseViewProps, 'children'>
 > = (props) => {
+  const submitGate =
+    props.disabled === undefined
+      ? { submitDisabledReason: props.submitDisabledReason }
+      : { disabled: props.disabled };
+
   return (
     <BaseView {...props}>
       <StandardForm
@@ -33,8 +37,7 @@ export const BaseFormView: FunctionComponent<
         customActions={props.customActions}
         submitButtonInner={props.submitButtonInner}
         saveActionLoadable={props.saveActionLoadable}
-        submitDisabledReason={props.submitDisabledReason}
-        disabled={props.disabled}
+        {...submitGate}
       >
         {props.children}
       </StandardForm>

--- a/webapp/src/component/layout/BaseSettingsView/SettingsMenu.tsx
+++ b/webapp/src/component/layout/BaseSettingsView/SettingsMenu.tsx
@@ -8,7 +8,7 @@ const MenuList = styled('nav')`
 export type SettingsMenuItem = {
   link: string;
   label: string;
-  'data-cy'?: string;
+  dataCyItem?: string;
 };
 
 type Props = {
@@ -27,7 +27,7 @@ export const SettingsMenu: React.FC<React.PropsWithChildren<Props>> = ({
             matchAsPrefix={true}
             linkTo={item.link}
             text={item.label}
-            dataCyItem={item['data-cy']}
+            dataCyItem={item.dataCyItem}
           />
         ))}
       </MenuList>

--- a/webapp/src/component/layout/TopBar/announcements/useTrialInfo.ts
+++ b/webapp/src/component/layout/TopBar/announcements/useTrialInfo.ts
@@ -1,14 +1,15 @@
 import { usePreferredOrganization } from 'tg.globalContext/helpers';
-import { LINKS, PARAMS } from 'tg.constants/links';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 import { useRouteMatch } from 'react-router-dom';
+import { memberCloudSubscription } from 'tg.fixtures/organizationEntitlement';
 import { useTestClock } from 'tg.service/useTestClock';
 import { Theme, useMediaQuery } from '@mui/material';
 
 export const useTrialInfo = () => {
   const { preferredOrganization } = usePreferredOrganization();
 
-  const subscriptionsLink = LINKS.ORGANIZATION_SUBSCRIPTIONS.build({
-    [PARAMS.ORGANIZATION_SLUG]: preferredOrganization?.slug ?? '',
+  const subscriptionsLink = billingLinkFor({
+    slug: preferredOrganization?.slug ?? '',
   });
 
   const isCurrentSubscriptionPage = useRouteMatch(subscriptionsLink);
@@ -19,8 +20,9 @@ export const useTrialInfo = () => {
     theme.breakpoints.down('md')
   );
 
-  const activeCloudSubscription =
-    preferredOrganization?.activeCloudSubscription;
+  const activeCloudSubscription = memberCloudSubscription(
+    preferredOrganization
+  );
 
   const trialEnd = activeCloudSubscription?.trialEnd;
 

--- a/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
@@ -17,7 +17,6 @@ type Props = {
   anchorEl: HTMLElement;
   selected: OrganizationModel | undefined;
   onAddNew: () => void;
-  ownedOnly?: boolean;
   onCommunityNavigate?: () => void;
   communitySelected?: boolean;
 };
@@ -29,7 +28,6 @@ export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
   anchorEl,
   selected,
   onAddNew,
-  ownedOnly,
   onCommunityNavigate,
   communitySelected,
 }) => {
@@ -41,7 +39,7 @@ export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
     useIsAdmin() || config.userCanCreateOrganizations;
 
   const query = {
-    filterCurrentUserOwner: Boolean(ownedOnly),
+    filterCurrentUserOwner: false,
     search: search || undefined,
     size: 20,
     sort: ['name'],

--- a/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
@@ -5,7 +5,7 @@ import { OrganizationItem } from './OrganizationItem';
 import { CommunityTranslationItem } from './CommunityTranslationItem';
 import { components } from 'tg.service/apiSchema.generated';
 import { useApiInfiniteQuery } from 'tg.service/http/useQueryApi';
-import { useConfig, useIsAdmin } from 'tg.globalContext/helpers';
+import { useCanCreateOrganization } from 'tg.globalContext/helpers';
 import { SwitchPopover } from 'tg.component/SwitchPopover/SwitchPopover';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
@@ -15,10 +15,10 @@ type Props = {
   onClose: () => void;
   onSelect: (value: OrganizationModel) => void;
   anchorEl: HTMLElement;
-  selected: OrganizationModel | undefined;
+  selectedId?: number;
   onAddNew: () => void;
-  onCommunityNavigate?: () => void;
-  communitySelected?: boolean;
+  offersCommunityFooter: boolean;
+  onCommunity: () => void;
 };
 
 export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
@@ -26,20 +26,17 @@ export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
   onClose,
   onSelect,
   anchorEl,
-  selected,
+  selectedId,
   onAddNew,
-  onCommunityNavigate,
-  communitySelected,
+  offersCommunityFooter,
+  onCommunity,
 }) => {
   const { t } = useTranslate();
   const [search, setSearch] = useState('');
 
-  const config = useConfig();
-  const canCreateOrganizations =
-    useIsAdmin() || config.userCanCreateOrganizations;
+  const canCreateOrganizations = useCanCreateOrganization();
 
   const query = {
-    filterCurrentUserOwner: false,
     search: search || undefined,
     size: 20,
     sort: ['name'],
@@ -80,17 +77,13 @@ export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
     setSearch(value);
   }, []);
 
-  if (!selected) {
-    return null;
-  }
-
   return (
     <SwitchPopover
       open={open}
       onClose={onClose}
       onSelect={onSelect}
       anchorEl={anchorEl}
-      selectedId={communitySelected ? undefined : selected.id}
+      selectedId={selectedId}
       items={items || []}
       isLoading={organizationsLoadable.isFetching}
       hasNextPage={organizationsLoadable.hasNextPage ?? false}
@@ -103,10 +96,10 @@ export const OrganizationPopover: React.FC<React.PropsWithChildren<Props>> = ({
       onAddNew={canCreateOrganizations ? onAddNew : undefined}
       addNewTooltip={t('organizations_add_new')}
       footerAction={
-        onCommunityNavigate
+        offersCommunityFooter
           ? {
               content: <CommunityTranslationItem />,
-              onClick: onCommunityNavigate,
+              onClick: onCommunity,
               dataCyAction: 'organization-switch-community',
             }
           : undefined

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -65,11 +65,22 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
 
   const isCommunitySurface = selectedSurface === 'community';
 
+  if (!preferredOrganization) {
+    if (!isCommunitySurface) {
+      return null;
+    }
+    return (
+      <Box display="flex" overflow="hidden">
+        <CommunityTranslationItem />
+      </Box>
+    );
+  }
+
   const switchLabel = isCommunitySurface ? (
     <CommunityTranslationItem />
-  ) : preferredOrganization ? (
+  ) : (
     <OrganizationItem data={preferredOrganization} />
-  ) : null;
+  );
 
   return (
     <Box display="flex" data-cy="organization-switch" overflow="hidden">

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -7,15 +7,11 @@ import { OrganizationItem } from './OrganizationItem';
 import { CommunityTranslationItem } from './CommunityTranslationItem';
 import { useHistory } from 'react-router-dom';
 import { LINKS } from 'tg.constants/links';
-import {
-  useHasCommunityContributions,
-  usePreferredOrganization,
-} from 'tg.globalContext/helpers';
+import { usePreferredOrganization } from 'tg.globalContext/helpers';
 import { OrganizationPopover } from './OrganizationPopover';
+import { useOrganizationSwitchShape } from 'tg.component/organizationSwitch/useOrganizationSwitchShape';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
-
-export type SwitchSurface = 'organization' | 'community';
 
 const StyledLink = styled(Link, {
   shouldForwardProp: (prop) => prop !== 'plain',
@@ -30,20 +26,17 @@ const StyledLink = styled(Link, {
 
 type Props = {
   onSelect?: (organization: OrganizationModel) => void;
-  selectedSurface?: SwitchSurface;
   plain?: boolean;
 };
 
 export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
   onSelect,
-  selectedSurface = 'organization',
   plain,
 }) => {
   const anchorEl = useRef<HTMLAnchorElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const { preferredOrganization, updatePreferredOrganization } =
     usePreferredOrganization();
-  const hasCommunityContributions = useHasCommunityContributions();
   const history = useHistory();
 
   const handleClose = () => {
@@ -56,8 +49,9 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
 
   const handleSelectOrganization = async (organization: OrganizationModel) => {
     handleClose();
-    await updatePreferredOrganization(organization.id);
-    onSelect?.(organization);
+    if (await updatePreferredOrganization(organization.id)) {
+      onSelect?.(organization);
+    }
   };
 
   const handleCreateNewOrg = () => {
@@ -65,12 +59,18 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
     history.push(LINKS.ORGANIZATIONS_ADD.build());
   };
 
-  const isCommunitySurface = selectedSurface === 'community';
+  const handleCommunity = () => {
+    handleClose();
+    history.push(LINKS.COMMUNITY_PROJECTS.build());
+  };
 
-  if (!preferredOrganization) {
-    if (!isCommunitySurface) {
-      return null;
-    }
+  const shape = useOrganizationSwitchShape();
+
+  if (shape.render === 'hidden') {
+    return null;
+  }
+
+  if (shape.render === 'community-label') {
     return (
       <Box display="flex" overflow="hidden">
         <CommunityTranslationItem />
@@ -78,11 +78,14 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
     );
   }
 
-  const switchLabel = isCommunitySurface ? (
-    <CommunityTranslationItem />
-  ) : (
-    <OrganizationItem data={preferredOrganization} />
-  );
+  const switchLabel =
+    // `&& preferredOrganization` narrows for the compiler; the rule itself lives in
+    // organizationSwitchShape, which only answers 'organization' when there is one.
+    shape.label === 'organization' && preferredOrganization ? (
+      <OrganizationItem data={preferredOrganization} />
+    ) : (
+      <CommunityTranslationItem />
+    );
 
   return (
     <Box display="flex" data-cy="organization-switch" overflow="hidden">
@@ -94,16 +97,14 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
       <OrganizationPopover
         open={isOpen}
         onClose={handleClose}
-        selected={preferredOrganization}
+        selectedId={
+          shape.communitySelected ? undefined : preferredOrganization?.id
+        }
         onSelect={handleSelectOrganization}
         anchorEl={anchorEl.current!}
         onAddNew={handleCreateNewOrg}
-        communitySelected={isCommunitySurface}
-        onCommunityNavigate={
-          hasCommunityContributions
-            ? () => history.push(LINKS.COMMUNITY_PROJECTS.build())
-            : undefined
-        }
+        offersCommunityFooter={shape.offersCommunityFooter}
+        onCommunity={handleCommunity}
       />
     </Box>
   );

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -30,14 +30,12 @@ const StyledLink = styled(Link, {
 
 type Props = {
   onSelect?: (organization: OrganizationModel) => void;
-  ownedOnly?: boolean;
   selectedSurface?: SwitchSurface;
   plain?: boolean;
 };
 
 export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
   onSelect,
-  ownedOnly,
   selectedSurface = 'organization',
   plain,
 }) => {
@@ -69,11 +67,22 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
 
   const isCommunitySurface = selectedSurface === 'community';
 
+  if (!preferredOrganization) {
+    if (!isCommunitySurface) {
+      return null;
+    }
+    return (
+      <Box display="flex" overflow="hidden">
+        <CommunityTranslationItem />
+      </Box>
+    );
+  }
+
   const switchLabel = isCommunitySurface ? (
     <CommunityTranslationItem />
-  ) : preferredOrganization ? (
+  ) : (
     <OrganizationItem data={preferredOrganization} />
-  ) : null;
+  );
 
   return (
     <Box display="flex" data-cy="organization-switch" overflow="hidden">
@@ -83,7 +92,6 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
       </StyledLink>
 
       <OrganizationPopover
-        ownedOnly={ownedOnly}
         open={isOpen}
         onClose={handleClose}
         selected={preferredOrganization}

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -27,14 +27,12 @@ const StyledLink = styled(Link, {
 
 type Props = {
   onSelect?: (organization: OrganizationModel) => void;
-  ownedOnly?: boolean;
   selectedSurface?: SwitchSurface;
   plain?: boolean;
 };
 
 export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
   onSelect,
-  ownedOnly,
   selectedSurface = 'organization',
   plain,
 }) => {
@@ -90,7 +88,6 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
       </StyledLink>
 
       <OrganizationPopover
-        ownedOnly={ownedOnly}
         open={isOpen}
         onClose={handleClose}
         selected={preferredOrganization}

--- a/webapp/src/component/organizationSwitch/useIsCommunitySurface.ts
+++ b/webapp/src/component/organizationSwitch/useIsCommunitySurface.ts
@@ -1,0 +1,6 @@
+import { useRouteMatch } from 'react-router-dom';
+
+import { LINKS } from 'tg.constants/links';
+
+export const useIsCommunitySurface = () =>
+  Boolean(useRouteMatch(LINKS.COMMUNITY_PROJECTS.template));

--- a/webapp/src/component/organizationSwitch/useOrganizationSwitchShape.ts
+++ b/webapp/src/component/organizationSwitch/useOrganizationSwitchShape.ts
@@ -1,0 +1,26 @@
+import {
+  useCanCreateOrganization,
+  useHasCommunityContributions,
+  usePreferredOrganization,
+} from 'tg.globalContext/helpers';
+import { offersCommunityProjects } from 'tg.fixtures/communitySurface';
+import { organizationSwitchShape } from 'tg.fixtures/organizationSwitchShape';
+
+import { useIsCommunitySurface } from 'tg.component/organizationSwitch/useIsCommunitySurface';
+
+export const useOrganizationSwitchShape = () => {
+  const { preferredOrganization } = usePreferredOrganization();
+  const hasCommunityContributions = useHasCommunityContributions();
+  const canCreateOrganization = useCanCreateOrganization();
+  const isCommunitySurface = useIsCommunitySurface();
+
+  return organizationSwitchShape({
+    hasPreferredOrganization: Boolean(preferredOrganization),
+    isCommunitySurface,
+    canCreateOrganization,
+    showsCommunityProjects: offersCommunityProjects({
+      hasCommunityContributions,
+      organization: preferredOrganization,
+    }),
+  });
+};

--- a/webapp/src/component/security/OrganizationBillingRedirect.tsx
+++ b/webapp/src/component/security/OrganizationBillingRedirect.tsx
@@ -1,34 +1,41 @@
-import { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 
-import { LINKS, PARAMS } from 'tg.constants/links';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import { LINKS } from 'tg.constants/links';
 import { FullPageLoading } from 'tg.component/common/FullPageLoading';
+import {
+  useBillingRefusal,
+  usePreferredOrganizationResolution,
+} from 'tg.globalContext/helpers';
+import { NoPermissionsView } from 'tg.component/common/NoPermissionsView';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 
 type Props = {
   selfHosted: boolean;
 };
 
 export const OrganizationBillingRedirect = ({ selfHosted }: Props) => {
-  const { preferredOrganization } = usePreferredOrganization();
-  const history = useHistory();
+  const resolution = usePreferredOrganizationResolution();
+  const refusal = useBillingRefusal();
 
-  useEffect(() => {
-    if (preferredOrganization) {
-      if (selfHosted) {
-        history.replace(
-          LINKS.ORGANIZATION_SUBSCRIPTIONS_SELF_HOSTED_EE.build({
-            [PARAMS.ORGANIZATION_SLUG]: preferredOrganization.slug,
-          })
-        );
-      } else {
-        history.replace(
-          LINKS.ORGANIZATION_BILLING.build({
-            [PARAMS.ORGANIZATION_SLUG]: preferredOrganization.slug,
-          })
-        );
-      }
-    }
-  }, [preferredOrganization, selfHosted]);
-  return <FullPageLoading />;
+  if (resolution.status === 'resolving') {
+    return <FullPageLoading />;
+  }
+
+  if (resolution.status === 'missing') {
+    return <Redirect to={LINKS.COMMUNITY_PROJECTS.build()} />;
+  }
+
+  if (refusal === 'billing-disabled') {
+    return <Redirect to={LINKS.PROJECTS.build()} />;
+  }
+
+  if (refusal) {
+    return <NoPermissionsView reason={refusal} />;
+  }
+
+  return (
+    <Redirect
+      to={billingLinkFor({ slug: resolution.organization.slug, selfHosted })}
+    />
+  );
 };

--- a/webapp/src/component/security/PreferredOrganizationRedirect.tsx
+++ b/webapp/src/component/security/PreferredOrganizationRedirect.tsx
@@ -1,29 +1,30 @@
-import { useEffect } from 'react';
-import { useHistory, useLocation } from 'react-router-dom';
+import { Redirect, useLocation } from 'react-router-dom';
 
 import { LINKS, PARAMS } from 'tg.constants/links';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
-import { BoxLoading } from 'tg.component/common/BoxLoading';
+import { FullPageLoading } from 'tg.component/common/FullPageLoading';
+import { usePreferredOrganizationResolution } from 'tg.globalContext/helpers';
 
 export const PreferredOrganizationRedirect = () => {
-  const { preferredOrganization } = usePreferredOrganization();
-  const history = useHistory();
   const location = useLocation();
+  const resolution = usePreferredOrganizationResolution();
 
-  useEffect(() => {
-    if (preferredOrganization) {
-      const queryParameters = new URLSearchParams(location.search);
-      const path = queryParameters.get('path');
-      const fullPath = [
-        LINKS.ORGANIZATION.build({
-          [PARAMS.ORGANIZATION_SLUG]: preferredOrganization.slug,
-        }),
-        path,
-      ]
-        .filter(Boolean)
-        .join('/');
-      history.replace(fullPath);
-    }
-  }, [preferredOrganization]);
-  return <BoxLoading />;
+  if (resolution.status === 'resolving') {
+    return <FullPageLoading />;
+  }
+
+  if (resolution.status === 'missing') {
+    return <Redirect to={LINKS.COMMUNITY_PROJECTS.build()} />;
+  }
+
+  const path = new URLSearchParams(location.search).get('path');
+  const target = [
+    LINKS.ORGANIZATION.build({
+      [PARAMS.ORGANIZATION_SLUG]: resolution.organization.slug,
+    }),
+    path,
+  ]
+    .filter(Boolean)
+    .join('/');
+
+  return <Redirect to={target} />;
 };

--- a/webapp/src/component/security/UserMenu/OrganizationSwitch.tsx
+++ b/webapp/src/component/security/UserMenu/OrganizationSwitch.tsx
@@ -5,41 +5,48 @@ import { ArrowDropDown } from 'tg.component/CustomIcons';
 import { usePreferredOrganization } from 'tg.globalContext/helpers';
 import { components } from 'tg.service/apiSchema.generated';
 import { OrganizationPopover } from 'tg.component/organizationSwitch/OrganizationPopover';
+import { useOrganizationSwitchShape } from 'tg.component/organizationSwitch/useOrganizationSwitchShape';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
 
 type Props = {
   onSelect: (organization: OrganizationModel) => void;
   onCreateNew: () => void;
+  onCommunity: () => void;
 };
 
 export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
   onSelect,
   onCreateNew,
+  onCommunity,
 }) => {
   const anchorEl = useRef<any>(null);
   const [isOpen, setIsOpen] = useState(false);
   const { preferredOrganization } = usePreferredOrganization();
+  const { offersCommunityFooter } = useOrganizationSwitchShape();
 
   const handleClose = () => setIsOpen(false);
 
   const handleSelectOrganization = (organization: OrganizationModel) => {
-    setIsOpen(false);
+    handleClose();
     onSelect(organization);
   };
 
   const handleCreateNewOrg = () => {
-    setIsOpen(false);
+    handleClose();
     onCreateNew();
   };
 
-  const handleMenuClick = (e) => {
-    if (isOpen) {
-      setIsOpen(false);
-    } else {
-      setIsOpen(true);
-    }
+  const handleCommunity = () => {
+    handleClose();
+    onCommunity();
   };
+
+  const handleMenuClick = () => setIsOpen((open) => !open);
+
+  if (!preferredOrganization) {
+    return null;
+  }
 
   return (
     <>
@@ -59,10 +66,12 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
       <OrganizationPopover
         open={isOpen}
         onClose={handleClose}
-        selected={preferredOrganization}
+        selectedId={preferredOrganization?.id}
         anchorEl={anchorEl.current}
         onSelect={handleSelectOrganization}
         onAddNew={handleCreateNewOrg}
+        offersCommunityFooter={offersCommunityFooter}
+        onCommunity={handleCommunity}
       />
     </>
   );

--- a/webapp/src/component/security/UserMenu/UserPresentAvatarMenu.tsx
+++ b/webapp/src/component/security/UserMenu/UserPresentAvatarMenu.tsx
@@ -69,13 +69,19 @@ export const UserPresentAvatarMenu: React.FC<
 
   const handleSelectOrganization = async (organization: OrganizationModel) => {
     setAnchorEl(null);
-    await updatePreferredOrganization(organization.id);
-    history.push(LINKS.PROJECTS.build());
+    if (await updatePreferredOrganization(organization.id)) {
+      history.push(LINKS.PROJECTS.build());
+    }
   };
 
   const handleCreateNewOrganization = () => {
     setAnchorEl(null);
     history.push(LINKS.ORGANIZATIONS_ADD.build());
+  };
+
+  const handleCommunityProjects = () => {
+    setAnchorEl(null);
+    history.push(LINKS.COMMUNITY_PROJECTS.build());
   };
 
   const getOrganizationMenuItems = () =>
@@ -162,6 +168,7 @@ export const UserPresentAvatarMenu: React.FC<
             <OrganizationSwitch
               onSelect={handleSelectOrganization}
               onCreateNew={handleCreateNewOrganization}
+              onCommunity={handleCommunityProjects}
             />
           </>
         )}

--- a/webapp/src/ee/billing/component/CriticalUsageCircle.tsx
+++ b/webapp/src/ee/billing/component/CriticalUsageCircle.tsx
@@ -4,13 +4,13 @@ import { Link } from 'react-router-dom';
 import { Box, keyframes, styled, Tooltip } from '@mui/material';
 
 import { CircularBillingProgress } from './CircularBillingProgress';
-import { LINKS, PARAMS } from 'tg.constants/links';
 import {
+  useBillingOrganization,
   useOrganizationUsage,
-  usePreferredOrganization,
 } from 'tg.globalContext/helpers';
 import { UsageDetailed } from './UsageDetailed';
 import { getProgressData } from './getProgressData';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 
 export const USAGE_ELEMENT_ID = 'billing_organization_usage';
 
@@ -56,8 +56,7 @@ const StyledTitle = styled('div')`
 `;
 
 export const CriticalUsageCircle: FC<React.PropsWithChildren<unknown>> = () => {
-  const { preferredOrganization } = usePreferredOrganization();
-  const { planLimitErrors } = useOrganizationUsage();
+  const { planLimitErrors, usage } = useOrganizationUsage();
 
   const previousShown = useRef(true);
   const firstRender = useRef(true);
@@ -75,10 +74,7 @@ export const CriticalUsageCircle: FC<React.PropsWithChildren<unknown>> = () => {
     firstRender.current = false;
   }, [planLimitErrors]);
 
-  const isOrganizationOwner =
-    preferredOrganization?.currentUserRole === 'OWNER';
-
-  const { usage } = useOrganizationUsage();
+  const billingOrganization = useBillingOrganization();
 
   const progressData = usage && getProgressData({ usage });
 
@@ -89,12 +85,8 @@ export const CriticalUsageCircle: FC<React.PropsWithChildren<unknown>> = () => {
   const OptionalLink: React.FC<React.PropsWithChildren<unknown>> = ({
     children,
   }) =>
-    isOrganizationOwner ? (
-      <Link
-        to={LINKS.ORGANIZATION_BILLING.build({
-          [PARAMS.ORGANIZATION_SLUG]: preferredOrganization.slug,
-        })}
-      >
+    billingOrganization ? (
+      <Link to={billingLinkFor({ slug: billingOrganization.slug })}>
         {children}
       </Link>
     ) : (

--- a/webapp/src/ee/billing/component/UserMenu/BillingMenuItem.tsx
+++ b/webapp/src/ee/billing/component/UserMenu/BillingMenuItem.tsx
@@ -2,13 +2,11 @@ import { Box, MenuItem } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { useTranslate } from '@tolgee/react';
 
-import { LINKS, PARAMS } from 'tg.constants/links';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 import { FC } from 'react';
 import {
-  useConfig,
+  useBillingOrganization,
   useOrganizationUsage,
-  usePreferredOrganization,
-  useUser,
 } from 'tg.globalContext/helpers';
 import { CircularBillingProgress } from '../CircularBillingProgress';
 import { BillingMenuItemsProps } from 'eeSetup/EeModuleType';
@@ -19,30 +17,18 @@ export const BillingMenuItem: FC<
 > = ({ onClose }) => {
   const { t } = useTranslate();
 
-  const { preferredOrganization } = usePreferredOrganization();
-
   const { usage } = useOrganizationUsage();
   const progressData = usage && getProgressData({ usage });
-  const config = useConfig();
-  const user = useUser()!;
+  const billingOrganization = useBillingOrganization();
 
-  const showBilling =
-    config.billing.enabled &&
-    preferredOrganization &&
-    (preferredOrganization?.currentUserRole === 'OWNER' ||
-      user.globalServerRole === 'ADMIN' ||
-      user.globalServerRole === 'SUPPORTER');
-
-  if (!showBilling) {
+  if (!billingOrganization) {
     return null;
   }
 
   return (
     <MenuItem
       component={Link}
-      to={LINKS.ORGANIZATION_SUBSCRIPTIONS.build({
-        [PARAMS.ORGANIZATION_SLUG]: preferredOrganization.slug,
-      })}
+      to={billingLinkFor({ slug: billingOrganization.slug })}
       onClick={onClose}
       data-cy="user-menu-organization-settings"
     >

--- a/webapp/src/ee/billing/component/topBar/TrialChipTooltip.tsx
+++ b/webapp/src/ee/billing/component/topBar/TrialChipTooltip.tsx
@@ -22,6 +22,7 @@ import { IncludedFeatures } from 'tg.ee.module/billing/component/Plan/IncludedFe
 import { IncludedUsage } from '../Plan/IncludedUsage';
 import { components } from 'tg.service/billingApiSchema.generated';
 import { Link } from 'react-router-dom';
+import { memberCloudSubscription } from 'tg.fixtures/organizationEntitlement';
 
 const CustomWidthTooltip = styled(({ className, ...props }: TooltipProps) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -45,7 +46,7 @@ export const TrialChipTooltip: FC<
 > = ({ children, onOpen, open, onClose }) => {
   const { preferredOrganization: organization } = usePreferredOrganization();
 
-  const activeSubscription = organization?.activeCloudSubscription;
+  const activeSubscription = memberCloudSubscription(organization);
 
   const { subscriptionsLink } = useTrialInfo();
 

--- a/webapp/src/ee/billing/limitPopover/PlanLimitPopoverCloud.tsx
+++ b/webapp/src/ee/billing/limitPopover/PlanLimitPopoverCloud.tsx
@@ -2,14 +2,14 @@ import { Button } from '@mui/material';
 import { T } from '@tolgee/react';
 import { useHistory } from 'react-router-dom';
 
-import { LINKS, PARAMS } from 'tg.constants/links';
 import {
+  useBillingOrganization,
   useOrganizationUsage,
-  usePreferredOrganization,
 } from 'tg.globalContext/helpers';
 import { getProgressData } from '../component/getProgressData';
 import { GenericPlanLimitPopover } from './generic/GenericPlanLimitPopover';
 import React from 'react';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 
 type Props = {
   onClose: () => void;
@@ -19,18 +19,16 @@ type Props = {
 export const PlanLimitPopoverCloud: React.FC<
   React.PropsWithChildren<Props>
 > = ({ open, onClose }) => {
-  const { preferredOrganization } = usePreferredOrganization();
   const { usage } = useOrganizationUsage();
-  const isOwner = preferredOrganization?.currentUserRole === 'OWNER';
+  const billingOrganization = useBillingOrganization();
   const history = useHistory();
 
   const handleConfirm = () => {
+    if (!billingOrganization) {
+      return;
+    }
     onClose();
-    history.push(
-      LINKS.ORGANIZATION_BILLING.build({
-        [PARAMS.ORGANIZATION_SLUG]: preferredOrganization!.slug,
-      })
-    );
+    history.push(billingLinkFor({ slug: billingOrganization.slug }));
   };
 
   const progressData = usage && getProgressData({ usage });
@@ -42,7 +40,7 @@ export const PlanLimitPopoverCloud: React.FC<
       isPayAsYouGo={usage?.isPayAsYouGo}
       progressData={progressData}
       actionButton={
-        isOwner && (
+        billingOrganization && (
           <Button
             data-cy="global-confirmation-confirm"
             color="primary"

--- a/webapp/src/ee/organizationApps/SlackApp.tsx
+++ b/webapp/src/ee/organizationApps/SlackApp.tsx
@@ -4,11 +4,16 @@ import { T } from '@tolgee/react';
 import { LINKS } from 'tg.constants/links';
 import { useApiMutation, useApiQuery } from 'tg.service/http/useQueryApi';
 import { useOrganization } from 'tg.views/organizations/useOrganization';
+import { canManageOrganization } from 'tg.fixtures/organizationRole';
 import { PrivateRoute } from 'tg.component/common/PrivateRoute';
 import { OrganizationSlackSuccessHandler } from 'tg.views/organizations/apps/slack/OrganizationSlackSuccessHandler';
 import { DisconnectButton } from 'tg.views/organizations/apps/slack/DisconnectButton';
 import LoadingButton from 'tg.component/common/form/LoadingButton';
-import { useConfig, useEnabledFeatures } from 'tg.globalContext/helpers';
+import {
+  useConfig,
+  useEnabledFeatures,
+  useIsAdmin,
+} from 'tg.globalContext/helpers';
 import { NotConfiguredBanner } from 'tg.views/organizations/apps/slack/NotConfiguredBanner';
 import { NoNeedToConnectBanner } from 'tg.views/organizations/apps/slack/NoNeedToConnectBanner';
 import { DisabledFeatureBanner } from 'tg.component/common/DisabledFeatureBanner';
@@ -62,6 +67,11 @@ const StyledTeamId = styled('div')`
 
 export const SlackApp = () => {
   const organization = useOrganization();
+  const isAdmin = useIsAdmin();
+  const canManageApps = canManageOrganization(
+    organization?.currentUserRole,
+    isAdmin
+  );
   const { isEnabled } = useEnabledFeatures();
   const featureNotEnabled = !isEnabled('SLACK_INTEGRATION');
   const config = useConfig();
@@ -121,7 +131,9 @@ export const SlackApp = () => {
               color="primary"
               variant="contained"
               loading={getUrlMutation.isLoading}
-              disabled={featureNotEnabled || !slackConfig.enabled}
+              disabled={
+                featureNotEnabled || !slackConfig.enabled || !canManageApps
+              }
             >
               <T keyName="organization_slack_connect_button" />
             </LoadingButton>
@@ -149,7 +161,7 @@ export const SlackApp = () => {
                 <div>{item.slackTeamName}</div>
                 <StyledTeamId>{item.slackTeamId}</StyledTeamId>
               </Box>
-              <DisconnectButton workspaceId={item.id} />
+              {canManageApps && <DisconnectButton workspaceId={item.id} />}
             </StyledItem>
           ))}
         </div>

--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -17,6 +17,7 @@ import { useGlobalContext } from '../globalContext/GlobalContext';
 import { useUserTasks } from '../globalContext/useUserTasks';
 import { AdministrationEeLicenseView } from 'tg.ee.module/billing/administration/AdministrationEeLicenseView';
 import { SlackApp } from '../ee/organizationApps/SlackApp';
+import { RequireOrganizationAccess } from 'tg.component/common/RequireOrganizationAccess';
 import {
   useConfig,
   useEnabledFeatures,
@@ -135,16 +136,36 @@ export const routes = {
   ),
   Organization: () => {
     const config = useConfig();
+    // billingModule.OrganizationRoutes has no path of its own: a redirecting guard wrapped around
+    // it fires on every organization URL.
+    const onManageBillingRoute = Boolean(
+      useRouteMatch([
+        LINKS.ORGANIZATION_SUBSCRIPTIONS.template,
+        LINKS.ORGANIZATION_INVOICES.template,
+        LINKS.ORGANIZATION_BILLING.template,
+        LINKS.ORGANIZATION_BILLING_TEST_CLOCK_HELPER.template,
+      ])
+    );
     return (
       <>
         {config.llm.enabled && (
           <PrivateRoute path={LINKS.ORGANIZATION_LLM_PROVIDERS.template}>
-            <OrganizationLlmProvidersView />
+            <RequireOrganizationAccess level="manage">
+              <OrganizationLlmProvidersView />
+            </RequireOrganizationAccess>
           </PrivateRoute>
         )}
-        <billingModule.OrganizationRoutes />
+        {onManageBillingRoute ? (
+          <RequireOrganizationAccess level="manage">
+            <billingModule.OrganizationRoutes />
+          </RequireOrganizationAccess>
+        ) : (
+          <billingModule.OrganizationRoutes />
+        )}
         <PrivateRoute path={LINKS.ORGANIZATION_SSO.template}>
-          <OrganizationSsoView />
+          <RequireOrganizationAccess level="manage">
+            <OrganizationSsoView />
+          </RequireOrganizationAccess>
         </PrivateRoute>
         <PrivateRoute exact path={LINKS.ORGANIZATION_GLOSSARIES.template}>
           <GlossariesListView />
@@ -156,13 +177,17 @@ export const routes = {
           exact
           path={LINKS.ORGANIZATION_TRANSLATION_MEMORIES.template}
         >
-          <TranslationMemoriesListView />
+          <RequireOrganizationAccess level="member">
+            <TranslationMemoriesListView />
+          </RequireOrganizationAccess>
         </PrivateRoute>
         <PrivateRoute
           exact
           path={LINKS.ORGANIZATION_TRANSLATION_MEMORY.template}
         >
-          <TranslationMemoryView />
+          <RequireOrganizationAccess level="member">
+            <TranslationMemoryView />
+          </RequireOrganizationAccess>
         </PrivateRoute>
       </>
     );

--- a/webapp/src/fixtures/__tests__/billingAccess.test.ts
+++ b/webapp/src/fixtures/__tests__/billingAccess.test.ts
@@ -1,0 +1,115 @@
+import { billingRefusal, canSeeBilling } from 'tg.fixtures/billingAccess';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+const params = (over: Partial<Parameters<typeof canSeeBilling>[0]> = {}) => ({
+  billingEnabled: true,
+  isAdminOrSupporter: false,
+  organization: organization({ currentUserRole: 'OWNER' }),
+  ...over,
+});
+
+describe('canSeeBilling', () => {
+  it('refuses everyone when billing is disabled', () => {
+    expect(canSeeBilling(params({ billingEnabled: false }))).toBe(false);
+    expect(
+      canSeeBilling(params({ billingEnabled: false, isAdminOrSupporter: true }))
+    ).toBe(false);
+  });
+
+  it('accepts the owner of the preferred organization', () => {
+    expect(canSeeBilling(params())).toBe(true);
+  });
+
+  it('refuses members and maintainers', () => {
+    expect(
+      canSeeBilling(
+        params({ organization: organization({ currentUserRole: 'MEMBER' }) })
+      )
+    ).toBe(false);
+    expect(
+      canSeeBilling(
+        params({
+          organization: organization({ currentUserRole: 'MAINTAINER' }),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('refuses a viewer of an adopted organization they hold no role in', () => {
+    expect(
+      canSeeBilling(
+        params({
+          organization: organization({
+            limitedView: true,
+            currentUserRole: undefined,
+          }),
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('refuses an admin who has no organization, since there is no billing to open', () => {
+    expect(
+      canSeeBilling(
+        params({ isAdminOrSupporter: true, organization: undefined })
+      )
+    ).toBe(false);
+  });
+
+  it('accepts admins and supporters regardless of role', () => {
+    expect(
+      canSeeBilling(
+        params({
+          isAdminOrSupporter: true,
+          organization: organization({ currentUserRole: undefined }),
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('refuses when there is no organization at all', () => {
+    expect(canSeeBilling(params({ organization: undefined }))).toBe(false);
+  });
+});
+
+describe('billingRefusal', () => {
+  const params = (over = {}) => ({
+    billingEnabled: true,
+    isAdminOrSupporter: false,
+    organization: organization({ currentUserRole: 'OWNER' }),
+    ...over,
+  });
+
+  it('names the server setting before anything about the viewer', () => {
+    expect(
+      billingRefusal(params({ billingEnabled: false, organization: undefined }))
+    ).toBe('billing-disabled');
+  });
+
+  it('names the missing organization, so every denial can explain itself', () => {
+    expect(billingRefusal(params({ organization: undefined }))).toBe(
+      'no-organization'
+    );
+    expect(canSeeBilling(params({ organization: undefined }))).toBe(false);
+  });
+
+  it('names the role when the viewer has an organization they do not own', () => {
+    expect(
+      billingRefusal(
+        params({ organization: organization({ currentUserRole: 'MEMBER' }) })
+      )
+    ).toBe('billing-not-an-owner');
+  });
+
+  it('refuses nothing to an owner or an admin', () => {
+    expect(billingRefusal(params())).toBeUndefined();
+    expect(
+      billingRefusal(
+        params({
+          isAdminOrSupporter: true,
+          organization: organization({ currentUserRole: undefined }),
+        })
+      )
+    ).toBeUndefined();
+  });
+});

--- a/webapp/src/fixtures/__tests__/billingLink.test.ts
+++ b/webapp/src/fixtures/__tests__/billingLink.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { billingLinkFor } from 'tg.fixtures/billingLink';
+
+describe('billingLinkFor', () => {
+  it('sends a cloud organization straight to the page that sells plans', () => {
+    expect(billingLinkFor({ slug: 'acme-inc' })).toBe(
+      '/organizations/acme-inc/subscriptions'
+    );
+  });
+
+  it('sends a self-hosted organization to its self-hosted subscriptions page', () => {
+    expect(billingLinkFor({ slug: 'acme-inc', selfHosted: true })).toBe(
+      '/organizations/acme-inc/subscriptions/self-hosted-ee'
+    );
+  });
+});

--- a/webapp/src/fixtures/__tests__/chatwootOrganizationPayload.test.ts
+++ b/webapp/src/fixtures/__tests__/chatwootOrganizationPayload.test.ts
@@ -1,0 +1,43 @@
+import { chatwootOrganizationPayload } from 'tg.fixtures/chatwootOrganizationPayload';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+const subscription = () =>
+  ({
+    plan: { name: 'Premium' },
+    status: 'ACTIVE',
+  } as any);
+
+describe('chatwootOrganizationPayload', () => {
+  it('reports the plan a member is on', () => {
+    const payload = chatwootOrganizationPayload(
+      organization({
+        currentUserRole: 'MEMBER',
+        activeCloudSubscription: subscription(),
+      })
+    );
+
+    expect(payload.plan).toBe('Premium');
+    expect(payload.subscriptionStatus).toBe('ACTIVE');
+    expect(payload.organizationId).toBe(1);
+  });
+
+  it('withholds a subscription the viewer is not a member of', () => {
+    const payload = chatwootOrganizationPayload(
+      organization({
+        currentUserRole: undefined,
+        activeCloudSubscription: subscription(),
+      })
+    );
+
+    expect(payload.plan).toBe('free');
+    expect(payload.subscriptionStatus).toBe('inactive');
+    expect(payload.organizationName).toBe('Org');
+  });
+
+  it('passes the viewer role through', () => {
+    expect(
+      chatwootOrganizationPayload(organization({ currentUserRole: 'OWNER' }))
+        .currentUserRole
+    ).toBe('OWNER');
+  });
+});

--- a/webapp/src/fixtures/__tests__/chatwootSession.test.ts
+++ b/webapp/src/fixtures/__tests__/chatwootSession.test.ts
@@ -1,0 +1,148 @@
+import {
+  applyChatwootSession,
+  chatwootSessionAction,
+  openChatwootSession,
+} from 'tg.fixtures/chatwootSession';
+
+const freshSdk = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    sdk: {
+      setAttributes: (organization: number) =>
+        calls.push(`set:${organization}`),
+      reset: () => calls.push('reset'),
+    },
+  };
+};
+
+const step = (
+  identifiedUserId: number | undefined,
+  {
+    currentUserId,
+    organization,
+    canOpenSupportChat = organization !== undefined,
+  }: {
+    currentUserId?: number;
+    organization?: number;
+    canOpenSupportChat?: boolean;
+  },
+  sdk: ReturnType<typeof freshSdk>['sdk']
+) =>
+  applyChatwootSession(
+    chatwootSessionAction({
+      canOpenSupportChat,
+      identifiedUserId,
+      currentUserId,
+    }),
+    organization,
+    identifiedUserId,
+    sdk
+  );
+
+describe('applyChatwootSession', () => {
+  it('reports nothing when there is no organization to report', () => {
+    const { calls, sdk } = freshSdk();
+
+    expect(applyChatwootSession('set-attributes', undefined, 1, sdk)).toBe(1);
+    expect(calls).toEqual([]);
+  });
+
+  it('reports the current organization onto a session this user opened', () => {
+    const { calls, sdk } = freshSdk();
+    expect(step(1, { currentUserId: 1, organization: 10 }, sdk)).toBe(1);
+    expect(calls).toEqual(['set:10']);
+  });
+
+  it('clears the contact a different account left behind, and stops tracking it', () => {
+    const { calls, sdk } = freshSdk();
+    expect(
+      step(2, { currentUserId: 1, organization: 10 }, sdk)
+    ).toBeUndefined();
+    expect(calls).toEqual(['reset']);
+  });
+
+  it('clears the contact on logout', () => {
+    const { calls, sdk } = freshSdk();
+    expect(
+      step(1, { currentUserId: undefined, organization: 10 }, sdk)
+    ).toBeUndefined();
+    expect(calls).toEqual(['reset']);
+  });
+
+  it('leaves a conversation alone on an organization without support chat', () => {
+    const { calls, sdk } = freshSdk();
+    expect(
+      step(
+        1,
+        { currentUserId: 1, organization: 10, canOpenSupportChat: false },
+        sdk
+      )
+    ).toBe(1);
+    expect(calls).toEqual([]);
+  });
+
+  it('tells an entitled visitor nothing until they open the chat themselves', () => {
+    const { calls, sdk } = freshSdk();
+    expect(
+      step(undefined, { currentUserId: 1, organization: 10 }, sdk)
+    ).toBeUndefined();
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('openChatwootSession', () => {
+  const openSdk = () => {
+    const calls: string[] = [];
+    return {
+      calls,
+      sdk: {
+        reset: () => calls.push('reset'),
+        setUser: (user: number) => calls.push(`setUser:${user}`),
+        setAttributes: (organization: number) =>
+          calls.push(`set:${organization}`),
+        toggle: () => calls.push('toggle'),
+      },
+    };
+  };
+
+  it('clears the previous account before identifying this one, and tracks the new one', () => {
+    const { calls, sdk } = openSdk();
+    expect(
+      openChatwootSession(
+        'reset',
+        { user: 2, userId: 2, organization: 10 },
+        sdk
+      )
+    ).toBe(2);
+    expect(calls).toEqual(['reset', 'setUser:2', 'set:10', 'toggle']);
+  });
+
+  it('does not clear a session that already belongs to this user', () => {
+    const { calls, sdk } = openSdk();
+    openChatwootSession(
+      'set-attributes',
+      { user: 1, userId: 1, organization: 10 },
+      sdk
+    );
+    expect(calls).toEqual(['setUser:1', 'set:10', 'toggle']);
+  });
+
+  it('reports the organization the first time the visitor opens the chat themselves', () => {
+    const { calls, sdk } = openSdk();
+    expect(
+      openChatwootSession('none', { user: 1, userId: 1, organization: 10 }, sdk)
+    ).toBe(1);
+    expect(calls).toEqual(['setUser:1', 'set:10', 'toggle']);
+  });
+
+  it('opens without organization attributes when there is none to report', () => {
+    const { calls, sdk } = openSdk();
+    openChatwootSession(
+      'none',
+      { user: 1, userId: 1, organization: undefined },
+      sdk
+    );
+    expect(calls).toEqual(['setUser:1', 'toggle']);
+  });
+});

--- a/webapp/src/fixtures/__tests__/communitySurface.test.ts
+++ b/webapp/src/fixtures/__tests__/communitySurface.test.ts
@@ -1,0 +1,40 @@
+import { offersCommunityProjects } from 'tg.fixtures/communitySurface';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+describe('offersCommunityProjects', () => {
+  it('offers the list to a contributor whatever organization they are on', () => {
+    expect(
+      offersCommunityProjects({
+        hasCommunityContributions: true,
+        organization: organization({ limitedView: false }),
+      })
+    ).toBe(true);
+  });
+
+  it('offers the list while on an organization reached through its public projects', () => {
+    expect(
+      offersCommunityProjects({
+        hasCommunityContributions: false,
+        organization: organization({ limitedView: true }),
+      })
+    ).toBe(true);
+  });
+
+  it('does not offer the list to a member with no contributions', () => {
+    expect(
+      offersCommunityProjects({
+        hasCommunityContributions: false,
+        organization: organization({ limitedView: false }),
+      })
+    ).toBe(false);
+  });
+
+  it('does not offer the list to a viewer with no organization and no contributions', () => {
+    expect(
+      offersCommunityProjects({
+        hasCommunityContributions: false,
+        organization: undefined,
+      })
+    ).toBe(false);
+  });
+});

--- a/webapp/src/fixtures/__tests__/intercomCompanyPayload.test.ts
+++ b/webapp/src/fixtures/__tests__/intercomCompanyPayload.test.ts
@@ -1,0 +1,54 @@
+import { PrivateOrganizationModel } from 'tg.service/apiSchemaTypes.generated';
+import { intercomCompanyPayload } from 'tg.fixtures/intercomCompanyPayload';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+type CloudSubscription = NonNullable<
+  PrivateOrganizationModel['activeCloudSubscription']
+>;
+
+const subscription = (): CloudSubscription =>
+  ({
+    plan: { name: 'Premium' },
+    status: 'ACTIVE',
+  } as CloudSubscription);
+
+describe('intercomCompanyPayload', () => {
+  it('reports nothing for an organization the viewer only reaches through public projects', () => {
+    expect(
+      intercomCompanyPayload(
+        organization({
+          limitedView: true,
+          currentUserRole: undefined,
+          activeCloudSubscription: subscription(),
+        })
+      )
+    ).toBeUndefined();
+  });
+
+  it('maps an organization that has an active cloud subscription', () => {
+    expect(
+      intercomCompanyPayload(
+        organization({
+          id: 42,
+          name: 'Acme',
+          enabledFeatures: ['STANDARD_SUPPORT', 'TASKS'],
+          activeCloudSubscription: subscription(),
+        })
+      )
+    ).toEqual({
+      company_id: 42,
+      name: 'Acme',
+      plan: 'Premium',
+      subscriptionStatus: 'ACTIVE',
+      enabledFeatures: 'STANDARD_SUPPORT, TASKS',
+    });
+  });
+
+  it('reports no company for an organization without a cloud subscription', () => {
+    expect(intercomCompanyPayload(organization({}))).toBeUndefined();
+  });
+
+  it('reports no company for a viewer without any organization', () => {
+    expect(intercomCompanyPayload(undefined)).toBeUndefined();
+  });
+});

--- a/webapp/src/fixtures/__tests__/intercomSession.test.ts
+++ b/webapp/src/fixtures/__tests__/intercomSession.test.ts
@@ -1,0 +1,156 @@
+import {
+  applyIntercomSession,
+  IntercomTrackers,
+  intercomSessionAction,
+} from 'tg.fixtures/intercomSession';
+
+const action = (over: Partial<Parameters<typeof intercomSessionAction>[0]>) =>
+  intercomSessionAction({
+    canOpenSupportChat: false,
+    installed: false,
+    booted: false,
+    identityChanged: false,
+    ...over,
+  });
+
+describe('intercomSessionAction', () => {
+  it('installs the widget the first time support chat is available', () => {
+    expect(action({ canOpenSupportChat: true })).toBe('install');
+  });
+
+  it('boots a shut-down session rather than re-installing the widget', () => {
+    expect(action({ canOpenSupportChat: true, installed: true })).toBe('boot');
+  });
+
+  it('updates a live session instead of tearing it down and re-booting', () => {
+    expect(
+      action({ canOpenSupportChat: true, installed: true, booted: true })
+    ).toBe('update');
+  });
+
+  it('ends the first session before starting one for a different user', () => {
+    expect(
+      action({
+        canOpenSupportChat: true,
+        installed: true,
+        booted: true,
+        identityChanged: true,
+      })
+    ).toBe('reboot');
+  });
+
+  it('moves a live session to another company without discarding it', () => {
+    expect(
+      action({
+        canOpenSupportChat: true,
+        installed: true,
+        booted: true,
+      })
+    ).toBe('update');
+  });
+
+  it('shuts a live session down when support chat is withdrawn', () => {
+    expect(action({ installed: true, booted: true })).toBe('shutdown');
+  });
+
+  it('never boots a viewer without the entitlement, whose identity would then reach Intercom', () => {
+    expect(action({ canOpenSupportChat: false })).toBe('none');
+    expect(action({ canOpenSupportChat: false, installed: true })).toBe('none');
+  });
+
+  it('does nothing when there is no session to shut down', () => {
+    expect(action({ installed: true })).toBe('none');
+  });
+});
+
+type Settings = { company?: number };
+
+const freshSdk = () => {
+  const calls: string[] = [];
+  return {
+    calls,
+    sdk: {
+      install: () => calls.push('install'),
+      boot: () => calls.push('boot'),
+      update: () => calls.push('update'),
+      shutdown: () => calls.push('shutdown'),
+    },
+  };
+};
+
+const closed: IntercomTrackers = {
+  installed: false,
+  booted: false,
+  bootedFor: undefined,
+};
+
+const step = (
+  trackers: IntercomTrackers,
+  { userId, companyId }: { userId?: number; companyId?: number },
+  sdk: ReturnType<typeof freshSdk>['sdk']
+) => {
+  // Mirrors useIntercom: without a company there is nothing to attribute a session to.
+  const canOpenSupportChat = userId !== undefined && companyId !== undefined;
+  const action = intercomSessionAction({
+    canOpenSupportChat,
+    installed: trackers.installed,
+    booted: trackers.booted,
+    identityChanged: trackers.bootedFor !== userId,
+  });
+  return applyIntercomSession<Settings>(
+    action,
+    { settings: () => ({ company: companyId }), userId, companyId },
+    trackers,
+    sdk
+  );
+};
+
+describe('applyIntercomSession', () => {
+  it('walks a session through install, company switch, company loss, logout and remount', () => {
+    const { calls, sdk } = freshSdk();
+    let trackers = closed;
+
+    trackers = step(trackers, { userId: 1, companyId: 10 }, sdk);
+    expect(calls).toEqual(['install']);
+    expect(trackers).toEqual({
+      installed: true,
+      booted: true,
+      bootedFor: 1,
+    });
+
+    trackers = step(trackers, { userId: 1, companyId: 20 }, sdk);
+    expect(calls).toEqual(['install', 'update']);
+
+    // Losing the company withdraws the entitlement itself, so the session ends rather than reboots.
+    trackers = step(trackers, { userId: 1, companyId: undefined }, sdk);
+    expect(calls).toEqual(['install', 'update', 'shutdown']);
+
+    trackers = step(trackers, {}, sdk);
+    expect(calls.at(-1)).toBe('shutdown');
+    expect(trackers).toEqual({
+      installed: true,
+      booted: false,
+      bootedFor: undefined,
+      bootedCompany: undefined,
+    });
+
+    trackers = step(trackers, { userId: 2, companyId: 30 }, sdk);
+    expect(calls.at(-1)).toBe('boot');
+    expect(trackers.bootedFor).toBe(2);
+  });
+
+  it('ends the previous session before starting one for a different user', () => {
+    const { calls, sdk } = freshSdk();
+    let trackers = step(closed, { userId: 1, companyId: 10 }, sdk);
+    trackers = step(trackers, { userId: 2, companyId: 10 }, sdk);
+
+    expect(calls).toEqual(['install', 'shutdown', 'boot']);
+    expect(trackers.bootedFor).toBe(2);
+  });
+
+  it('does nothing when there is no session and no entitlement', () => {
+    const { calls, sdk } = freshSdk();
+    expect(step(closed, {}, sdk)).toEqual(closed);
+    expect(calls).toEqual([]);
+  });
+});

--- a/webapp/src/fixtures/__tests__/limitErrorCounters.test.ts
+++ b/webapp/src/fixtures/__tests__/limitErrorCounters.test.ts
@@ -1,0 +1,42 @@
+import {
+  limitErrorCounters,
+  noLimitErrors,
+} from 'tg.fixtures/limitErrorCounters';
+
+const after = (...events: Parameters<typeof limitErrorCounters>[1][]) =>
+  events.reduce(limitErrorCounters, noLimitErrors());
+
+describe('limitErrorCounters', () => {
+  it('counts each plan and spending limit error', () => {
+    expect(after({ kind: 'plan-limit' }, { kind: 'plan-limit' })).toMatchObject(
+      {
+        planLimitErrors: 2,
+        spendingLimitErrors: 0,
+      }
+    );
+    expect(after({ kind: 'spending-limit' })).toMatchObject({
+      spendingLimitErrors: 1,
+    });
+  });
+
+  it('reports a credit error once, however often it recurs', () => {
+    expect(
+      after(
+        { kind: 'credit-plan-limit' },
+        { kind: 'credit-plan-limit' },
+        { kind: 'credit-spending-limit' },
+        { kind: 'credit-spending-limit' }
+      )
+    ).toMatchObject({ planLimitErrors: 1, spendingLimitErrors: 1 });
+  });
+
+  it('drops counts from the organization the viewer just left', () => {
+    expect(
+      after(
+        { kind: 'plan-limit' },
+        { kind: 'spending-limit' },
+        { kind: 'organization-changed' }
+      )
+    ).toEqual(noLimitErrors());
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationCreation.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationCreation.test.ts
@@ -1,0 +1,112 @@
+import {
+  canCreateOrganization,
+  organizationCreationRefusal,
+} from 'tg.fixtures/organizationCreation';
+
+describe('canCreateOrganization', () => {
+  it('lets an admin create even through SSO on a server that forbids it', () => {
+    expect(
+      canCreateOrganization({
+        isAdmin: true,
+        thirdPartyAuthType: 'SSO',
+        userCanCreateOrganizations: false,
+      })
+    ).toBe(true);
+  });
+
+  it('refuses a non-admin SSO account even where the server allows creation', () => {
+    expect(
+      canCreateOrganization({
+        isAdmin: false,
+        thirdPartyAuthType: 'SSO',
+        userCanCreateOrganizations: true,
+      })
+    ).toBe(false);
+  });
+
+  it('lets a server-wide SSO account create, since only organization-wide SSO restricts it', () => {
+    expect(
+      canCreateOrganization({
+        isAdmin: false,
+        thirdPartyAuthType: 'SSO_GLOBAL',
+        userCanCreateOrganizations: true,
+      })
+    ).toBe(true);
+  });
+
+  it('does not refuse other third party accounts', () => {
+    expect(
+      canCreateOrganization({
+        isAdmin: false,
+        thirdPartyAuthType: 'GOOGLE',
+        userCanCreateOrganizations: true,
+      })
+    ).toBe(true);
+  });
+
+  it('follows the server property for a plain account', () => {
+    expect(
+      canCreateOrganization({
+        isAdmin: false,
+        thirdPartyAuthType: undefined,
+        userCanCreateOrganizations: true,
+      })
+    ).toBe(true);
+    expect(
+      canCreateOrganization({
+        isAdmin: false,
+        thirdPartyAuthType: undefined,
+        userCanCreateOrganizations: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('organizationCreationRefusal', () => {
+  it('reports the server property for a plain account', () => {
+    expect(
+      organizationCreationRefusal({
+        isAdmin: false,
+        thirdPartyAuthType: undefined,
+        userCanCreateOrganizations: false,
+      })
+    ).toBe('server-disallows');
+  });
+
+  it('reports SSO where the server would otherwise allow creation', () => {
+    expect(
+      organizationCreationRefusal({
+        isAdmin: false,
+        thirdPartyAuthType: 'SSO',
+        userCanCreateOrganizations: true,
+      })
+    ).toBe('sso');
+  });
+
+  it('reports the server property before SSO when both apply', () => {
+    expect(
+      organizationCreationRefusal({
+        isAdmin: false,
+        thirdPartyAuthType: 'SSO',
+        userCanCreateOrganizations: false,
+      })
+    ).toBe('server-disallows');
+  });
+
+  it('reports nothing for a viewer who may create', () => {
+    expect(
+      organizationCreationRefusal({
+        isAdmin: false,
+        thirdPartyAuthType: undefined,
+        userCanCreateOrganizations: true,
+      })
+    ).toBeUndefined();
+    expect(
+      organizationCreationRefusal({
+        isAdmin: true,
+        thirdPartyAuthType: 'SSO',
+        userCanCreateOrganizations: false,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
@@ -1,0 +1,100 @@
+import { components } from 'tg.service/apiSchema.generated';
+import {
+  organizationCompanyInfo,
+  organizationHasSupportChat,
+} from '../organizationEntitlement';
+
+type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
+type CloudSubscription = NonNullable<
+  PrivateOrganization['activeCloudSubscription']
+>;
+
+const organization = (
+  data: Partial<PrivateOrganization>
+): PrivateOrganization =>
+  ({
+    id: 1,
+    name: 'Org',
+    slug: 'org',
+    basePermissions: {},
+    enabledFeatures: [],
+    limitedView: false,
+    ...data,
+  } as PrivateOrganization);
+
+const subscription = (): CloudSubscription =>
+  ({
+    plan: { name: 'Premium' },
+    status: 'ACTIVE',
+  } as CloudSubscription);
+
+describe('organizationHasSupportChat', () => {
+  it('accepts either support tier', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['STANDARD_SUPPORT'] })
+      )
+    ).toBe(true);
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['PREMIUM_SUPPORT'] })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an organization with neither support tier', () => {
+    expect(organizationHasSupportChat(organization({}))).toBe(false);
+  });
+
+  it('rejects both support tiers on a limited-view organization', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          enabledFeatures: ['STANDARD_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          enabledFeatures: ['PREMIUM_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a viewer without any organization', () => {
+    expect(organizationHasSupportChat(undefined)).toBe(false);
+  });
+});
+
+describe('organizationCompanyInfo', () => {
+  it('maps an organization that has an active cloud subscription', () => {
+    expect(
+      organizationCompanyInfo(
+        organization({
+          id: 42,
+          name: 'Acme',
+          enabledFeatures: ['STANDARD_SUPPORT', 'TASKS'],
+          activeCloudSubscription: subscription(),
+        })
+      )
+    ).toEqual({
+      company_id: 42,
+      name: 'Acme',
+      plan: 'Premium',
+      subscriptionStatus: 'ACTIVE',
+      enabledFeatures: 'STANDARD_SUPPORT, TASKS',
+    });
+  });
+
+  it('returns null for an organization without a cloud subscription', () => {
+    expect(organizationCompanyInfo(organization({}))).toBeNull();
+  });
+
+  it('returns null for a viewer without any organization', () => {
+    expect(organizationCompanyInfo(undefined)).toBeNull();
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
@@ -2,7 +2,7 @@ import { components } from 'tg.service/apiSchema.generated';
 import {
   organizationCompanyInfo,
   organizationHasSupportChat,
-} from '../organizationEntitlement';
+} from 'tg.fixtures/organizationEntitlement';
 
 type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
 type CloudSubscription = NonNullable<

--- a/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
@@ -1,0 +1,100 @@
+import { components } from 'tg.service/apiSchema.generated';
+import {
+  organizationCompanyInfo,
+  organizationHasSupportChat,
+} from 'tg.fixtures/organizationEntitlement';
+
+type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
+type CloudSubscription = NonNullable<
+  PrivateOrganization['activeCloudSubscription']
+>;
+
+const organization = (
+  data: Partial<PrivateOrganization>
+): PrivateOrganization =>
+  ({
+    id: 1,
+    name: 'Org',
+    slug: 'org',
+    basePermissions: {},
+    enabledFeatures: [],
+    limitedView: false,
+    ...data,
+  } as PrivateOrganization);
+
+const subscription = (): CloudSubscription =>
+  ({
+    plan: { name: 'Premium' },
+    status: 'ACTIVE',
+  } as CloudSubscription);
+
+describe('organizationHasSupportChat', () => {
+  it('accepts either support tier', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['STANDARD_SUPPORT'] })
+      )
+    ).toBe(true);
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['PREMIUM_SUPPORT'] })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an organization with neither support tier', () => {
+    expect(organizationHasSupportChat(organization({}))).toBe(false);
+  });
+
+  it('rejects both support tiers on a limited-view organization', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          enabledFeatures: ['STANDARD_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          enabledFeatures: ['PREMIUM_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a viewer without any organization', () => {
+    expect(organizationHasSupportChat(undefined)).toBe(false);
+  });
+});
+
+describe('organizationCompanyInfo', () => {
+  it('maps an organization that has an active cloud subscription', () => {
+    expect(
+      organizationCompanyInfo(
+        organization({
+          id: 42,
+          name: 'Acme',
+          enabledFeatures: ['STANDARD_SUPPORT', 'TASKS'],
+          activeCloudSubscription: subscription(),
+        })
+      )
+    ).toEqual({
+      company_id: 42,
+      name: 'Acme',
+      plan: 'Premium',
+      subscriptionStatus: 'ACTIVE',
+      enabledFeatures: 'STANDARD_SUPPORT, TASKS',
+    });
+  });
+
+  it('returns null for an organization without a cloud subscription', () => {
+    expect(organizationCompanyInfo(organization({}))).toBeNull();
+  });
+
+  it('returns null for a viewer without any organization', () => {
+    expect(organizationCompanyInfo(undefined)).toBeNull();
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationEntitlement.test.ts
@@ -1,100 +1,56 @@
-import { components } from 'tg.service/apiSchema.generated';
 import {
-  organizationCompanyInfo,
-  organizationHasSupportChat,
+  organizationOwnedFeatures,
+  memberIsEntitledTo,
 } from 'tg.fixtures/organizationEntitlement';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
 
-type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
-type CloudSubscription = NonNullable<
-  PrivateOrganization['activeCloudSubscription']
->;
-
-const organization = (
-  data: Partial<PrivateOrganization>
-): PrivateOrganization =>
-  ({
-    id: 1,
-    name: 'Org',
-    slug: 'org',
-    basePermissions: {},
-    enabledFeatures: [],
-    limitedView: false,
-    ...data,
-  } as PrivateOrganization);
-
-const subscription = (): CloudSubscription =>
-  ({
-    plan: { name: 'Premium' },
-    status: 'ACTIVE',
-  } as CloudSubscription);
-
-describe('organizationHasSupportChat', () => {
-  it('accepts either support tier', () => {
-    expect(
-      organizationHasSupportChat(
-        organization({ enabledFeatures: ['STANDARD_SUPPORT'] })
-      )
-    ).toBe(true);
-    expect(
-      organizationHasSupportChat(
-        organization({ enabledFeatures: ['PREMIUM_SUPPORT'] })
-      )
-    ).toBe(true);
-  });
-
-  it('rejects an organization with neither support tier', () => {
-    expect(organizationHasSupportChat(organization({}))).toBe(false);
-  });
-
-  it('rejects both support tiers on a limited-view organization', () => {
-    expect(
-      organizationHasSupportChat(
-        organization({
-          limitedView: true,
-          enabledFeatures: ['STANDARD_SUPPORT'],
-        })
-      )
-    ).toBe(false);
-    expect(
-      organizationHasSupportChat(
-        organization({
-          limitedView: true,
-          enabledFeatures: ['PREMIUM_SUPPORT'],
-        })
-      )
-    ).toBe(false);
-  });
-
-  it('rejects a viewer without any organization', () => {
-    expect(organizationHasSupportChat(undefined)).toBe(false);
-  });
-});
-
-describe('organizationCompanyInfo', () => {
-  it('maps an organization that has an active cloud subscription', () => {
-    expect(
-      organizationCompanyInfo(
-        organization({
-          id: 42,
-          name: 'Acme',
-          enabledFeatures: ['STANDARD_SUPPORT', 'TASKS'],
-          activeCloudSubscription: subscription(),
-        })
-      )
-    ).toEqual({
-      company_id: 42,
-      name: 'Acme',
-      plan: 'Premium',
-      subscriptionStatus: 'ACTIVE',
-      enabledFeatures: 'STANDARD_SUPPORT, TASKS',
+describe('organizationOwnedFeatures vs memberIsEntitledTo', () => {
+  it('reports whatever features the payload carries, whatever the viewer role', () => {
+    const roleless = organization({
+      currentUserRole: undefined,
+      enabledFeatures: ['GLOSSARY'],
     });
+
+    expect(organizationOwnedFeatures(roleless)).toContain('GLOSSARY');
+    expect(memberIsEntitledTo(roleless, 'GLOSSARY')).toBe(false);
   });
 
-  it('returns null for an organization without a cloud subscription', () => {
-    expect(organizationCompanyInfo(organization({}))).toBeNull();
+  it("carries a limited-view organization's own features, but entitles the viewer to none", () => {
+    const limitedView = organization({
+      limitedView: true,
+      currentUserRole: undefined,
+      enabledFeatures: ['GLOSSARY'],
+    });
+
+    // A project inherits its organization's features whoever is browsing it, so the array is not
+    // redacted; membership is what `memberIsEntitledTo` answers, and there is none.
+    expect(organizationOwnedFeatures(limitedView)).toEqual(['GLOSSARY']);
+    expect(memberIsEntitledTo(limitedView, 'GLOSSARY')).toBe(false);
   });
 
-  it('returns null for a viewer without any organization', () => {
-    expect(organizationCompanyInfo(undefined)).toBeNull();
+  it('reports both for an organization the viewer belongs to', () => {
+    const own = organization({
+      enabledFeatures: ['GLOSSARY'],
+      currentUserRole: 'MEMBER',
+    });
+
+    expect(organizationOwnedFeatures(own)).toContain('GLOSSARY');
+    expect(memberIsEntitledTo(own, 'GLOSSARY')).toBe(true);
+  });
+
+  it('refuses the viewer entitlement to an admin reading a customer organization unlimited', () => {
+    const customer = organization({
+      enabledFeatures: ['GLOSSARY'],
+      limitedView: false,
+      currentUserRole: undefined,
+    });
+
+    expect(organizationOwnedFeatures(customer)).toContain('GLOSSARY');
+    expect(memberIsEntitledTo(customer, 'GLOSSARY')).toBe(false);
+  });
+
+  it('reports nothing without an organization', () => {
+    expect(organizationOwnedFeatures(undefined)).toEqual([]);
+    expect(memberIsEntitledTo(undefined, 'GLOSSARY')).toBe(false);
   });
 });

--- a/webapp/src/fixtures/__tests__/organizationRole.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationRole.test.ts
@@ -1,4 +1,4 @@
-import { isAtLeastMemberOrgRole } from '../organizationRole';
+import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
 
 describe('isAtLeastMemberOrgRole', () => {
   it('treats MEMBER and above as members', () => {

--- a/webapp/src/fixtures/__tests__/organizationRole.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationRole.test.ts
@@ -1,4 +1,8 @@
-import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
+import {
+  canManageOrganization,
+  isAtLeastMemberOrgRole,
+  isOwnerOrMaintainerOrgRole,
+} from 'tg.fixtures/organizationRole';
 
 describe('isAtLeastMemberOrgRole', () => {
   it('treats MEMBER and above as members', () => {
@@ -10,5 +14,39 @@ describe('isAtLeastMemberOrgRole', () => {
   it('does not treat a missing role as a member', () => {
     expect(isAtLeastMemberOrgRole(undefined)).toBe(false);
     expect(isAtLeastMemberOrgRole(null)).toBe(false);
+  });
+});
+
+describe('isOwnerOrMaintainerOrgRole', () => {
+  it('accepts OWNER and MAINTAINER', () => {
+    expect(isOwnerOrMaintainerOrgRole('OWNER')).toBe(true);
+    expect(isOwnerOrMaintainerOrgRole('MAINTAINER')).toBe(true);
+  });
+
+  it('rejects MEMBER', () => {
+    expect(isOwnerOrMaintainerOrgRole('MEMBER')).toBe(false);
+  });
+
+  it('rejects a missing role', () => {
+    expect(isOwnerOrMaintainerOrgRole(undefined)).toBe(false);
+    expect(isOwnerOrMaintainerOrgRole(null)).toBe(false);
+  });
+});
+
+describe('canManageOrganization', () => {
+  it('admits an owner of the organization', () => {
+    expect(canManageOrganization('OWNER', false)).toBe(true);
+  });
+
+  it('admits staff who hold no role in it', () => {
+    expect(canManageOrganization(undefined, true)).toBe(true);
+  });
+
+  it('refuses a plain member', () => {
+    expect(canManageOrganization('MEMBER', false)).toBe(false);
+  });
+
+  it('refuses a maintainer, who cannot reach owner-only settings', () => {
+    expect(canManageOrganization('MAINTAINER', false)).toBe(false);
   });
 });

--- a/webapp/src/fixtures/__tests__/organizationSettingsMenu.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationSettingsMenu.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { organizationSettingsMenu } from 'tg.fixtures/organizationSettingsMenu';
+
+const menu = (over: Partial<Parameters<typeof organizationSettingsMenu>[0]>) =>
+  organizationSettingsMenu({
+    canManage: false,
+    isAtLeastOrganizationMember: false,
+    llmEnabled: false,
+    billingEnabled: false,
+    internalControllerEnabled: false,
+    ...over,
+  });
+
+describe('organizationSettingsMenu', () => {
+  it('offers a viewer with no role only the profile and the glossaries', () => {
+    expect(menu({})).toEqual(['profile', 'glossaries']);
+  });
+
+  it('adds translation memories for a member without hinting at management', () => {
+    expect(menu({ isAtLeastOrganizationMember: true })).toEqual([
+      'profile',
+      'glossaries',
+      'translation-memories',
+    ]);
+  });
+
+  it('keeps the members pages ahead of the glossaries for a manager', () => {
+    expect(menu({ canManage: true })).toEqual([
+      'profile',
+      'members',
+      'member-privileges',
+      'glossaries',
+      'apps',
+      'sso',
+    ]);
+  });
+
+  it('withholds every manage-only page from a member, whatever the server enables', () => {
+    expect(
+      menu({
+        isAtLeastOrganizationMember: true,
+        llmEnabled: true,
+        billingEnabled: true,
+        internalControllerEnabled: true,
+      })
+    ).toEqual(['profile', 'glossaries', 'translation-memories']);
+  });
+
+  it('offers the LLM providers only where the server runs them', () => {
+    expect(menu({ canManage: true, llmEnabled: true })).toContain(
+      'llm-providers'
+    );
+    expect(menu({ canManage: true })).not.toContain('llm-providers');
+  });
+
+  it('offers the billing pages only where billing is enabled', () => {
+    expect(menu({ canManage: true, billingEnabled: true })).toEqual([
+      'profile',
+      'members',
+      'member-privileges',
+      'glossaries',
+      'apps',
+      'sso',
+      'subscriptions',
+      'invoices',
+    ]);
+  });
+
+  it('hides the test-clock helper unless the internal controller is on, and never without billing', () => {
+    expect(
+      menu({
+        canManage: true,
+        billingEnabled: true,
+        internalControllerEnabled: true,
+      })
+    ).toContain('billing-test-clock');
+    expect(
+      menu({ canManage: true, internalControllerEnabled: true })
+    ).not.toContain('billing-test-clock');
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationSwitchShape.test.ts
+++ b/webapp/src/fixtures/__tests__/organizationSwitchShape.test.ts
@@ -1,0 +1,78 @@
+import { organizationSwitchShape } from 'tg.fixtures/organizationSwitchShape';
+
+const shape = (over: Partial<Parameters<typeof organizationSwitchShape>[0]>) =>
+  organizationSwitchShape({
+    hasPreferredOrganization: false,
+    isCommunitySurface: false,
+    canCreateOrganization: false,
+    showsCommunityProjects: false,
+    ...over,
+  });
+
+describe('organizationSwitchShape', () => {
+  it('names the preferred organization on an organization surface', () => {
+    expect(shape({ hasPreferredOrganization: true })).toEqual({
+      render: 'switch',
+      label: 'organization',
+      offersCommunityFooter: false,
+      communitySelected: false,
+    });
+  });
+
+  it('hides itself entirely for a viewer with no organization outside the community surface', () => {
+    expect(shape({}).render).toBe('hidden');
+  });
+
+  it('offers the community footer from an organization, not from the community surface', () => {
+    expect(
+      shape({ hasPreferredOrganization: true, showsCommunityProjects: true })
+    ).toEqual({
+      render: 'switch',
+      label: 'organization',
+      offersCommunityFooter: true,
+      communitySelected: false,
+    });
+  });
+
+  it('offers the switch when the only thing to do is create an organization', () => {
+    expect(
+      shape({ isCommunitySurface: true, canCreateOrganization: true }).render
+    ).toBe('switch');
+  });
+
+  it('falls back to an inert label when the popover would have nothing to offer', () => {
+    expect(shape({ isCommunitySurface: true })).toEqual({
+      render: 'community-label',
+      offersCommunityFooter: false,
+      communitySelected: true,
+    });
+  });
+
+  it('stays inert for an org-less viewer already on the community surface', () => {
+    // Its only action would navigate to the page they are already on, so there is no popover worth
+    // opening — the same outcome as having no community projects at all.
+    expect(
+      shape({
+        hasPreferredOrganization: false,
+        isCommunitySurface: true,
+        canCreateOrganization: false,
+        showsCommunityProjects: true,
+      })
+    ).toEqual({
+      render: 'community-label',
+      offersCommunityFooter: false,
+      communitySelected: true,
+    });
+  });
+
+  it('keeps the community label on the community surface even with an organization', () => {
+    expect(
+      shape({ hasPreferredOrganization: true, isCommunitySurface: true })
+    ).toEqual({
+      render: 'switch',
+      label: 'community',
+      offersCommunityFooter: false,
+      communitySelected: true,
+    });
+  });
+});

--- a/webapp/src/fixtures/__tests__/organizationTestData.ts
+++ b/webapp/src/fixtures/__tests__/organizationTestData.ts
@@ -1,0 +1,14 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+
+export const organization = (
+  data: Partial<ContextOrganizationModel> = {}
+): ContextOrganizationModel => ({
+  id: 1,
+  name: 'Org',
+  slug: 'org',
+  basePermissions: { scopes: [] },
+  enabledFeatures: [],
+  limitedView: false,
+  currentUserRole: 'MEMBER',
+  ...data,
+});

--- a/webapp/src/fixtures/__tests__/preferredOrganizationResolution.test.ts
+++ b/webapp/src/fixtures/__tests__/preferredOrganizationResolution.test.ts
@@ -1,0 +1,33 @@
+import { preferredOrganizationResolution } from 'tg.fixtures/preferredOrganizationResolution';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+describe('preferredOrganizationResolution', () => {
+  it('resolves to the organization the viewer already has', () => {
+    const preferred = organization({ id: 7 });
+
+    expect(
+      preferredOrganizationResolution({
+        organization: preferred,
+        isSwitching: false,
+      })
+    ).toEqual({ status: 'resolved', organization: preferred });
+  });
+
+  it('holds while a switch is still in flight, rather than reporting none', () => {
+    expect(
+      preferredOrganizationResolution({
+        organization: undefined,
+        isSwitching: true,
+      })
+    ).toEqual({ status: 'resolving' });
+  });
+
+  it('reports none once nothing is in flight to produce one', () => {
+    expect(
+      preferredOrganizationResolution({
+        organization: undefined,
+        isSwitching: false,
+      })
+    ).toEqual({ status: 'missing' });
+  });
+});

--- a/webapp/src/fixtures/__tests__/projectCreation.test.ts
+++ b/webapp/src/fixtures/__tests__/projectCreation.test.ts
@@ -1,0 +1,82 @@
+import { OrganizationRole } from 'tg.fixtures/organizationRole';
+import {
+  canCreateProject,
+  projectCreationRefusal,
+} from 'tg.fixtures/projectCreation';
+import { organization as buildOrganization } from 'tg.fixtures/__tests__/organizationTestData';
+
+const organization = (currentUserRole: OrganizationRole) =>
+  buildOrganization({ currentUserRole });
+
+describe('canCreateProject', () => {
+  it('lets a server admin create in an organization they have no role in', () => {
+    expect(
+      canCreateProject({ isAdmin: true, organization: organization(undefined) })
+    ).toBe(true);
+  });
+
+  it('refuses a server admin with no organization at all', () => {
+    expect(canCreateProject({ isAdmin: true, organization: undefined })).toBe(
+      false
+    );
+  });
+
+  it('lets an owner or a maintainer create', () => {
+    expect(
+      canCreateProject({ isAdmin: false, organization: organization('OWNER') })
+    ).toBe(true);
+    expect(
+      canCreateProject({
+        isAdmin: false,
+        organization: organization('MAINTAINER'),
+      })
+    ).toBe(true);
+  });
+
+  it('refuses a plain member', () => {
+    expect(
+      canCreateProject({ isAdmin: false, organization: organization('MEMBER') })
+    ).toBe(false);
+  });
+
+  it('refuses a viewer with no role in the organization', () => {
+    expect(
+      canCreateProject({
+        isAdmin: false,
+        organization: organization(undefined),
+      })
+    ).toBe(false);
+  });
+});
+
+describe('projectCreationRefusal', () => {
+  it('names the missing organization', () => {
+    expect(
+      projectCreationRefusal({ isAdmin: false, organization: undefined })
+    ).toBe('no-organization');
+  });
+
+  it('names the role when the viewer has an organization they may not create in', () => {
+    expect(
+      projectCreationRefusal({
+        isAdmin: false,
+        organization: organization('MEMBER'),
+      })
+    ).toBe('not-owner-or-maintainer');
+  });
+
+  it('refuses nothing to a maintainer or an admin', () => {
+    expect(
+      projectCreationRefusal({
+        isAdmin: false,
+        organization: organization('MAINTAINER'),
+      })
+    ).toBeUndefined();
+    expect(
+      projectCreationRefusal({
+        isAdmin: true,
+        organization: organization(undefined),
+      })
+    ).toBeUndefined();
+  });
+});

--- a/webapp/src/fixtures/__tests__/supportChat.test.ts
+++ b/webapp/src/fixtures/__tests__/supportChat.test.ts
@@ -1,0 +1,46 @@
+import { organizationHasSupportChat } from 'tg.fixtures/supportChat';
+import { organization } from 'tg.fixtures/__tests__/organizationTestData';
+
+describe('organizationHasSupportChat', () => {
+  it('accepts either support tier', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['STANDARD_SUPPORT'] })
+      )
+    ).toBe(true);
+    expect(
+      organizationHasSupportChat(
+        organization({ enabledFeatures: ['PREMIUM_SUPPORT'] })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects an organization with neither support tier', () => {
+    expect(organizationHasSupportChat(organization({}))).toBe(false);
+  });
+
+  it('rejects both support tiers on an organization the viewer does not belong to', () => {
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          currentUserRole: undefined,
+          enabledFeatures: ['STANDARD_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+    expect(
+      organizationHasSupportChat(
+        organization({
+          limitedView: true,
+          currentUserRole: undefined,
+          enabledFeatures: ['PREMIUM_SUPPORT'],
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects a viewer without any organization', () => {
+    expect(organizationHasSupportChat(undefined)).toBe(false);
+  });
+});

--- a/webapp/src/fixtures/__tests__/switchProgress.test.ts
+++ b/webapp/src/fixtures/__tests__/switchProgress.test.ts
@@ -1,0 +1,47 @@
+import {
+  isSwitchInProgress,
+  noSwitchInProgress,
+  switchProgress,
+} from 'tg.fixtures/switchProgress';
+
+const after = (...events: Parameters<typeof switchProgress>[1][]) =>
+  events.reduce(switchProgress, noSwitchInProgress());
+
+describe('switchProgress', () => {
+  it('is switching from the request until its settle arrives', () => {
+    expect(isSwitchInProgress(after({ kind: 'requested', request: 1 }))).toBe(
+      true
+    );
+    expect(
+      isSwitchInProgress(
+        after(
+          { kind: 'requested', request: 1 },
+          { kind: 'settled', request: 1 }
+        )
+      )
+    ).toBe(false);
+  });
+
+  it('stops switching once a stale write settles after a newer one', () => {
+    const state = after(
+      { kind: 'requested', request: 1 },
+      { kind: 'settled', request: 1 },
+      { kind: 'requested', request: 2 },
+      { kind: 'settled', request: 2 },
+      { kind: 'settled', request: 1 }
+    );
+
+    expect(state.settled).toBe(2);
+    expect(isSwitchInProgress(state)).toBe(false);
+  });
+
+  it('keeps switching while a newer request is still outstanding', () => {
+    const state = after(
+      { kind: 'requested', request: 1 },
+      { kind: 'settled', request: 1 },
+      { kind: 'requested', request: 2 }
+    );
+
+    expect(isSwitchInProgress(state)).toBe(true);
+  });
+});

--- a/webapp/src/fixtures/billingAccess.ts
+++ b/webapp/src/fixtures/billingAccess.ts
@@ -1,0 +1,32 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { isOwnerOrgRole } from 'tg.fixtures/organizationRole';
+import { BillingRefusal } from 'tg.fixtures/refusal';
+
+type Params = {
+  billingEnabled: boolean;
+  isAdminOrSupporter: boolean;
+  organization: ContextOrganizationModel | undefined;
+};
+
+export const canSeeBilling = (params: Params): boolean =>
+  billingRefusal(params) === undefined;
+
+export const billingRefusal = ({
+  billingEnabled,
+  isAdminOrSupporter,
+  organization,
+}: Params): BillingRefusal | undefined => {
+  if (!billingEnabled) {
+    return 'billing-disabled';
+  }
+
+  if (!organization) {
+    return 'no-organization';
+  }
+
+  if (isAdminOrSupporter || isOwnerOrgRole(organization.currentUserRole)) {
+    return undefined;
+  }
+
+  return 'billing-not-an-owner';
+};

--- a/webapp/src/fixtures/billingLink.ts
+++ b/webapp/src/fixtures/billingLink.ts
@@ -1,0 +1,13 @@
+import { LINKS, PARAMS } from 'tg.constants/links';
+
+type Target = {
+  slug: string;
+  selfHosted?: boolean;
+};
+
+// Subscriptions, not ORGANIZATION_BILLING: see OrganizationBillingView in the billing repo.
+export const billingLinkFor = ({ slug, selfHosted }: Target) =>
+  (selfHosted
+    ? LINKS.ORGANIZATION_SUBSCRIPTIONS_SELF_HOSTED_EE
+    : LINKS.ORGANIZATION_SUBSCRIPTIONS
+  ).build({ [PARAMS.ORGANIZATION_SLUG]: slug });

--- a/webapp/src/fixtures/chatwootOrganizationPayload.ts
+++ b/webapp/src/fixtures/chatwootOrganizationPayload.ts
@@ -1,0 +1,17 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { memberCloudSubscription } from 'tg.fixtures/organizationEntitlement';
+
+export const chatwootOrganizationPayload = (
+  organization: ContextOrganizationModel
+) => {
+  const subscription = memberCloudSubscription(organization);
+
+  return {
+    plan: subscription?.plan?.name || 'free',
+    subscriptionStatus: subscription?.status || 'inactive',
+    organizationId: organization.id,
+    organizationName: organization.name,
+    enabledFeatures: organization.enabledFeatures.join(', '),
+    currentUserRole: organization.currentUserRole,
+  };
+};

--- a/webapp/src/fixtures/chatwootSession.ts
+++ b/webapp/src/fixtures/chatwootSession.ts
@@ -1,0 +1,74 @@
+type SessionState = {
+  canOpenSupportChat: boolean;
+  identifiedUserId: number | undefined;
+  currentUserId: number | undefined;
+};
+
+type ChatwootSessionAction = 'set-attributes' | 'reset' | 'none';
+
+export const chatwootSessionAction = ({
+  canOpenSupportChat,
+  identifiedUserId,
+  currentUserId,
+}: SessionState): ChatwootSessionAction => {
+  if (identifiedUserId === undefined) {
+    return 'none';
+  }
+  if (identifiedUserId !== currentUserId) {
+    return 'reset';
+  }
+  // Not reset: that is Chatwoot's logout and would discard a conversation in progress.
+  return canOpenSupportChat ? 'set-attributes' : 'none';
+};
+
+type ChatwootSdk<O> = {
+  setAttributes: (organization: O) => void;
+  reset: () => void;
+};
+
+type ChatwootOpenSdk<U, O> = ChatwootSdk<O> & {
+  setUser: (user: U) => void;
+  toggle: () => void;
+};
+
+export const applyChatwootSession = <O>(
+  action: ChatwootSessionAction,
+  organization: O | undefined,
+  identifiedUserId: number | undefined,
+  sdk: ChatwootSdk<O>
+): number | undefined => {
+  if (action === 'reset') {
+    sdk.reset();
+    return undefined;
+  }
+
+  if (action === 'set-attributes' && organization !== undefined) {
+    sdk.setAttributes(organization);
+  }
+
+  return identifiedUserId;
+};
+
+export const openChatwootSession = <U, O>(
+  action: ChatwootSessionAction,
+  {
+    user,
+    userId,
+    organization,
+  }: { user: U; userId: number; organization: O | undefined },
+  sdk: ChatwootOpenSdk<U, O>
+): number => {
+  if (action === 'reset') {
+    sdk.reset();
+  }
+
+  sdk.setUser(user);
+
+  if (organization !== undefined) {
+    sdk.setAttributes(organization);
+  }
+
+  sdk.toggle();
+
+  return userId;
+};

--- a/webapp/src/fixtures/communitySurface.ts
+++ b/webapp/src/fixtures/communitySurface.ts
@@ -1,0 +1,12 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+
+type Params = {
+  hasCommunityContributions: boolean;
+  organization: ContextOrganizationModel | undefined;
+};
+
+export const offersCommunityProjects = ({
+  hasCommunityContributions,
+  organization,
+}: Params): boolean =>
+  hasCommunityContributions || Boolean(organization?.limitedView);

--- a/webapp/src/fixtures/intercomCompanyPayload.ts
+++ b/webapp/src/fixtures/intercomCompanyPayload.ts
@@ -1,0 +1,20 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { memberCloudSubscription } from 'tg.fixtures/organizationEntitlement';
+
+export const intercomCompanyPayload = (
+  organization: ContextOrganizationModel | undefined
+) => {
+  const subscription = memberCloudSubscription(organization);
+
+  if (!organization || !subscription) {
+    return undefined;
+  }
+
+  return {
+    company_id: organization.id,
+    name: organization.name,
+    plan: subscription.plan.name,
+    subscriptionStatus: subscription.status,
+    enabledFeatures: organization.enabledFeatures.join(', '),
+  };
+};

--- a/webapp/src/fixtures/intercomSession.ts
+++ b/webapp/src/fixtures/intercomSession.ts
@@ -1,0 +1,97 @@
+type SessionState = {
+  canOpenSupportChat: boolean;
+  installed: boolean;
+  booted: boolean;
+  identityChanged: boolean;
+};
+
+type IntercomSessionAction =
+  | 'install'
+  | 'boot'
+  | 'reboot'
+  | 'update'
+  | 'shutdown'
+  | 'none';
+
+export const intercomSessionAction = ({
+  canOpenSupportChat,
+  installed,
+  booted,
+  identityChanged,
+}: SessionState): IntercomSessionAction => {
+  if (!canOpenSupportChat) {
+    return booted ? 'shutdown' : 'none';
+  }
+  if (!installed) {
+    return 'install';
+  }
+  // Intercom() re-runs the loader on every call; it does not resume a shut-down session.
+  if (!booted) {
+    return 'boot';
+  }
+  if (identityChanged) {
+    return 'reboot';
+  }
+  return 'update';
+};
+
+export type IntercomTrackers = {
+  installed: boolean;
+  booted: boolean;
+  bootedFor: number | undefined;
+};
+
+type IntercomSdk<S> = {
+  install: (settings: S) => void;
+  boot: (settings: S) => void;
+  update: (settings: S) => void;
+  shutdown: () => void;
+};
+
+type SessionInput<S> = {
+  settings: () => S;
+  userId: number | undefined;
+  companyId: number | undefined;
+};
+
+export const applyIntercomSession = <S>(
+  action: IntercomSessionAction,
+  { settings, userId, companyId }: SessionInput<S>,
+  trackers: IntercomTrackers,
+  sdk: IntercomSdk<S>
+): IntercomTrackers => {
+  if (action === 'shutdown') {
+    sdk.shutdown();
+    return {
+      ...trackers,
+      booted: false,
+      bootedFor: undefined,
+    };
+  }
+
+  if (action === 'none') {
+    return trackers;
+  }
+
+  if (action === 'update') {
+    sdk.update(settings());
+    return { ...trackers, bootedFor: userId };
+  }
+
+  if (action === 'reboot') {
+    sdk.shutdown();
+  }
+
+  const installs = action === 'install';
+  if (installs) {
+    sdk.install(settings());
+  } else {
+    sdk.boot(settings());
+  }
+
+  return {
+    installed: trackers.installed || installs,
+    booted: true,
+    bootedFor: userId,
+  };
+};

--- a/webapp/src/fixtures/limitErrorCounters.ts
+++ b/webapp/src/fixtures/limitErrorCounters.ts
@@ -1,0 +1,39 @@
+export type LimitErrorCounters = {
+  planLimitErrors: number;
+  spendingLimitErrors: number;
+};
+
+export type LimitErrorEvent =
+  | { kind: 'plan-limit' }
+  | { kind: 'spending-limit' }
+  | { kind: 'credit-plan-limit' }
+  | { kind: 'credit-spending-limit' }
+  | { kind: 'organization-changed' };
+
+export const noLimitErrors = (): LimitErrorCounters => ({
+  planLimitErrors: 0,
+  spendingLimitErrors: 0,
+});
+
+export const limitErrorCounters = (
+  state: LimitErrorCounters,
+  event: LimitErrorEvent
+): LimitErrorCounters => {
+  switch (event.kind) {
+    case 'plan-limit':
+      return { ...state, planLimitErrors: state.planLimitErrors + 1 };
+    case 'spending-limit':
+      return { ...state, spendingLimitErrors: state.spendingLimitErrors + 1 };
+    case 'credit-plan-limit':
+      return state.planLimitErrors > 0
+        ? state
+        : { ...state, planLimitErrors: 1 };
+    case 'credit-spending-limit':
+      return state.spendingLimitErrors > 0
+        ? state
+        : { ...state, spendingLimitErrors: 1 };
+    case 'organization-changed':
+      // The caller's effect is keyed on the organization id, so reaching here IS the change.
+      return noLimitErrors();
+  }
+};

--- a/webapp/src/fixtures/organizationCreation.ts
+++ b/webapp/src/fixtures/organizationCreation.ts
@@ -1,0 +1,34 @@
+import { PrivateUserAccountModel } from 'tg.service/apiSchemaTypes.generated';
+import { OrganizationCreationRefusal } from 'tg.fixtures/refusal';
+
+type ThirdPartyAuthType = PrivateUserAccountModel['thirdPartyAuthType'];
+
+type Params = {
+  isAdmin: boolean;
+  thirdPartyAuthType: ThirdPartyAuthType;
+  userCanCreateOrganizations: boolean;
+};
+
+export const canCreateOrganization = (params: Params): boolean =>
+  organizationCreationRefusal(params) === undefined;
+
+// Mirrors OrganizationService.organizationCreationRefusal.
+export const organizationCreationRefusal = ({
+  isAdmin,
+  thirdPartyAuthType,
+  userCanCreateOrganizations,
+}: Params): OrganizationCreationRefusal | undefined => {
+  if (isAdmin) {
+    return undefined;
+  }
+
+  if (!userCanCreateOrganizations) {
+    return 'server-disallows';
+  }
+
+  if (thirdPartyAuthType === 'SSO') {
+    return 'sso';
+  }
+
+  return undefined;
+};

--- a/webapp/src/fixtures/organizationEntitlement.ts
+++ b/webapp/src/fixtures/organizationEntitlement.ts
@@ -1,0 +1,39 @@
+import { components } from 'tg.service/apiSchema.generated';
+import { Feature } from 'tg.service/apiSchemaTypes';
+
+type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
+
+export const organizationHasSupportChat = (
+  organization: PrivateOrganization | undefined
+): boolean =>
+  isOrganizationEntitledTo(organization, 'STANDARD_SUPPORT') ||
+  isOrganizationEntitledTo(organization, 'PREMIUM_SUPPORT');
+
+export const organizationCompanyInfo = (
+  organization: PrivateOrganization | undefined
+) => {
+  const subscription = organization?.activeCloudSubscription;
+
+  if (!organization || !subscription) {
+    return null;
+  }
+
+  return {
+    company_id: organization.id,
+    name: organization.name,
+    plan: subscription.plan.name,
+    subscriptionStatus: subscription.status,
+    enabledFeatures: organization.enabledFeatures.join(', '),
+  };
+};
+
+const isOrganizationEntitledTo = (
+  organization: PrivateOrganization | undefined,
+  feature: Feature
+): boolean => {
+  if (!organization || organization.limitedView) {
+    return false;
+  }
+
+  return organization.enabledFeatures.includes(feature);
+};

--- a/webapp/src/fixtures/organizationEntitlement.ts
+++ b/webapp/src/fixtures/organizationEntitlement.ts
@@ -1,39 +1,23 @@
-import { components } from 'tg.service/apiSchema.generated';
 import { Feature } from 'tg.service/apiSchemaTypes';
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
 
-type PrivateOrganization = components['schemas']['PrivateOrganizationModel'];
-
-export const organizationHasSupportChat = (
-  organization: PrivateOrganization | undefined
-): boolean =>
-  isOrganizationEntitledTo(organization, 'STANDARD_SUPPORT') ||
-  isOrganizationEntitledTo(organization, 'PREMIUM_SUPPORT');
-
-export const organizationCompanyInfo = (
-  organization: PrivateOrganization | undefined
-) => {
-  const subscription = organization?.activeCloudSubscription;
-
-  if (!organization || !subscription) {
-    return null;
-  }
-
-  return {
-    company_id: organization.id,
-    name: organization.name,
-    plan: subscription.plan.name,
-    subscriptionStatus: subscription.status,
-    enabledFeatures: organization.enabledFeatures.join(', '),
-  };
-};
-
-const isOrganizationEntitledTo = (
-  organization: PrivateOrganization | undefined,
+export const memberIsEntitledTo = (
+  organization: ContextOrganizationModel | undefined,
   feature: Feature
-): boolean => {
-  if (!organization || organization.limitedView) {
-    return false;
-  }
+): boolean =>
+  isAtLeastMemberOrgRole(organization?.currentUserRole) &&
+  organizationOwnedFeatures(organization).includes(feature);
 
-  return organization.enabledFeatures.includes(feature);
-};
+export const memberCloudSubscription = (
+  organization: ContextOrganizationModel | undefined
+) =>
+  isAtLeastMemberOrgRole(organization?.currentUserRole)
+    ? organization?.activeCloudSubscription
+    : undefined;
+
+const NO_FEATURES: Feature[] = [];
+
+export const organizationOwnedFeatures = (
+  organization: ContextOrganizationModel | undefined
+): Feature[] => organization?.enabledFeatures ?? NO_FEATURES;

--- a/webapp/src/fixtures/organizationRole.ts
+++ b/webapp/src/fixtures/organizationRole.ts
@@ -2,9 +2,23 @@ import { PrivateOrganizationModel } from 'tg.service/apiSchemaTypes.generated';
 
 export type OrganizationRole = PrivateOrganizationModel['currentUserRole'];
 
+export const canManageOrganization = (
+  role: OrganizationRole | undefined | null,
+  staffOverride: boolean
+): boolean => isOwnerOrgRole(role) || staffOverride;
+
+export const canViewOrganization = (
+  role: OrganizationRole | undefined | null,
+  staffOverride: boolean
+): boolean => isAtLeastMemberOrgRole(role) || staffOverride;
+
 export const isAtLeastMemberOrgRole = (
   role: OrganizationRole | undefined | null
 ): boolean => Boolean(role);
+
+export const isOwnerOrgRole = (
+  role: OrganizationRole | undefined | null
+): boolean => role === 'OWNER';
 
 export const isOwnerOrMaintainerOrgRole = (
   role: OrganizationRole | undefined | null

--- a/webapp/src/fixtures/organizationRole.ts
+++ b/webapp/src/fixtures/organizationRole.ts
@@ -1,8 +1,11 @@
-import { components } from 'tg.service/apiSchema.generated';
+import { PrivateOrganizationModel } from 'tg.service/apiSchemaTypes.generated';
 
-type OrganizationRole =
-  components['schemas']['PrivateOrganizationModel']['currentUserRole'];
+export type OrganizationRole = PrivateOrganizationModel['currentUserRole'];
 
 export const isAtLeastMemberOrgRole = (
   role: OrganizationRole | undefined | null
 ): boolean => Boolean(role);
+
+export const isOwnerOrMaintainerOrgRole = (
+  role: OrganizationRole | undefined | null
+): boolean => role === 'OWNER' || role === 'MAINTAINER';

--- a/webapp/src/fixtures/organizationSettingsMenu.ts
+++ b/webapp/src/fixtures/organizationSettingsMenu.ts
@@ -1,0 +1,63 @@
+export type OrganizationMenuItemId =
+  | 'profile'
+  | 'members'
+  | 'member-privileges'
+  | 'glossaries'
+  | 'translation-memories'
+  | 'apps'
+  | 'llm-providers'
+  | 'sso'
+  | 'subscriptions'
+  | 'invoices'
+  | 'billing-test-clock';
+
+type Params = {
+  canManage: boolean;
+  /** Role half only — SharedTranslationMemoryController also gates on Feature.TRANSLATION_MEMORY. */
+  isAtLeastOrganizationMember: boolean;
+  llmEnabled: boolean;
+  billingEnabled: boolean;
+  internalControllerEnabled: boolean;
+};
+
+export const organizationSettingsMenu = ({
+  canManage,
+  isAtLeastOrganizationMember,
+  llmEnabled,
+  billingEnabled,
+  internalControllerEnabled,
+}: Params): OrganizationMenuItemId[] => {
+  const items: OrganizationMenuItemId[] = ['profile'];
+
+  if (canManage) {
+    items.push('members', 'member-privileges');
+  }
+
+  items.push('glossaries');
+
+  if (isAtLeastOrganizationMember) {
+    items.push('translation-memories');
+  }
+
+  if (!canManage) {
+    return items;
+  }
+
+  items.push('apps');
+
+  if (llmEnabled) {
+    items.push('llm-providers');
+  }
+
+  items.push('sso');
+
+  if (billingEnabled) {
+    items.push('subscriptions', 'invoices');
+
+    if (internalControllerEnabled) {
+      items.push('billing-test-clock');
+    }
+  }
+
+  return items;
+};

--- a/webapp/src/fixtures/organizationSwitchShape.ts
+++ b/webapp/src/fixtures/organizationSwitchShape.ts
@@ -1,0 +1,47 @@
+type Params = {
+  hasPreferredOrganization: boolean;
+  isCommunitySurface: boolean;
+  canCreateOrganization: boolean;
+  showsCommunityProjects: boolean;
+};
+
+type OrganizationSwitchShape = {
+  offersCommunityFooter: boolean;
+  communitySelected: boolean;
+} & (
+  | { render: 'hidden' }
+  | { render: 'community-label' }
+  | { render: 'switch'; label: 'community' | 'organization' }
+);
+
+export const organizationSwitchShape = ({
+  hasPreferredOrganization,
+  isCommunitySurface,
+  canCreateOrganization,
+  showsCommunityProjects,
+}: Params): OrganizationSwitchShape => {
+  const popover = {
+    // Not offered on the community surface itself: the footer's destination is the current page.
+    offersCommunityFooter: showsCommunityProjects && !isCommunitySurface,
+    communitySelected: isCommunitySurface,
+  };
+
+  if (!hasPreferredOrganization && !isCommunitySurface) {
+    return { ...popover, render: 'hidden' };
+  }
+
+  // Only the community surface reaches here without an organization, and its footer would navigate
+  // to the current page — so creating one is the only thing a popover could offer.
+  if (!hasPreferredOrganization && !canCreateOrganization) {
+    return { ...popover, render: 'community-label' };
+  }
+
+  return {
+    ...popover,
+    render: 'switch',
+    label:
+      isCommunitySurface || !hasPreferredOrganization
+        ? 'community'
+        : 'organization',
+  };
+};

--- a/webapp/src/fixtures/preferredOrganizationResolution.ts
+++ b/webapp/src/fixtures/preferredOrganizationResolution.ts
@@ -1,0 +1,26 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+
+type Params = {
+  organization: ContextOrganizationModel | undefined;
+  isSwitching: boolean;
+};
+
+export type PreferredOrganizationResolution =
+  | { status: 'resolving' }
+  | { status: 'missing' }
+  | { status: 'resolved'; organization: ContextOrganizationModel };
+
+export const preferredOrganizationResolution = ({
+  organization,
+  isSwitching,
+}: Params): PreferredOrganizationResolution => {
+  if (organization) {
+    return { status: 'resolved', organization };
+  }
+
+  if (isSwitching) {
+    return { status: 'resolving' };
+  }
+
+  return { status: 'missing' };
+};

--- a/webapp/src/fixtures/projectCreation.ts
+++ b/webapp/src/fixtures/projectCreation.ts
@@ -1,0 +1,27 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { isOwnerOrMaintainerOrgRole } from 'tg.fixtures/organizationRole';
+import { ProjectCreationRefusal } from 'tg.fixtures/refusal';
+
+type Params = {
+  isAdmin: boolean;
+  organization: ContextOrganizationModel | undefined;
+};
+
+export const canCreateProject = (params: Params): boolean =>
+  projectCreationRefusal(params) === undefined;
+
+// Mirrors OrganizationRoleService.checkUserCanCreateProject.
+export const projectCreationRefusal = ({
+  isAdmin,
+  organization,
+}: Params): ProjectCreationRefusal | undefined => {
+  if (!organization) {
+    return 'no-organization';
+  }
+
+  if (isAdmin || isOwnerOrMaintainerOrgRole(organization.currentUserRole)) {
+    return undefined;
+  }
+
+  return 'not-owner-or-maintainer';
+};

--- a/webapp/src/fixtures/refusal.ts
+++ b/webapp/src/fixtures/refusal.ts
@@ -1,0 +1,22 @@
+type NoOrganizationRefusal = 'no-organization';
+
+export type BillingRefusal =
+  | 'billing-disabled'
+  | 'billing-not-an-owner'
+  | NoOrganizationRefusal;
+
+export type ProjectCreationRefusal =
+  | NoOrganizationRefusal
+  | 'not-owner-or-maintainer';
+
+export type OrganizationCreationRefusal = 'server-disallows' | 'sso';
+
+type Refusal =
+  | BillingRefusal
+  | OrganizationCreationRefusal
+  | ProjectCreationRefusal;
+
+export type DisplayedRefusal = Exclude<
+  Refusal,
+  'billing-disabled' | 'not-owner-or-maintainer'
+>;

--- a/webapp/src/fixtures/supportChat.ts
+++ b/webapp/src/fixtures/supportChat.ts
@@ -1,0 +1,8 @@
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { memberIsEntitledTo } from 'tg.fixtures/organizationEntitlement';
+
+export const organizationHasSupportChat = (
+  organization: ContextOrganizationModel | undefined
+): boolean =>
+  memberIsEntitledTo(organization, 'STANDARD_SUPPORT') ||
+  memberIsEntitledTo(organization, 'PREMIUM_SUPPORT');

--- a/webapp/src/fixtures/switchProgress.ts
+++ b/webapp/src/fixtures/switchProgress.ts
@@ -1,0 +1,26 @@
+export type SwitchProgress = {
+  requested: number;
+  settled: number;
+};
+
+export type SwitchProgressEvent = {
+  kind: 'requested' | 'settled';
+  request: number;
+};
+
+export const noSwitchInProgress = (): SwitchProgress => ({
+  requested: 0,
+  settled: 0,
+});
+
+/** Newest-wins, not a balanced counter: see 'keeps a stale settle from re-opening a finished switch'. */
+export const switchProgress = (
+  state: SwitchProgress,
+  { kind, request }: SwitchProgressEvent
+): SwitchProgress =>
+  kind === 'requested'
+    ? { ...state, requested: Math.max(state.requested, request) }
+    : { ...state, settled: Math.max(state.settled, request) };
+
+export const isSwitchInProgress = ({ requested, settled }: SwitchProgress) =>
+  settled < requested;

--- a/webapp/src/globalContext/__tests__/organizationSwitchSequencer.test.ts
+++ b/webapp/src/globalContext/__tests__/organizationSwitchSequencer.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ORGANIZATION_SWITCH_DEADLINE_MS,
+  createOrganizationSwitchSequencer,
+} from 'tg.globalContext/organizationSwitchSequencer';
+
+type Written = { id: number };
+
+const deferred = () => {
+  let resolve!: (value: Written) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<Written>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const harness = () => {
+  const pending: Record<number, ReturnType<typeof deferred>> = {};
+  const applied: number[] = [];
+  const written: number[] = [];
+  const settled: number[] = [];
+  const requested: number[] = [];
+
+  const switchTo = createOrganizationSwitchSequencer<Written>({
+    write: (organizationId) => {
+      written.push(organizationId);
+      pending[organizationId] = deferred();
+      return pending[organizationId].promise;
+    },
+    apply: (data) => applied.push(data.id),
+    onRequested: (request) => requested.push(request),
+    onSettled: (request) => settled.push(request),
+  });
+
+  return {
+    switchTo,
+    applied,
+    written,
+    settled,
+    requested,
+    settle: (organizationId: number) =>
+      pending[organizationId].resolve({ id: organizationId }),
+    fail: (organizationId: number) =>
+      pending[organizationId].reject(new Error('refused')),
+  };
+};
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('createOrganizationSwitchSequencer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('settles every request it announced, including one superseded before its write ran', async () => {
+    const h = harness();
+
+    h.switchTo(1, undefined);
+    const second = h.switchTo(2, undefined);
+    await flush();
+
+    h.settle(2);
+    expect(await second).toBe(true);
+    await flush();
+
+    expect([...h.settled].sort()).toEqual([...h.requested].sort());
+  });
+
+  it('gives up waiting on a write that never settles, without blocking the UI forever', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.settled).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS);
+
+    expect(await first).toBe(false);
+    expect(h.settled).toEqual([1]);
+    expect(h.applied).toEqual([]);
+  });
+
+  it('still issues a later switch after an earlier write blew its deadline', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS);
+
+    expect(await first).toBe(false);
+
+    const second = h.switchTo(2, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.written).toEqual([1, 2]);
+
+    h.settle(2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(await second).toBe(true);
+    expect(h.applied).toEqual([2]);
+
+    h.settle(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.settled).toEqual([1, 2, 1]);
+  });
+
+  it('gives a queued switch its whole budget, not what the blocked predecessor left over', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+
+    const first = h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const second = h.switchTo(2, undefined);
+
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS - 1000);
+    expect(await first).toBe(false);
+    expect(h.written).toEqual([1, 2]);
+
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS - 1000);
+    h.settle(2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(await second).toBe(true);
+    expect(h.applied).toEqual([2]);
+  });
+
+  it('does not report the previous organization as already-preferred while an abandoned write can still land', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+
+    const away = h.switchTo(2, 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS);
+    expect(await away).toBe(false);
+
+    h.switchTo(1, 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    h.settle(2);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.applied).toEqual([]);
+  });
+
+  it('retries the same organization after its write blew the deadline, instead of handing back the failed promise', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS);
+
+    expect(await first).toBe(false);
+
+    h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.written).toEqual([1, 1]);
+  });
+
+  it('still applies a write that lands after its deadline, so the client cannot end up behind the server', async () => {
+    vi.useFakeTimers();
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(ORGANIZATION_SWITCH_DEADLINE_MS);
+
+    expect(await first).toBe(false);
+
+    h.settle(1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(h.applied).toEqual([1]);
+  });
+
+  it('applies the write when nothing supersedes it', async () => {
+    const h = harness();
+    const switched = h.switchTo(1, undefined);
+    await flush();
+
+    h.settle(1);
+
+    expect(await switched).toBe(true);
+    expect(h.applied).toEqual([1]);
+  });
+
+  it('does not apply a request that a newer one superseded while it was in flight', async () => {
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await flush();
+    expect(h.written).toEqual([1]);
+
+    const second = h.switchTo(2, undefined);
+    h.settle(1);
+
+    expect(await first).toBe(false);
+    await flush();
+    h.settle(2);
+    expect(await second).toBe(true);
+
+    expect(h.applied).toEqual([2]);
+  });
+
+  it('never issues the write for a request superseded before the chain reached it', async () => {
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await flush();
+
+    const second = h.switchTo(2, undefined);
+    const third = h.switchTo(3, undefined);
+
+    h.settle(1);
+    await flush();
+
+    expect(await first).toBe(false);
+    expect(await second).toBe(false);
+    expect(h.written).toEqual([1, 3]);
+
+    h.settle(3);
+    expect(await third).toBe(true);
+    expect(h.applied).toEqual([3]);
+  });
+
+  it('shares the in-flight promise when the same organization is requested again', async () => {
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    const again = h.switchTo(1, undefined);
+    await flush();
+
+    expect(h.written).toEqual([1]);
+    expect(h.requested).toEqual([1]);
+
+    h.settle(1);
+    expect(await first).toBe(true);
+    expect(await again).toBe(true);
+  });
+
+  it('skips the write when the organization is already preferred and nothing is in flight', async () => {
+    const h = harness();
+
+    expect(await h.switchTo(7, 7)).toBe(true);
+    expect(h.written).toEqual([]);
+    expect(h.requested).toEqual([]);
+  });
+
+  it('settles a failed write without applying it, and lets the next one through', async () => {
+    const h = harness();
+    const first = h.switchTo(1, undefined);
+    await flush();
+
+    h.fail(1);
+    expect(await first).toBe(false);
+    expect(h.applied).toEqual([]);
+    expect(h.settled).toEqual([1]);
+
+    const second = h.switchTo(2, undefined);
+    await flush();
+    h.settle(2);
+
+    expect(await second).toBe(true);
+    expect(h.applied).toEqual([2]);
+  });
+});

--- a/webapp/src/globalContext/__tests__/preferredOrganizationWritePolicy.test.ts
+++ b/webapp/src/globalContext/__tests__/preferredOrganizationWritePolicy.test.ts
@@ -1,0 +1,48 @@
+import { decidePreferredOrganizationWrite } from 'tg.globalContext/preferredOrganizationWritePolicy';
+
+const decide = (
+  over: Partial<Parameters<typeof decidePreferredOrganizationWrite>[0]>
+) =>
+  decidePreferredOrganizationWrite({
+    organizationId: 1,
+    inFlightOrganizationId: undefined,
+    preferredOrganizationId: undefined,
+    hasUnsettledWrite: false,
+    ...over,
+  });
+
+describe('decidePreferredOrganizationWrite', () => {
+  it('reuses the in-flight write when the same organization is asked for again', () => {
+    expect(decide({ inFlightOrganizationId: 1 })).toBe('await-in-flight');
+  });
+
+  it('issues a write when a different organization is asked for mid-flight', () => {
+    expect(decide({ organizationId: 2, inFlightOrganizationId: 1 })).toBe(
+      'issue-write'
+    );
+  });
+
+  it('does nothing when the organization is already the preferred one', () => {
+    expect(decide({ preferredOrganizationId: 1 })).toBe('already-preferred');
+  });
+
+  it('still issues a write for the preferred organization while a switch away is in flight', () => {
+    expect(
+      decide({ preferredOrganizationId: 1, inFlightOrganizationId: 2 })
+    ).toBe('issue-write');
+  });
+
+  it('issues a write for a viewer with no preferred organization', () => {
+    expect(decide({})).toBe('issue-write');
+  });
+
+  it('still writes for the already-preferred organization while an abandoned write is live', () => {
+    expect(
+      decide({
+        organizationId: 1,
+        preferredOrganizationId: 1,
+        hasUnsettledWrite: true,
+      })
+    ).toBe('issue-write');
+  });
+});

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -1,4 +1,5 @@
 import { Feature, QaCheckType } from 'tg.service/apiSchemaTypes';
+import { organizationHasSupportChat } from 'tg.fixtures/organizationEntitlement';
 
 import { useGlobalActions, useGlobalContext } from './GlobalContext';
 
@@ -82,5 +83,8 @@ export const useEnabledFeatures = () => {
     },
   };
 };
+
+export const useHasSupportChat = () =>
+  organizationHasSupportChat(usePreferredOrganization().preferredOrganization);
 
 const EMPTY_LIST = [];

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -1,4 +1,6 @@
 import { Feature, QaCheckType } from 'tg.service/apiSchemaTypes';
+import { organizationHasSupportChat } from 'tg.fixtures/organizationEntitlement';
+import { isOwnerOrMaintainerOrgRole } from 'tg.fixtures/organizationRole';
 
 import { useGlobalActions, useGlobalContext } from './GlobalContext';
 
@@ -56,8 +58,19 @@ export const usePreferredOrganization = () => {
 
 export const useIsOrganizationOwnerOrMaintainer = () => {
   const { preferredOrganization } = usePreferredOrganization();
-  const role = preferredOrganization?.currentUserRole;
-  return ['OWNER', 'MAINTAINER'].includes(role || '');
+  return isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole);
+};
+
+export const useCanCreateProject = () => {
+  const { preferredOrganization, isFetching } = usePreferredOrganization();
+  const isAdmin = useIsAdmin();
+
+  return {
+    isFetching,
+    canCreateProject:
+      isAdmin ||
+      isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole),
+  };
 };
 
 export const useOrganizationUsage = () => {
@@ -85,5 +98,8 @@ export const useEnabledFeatures = () => {
     },
   };
 };
+
+export const useHasSupportChat = () =>
+  organizationHasSupportChat(usePreferredOrganization().preferredOrganization);
 
 const EMPTY_LIST = [];

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -1,5 +1,6 @@
 import { Feature, QaCheckType } from 'tg.service/apiSchemaTypes';
 import { organizationHasSupportChat } from 'tg.fixtures/organizationEntitlement';
+import { isOwnerOrMaintainerOrgRole } from 'tg.fixtures/organizationRole';
 
 import { useGlobalActions, useGlobalContext } from './GlobalContext';
 
@@ -54,8 +55,26 @@ export const usePreferredOrganization = () => {
 
 export const useIsOrganizationOwnerOrMaintainer = () => {
   const { preferredOrganization } = usePreferredOrganization();
-  const role = preferredOrganization?.currentUserRole;
-  return ['OWNER', 'MAINTAINER'].includes(role || '');
+  return isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole);
+};
+
+export const useCanCreateProject = () => {
+  const { preferredOrganization, isFetching } = usePreferredOrganization();
+  const isAdmin = useIsAdmin();
+
+  if (isAdmin) {
+    return {
+      isFetching: false,
+      canCreateProject: true,
+    };
+  }
+
+  return {
+    isFetching: isFetching,
+    canCreateProject: isOwnerOrMaintainerOrgRole(
+      preferredOrganization?.currentUserRole
+    ),
+  };
 };
 
 export const useOrganizationUsage = () => {

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -1,5 +1,17 @@
 import { Feature, QaCheckType } from 'tg.service/apiSchemaTypes';
-import { organizationHasSupportChat } from 'tg.fixtures/organizationEntitlement';
+import { QaCheckCategoryModel } from 'tg.service/apiSchemaTypes.generated';
+import { organizationHasSupportChat } from 'tg.fixtures/supportChat';
+import {
+  canCreateOrganization,
+  organizationCreationRefusal,
+} from 'tg.fixtures/organizationCreation';
+import { preferredOrganizationResolution } from 'tg.fixtures/preferredOrganizationResolution';
+import {
+  canCreateProject,
+  projectCreationRefusal,
+} from 'tg.fixtures/projectCreation';
+import { billingRefusal, canSeeBilling } from 'tg.fixtures/billingAccess';
+import { organizationOwnedFeatures } from 'tg.fixtures/organizationEntitlement';
 import { isOwnerOrMaintainerOrgRole } from 'tg.fixtures/organizationRole';
 
 import { useGlobalActions, useGlobalContext } from './GlobalContext';
@@ -47,12 +59,33 @@ export const usePreferredOrganization = () => {
   const preferredOrganization = useGlobalContext(
     (c) => c.initialData.preferredOrganization
   );
-  const isFetching = useGlobalContext((c) => c.initialData.isFetching);
-
   return {
     preferredOrganization,
     updatePreferredOrganization,
-    isFetching,
+  };
+};
+
+export const useIsBillingEnabled = () =>
+  useGlobalContext((c) => c.initialData.serverConfiguration.billing.enabled);
+
+export const useCanSeeBilling = () => canSeeBilling(useBillingAccessParams());
+
+export const useBillingRefusal = () => billingRefusal(useBillingAccessParams());
+
+export const useBillingOrganization = () => {
+  const params = useBillingAccessParams();
+  return canSeeBilling(params) ? params.organization : undefined;
+};
+
+const useBillingAccessParams = () => {
+  const billingEnabled = useIsBillingEnabled();
+  const { preferredOrganization } = usePreferredOrganization();
+  const isAdminOrSupporter = useIsAdminOrSupporter();
+
+  return {
+    billingEnabled,
+    isAdminOrSupporter,
+    organization: preferredOrganization,
   };
 };
 
@@ -61,16 +94,48 @@ export const useIsOrganizationOwnerOrMaintainer = () => {
   return isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole);
 };
 
-export const useCanCreateProject = () => {
-  const { preferredOrganization, isFetching } = usePreferredOrganization();
+export const useCanCreateOrganization = () =>
+  canCreateOrganization(useOrganizationCreationParams());
+
+export const useOrganizationCreationRefusal = () =>
+  organizationCreationRefusal(useOrganizationCreationParams());
+
+const useOrganizationCreationParams = () => {
   const isAdmin = useIsAdmin();
+  const config = useConfig();
+  const user = useUser();
 
   return {
-    isFetching,
-    canCreateProject:
-      isAdmin ||
-      isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole),
+    isAdmin,
+    thirdPartyAuthType: user?.thirdPartyAuthType,
+    userCanCreateOrganizations: config.userCanCreateOrganizations,
   };
+};
+
+export const useIsSwitchingOrganization = () =>
+  useGlobalContext((c) => c.initialData.isSwitchingOrganization);
+
+export const usePreferredOrganizationResolution = () => {
+  const { preferredOrganization } = usePreferredOrganization();
+  const isSwitching = useIsSwitchingOrganization();
+
+  return preferredOrganizationResolution({
+    organization: preferredOrganization,
+    isSwitching,
+  });
+};
+
+export const useCanCreateProject = () =>
+  canCreateProject(useProjectCreationParams());
+
+export const useProjectCreationRefusal = () =>
+  projectCreationRefusal(useProjectCreationParams());
+
+const useProjectCreationParams = () => {
+  const isAdmin = useIsAdmin();
+  const { preferredOrganization } = usePreferredOrganization();
+
+  return { isAdmin, organization: preferredOrganization };
 };
 
 export const useOrganizationUsage = () => {
@@ -86,10 +151,8 @@ export const useQaCheckTypes = (): QaCheckType[] => {
 };
 
 export const useEnabledFeatures = () => {
-  const features =
-    useGlobalContext(
-      (c) => c.initialData.preferredOrganization?.enabledFeatures
-    ) || EMPTY_LIST;
+  const { preferredOrganization } = usePreferredOrganization();
+  const features = organizationOwnedFeatures(preferredOrganization);
 
   return {
     features,
@@ -99,7 +162,10 @@ export const useEnabledFeatures = () => {
   };
 };
 
-export const useHasSupportChat = () =>
-  organizationHasSupportChat(usePreferredOrganization().preferredOrganization);
+export const useHasSupportChat = () => {
+  const { preferredOrganization } = usePreferredOrganization();
 
-const EMPTY_LIST = [];
+  return organizationHasSupportChat(preferredOrganization);
+};
+
+const EMPTY_LIST: QaCheckCategoryModel[] = [];

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -62,18 +62,11 @@ export const useCanCreateProject = () => {
   const { preferredOrganization, isFetching } = usePreferredOrganization();
   const isAdmin = useIsAdmin();
 
-  if (isAdmin) {
-    return {
-      isFetching: false,
-      canCreateProject: true,
-    };
-  }
-
   return {
-    isFetching: isFetching,
-    canCreateProject: isOwnerOrMaintainerOrgRole(
-      preferredOrganization?.currentUserRole
-    ),
+    isFetching,
+    canCreateProject:
+      isAdmin ||
+      isOwnerOrMaintainerOrgRole(preferredOrganization?.currentUserRole),
   };
 };
 

--- a/webapp/src/globalContext/organizationSwitchSequencer.ts
+++ b/webapp/src/globalContext/organizationSwitchSequencer.ts
@@ -1,0 +1,120 @@
+import {
+  decidePreferredOrganizationWrite,
+  ownsWriteRequest,
+} from 'tg.globalContext/preferredOrganizationWritePolicy';
+
+export type SwitchHandlers<T> = {
+  write: (organizationId: number) => Promise<T>;
+  apply: (written: T) => void;
+  onRequested: (request: number) => void;
+  onSettled: (request: number) => void;
+};
+
+type InFlight = {
+  organizationId: number;
+  request: number;
+  promise: Promise<boolean>;
+};
+
+export type OrganizationSwitchTo = (
+  organizationId: number,
+  preferredOrganizationId: number | undefined
+) => Promise<boolean>;
+
+export const ORGANIZATION_SWITCH_DEADLINE_MS = 8000;
+
+export const createOrganizationSwitchSequencer = <T>({
+  write,
+  apply,
+  onRequested,
+  onSettled,
+}: SwitchHandlers<T>) => {
+  let requested = 0;
+  let chain: Promise<unknown> = Promise.resolve();
+  let inFlight: InFlight | undefined = undefined;
+  let unsettledWrites = 0;
+
+  const switchTo = (
+    organizationId: number,
+    preferredOrganizationId: number | undefined
+  ): Promise<boolean> => {
+    const decision = decidePreferredOrganizationWrite({
+      organizationId,
+      inFlightOrganizationId: inFlight?.organizationId,
+      preferredOrganizationId,
+      hasUnsettledWrite: unsettledWrites > 0,
+    });
+
+    if (decision === 'await-in-flight' && inFlight) {
+      return inFlight.promise;
+    }
+
+    if (decision === 'already-preferred') {
+      return Promise.resolve(true);
+    }
+
+    const request = ++requested;
+    onRequested(request);
+
+    // Chained on the bounded promise, and the deadline is armed inside it: see 'still issues a later
+    // switch after an earlier write blew its deadline' and 'gives a queued switch its whole budget'.
+    const promise = chain.then(() =>
+      withDeadline(request, () => run(organizationId, request))
+    );
+    chain = promise;
+    inFlight = { organizationId, request, promise };
+    return promise;
+  };
+
+  const run = async (
+    organizationId: number,
+    request: number
+  ): Promise<boolean> => {
+    if (!owns(request)) {
+      onSettled(request);
+      return false;
+    }
+    unsettledWrites += 1;
+    try {
+      const written = await write(organizationId);
+      if (!owns(request)) {
+        return false;
+      }
+      apply(written);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      unsettledWrites -= 1;
+      onSettled(request);
+    }
+  };
+
+  const release = (request: number) => {
+    if (inFlight?.request === request) {
+      inFlight = undefined;
+    }
+  };
+
+  const withDeadline = (
+    request: number,
+    issue: () => Promise<boolean>
+  ): Promise<boolean> =>
+    new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        release(request);
+        onSettled(request);
+        resolve(false);
+      }, ORGANIZATION_SWITCH_DEADLINE_MS);
+
+      issue().then((switched) => {
+        clearTimeout(timer);
+        release(request);
+        resolve(switched);
+      });
+    });
+
+  const owns = (request: number) => ownsWriteRequest(request, requested);
+
+  return switchTo;
+};

--- a/webapp/src/globalContext/preferredOrganizationWritePolicy.ts
+++ b/webapp/src/globalContext/preferredOrganizationWritePolicy.ts
@@ -1,0 +1,33 @@
+type Params = {
+  organizationId: number;
+  inFlightOrganizationId: number | undefined;
+  preferredOrganizationId: number | undefined;
+  hasUnsettledWrite: boolean;
+};
+
+type WriteDecision = 'await-in-flight' | 'already-preferred' | 'issue-write';
+
+/** `hasUnsettledWrite` is load-bearing: see 'does not report the previous organization as already-preferred while an abandoned write can still land'. */
+export const decidePreferredOrganizationWrite = ({
+  organizationId,
+  inFlightOrganizationId,
+  preferredOrganizationId,
+  hasUnsettledWrite,
+}: Params): WriteDecision => {
+  if (inFlightOrganizationId === organizationId) {
+    return 'await-in-flight';
+  }
+
+  if (
+    inFlightOrganizationId === undefined &&
+    !hasUnsettledWrite &&
+    organizationId === preferredOrganizationId
+  ) {
+    return 'already-preferred';
+  }
+
+  return 'issue-write';
+};
+
+export const ownsWriteRequest = (request: number, newestRequest: number) =>
+  request === newestRequest;

--- a/webapp/src/globalContext/types.ts
+++ b/webapp/src/globalContext/types.ts
@@ -1,0 +1,6 @@
+import { PrivateOrganizationModel } from 'tg.service/apiSchemaTypes.generated';
+
+export type ContextOrganizationModel = Omit<
+  PrivateOrganizationModel,
+  'quickStart'
+>;

--- a/webapp/src/globalContext/useInitialDataService.ts
+++ b/webapp/src/globalContext/useInitialDataService.ts
@@ -1,16 +1,43 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useApiMutation, useApiQuery } from 'tg.service/http/useQueryApi';
 import { components } from 'tg.service/apiSchema.generated';
+import { ContextOrganizationModel } from 'tg.globalContext/types';
 import { useTolgee } from '@tolgee/react';
+import {
+  SwitchHandlers,
+  OrganizationSwitchTo,
+  createOrganizationSwitchSequencer,
+} from 'tg.globalContext/organizationSwitchSequencer';
+import {
+  isSwitchInProgress,
+  noSwitchInProgress,
+  switchProgress,
+} from 'tg.fixtures/switchProgress';
 
 type PrivateOrganizationModel =
   components['schemas']['PrivateOrganizationModel'];
+
 type AnnouncementDto = components['schemas']['AnnouncementDto'];
 type QuickStartModel = components['schemas']['QuickStartModel'];
 type InitialDataModel = components['schemas']['InitialDataModel'];
 
 export const useInitialDataService = () => {
-  const [isSwitchingOrganization, setIsSwitchingOrganization] = useState(false);
+  const [progress, setProgress] = useState(noSwitchInProgress);
+  const switchHandlersRef = useRef<SwitchHandlers<PrivateOrganizationModel>>(
+    undefined as never
+  );
+  const switchToRef = useRef<OrganizationSwitchTo | undefined>(undefined);
+  if (!switchToRef.current) {
+    switchToRef.current = createOrganizationSwitchSequencer({
+      write: (organizationId) =>
+        switchHandlersRef.current.write(organizationId),
+      apply: (data) => switchHandlersRef.current.apply(data),
+      onRequested: (request) => switchHandlersRef.current.onRequested(request),
+      onSettled: (request) => switchHandlersRef.current.onSettled(request),
+    });
+  }
+  const switchTo = switchToRef.current;
+  const isSwitchingOrganization = isSwitchInProgress(progress);
   const tolgee = useTolgee();
 
   const [organization, setOrganization] = useState<
@@ -48,8 +75,6 @@ export const useInitialDataService = () => {
   useEffect(() => {
     // once initial data are loaded for first time
     if (initialData) {
-      // set organization data only if missing
-      setOrganization((org) => (org ? org : initialData.preferredOrganization));
       if (initialData.languageTag) {
         // switch ui language, once user is signed in
         tolgee.changeLanguage(initialData.languageTag);
@@ -57,14 +82,10 @@ export const useInitialDataService = () => {
     }
   }, [Boolean(initialData)]);
 
-  const preferredOrganizationLoadable = useApiMutation({
-    url: '/v2/preferred-organization',
-    method: 'get',
-  });
-
   const setPreferredOrganization = useApiMutation({
     url: '/v2/user-preferences/set-preferred-organization/{organizationId}',
     method: 'put',
+    options: { noGlobalLoading: true },
   });
 
   const dismissAnnouncementLoadable = useApiMutation({
@@ -143,27 +164,26 @@ export const useInitialDataService = () => {
   const preferredOrganization =
     organization ?? initialData?.preferredOrganization;
 
-  const updatePreferredOrganization = async (organizationId: number) => {
-    if (organizationId !== preferredOrganization?.id) {
-      setIsSwitchingOrganization(true);
-      try {
-        // set preferred organization
-        await setPreferredOrganization.mutateAsync({
-          path: { organizationId },
-        });
-
-        // load new preferred organization
-        const data = await preferredOrganizationLoadable.mutateAsync({});
-        setQuickStart(data.quickStart);
-        setOrganization(data);
-      } catch {
-        // the global API error handler already surfaced the failure; callers fire-and-forget
-        // this on every project open, so a rethrow would be an unhandled rejection
-      } finally {
-        setIsSwitchingOrganization(false);
-      }
-    }
+  switchHandlersRef.current = {
+    write: (organizationId: number) =>
+      setPreferredOrganization.mutateAsync({ path: { organizationId } }),
+    apply: (data) => {
+      setQuickStart(data.quickStart);
+      setOrganization(data);
+    },
+    onRequested: (request) =>
+      setProgress((state) =>
+        switchProgress(state, { kind: 'requested', request })
+      ),
+    onSettled: (request) =>
+      setProgress((state) =>
+        switchProgress(state, { kind: 'settled', request })
+      ),
   };
+
+  const updatePreferredOrganization = (
+    organizationId: number
+  ): Promise<boolean> => switchTo(organizationId, preferredOrganization?.id);
 
   const refetchInitialData = () => {
     setQuickStart(undefined);
@@ -188,21 +208,22 @@ export const useInitialDataService = () => {
     );
   };
 
-  const isFetching =
-    initialDataLoadable.isFetching ||
-    setPreferredOrganization.isLoading ||
-    preferredOrganizationLoadable.isLoading ||
-    dismissAnnouncementLoadable.isLoading ||
-    isSwitchingOrganization;
+  const publishedPreferredOrganization: ContextOrganizationModel | undefined =
+    useMemo(() => {
+      if (!preferredOrganization) {
+        return undefined;
+      }
+      const { quickStart: _quickStart, ...rest } = preferredOrganization;
+      return rest;
+    }, [preferredOrganization]);
 
   const state = initialData
     ? {
-        ...initialData!,
-        preferredOrganization: preferredOrganization
-          ? { ...preferredOrganization, quickStart }
-          : undefined,
+        ...initialData,
+        preferredOrganization: publishedPreferredOrganization,
+        quickStart,
         announcement,
-        isFetching,
+        isSwitchingOrganization,
       }
     : undefined;
 

--- a/webapp/src/globalContext/useInitialDataService.ts
+++ b/webapp/src/globalContext/useInitialDataService.ts
@@ -10,7 +10,7 @@ type QuickStartModel = components['schemas']['QuickStartModel'];
 type InitialDataModel = components['schemas']['InitialDataModel'];
 
 export const useInitialDataService = () => {
-  const [organizationLoading, setOrganizationLoading] = useState(false);
+  const [isSwitchingOrganization, setIsSwitchingOrganization] = useState(false);
   const tolgee = useTolgee();
 
   const [organization, setOrganization] = useState<
@@ -145,7 +145,7 @@ export const useInitialDataService = () => {
 
   const updatePreferredOrganization = async (organizationId: number) => {
     if (organizationId !== preferredOrganization?.id) {
-      setOrganizationLoading(true);
+      setIsSwitchingOrganization(true);
       try {
         // set preferred organization
         await setPreferredOrganization.mutateAsync({
@@ -160,7 +160,7 @@ export const useInitialDataService = () => {
         // the global API error handler already surfaced the failure; callers fire-and-forget
         // this on every project open, so a rethrow would be an unhandled rejection
       } finally {
-        setOrganizationLoading(false);
+        setIsSwitchingOrganization(false);
       }
     }
   };
@@ -193,7 +193,7 @@ export const useInitialDataService = () => {
     setPreferredOrganization.isLoading ||
     preferredOrganizationLoadable.isLoading ||
     dismissAnnouncementLoadable.isLoading ||
-    organizationLoading;
+    isSwitchingOrganization;
 
   const state = initialData
     ? {

--- a/webapp/src/globalContext/useOrganizationAdoption.ts
+++ b/webapp/src/globalContext/useOrganizationAdoption.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import { ownsWriteRequest } from 'tg.globalContext/preferredOrganizationWritePolicy';
+
+export const useOrganizationAdoption = (organizationId: number | undefined) => {
+  const { preferredOrganization, updatePreferredOrganization } =
+    usePreferredOrganization();
+  const [settledFor, setSettledFor] = useState<number | undefined>(undefined);
+  const [trackedOrganizationId, setTrackedOrganizationId] = useState<
+    number | undefined
+  >(organizationId);
+  const requestedAdoptionRef = useRef(0);
+
+  const [seenActiveId, setSeenActiveId] = useState(preferredOrganization?.id);
+
+  if (organizationId !== trackedOrganizationId) {
+    setTrackedOrganizationId(organizationId);
+    setSettledFor(undefined);
+  }
+
+  // Re-arm when the active organization changes underneath us — the switcher on this very page can
+  // do that. Keyed on a CHANGE, not on a mismatch: a refused adoption leaves the two different
+  // forever, and re-arming on that would write in a loop.
+  if (preferredOrganization?.id !== seenActiveId) {
+    setSeenActiveId(preferredOrganization?.id);
+    if (
+      organizationId !== undefined &&
+      preferredOrganization?.id !== organizationId
+    ) {
+      setSettledFor(undefined);
+    }
+  }
+
+  useEffect(() => {
+    if (organizationId === undefined) {
+      return;
+    }
+    const adoption = ++requestedAdoptionRef.current;
+
+    // finally, not then: both consumers block on this marker with no timeout of their own, so a
+    // rejection here would leave the page loading forever rather than degraded.
+    updatePreferredOrganization(organizationId).finally(() => {
+      if (ownsWriteRequest(adoption, requestedAdoptionRef.current)) {
+        setSettledFor(organizationId);
+      }
+    });
+  }, [organizationId]);
+
+  const awaitingAdoption =
+    organizationId !== undefined && settledFor !== organizationId;
+
+  return {
+    // The project page renders during an in-flight adoption on purpose, so it waits only when there
+    // is no organization at all; the organization pages wait for any cross-organization arrival,
+    // where the chrome would otherwise show the previously active organization.
+    awaitingFirstOrganization: awaitingAdoption && !preferredOrganization,
+    awaitingOrganization:
+      awaitingAdoption && preferredOrganization?.id !== organizationId,
+  };
+};

--- a/webapp/src/globalContext/useOrganizationUsageService.ts
+++ b/webapp/src/globalContext/useOrganizationUsageService.ts
@@ -1,10 +1,15 @@
 import { useEffect, useState } from 'react';
+
+import {
+  LimitErrorEvent,
+  limitErrorCounters,
+  noLimitErrors,
+} from 'tg.fixtures/limitErrorCounters';
 import { components } from 'tg.service/apiSchema.generated';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
-type UsageModel = components['schemas']['PublicUsageModel'];
 
 type Props = {
   organization?: OrganizationModel;
@@ -18,11 +23,8 @@ export const useOrganizationUsageService = ({
   const isOrganizationMember = isAtLeastMemberOrgRole(
     organization?.currentUserRole
   );
-  const [organizationUsage, setOrganizationUsage] = useState<
-    UsageModel | undefined
-  >(undefined);
-  const [planLimitErrors, setPlanLimitErrors] = useState(0);
-  const [spendingLimitErrors, setSpendingLimitErrors] = useState(0);
+  const [counters, setCounters] = useState(() => noLimitErrors());
+  const { planLimitErrors, spendingLimitErrors } = counters;
 
   const usageEnabled =
     organization?.id !== undefined && enabled && isOrganizationMember;
@@ -42,55 +44,29 @@ export const useOrganizationUsageService = ({
       refetchOnMount: false,
       cacheTime: Infinity,
       enabled: usageEnabled,
-      onSuccess(data) {
-        setOrganizationUsage(data);
-      },
     },
   });
 
-  const updateUsageData = (data: Partial<UsageModel>) =>
-    setOrganizationUsage((val) =>
-      val
-        ? {
-            ...val,
-            ...data,
-          }
-        : val
+  useEffect(() => {
+    setCounters((state) =>
+      limitErrorCounters(state, { kind: 'organization-changed' })
     );
+  }, [organization?.id]);
 
-  const incrementPlanLimitErrors = () => {
-    setPlanLimitErrors((v) => v + 1);
-  };
+  const organizationUsage = usageLoadable.data;
 
-  const incrementSpendingLimitErrors = () => {
-    setSpendingLimitErrors((v) => v + 1);
-  };
+  const report = (event: LimitErrorEvent) =>
+    setCounters((state) => limitErrorCounters(state, event));
 
-  /**
-   * For MT credit error, we want to show the error only once.
-   * We don't want to disturb the translators that much with the error.
-   */
-  const increaseCreditPlanLimitErrors = () => {
-    setPlanLimitErrors((v) => {
-      if (v > 0) {
-        return v;
-      }
-      return v + 1;
-    });
-  };
+  const incrementPlanLimitErrors = () => report({ kind: 'plan-limit' });
 
-  /**
-   * For MT credit error, we want to show the error only once.
-   * We don't want to disturb the translators that much with the error.
-   */
-  const increaseCreditSpendingLimitErrors = () => {
-    setSpendingLimitErrors((v) => {
-      if (v > 0) {
-        return v;
-      }
-      return v + 1;
-    });
-  };
+  const incrementSpendingLimitErrors = () => report({ kind: 'spending-limit' });
+
+  const increaseCreditPlanLimitErrors = () =>
+    report({ kind: 'credit-plan-limit' });
+
+  const increaseCreditSpendingLimitErrors = () =>
+    report({ kind: 'credit-spending-limit' });
 
   const refetchUsage = () => {
     if (usageEnabled) {
@@ -112,7 +88,6 @@ export const useOrganizationUsageService = ({
     },
     actions: {
       refetchUsage,
-      updateUsageData,
       incrementPlanLimitErrors,
       incrementSpendingLimitErrors,
       increaseCreditPlanLimitErrors,

--- a/webapp/src/globalContext/useQuickStartGuideService.tsx
+++ b/webapp/src/globalContext/useQuickStartGuideService.tsx
@@ -6,6 +6,7 @@ import {
 } from 'tg.component/layout/QuickStartGuide/enums';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
+import { isOwnerOrgRole } from 'tg.fixtures/organizationRole';
 import type { useInitialDataService } from './useInitialDataService';
 
 export const useQuickStartGuideService = (
@@ -20,8 +21,9 @@ export const useQuickStartGuideService = (
   const projectIdParam = match?.params[PARAMS.PROJECT_ID];
   const projectId = isNaN(projectIdParam) ? undefined : projectIdParam;
   const organizationSlug = initialData.state?.preferredOrganization?.slug;
-  const isOwner =
-    initialData.state?.preferredOrganization?.currentUserRole === 'OWNER';
+  const isOwner = isOwnerOrgRole(
+    initialData.state?.preferredOrganization?.currentUserRole
+  );
 
   const projects = useApiQuery({
     url: '/v2/organizations/{slug}/projects',
@@ -43,10 +45,7 @@ export const useQuickStartGuideService = (
     ? projectId
     : projects.data?._embedded?.projects?.[0]?.id;
 
-  const completed =
-    initialData.state?.preferredOrganization?.quickStart?.completedSteps || [];
-
-  const allCompleted = completed;
+  const completed = initialData.state?.quickStart?.completedSteps || [];
 
   function quickStartBegin(step: ItemStep, items: HighlightItem[]) {
     setActiveStep(step);
@@ -77,19 +76,18 @@ export const useQuickStartGuideService = (
   }
 
   const enabled =
-    initialData.state?.preferredOrganization?.quickStart?.finished === false &&
+    initialData.state?.quickStart?.finished === false &&
     isEmailVerified &&
     isOwner;
 
-  const open =
-    enabled && initialData.state?.preferredOrganization?.quickStart?.open;
+  const open = enabled && initialData.state?.quickStart?.open;
 
   const state = {
     enabled,
     open,
     active: active[0],
     lastProjectId,
-    completed: allCompleted,
+    completed,
     floatingOpen,
     floatingForced,
   };

--- a/webapp/src/hooks/ProjectContext.tsx
+++ b/webapp/src/hooks/ProjectContext.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { createProvider } from 'tg.fixtures/createProvider';
 import { useGlobalLoading } from 'tg.component/GlobalLoading';
 import { BatchJobProgress } from 'tg.websocket-client/WebsocketClient';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import { useOrganizationAdoption } from 'tg.globalContext/useOrganizationAdoption';
 import { GlobalError } from '../error/GlobalError';
 import { useApiQuery } from '../service/http/useQueryApi';
 import {
@@ -132,15 +132,12 @@ export const [ProjectContext, useProjectActions, useProjectContext] =
       }
     }, [id, client]);
 
-    const { updatePreferredOrganization } = usePreferredOrganization();
+    const { awaitingFirstOrganization } = useOrganizationAdoption(
+      project.data?.organizationOwner?.id
+    );
 
-    useEffect(() => {
-      if (project.data?.organizationOwner) {
-        updatePreferredOrganization(project.data.organizationOwner.id);
-      }
-    }, [project.data]);
-
-    const isLoading = project.isLoading || settings.isLoading;
+    const isLoading =
+      project.isLoading || settings.isLoading || awaitingFirstOrganization;
 
     useGlobalLoading(isLoading);
 

--- a/webapp/src/hooks/useChatwoot.ts
+++ b/webapp/src/hooks/useChatwoot.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useTheme } from '@mui/material';
 import {
   useConfig,
+  useHasSupportChat,
   usePreferredOrganization,
   useUser,
 } from 'tg.globalContext/helpers';
@@ -55,8 +56,8 @@ async function loadChatwootOnce(websiteToken: string, darkMode: boolean) {
 
 function setChatwootUser(user: User) {
   window['$chatwoot']?.setUser(user.id, {
-    email: user!.username,
-    name: user!.name,
+    email: user.username,
+    name: user.name,
     url: window.location,
   });
 }
@@ -83,25 +84,18 @@ export function useChatwoot() {
   const config = useConfig();
   const token = config?.chatwootToken;
 
-  const enabledFeatures = preferredOrganization?.enabledFeatures;
+  const hasSupportChat = useHasSupportChat();
 
-  const hasStandardSupport =
-    enabledFeatures?.includes('STANDARD_SUPPORT') ||
-    enabledFeatures?.includes('PREMIUM_SUPPORT');
+  const available = !!(token && user && hasSupportChat);
 
-  const available = !!(token && user && hasStandardSupport);
-
-  const {
-    palette: { mode },
-  } = useTheme();
-
-  const darkMode = mode === 'dark';
+  const theme = useTheme();
+  const darkMode = theme.palette.mode === 'dark';
 
   useEffect(() => {
-    if (token) {
+    if (available) {
       loadChatwootOnce(token, darkMode);
     }
-  }, [token]);
+  }, [available]);
 
   const openChatwoot = async () => {
     if (!available) {

--- a/webapp/src/hooks/useChatwoot.ts
+++ b/webapp/src/hooks/useChatwoot.ts
@@ -7,12 +7,138 @@ import {
   useUser,
 } from 'tg.globalContext/helpers';
 import { components } from 'tg.service/apiSchema.generated';
+import { ContextOrganizationModel } from 'tg.globalContext/types';
+import { chatwootOrganizationPayload } from 'tg.fixtures/chatwootOrganizationPayload';
+import {
+  applyChatwootSession,
+  chatwootSessionAction,
+  openChatwootSession,
+} from 'tg.fixtures/chatwootSession';
 
 type User = components['schemas']['PrivateUserAccountModel'];
-type Organization = components['schemas']['PrivateOrganizationModel'];
 
 const BASE_URL = 'https://app.chatwoot.com';
 let chatwootLoadPromise: Promise<void> | null = null;
+let chatwootIdentifiedUserId: number | undefined;
+
+export function useChatwoot() {
+  const user = useUser();
+  const { preferredOrganization } = usePreferredOrganization();
+  const config = useConfig();
+  const token = config?.chatwootToken;
+
+  const hasSupportChat = useHasSupportChat();
+
+  const canOpenSupportChat = !!(token && user && hasSupportChat);
+
+  const sessionAction = () =>
+    chatwootSessionAction({
+      canOpenSupportChat,
+      identifiedUserId: chatwootIdentifiedUserId,
+      currentUserId: user?.id,
+    });
+
+  const theme = useTheme();
+  const darkMode = theme.palette.mode === 'dark';
+
+  useEffect(() => {
+    if (canOpenSupportChat) {
+      loadChatwootOnce(token, darkMode);
+    }
+  }, [canOpenSupportChat]);
+
+  useEffect(() => {
+    if (!chatwootLoadPromise) {
+      return;
+    }
+
+    let cancelled = false;
+    chatwootLoadPromise.then(() => {
+      if (cancelled) {
+        return;
+      }
+      chatwootIdentifiedUserId = applyChatwootSession(
+        sessionAction(),
+        preferredOrganization,
+        chatwootIdentifiedUserId,
+        chatwootSdk
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [canOpenSupportChat, preferredOrganization, user?.id]);
+
+  const openChatwoot = async () => {
+    if (!canOpenSupportChat) {
+      return;
+    }
+
+    await loadChatwootOnce(token, darkMode);
+    chatwootIdentifiedUserId = openChatwootSession(
+      sessionAction(),
+      { user, userId: user.id, organization: preferredOrganization },
+      chatwootSdk
+    );
+  };
+
+  return {
+    chatwootAvailable: canOpenSupportChat,
+    openChatwoot,
+  };
+}
+
+const chatwootSdk = {
+  reset: resetChatwootSession,
+  setUser: setChatwootUser,
+  setAttributes: setChatwootAttributes,
+  toggle: toggleChatwoot,
+};
+
+function setChatwootUser(user: User) {
+  window['$chatwoot']?.setUser(user.id, {
+    email: user.username,
+    name: user.name,
+    url: window.location,
+  });
+}
+
+function setChatwootAttributes(organization: ContextOrganizationModel) {
+  window['$chatwoot']?.setCustomAttributes(
+    chatwootOrganizationPayload(organization)
+  );
+}
+
+function resetChatwootSession() {
+  window['$chatwoot']?.reset();
+}
+
+function toggleChatwoot() {
+  window['$chatwoot']?.toggle();
+}
+
+async function loadChatwootOnce(websiteToken: string, darkMode: boolean) {
+  if (!chatwootLoadPromise) {
+    chatwootLoadPromise = loadChatwoot(websiteToken, darkMode);
+  }
+
+  await chatwootLoadPromise;
+}
+
+async function loadChatwoot(websiteToken: string, darkMode: boolean) {
+  window['chatwootSettings'] = {
+    darkMode: darkMode ? 'auto' : 'light',
+    hideMessageBubble: true,
+  };
+
+  await loadScript(document, BASE_URL + '/packs/js/sdk.js');
+
+  window['chatwootSDK']?.run({
+    websiteToken,
+    baseUrl: BASE_URL,
+  });
+}
 
 function loadScript(doc: Document, url: string) {
   return new Promise<void>((resolve) => {
@@ -30,89 +156,4 @@ function loadScript(doc: Document, url: string) {
 
     existingElement?.parentNode?.insertBefore(element, existingElement);
   });
-}
-
-async function loadChatwoot(websiteToken: string, darkMode: boolean) {
-  window['chatwootSettings'] = {
-    darkMode: darkMode ? 'auto' : 'light',
-    hideMessageBubble: true,
-  };
-
-  await loadScript(document, BASE_URL + '/packs/js/sdk.js');
-
-  window['chatwootSDK']?.run({
-    websiteToken,
-    baseUrl: BASE_URL,
-  });
-}
-
-async function loadChatwootOnce(websiteToken: string, darkMode: boolean) {
-  if (!chatwootLoadPromise) {
-    chatwootLoadPromise = loadChatwoot(websiteToken, darkMode);
-  }
-
-  await chatwootLoadPromise;
-}
-
-function setChatwootUser(user: User) {
-  window['$chatwoot']?.setUser(user.id, {
-    email: user.username,
-    name: user.name,
-    url: window.location,
-  });
-}
-
-function setChatwootAttributes(organization: Organization) {
-  const subscription = organization.activeCloudSubscription;
-  window['$chatwoot']?.setCustomAttributes({
-    plan: subscription?.plan?.name || 'free',
-    subscriptionStatus: subscription?.status || 'inactive',
-    organizationId: organization.id,
-    organizationName: organization.name,
-    enabledFeatures: organization.enabledFeatures.join(', '),
-    currentUserRole: organization.currentUserRole,
-  });
-}
-
-function toggleChatwoot() {
-  window['$chatwoot']?.toggle();
-}
-
-export function useChatwoot() {
-  const user = useUser();
-  const { preferredOrganization } = usePreferredOrganization();
-  const config = useConfig();
-  const token = config?.chatwootToken;
-
-  const hasSupportChat = useHasSupportChat();
-
-  const available = !!(token && user && hasSupportChat);
-
-  const theme = useTheme();
-  const darkMode = theme.palette.mode === 'dark';
-
-  useEffect(() => {
-    if (available) {
-      loadChatwootOnce(token, darkMode);
-    }
-  }, [available]);
-
-  const openChatwoot = async () => {
-    if (!available) {
-      return;
-    }
-
-    await loadChatwootOnce(token, darkMode);
-    setChatwootUser(user);
-    if (preferredOrganization) {
-      setChatwootAttributes(preferredOrganization);
-    }
-
-    toggleChatwoot();
-  };
-
-  return {
-    chatwootAvailable: available,
-    openChatwoot,
-  };
 }

--- a/webapp/src/hooks/useIntercom.ts
+++ b/webapp/src/hooks/useIntercom.ts
@@ -1,51 +1,52 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTheme } from '@mui/material';
 import {
   useConfig,
+  useHasSupportChat,
   usePreferredOrganization,
   useUser,
 } from 'tg.globalContext/helpers';
-import { Intercom, show, update } from '@intercom/messenger-js-sdk';
+import { organizationCompanyInfo } from 'tg.fixtures/organizationEntitlement';
+import { Intercom, show, shutdown, update } from '@intercom/messenger-js-sdk';
 
 export function useIntercom() {
   const user = useUser();
-  const { preferredOrganization } = usePreferredOrganization();
   const config = useConfig();
   const appId = config?.intercomAppId;
 
-  const enabledFeatures = preferredOrganization?.enabledFeatures;
-
-  const hasStandardSupport =
-    enabledFeatures?.includes('STANDARD_SUPPORT') ||
-    enabledFeatures?.includes('PREMIUM_SUPPORT');
-
-  const available = !!(appId && user && hasStandardSupport);
-  const theme = useTheme();
-  const {
-    palette: { mode },
-  } = useTheme();
-
-  const darkMode = mode === 'dark';
+  const hasSupportChat = useHasSupportChat();
 
   const companyInfo = useCompanyInfo();
 
+  const available = !!(appId && user && companyInfo && hasSupportChat);
+  const theme = useTheme();
+  const darkMode = theme.palette.mode === 'dark';
+
+  const bootedRef = useRef(false);
+
   useEffect(() => {
-    if (appId && companyInfo && user) {
+    if (available) {
       Intercom({
         app_id: appId,
         hide_default_launcher: true,
-        user_id: user?.id.toString(),
-        name: user?.name,
-        email: user?.username,
+        user_id: user.id.toString(),
+        name: user.name,
+        email: user.username,
         action_color: theme.palette.primary.main,
         company: companyInfo,
       });
+      bootedRef.current = true;
+    } else if (bootedRef.current) {
+      shutdown();
+      bootedRef.current = false;
     }
-  }, [user, preferredOrganization, companyInfo, appId]);
+  }, [available, user, companyInfo, appId]);
 
   useEffect(() => {
-    update({ theme_mode: darkMode ? 'dark' : 'light' });
-  }, [darkMode]);
+    if (available) {
+      update({ theme_mode: darkMode ? 'dark' : 'light' });
+    }
+  }, [darkMode, available]);
 
   const openIntercom = () => {
     if (!available) {
@@ -62,17 +63,9 @@ export function useIntercom() {
 
 function useCompanyInfo() {
   const { preferredOrganization } = usePreferredOrganization();
-  const subscription = preferredOrganization?.activeCloudSubscription;
 
-  if (!preferredOrganization || !subscription) {
-    return null;
-  }
-
-  return {
-    company_id: preferredOrganization?.id,
-    name: preferredOrganization?.name,
-    plan: subscription?.plan?.name || 'free',
-    subscriptionStatus: subscription?.status || 'inactive',
-    enabledFeatures: preferredOrganization?.enabledFeatures.join(', '),
-  };
+  return useMemo(
+    () => organizationCompanyInfo(preferredOrganization),
+    [preferredOrganization]
+  );
 }

--- a/webapp/src/hooks/useIntercom.ts
+++ b/webapp/src/hooks/useIntercom.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useTheme } from '@mui/material';
 import {
   useConfig,
@@ -6,8 +6,22 @@ import {
   usePreferredOrganization,
   useUser,
 } from 'tg.globalContext/helpers';
-import { organizationCompanyInfo } from 'tg.fixtures/organizationEntitlement';
-import { Intercom, show, shutdown, update } from '@intercom/messenger-js-sdk';
+import { intercomCompanyPayload } from 'tg.fixtures/intercomCompanyPayload';
+import {
+  applyIntercomSession,
+  intercomSessionAction,
+} from 'tg.fixtures/intercomSession';
+import {
+  boot,
+  Intercom,
+  show,
+  shutdown,
+  update,
+} from '@intercom/messenger-js-sdk';
+
+let intercomInstalled = false;
+let intercomBooted = false;
+let intercomBootedFor: number | undefined;
 
 export function useIntercom() {
   const user = useUser();
@@ -16,56 +30,81 @@ export function useIntercom() {
 
   const hasSupportChat = useHasSupportChat();
 
-  const companyInfo = useCompanyInfo();
+  const { preferredOrganization } = usePreferredOrganization();
+  const companyInfo = useMemo(
+    () => intercomCompanyPayload(preferredOrganization),
+    [preferredOrganization]
+  );
 
-  const available = !!(appId && user && companyInfo && hasSupportChat);
+  // `companyInfo` as well as the entitlement, matching the base gate: without an active cloud
+  // subscription there is no company to attribute the session to, and booting would transmit the
+  // user's identity to Intercom for an instance that never sent anything before.
+  const canOpenSupportChat = !!(appId && user && hasSupportChat && companyInfo);
   const theme = useTheme();
   const darkMode = theme.palette.mode === 'dark';
 
-  const bootedRef = useRef(false);
+  useEffect(() => {
+    const action = intercomSessionAction({
+      canOpenSupportChat,
+      installed: intercomInstalled,
+      booted: intercomBooted,
+      identityChanged: intercomBootedFor !== user?.id,
+    });
+
+    const trackers = applyIntercomSession(
+      action,
+      {
+        settings: () => ({
+          app_id: appId!,
+          hide_default_launcher: true,
+          user_id: user!.id.toString(),
+          name: user!.name,
+          email: user!.username,
+          action_color: theme.palette.primary.main,
+          theme_mode: darkMode ? 'dark' : 'light',
+          company: companyInfo,
+        }),
+        userId: user?.id,
+        companyId: companyInfo?.company_id,
+      },
+      {
+        installed: intercomInstalled,
+        booted: intercomBooted,
+        bootedFor: intercomBootedFor,
+      },
+      { install: Intercom, boot, update, shutdown }
+    );
+
+    intercomInstalled = trackers.installed;
+    intercomBooted = trackers.booted;
+    intercomBootedFor = trackers.bootedFor;
+  }, [
+    canOpenSupportChat,
+    appId,
+    user?.id,
+    user?.name,
+    user?.username,
+    companyInfo,
+  ]);
 
   useEffect(() => {
-    if (available) {
-      Intercom({
-        app_id: appId,
-        hide_default_launcher: true,
-        user_id: user.id.toString(),
-        name: user.name,
-        email: user.username,
+    if (canOpenSupportChat) {
+      update({
+        theme_mode: darkMode ? 'dark' : 'light',
         action_color: theme.palette.primary.main,
-        company: companyInfo,
       });
-      bootedRef.current = true;
-    } else if (bootedRef.current) {
-      shutdown();
-      bootedRef.current = false;
     }
-  }, [available, user, companyInfo, appId]);
-
-  useEffect(() => {
-    if (available) {
-      update({ theme_mode: darkMode ? 'dark' : 'light' });
-    }
-  }, [darkMode, available]);
+  }, [darkMode, canOpenSupportChat, theme.palette.primary.main]);
 
   const openIntercom = () => {
-    if (!available) {
+    if (!canOpenSupportChat) {
       return;
     }
     show();
   };
 
   return {
-    intercomAvailable: available,
+    intercomAvailable: canOpenSupportChat,
     openIntercom,
   };
-}
-
-function useCompanyInfo() {
-  const { preferredOrganization } = usePreferredOrganization();
-
-  return useMemo(
-    () => organizationCompanyInfo(preferredOrganization),
-    [preferredOrganization]
-  );
 }

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -5263,7 +5263,7 @@ export interface components {
       /** Format: int64 */
       id: number;
       /**
-       * @description Whether the user views the organization purely via public-project access
+       * @description True when the viewer reaches this organization only through its public projects
        * @example false
        */
       limitedView: boolean;
@@ -29500,7 +29500,11 @@ export interface operations {
     };
     responses: {
       /** OK */
-      200: unknown;
+      200: {
+        content: {
+          "application/json": components["schemas"]["PrivateOrganizationModel"];
+        };
+      };
       /** Bad Request */
       400: {
         content: {

--- a/webapp/src/views/administration/AdministrationOrganizations.tsx
+++ b/webapp/src/views/administration/AdministrationOrganizations.tsx
@@ -89,9 +89,10 @@ export const AdministrationOrganizations = ({
                     <Button
                       data-cy="administration-organizations-projects-button"
                       variant="contained"
-                      onClick={() => {
-                        updatePreferredOrganization(o.id);
-                        history.push(LINKS.PROJECTS.build());
+                      onClick={async () => {
+                        if (await updatePreferredOrganization(o.id)) {
+                          history.push(LINKS.PROJECTS.build());
+                        }
                       }}
                     >
                       <T keyName="administration_organization_projects" />

--- a/webapp/src/views/organizations/OrganizationCreateView.tsx
+++ b/webapp/src/views/organizations/OrganizationCreateView.tsx
@@ -1,13 +1,18 @@
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useState } from 'react';
+import { Typography } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 
 import { BaseFormView } from 'tg.component/layout/BaseFormView';
 import { DashboardPage } from 'tg.component/layout/DashboardPage';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
-import { LINKS } from 'tg.constants/links';
+import { LINKS, PARAMS } from 'tg.constants/links';
 import { components } from 'tg.service/apiSchema.generated';
 import { useApiMutation } from 'tg.service/http/useQueryApi';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import {
+  useOrganizationCreationRefusal,
+  usePreferredOrganization,
+} from 'tg.globalContext/helpers';
+import { NoPermissionsView } from 'tg.component/common/NoPermissionsView';
 import { messageService } from 'tg.service/MessageService';
 
 import { OrganizationFields } from './components/OrganizationFields';
@@ -24,16 +29,29 @@ export const OrganizationCreateView: FunctionComponent<
   });
   const { t } = useTranslate();
   const { updatePreferredOrganization } = usePreferredOrganization();
+  const creationRefusal = useOrganizationCreationRefusal();
   const history = useHistory();
+  const [createSubmitted, setCreateSubmitted] = useState(false);
+
+  if (creationRefusal) {
+    return <NoPermissionsView reason={creationRefusal} />;
+  }
 
   const onSubmit = (values) => {
     loadable.mutate(
       { content: { 'application/json': values } },
       {
-        onSuccess: (organization) => {
-          updatePreferredOrganization(organization.id);
-          history.push(LINKS.PROJECTS.build());
+        onSuccess: async (organization) => {
+          setCreateSubmitted(true);
           messageService.success(<T keyName="organization_created_message" />);
+          const switched = await updatePreferredOrganization(organization.id);
+          history.push(
+            switched
+              ? LINKS.PROJECTS.build()
+              : LINKS.ORGANIZATION_PROFILE.build({
+                  [PARAMS.ORGANIZATION_SLUG]: organization.slug,
+                })
+          );
         },
       }
     );
@@ -54,11 +72,22 @@ export const OrganizationCreateView: FunctionComponent<
         initialValues={initialValues}
         onSubmit={onSubmit}
         saveActionLoadable={loadable}
+        submitDisabledReason={
+          createSubmitted ? (
+            <Typography
+              variant="body2"
+              data-cy="organization-create-switching-message"
+            >
+              <T
+                keyName="switching_organization_message"
+                defaultValue="Switching organization…"
+              />
+            </Typography>
+          ) : undefined
+        }
         validationSchema={Validation.ORGANIZATION_CREATE_OR_EDIT(t, '')}
       >
-        <>
-          <OrganizationFields />
-        </>
+        <OrganizationFields />
       </BaseFormView>
     </DashboardPage>
   );

--- a/webapp/src/views/organizations/OrganizationProfileView.tsx
+++ b/webapp/src/views/organizations/OrganizationProfileView.tsx
@@ -10,7 +10,7 @@ import { LINKS, PARAMS } from 'tg.constants/links';
 import { confirmation } from 'tg.hooks/confirmation';
 import { messageService } from 'tg.service/MessageService';
 import { components } from 'tg.service/apiSchema.generated';
-import { useApiMutation, useApiQuery } from 'tg.service/http/useQueryApi';
+import { useApiMutation } from 'tg.service/http/useQueryApi';
 import { useGlobalActions } from 'tg.globalContext/GlobalContext';
 import { DangerButton } from 'tg.component/DangerZone/DangerButton';
 
@@ -19,7 +19,11 @@ import { OrganizationFields } from './components/OrganizationFields';
 import { OrganizationProfileAvatar } from './OrganizationProfileAvatar';
 import { useLeaveOrganization } from './useLeaveOrganization';
 import { useIsAdmin } from 'tg.globalContext/helpers';
-import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
+import {
+  isAtLeastMemberOrgRole,
+  canManageOrganization,
+} from 'tg.fixtures/organizationRole';
+import { useOrganizationLoadable } from 'tg.views/organizations/useOrganization';
 
 type OrganizationBody = components['schemas']['OrganizationDto'];
 
@@ -34,11 +38,7 @@ export const OrganizationProfileView: FunctionComponent<
   const match = useRouteMatch();
   const organizationSlug = match.params[PARAMS.ORGANIZATION_SLUG];
 
-  const organization = useApiQuery({
-    url: '/v2/organizations/{slug}',
-    method: 'get',
-    path: { slug: organizationSlug },
-  });
+  const organization = useOrganizationLoadable();
 
   const editOrganization = useApiMutation({
     url: '/v2/organizations/{id}',
@@ -54,8 +54,11 @@ export const OrganizationProfileView: FunctionComponent<
 
   const isAdmin = useIsAdmin();
 
-  const readOnly = organization.data?.currentUserRole !== 'OWNER' && !isAdmin;
-  const hasNoRole = !isAtLeastMemberOrgRole(organization.data?.currentUserRole);
+  const readOnly = !canManageOrganization(
+    organization.data?.currentUserRole,
+    isAdmin
+  );
+  const isMember = isAtLeastMemberOrgRole(organization.data?.currentUserRole);
 
   const onSubmit = (values: OrganizationBody) => {
     const toSave = {
@@ -151,7 +154,7 @@ export const OrganizationProfileView: FunctionComponent<
                 color="secondary"
                 variant="outlined"
                 onClick={handleLeave}
-                disabled={hasNoRole}
+                disabled={!isMember}
               >
                 <T keyName="organization_leave_button" />
               </Button>
@@ -164,29 +167,32 @@ export const OrganizationProfileView: FunctionComponent<
           </>
         </StandardForm>
 
-        <Box mt={2} mb={1}>
-          <Typography variant={'h5'}>
-            <T keyName="project_settings_danger_zone_title" />
-          </Typography>
-        </Box>
-        <DangerZone
-          actions={[
-            {
-              description: (
-                <T keyName="this_will_delete_organization_forever" />
-              ),
-              button: (
-                <DangerButton
-                  onClick={handleDelete}
-                  disabled={readOnly}
-                  data-cy="organization-profile-delete-button"
-                >
-                  <T keyName="organization_delete_button" />
-                </DangerButton>
-              ),
-            },
-          ]}
-        />
+        {!readOnly && (
+          <>
+            <Box mt={2} mb={1}>
+              <Typography variant={'h5'}>
+                <T keyName="project_settings_danger_zone_title" />
+              </Typography>
+            </Box>
+            <DangerZone
+              actions={[
+                {
+                  description: (
+                    <T keyName="this_will_delete_organization_forever" />
+                  ),
+                  button: (
+                    <DangerButton
+                      onClick={handleDelete}
+                      data-cy="organization-profile-delete-button"
+                    >
+                      <T keyName="organization_delete_button" />
+                    </DangerButton>
+                  ),
+                },
+              ]}
+            />
+          </>
+        )}
       </Box>
     </BaseOrganizationSettingsView>
   );

--- a/webapp/src/views/organizations/OrganizationsRouter.tsx
+++ b/webapp/src/views/organizations/OrganizationsRouter.tsx
@@ -1,51 +1,40 @@
 import { Box } from '@mui/material';
-import { Switch } from 'react-router-dom';
+import { Redirect, Switch } from 'react-router-dom';
 
 import { BoxLoading } from 'tg.component/common/BoxLoading';
+import { OrganizationLoadFailedView } from 'tg.component/common/OrganizationLoadFailedView';
 import { PrivateRoute } from 'tg.component/common/PrivateRoute';
 import { DashboardPage } from 'tg.component/layout/DashboardPage';
-import { LINKS } from 'tg.constants/links';
+import { LINKS, PARAMS } from 'tg.constants/links';
 import { useIsAdminOrSupporter } from 'tg.globalContext/helpers';
+import { useOrganizationAdoption } from 'tg.globalContext/useOrganizationAdoption';
+import { useOrganizationLoadable } from 'tg.views/organizations/useOrganization';
 
 import { OrganizationCreateView } from './OrganizationCreateView';
 import { OrganizationMemberPrivilegesView } from './OrganizationMemberPrivilegesView';
 import { OrganizationMembersView } from './members/OrganizationMembersView';
 import { OrganizationProfileView } from './OrganizationProfileView';
-import { useOrganization } from './useOrganization';
 import { OrganizationAppsView } from './apps/OrganizationAppsView';
+import { RequireOrganizationAccess } from 'tg.component/common/RequireOrganizationAccess';
+import { isOwnerOrgRole } from 'tg.fixtures/organizationRole';
 import { routes } from 'tg.ee';
 
+const RedirectToOrganizationProfile = ({ slug }: { slug: string }) => (
+  <Redirect
+    to={LINKS.ORGANIZATION_PROFILE.build({ [PARAMS.ORGANIZATION_SLUG]: slug })}
+  />
+);
+
 const SpecificOrganizationRouter = () => {
-  const organization = useOrganization();
+  const organization = useOrganizationLoadable();
   const isAdminOrSupporter = useIsAdminOrSupporter();
-  const isAdminAccess =
-    organization &&
-    organization?.currentUserRole !== 'OWNER' &&
-    isAdminOrSupporter;
+  const { awaitingOrganization } = useOrganizationAdoption(
+    organization.data?.id
+  );
 
-  return (
-    <DashboardPage isAdminAccess={isAdminAccess}>
-      {organization ? (
-        <>
-          <PrivateRoute exact path={LINKS.ORGANIZATION_PROFILE.template}>
-            <OrganizationProfileView />
-          </PrivateRoute>
-          <PrivateRoute exact path={LINKS.ORGANIZATION_MEMBERS.template}>
-            <OrganizationMembersView />
-          </PrivateRoute>
-          <PrivateRoute
-            exact
-            path={LINKS.ORGANIZATION_MEMBER_PRIVILEGES.template}
-          >
-            <OrganizationMemberPrivilegesView />
-          </PrivateRoute>
-
-          <PrivateRoute path={LINKS.ORGANIZATION_APPS.template}>
-            <OrganizationAppsView />
-          </PrivateRoute>
-          <routes.Organization />
-        </>
-      ) : (
+  if (organization.isLoading || awaitingOrganization) {
+    return (
+      <DashboardPage>
         <Box
           width="100%"
           height="100%"
@@ -55,23 +44,59 @@ const SpecificOrganizationRouter = () => {
         >
           <BoxLoading />
         </Box>
-      )}
+      </DashboardPage>
+    );
+  }
+
+  if (!organization.data) {
+    return <OrganizationLoadFailedView />;
+  }
+
+  const isAdminAccess =
+    !isOwnerOrgRole(organization.data.currentUserRole) && isAdminOrSupporter;
+
+  return (
+    <DashboardPage isAdminAccess={isAdminAccess}>
+      <PrivateRoute exact path={LINKS.ORGANIZATION_PROFILE.template}>
+        <OrganizationProfileView />
+      </PrivateRoute>
+
+      <PrivateRoute exact path={LINKS.ORGANIZATION_MEMBERS.template}>
+        <RequireOrganizationAccess level="member">
+          <OrganizationMembersView />
+        </RequireOrganizationAccess>
+      </PrivateRoute>
+
+      <PrivateRoute exact path={LINKS.ORGANIZATION_MEMBER_PRIVILEGES.template}>
+        <RequireOrganizationAccess level="manage">
+          <OrganizationMemberPrivilegesView />
+        </RequireOrganizationAccess>
+      </PrivateRoute>
+
+      <PrivateRoute path={LINKS.ORGANIZATION_APPS.template}>
+        <RequireOrganizationAccess level="manage">
+          <OrganizationAppsView />
+        </RequireOrganizationAccess>
+      </PrivateRoute>
+
+      <PrivateRoute exact path={LINKS.ORGANIZATION.template}>
+        <RedirectToOrganizationProfile slug={organization.data.slug} />
+      </PrivateRoute>
+      <routes.Organization />
     </DashboardPage>
   );
 };
 
 export const OrganizationsRouter = () => {
   return (
-    <>
-      <Switch>
-        <PrivateRoute exact path={LINKS.ORGANIZATIONS_ADD.template}>
-          <OrganizationCreateView />
-        </PrivateRoute>
+    <Switch>
+      <PrivateRoute exact path={LINKS.ORGANIZATIONS_ADD.template}>
+        <OrganizationCreateView />
+      </PrivateRoute>
 
-        <PrivateRoute path={LINKS.ORGANIZATION.template}>
-          <SpecificOrganizationRouter />
-        </PrivateRoute>
-      </Switch>
-    </>
+      <PrivateRoute path={LINKS.ORGANIZATION.template}>
+        <SpecificOrganizationRouter />
+      </PrivateRoute>
+    </Switch>
   );
 };

--- a/webapp/src/views/organizations/components/BaseOrganizationSettingsView.tsx
+++ b/webapp/src/views/organizations/components/BaseOrganizationSettingsView.tsx
@@ -2,7 +2,6 @@ import { useHistory, useRouteMatch } from 'react-router-dom';
 
 import { BaseViewProps } from 'tg.component/layout/BaseView';
 import { Link, LINKS, PARAMS } from 'tg.constants/links';
-import { useApiQuery } from 'tg.service/http/useQueryApi';
 
 import { components } from 'tg.service/apiSchema.generated';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
@@ -10,13 +9,18 @@ import { NavigationItem } from 'tg.component/navigation/Navigation';
 import { useTranslate } from '@tolgee/react';
 import { BaseSettingsView } from 'tg.component/layout/BaseSettingsView/BaseSettingsView';
 import { SettingsMenuItem } from 'tg.component/layout/BaseSettingsView/SettingsMenu';
+import { useConfig, useIsAdminOrSupporter } from 'tg.globalContext/helpers';
+import { useOrganizationLoadable } from 'tg.views/organizations/useOrganization';
 import {
-  useConfig,
-  useIsAdminOrSupporter,
-  usePreferredOrganization,
-} from 'tg.globalContext/helpers';
+  OrganizationMenuItemId,
+  organizationSettingsMenu,
+} from 'tg.fixtures/organizationSettingsMenu';
+import {
+  canViewOrganization,
+  canManageOrganization,
+  isOwnerOrgRole,
+} from 'tg.fixtures/organizationRole';
 import { CriticalUsageCircle } from 'tg.ee';
-import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
 
@@ -32,62 +36,54 @@ export const BaseOrganizationSettingsView: React.FC<
   const organizationSlug = match.params[PARAMS.ORGANIZATION_SLUG];
   const { t } = useTranslate();
   const history = useHistory();
-  const { preferredOrganization } = usePreferredOrganization();
   const isAdminOrSupporter = useIsAdminOrSupporter();
+  const organizationLoadable = useOrganizationLoadable();
 
   const handleOrganizationSelect = (organization: OrganizationModel) => {
-    const redirectLink =
-      organization.currentUserRole === 'OWNER'
-        ? link
-        : LINKS.ORGANIZATION_PROFILE;
+    const redirectLink = isOwnerOrgRole(organization.currentUserRole)
+      ? link
+      : LINKS.ORGANIZATION_PROFILE;
 
     history.push(
       redirectLink.build({ [PARAMS.ORGANIZATION_SLUG]: organization.slug })
     );
   };
 
-  const canManageOrganization =
-    preferredOrganization?.currentUserRole === 'OWNER' || isAdminOrSupporter;
+  const canManage = canManageOrganization(
+    organizationLoadable.data?.currentUserRole,
+    isAdminOrSupporter
+  );
+  const isAtLeastOrganizationMember = canViewOrganization(
+    organizationLoadable.data?.currentUserRole,
+    isAdminOrSupporter
+  );
 
-  const menuItems: SettingsMenuItem[] = [
-    {
+  const descriptors: Record<OrganizationMenuItemId, SettingsMenuItem> = {
+    profile: {
       link: LINKS.ORGANIZATION_PROFILE.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
       label: t('organization_menu_profile'),
-      'data-cy': 'profile',
     },
-  ];
-
-  if (canManageOrganization) {
-    menuItems.push({
+    members: {
       link: LINKS.ORGANIZATION_MEMBERS.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
       label: t('organization_menu_members'),
-    });
-    menuItems.push({
+    },
+    'member-privileges': {
       link: LINKS.ORGANIZATION_MEMBER_PRIVILEGES.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
       label: t('organization_menu_member_privileges'),
-    });
-  }
-
-  menuItems.push({
-    link: LINKS.ORGANIZATION_GLOSSARIES.build({
-      [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
-    }),
-    label: t('organization_menu_glossaries'),
-    'data-cy': 'glossaries',
-  });
-
-  // hide the link; below-MEMBER users would hit a 403 on the TM endpoints
-  if (
-    isAtLeastMemberOrgRole(preferredOrganization?.currentUserRole) ||
-    isAdminOrSupporter
-  ) {
-    menuItems.push({
+    },
+    glossaries: {
+      link: LINKS.ORGANIZATION_GLOSSARIES.build({
+        [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
+      }),
+      label: t('organization_menu_glossaries'),
+    },
+    'translation-memories': {
       link: LINKS.ORGANIZATION_TRANSLATION_MEMORIES.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
@@ -95,60 +91,52 @@ export const BaseOrganizationSettingsView: React.FC<
         'organization_menu_translation_memories',
         'Translation memories'
       ),
-      'data-cy': 'translation-memories',
-    });
-  }
-
-  if (canManageOrganization) {
-    menuItems.push({
+    },
+    apps: {
       link: LINKS.ORGANIZATION_APPS.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
       label: t('organization_menu_apps'),
-    });
-    if (config.llm.enabled) {
-      menuItems.push({
-        link: LINKS.ORGANIZATION_LLM_PROVIDERS.build({
-          [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
-        }),
-        label: t('organization_menu_llm_providers'),
-      });
-    }
-    menuItems.push({
+    },
+    'llm-providers': {
+      link: LINKS.ORGANIZATION_LLM_PROVIDERS.build({
+        [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
+      }),
+      label: t('organization_menu_llm_providers'),
+    },
+    sso: {
       link: LINKS.ORGANIZATION_SSO.build({
         [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
       }),
       label: t('organization_menu_sso_login'),
-    });
-    if (config.billing.enabled) {
-      menuItems.push({
-        link: LINKS.ORGANIZATION_SUBSCRIPTIONS.build({
-          [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
-        }),
-        label: t('organization_menu_subscriptions'),
-      });
-      menuItems.push({
-        link: LINKS.ORGANIZATION_INVOICES.build({
-          [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
-        }),
-        label: t('organization_menu_invoices'),
-      });
-      if (config.internalControllerEnabled) {
-        menuItems.push({
-          link: LINKS.ORGANIZATION_BILLING_TEST_CLOCK_HELPER.build({
-            [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
-          }),
-          label: t('organization-menu-billing-test-clock'),
-        });
-      }
-    }
-  }
+    },
+    subscriptions: {
+      link: LINKS.ORGANIZATION_SUBSCRIPTIONS.build({
+        [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
+      }),
+      label: t('organization_menu_subscriptions'),
+    },
+    invoices: {
+      link: LINKS.ORGANIZATION_INVOICES.build({
+        [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
+      }),
+      label: t('organization_menu_invoices'),
+    },
+    'billing-test-clock': {
+      link: LINKS.ORGANIZATION_BILLING_TEST_CLOCK_HELPER.build({
+        [PARAMS.ORGANIZATION_SLUG]: organizationSlug,
+      }),
+      label: t('organization-menu-billing-test-clock'),
+    },
+  };
 
-  const organizationLoadable = useApiQuery({
-    url: '/v2/organizations/{slug}',
-    method: 'get',
-    path: { slug: organizationSlug },
-  });
+  const menuItems: SettingsMenuItem[] = organizationSettingsMenu({
+    canManage,
+    isAtLeastOrganizationMember,
+    llmEnabled: config.llm.enabled,
+    billingEnabled: config.billing.enabled,
+    internalControllerEnabled: config.internalControllerEnabled,
+  }).map((id) => ({ ...descriptors[id], dataCyItem: id }));
 
   const navigationPrefix: NavigationItem[] = organizationLoadable.data
     ? [[<OrganizationSwitch key={0} onSelect={handleOrganizationSelect} />]]

--- a/webapp/src/views/organizations/members/InvitationItem.tsx
+++ b/webapp/src/views/organizations/members/InvitationItem.tsx
@@ -48,10 +48,13 @@ const StyledPermission = styled('div')`
 `;
 
 type Props = {
+  /** A write; see the floor named in OrganizationMembersView. */
+  canCancel: boolean;
   invitation: OrganizationInvitationModel;
 };
 
 export const InvitationItem: React.FC<React.PropsWithChildren<Props>> = ({
+  canCancel,
   invitation,
 }) => {
   const { t } = useTranslate();
@@ -98,15 +101,17 @@ export const InvitationItem: React.FC<React.PropsWithChildren<Props>> = ({
           </Tooltip>
         )}
 
-        <Tooltip title={t('invite_user_invitation_cancel_button')}>
-          <IconButton
-            data-cy="organization-invitation-cancel-button"
-            size="small"
-            onClick={handleCancel}
-          >
-            <XClose />
-          </IconButton>
-        </Tooltip>
+        {canCancel && (
+          <Tooltip title={t('invite_user_invitation_cancel_button')}>
+            <IconButton
+              data-cy="organization-invitation-cancel-button"
+              size="small"
+              onClick={handleCancel}
+            >
+              <XClose />
+            </IconButton>
+          </Tooltip>
+        )}
       </StyledItemActions>
     </StyledListItem>
   );

--- a/webapp/src/views/organizations/members/MemberItem.tsx
+++ b/webapp/src/views/organizations/members/MemberItem.tsx
@@ -68,11 +68,14 @@ const StyledItemUser = styled('div')`
 type Props = {
   user: UserAccountWithOrganizationRoleModel;
   organizationId: number;
+  /** Writes; see the floor named in OrganizationMembersView. */
+  canManageMembers: boolean;
 };
 
 export const MemberItem: React.FC<React.PropsWithChildren<Props>> = ({
   user,
   organizationId,
+  canManageMembers,
 }) => {
   const { t } = useTranslate();
   const currentUser = useUser();
@@ -93,7 +96,7 @@ export const MemberItem: React.FC<React.PropsWithChildren<Props>> = ({
       </StyledItemUser>
       <StyledItemActions>
         {user.organizationRole ? (
-          <UpdateRoleButton user={user} />
+          <UpdateRoleButton user={user} disabled={!canManageMembers} />
         ) : (
           <>
             <Tooltip title={t('organization_users_project_access_hint')}>
@@ -116,7 +119,9 @@ export const MemberItem: React.FC<React.PropsWithChildren<Props>> = ({
             </IconButton>
           </Tooltip>
         ) : (
-          <RemoveUserButton userId={user.id} userName={user.username} />
+          canManageMembers && (
+            <RemoveUserButton userId={user.id} userName={user.username} />
+          )
         )}
       </StyledItemActions>
       {projectsOpen && (

--- a/webapp/src/views/organizations/members/OrganizationMembersView.tsx
+++ b/webapp/src/views/organizations/members/OrganizationMembersView.tsx
@@ -7,6 +7,8 @@ import { useApiQuery } from 'tg.service/http/useQueryApi';
 
 import { BaseOrganizationSettingsView } from '../components/BaseOrganizationSettingsView';
 import { useOrganization } from '../useOrganization';
+import { canManageOrganization } from 'tg.fixtures/organizationRole';
+import { useIsAdmin, useIsAdminOrSupporter } from 'tg.globalContext/helpers';
 import { MemberItem } from './MemberItem';
 import { SimpleList } from 'tg.component/common/list/SimpleList';
 import { InviteDialog } from './InviteDialog';
@@ -18,6 +20,8 @@ export const OrganizationMembersView: FunctionComponent<
   React.PropsWithChildren<unknown>
 > = () => {
   const organization = useOrganization();
+  const isAdmin = useIsAdmin();
+  const isAdminOrSupporter = useIsAdminOrSupporter();
   const { t } = useTranslate();
 
   const [search, setSearch] = useState('');
@@ -39,12 +43,25 @@ export const OrganizationMembersView: FunctionComponent<
     },
   });
 
+  // Reads are a GET, which the interceptor's read-only bypass admits a supporter to.
+  const canReadInvitations = canManageOrganization(
+    organization?.currentUserRole,
+    isAdminOrSupporter
+  );
+  // One OWNER floor, two surfaces: V2InvitationController's invite/revoke and
+  // OrganizationController's setUserRole/removeUser are all @RequiresOrganizationRole(OWNER).
+  const canManageMembers = canManageOrganization(
+    organization?.currentUserRole,
+    isAdmin
+  );
+
   const invitationsLoadable = useApiQuery({
     url: '/v2/organizations/{organizationId}/invitations',
     method: 'get',
     path: { organizationId: organization!.id },
     options: {
       keepPreviousData: true,
+      enabled: canReadInvitations,
     },
   });
 
@@ -72,40 +89,53 @@ export const OrganizationMembersView: FunctionComponent<
         ],
       ]}
     >
-      <Box
-        mb={1}
-        display="flex"
-        justifyContent="space-between"
-        alignItems="center"
-      >
-        <Typography variant="h6">{t('invitations_title')}</Typography>
-        <Button
-          color="primary"
-          variant="contained"
-          onClick={() => setInviteOpen(true)}
-          data-cy="invite-generate-button"
-        >
-          {t('invitations_invite_button')}
-        </Button>
-      </Box>
+      {canReadInvitations && (
+        <>
+          <Box
+            mb={1}
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <Typography variant="h6">{t('invitations_title')}</Typography>
+            {canManageMembers && (
+              <Button
+                color="primary"
+                variant="contained"
+                onClick={() => setInviteOpen(true)}
+                data-cy="invite-generate-button"
+              >
+                {t('invitations_invite_button')}
+              </Button>
+            )}
+          </Box>
 
-      {!invitations && !invitationsLoadable.isLoading && (
-        <Box m={4} display="flex" justifyContent="center">
-          <Typography color="textSecondary">
-            {t('invite_user_nothing_found')}
-          </Typography>
-        </Box>
+          {!invitations && !invitationsLoadable.isLoading && (
+            <Box m={4} display="flex" justifyContent="center">
+              <Typography color="textSecondary">
+                {t('invite_user_nothing_found')}
+              </Typography>
+            </Box>
+          )}
+
+          {invitations && invitations.length > 0 && (
+            <SimpleList
+              data={invitations}
+              renderItem={(i) => (
+                <InvitationItem invitation={i} canCancel={canManageMembers} />
+              )}
+            />
+          )}
+          {canManageMembers && (
+            <InviteDialog
+              onClose={() => setInviteOpen(false)}
+              open={inviteOpen}
+            />
+          )}
+
+          <Box mt={4} />
+        </>
       )}
-
-      {invitations?.length && (
-        <SimpleList
-          data={invitations}
-          renderItem={(i) => <InvitationItem invitation={i} />}
-        />
-      )}
-      <InviteDialog onClose={() => setInviteOpen(false)} open={inviteOpen} />
-
-      <Box mt={4} />
       <PaginatedHateoasList
         loadable={membersLoadable}
         title={<T keyName="organization_members_view_title" />}
@@ -119,7 +149,11 @@ export const OrganizationMembersView: FunctionComponent<
           </Box>
         }
         renderItem={(user) => (
-          <MemberItem user={user} organizationId={organization!.id} />
+          <MemberItem
+            user={user}
+            organizationId={organization!.id}
+            canManageMembers={canManageMembers}
+          />
         )}
       />
     </BaseOrganizationSettingsView>

--- a/webapp/src/views/organizations/members/UpdateRoleButton.tsx
+++ b/webapp/src/views/organizations/members/UpdateRoleButton.tsx
@@ -14,6 +14,7 @@ import { useOrganization } from '../useOrganization';
 export const UpdateRoleButton: FunctionComponent<
   React.PropsWithChildren<{
     user: components['schemas']['UserAccountWithOrganizationRoleModel'];
+    disabled?: boolean;
   }>
 > = (props) => {
   const queryClient = useQueryClient();
@@ -50,7 +51,9 @@ export const UpdateRoleButton: FunctionComponent<
     <RoleMenu
       onSelect={(role) => handleSet(role)}
       role={props.user.organizationRole}
-      buttonProps={{ disabled: props.user.id === currentUser?.id }}
+      buttonProps={{
+        disabled: props.disabled || props.user.id === currentUser?.id,
+      }}
     />
   );
 };

--- a/webapp/src/views/organizations/useOrganization.ts
+++ b/webapp/src/views/organizations/useOrganization.ts
@@ -1,24 +1,17 @@
 import { useRouteMatch } from 'react-router-dom';
 
 import { PARAMS } from 'tg.constants/links';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 
-export const useOrganization = () => {
+export const useOrganization = () => useOrganizationLoadable().data;
+
+export const useOrganizationLoadable = () => {
   const match = useRouteMatch();
   const organizationSlug = match.params[PARAMS.ORGANIZATION_SLUG];
-  const { updatePreferredOrganization } = usePreferredOrganization();
 
-  const organization = useApiQuery({
+  return useApiQuery({
     url: '/v2/organizations/{slug}',
     method: 'get',
     path: { slug: organizationSlug },
-    options: {
-      onSuccess(data) {
-        updatePreferredOrganization(data.id);
-      },
-    },
   });
-
-  return organization.data;
 };

--- a/webapp/src/views/projects/BaseProjectView.tsx
+++ b/webapp/src/views/projects/BaseProjectView.tsx
@@ -8,6 +8,7 @@ import { SmallProjectAvatar } from 'tg.component/navigation/SmallProjectAvatar';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useProject } from 'tg.hooks/useProject';
+import { usePreferredOrganization } from 'tg.globalContext/helpers';
 import { BatchOperationsSummary } from './translations/BatchOperations/OperationsSummary/OperationsSummary';
 import { CriticalUsageCircle } from 'tg.ee';
 import { ProjectPage } from './ProjectPage';
@@ -28,14 +29,19 @@ export const BaseProjectView: React.FC<React.PropsWithChildren<Props>> = ({
   const project = useProject() as ReturnType<typeof useProject> | undefined;
   const { withBranchLink, withBranchUrl } = useBranchLinks();
   const history = useHistory();
+  const { preferredOrganization } = usePreferredOrganization();
 
   const handleOrganizationChange = () => {
     history.push(LINKS.PROJECTS.build());
   };
 
-  const prefixNavigation: NavigationItem[] = [
-    [<OrganizationSwitch key={0} onSelect={handleOrganizationChange} />],
-  ];
+  const prefixNavigation: NavigationItem[] = [];
+
+  if (preferredOrganization) {
+    prefixNavigation.push([
+      <OrganizationSwitch key={0} onSelect={handleOrganizationChange} />,
+    ]);
+  }
 
   if (project) {
     prefixNavigation.push([

--- a/webapp/src/views/projects/CommunityProjectsView.tsx
+++ b/webapp/src/views/projects/CommunityProjectsView.tsx
@@ -45,7 +45,6 @@ const CommunityProjects = () => {
         titleAdornment={
           <OrganizationSwitch
             plain
-            selectedSurface="community"
             onSelect={() => history.push(LINKS.ROOT.build())}
           />
         }

--- a/webapp/src/views/projects/ProjectListView.tsx
+++ b/webapp/src/views/projects/ProjectListView.tsx
@@ -11,8 +11,8 @@ import { ProjectsList } from 'tg.views/projects/ProjectsList';
 import { Button } from '@mui/material';
 import { Link } from 'react-router-dom';
 import {
+  useCanCreateProject,
   useIsAdminOrSupporter,
-  useIsOrganizationOwnerOrMaintainer,
   usePreferredOrganization,
 } from 'tg.globalContext/helpers';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
@@ -46,15 +46,14 @@ export const ProjectListView = () => {
 
   const { t } = useTranslate();
 
-  const isOrganizationOwnerOrMaintainer = useIsOrganizationOwnerOrMaintainer();
-
   const isAdminOrSupporter = useIsAdminOrSupporter();
 
   const isAdminAccess =
     !isAtLeastMemberOrgRole(preferredOrganization?.currentUserRole) &&
     isAdminOrSupporter;
 
-  const addAllowed = isOrganizationOwnerOrMaintainer || isAdminAccess;
+  const { canCreateProject, isFetching } = useCanCreateProject();
+  const addAllowed = canCreateProject || isFetching;
 
   const showSearch = useLatchedSearchVisibility(
     listPermitted.data?.page?.totalElements,
@@ -102,7 +101,7 @@ export const ProjectListView = () => {
             <EmptyListMessage
               loading={listPermitted.isFetching}
               hint={
-                isOrganizationOwnerOrMaintainer ? (
+                addAllowed ? (
                   <Button
                     component={Link}
                     to={LINKS.PROJECT_ADD.build()}

--- a/webapp/src/views/projects/ProjectListView.tsx
+++ b/webapp/src/views/projects/ProjectListView.tsx
@@ -52,8 +52,7 @@ export const ProjectListView = () => {
     !isAtLeastMemberOrgRole(preferredOrganization?.currentUserRole) &&
     isAdminOrSupporter;
 
-  const { canCreateProject, isFetching } = useCanCreateProject();
-  const addAllowed = canCreateProject || isFetching;
+  const canCreateProject = useCanCreateProject();
 
   const showSearch = useLatchedSearchVisibility(
     listPermitted.data?.page?.totalElements,
@@ -79,7 +78,7 @@ export const ProjectListView = () => {
         maxWidth={1000}
         allCentered
         addComponent={
-          addAllowed && (
+          canCreateProject && (
             <QuickStartHighlight itemKey="add_project">
               <BaseViewAddButton
                 addLinkTo={LINKS.PROJECT_ADD.build()}
@@ -101,7 +100,7 @@ export const ProjectListView = () => {
             <EmptyListMessage
               loading={listPermitted.isFetching}
               hint={
-                addAllowed ? (
+                canCreateProject ? (
                   <Button
                     component={Link}
                     to={LINKS.PROJECT_ADD.build()}

--- a/webapp/src/views/projects/ProjectsRouter.tsx
+++ b/webapp/src/views/projects/ProjectsRouter.tsx
@@ -1,23 +1,18 @@
-import { Switch, useRouteMatch } from 'react-router-dom';
+import { Switch } from 'react-router-dom';
 
 import { PrivateRoute } from 'tg.component/common/PrivateRoute';
 import { LINKS } from 'tg.constants/links';
+import { RequirePreferredOrganization } from 'tg.component/common/RequirePreferredOrganization';
 import { ProjectRouter } from './ProjectRouter';
 import { ProjectCreateView } from './project/ProjectCreateView';
-import React from 'react';
-import { RootView } from 'tg.views/RootView';
 
 export const ProjectsRouter = () => {
-  const match = useRouteMatch();
-
   return (
     <Switch>
-      <PrivateRoute exact path={`${match.path}`}>
-        <RootView />
-      </PrivateRoute>
-
-      <PrivateRoute exact path={`${LINKS.PROJECT_ADD.template}`}>
-        <ProjectCreateView />
+      <PrivateRoute exact path={LINKS.PROJECT_ADD.template}>
+        <RequirePreferredOrganization>
+          <ProjectCreateView />
+        </RequirePreferredOrganization>
       </PrivateRoute>
 
       <PrivateRoute path={LINKS.PROJECT.template}>

--- a/webapp/src/views/projects/ProjectsRouter.tsx
+++ b/webapp/src/views/projects/ProjectsRouter.tsx
@@ -2,7 +2,6 @@ import { Switch } from 'react-router-dom';
 
 import { PrivateRoute } from 'tg.component/common/PrivateRoute';
 import { LINKS } from 'tg.constants/links';
-import { RequirePreferredOrganization } from 'tg.component/common/RequirePreferredOrganization';
 import { ProjectRouter } from './ProjectRouter';
 import { ProjectCreateView } from './project/ProjectCreateView';
 
@@ -10,9 +9,7 @@ export const ProjectsRouter = () => {
   return (
     <Switch>
       <PrivateRoute exact path={LINKS.PROJECT_ADD.template}>
-        <RequirePreferredOrganization>
-          <ProjectCreateView />
-        </RequirePreferredOrganization>
+        <ProjectCreateView />
       </PrivateRoute>
 
       <PrivateRoute path={LINKS.PROJECT.template}>

--- a/webapp/src/views/projects/dashboard/ProjectTotals.tsx
+++ b/webapp/src/views/projects/dashboard/ProjectTotals.tsx
@@ -8,12 +8,12 @@ import { useHistory } from 'react-router-dom';
 import { components } from 'tg.service/apiSchema.generated';
 import { useProject } from 'tg.hooks/useProject';
 import { getProjectTranslationsUrl, LINKS, PARAMS } from 'tg.constants/links';
+import { billingLinkFor } from 'tg.fixtures/billingLink';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { useProjectPermissions } from 'tg.hooks/useProjectPermissions';
-import { useConfig, usePreferredOrganization } from 'tg.globalContext/helpers';
+import { useBillingOrganization, useConfig } from 'tg.globalContext/helpers';
 import { useCurrentLanguage } from '@tginternal/library/hooks/useCurrentLanguage';
 import { PercentFormat } from './PercentFormat';
-import { useGlobalContext } from 'tg.globalContext/GlobalContext';
 import { StringsHint } from 'tg.component/common/StringsHint';
 
 const StyledTiles = styled(Box)`
@@ -131,14 +131,8 @@ export const ProjectTotals: React.FC<
   });
   const locale = useCurrentLanguage();
 
-  const billingEnabled = useGlobalContext(
-    (c) => c.initialData.serverConfiguration.billing.enabled
-  );
-  const isOrganizationOwner = useGlobalContext(
-    (c) => c.initialData.preferredOrganization?.currentUserRole === 'OWNER'
-  );
-  const { preferredOrganization } = usePreferredOrganization();
-  const canGoToBilling = billingEnabled && isOrganizationOwner;
+  const billingOrganization = useBillingOrganization();
+  const canGoToBilling = Boolean(billingOrganization);
 
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const anchorWidth = useRef();
@@ -176,11 +170,10 @@ export const ProjectTotals: React.FC<
   };
 
   const redirectToBilling = () => {
-    history.push(
-      LINKS.ORGANIZATION_BILLING.build({
-        [PARAMS.ORGANIZATION_SLUG]: preferredOrganization?.id || '',
-      })
-    );
+    if (!billingOrganization) {
+      return;
+    }
+    history.push(billingLinkFor({ slug: billingOrganization.slug }));
   };
 
   const { satisfiesPermission } = useProjectPermissions();

--- a/webapp/src/views/projects/project/ProjectCreateView.tsx
+++ b/webapp/src/views/projects/project/ProjectCreateView.tsx
@@ -9,9 +9,12 @@ import { BaseFormView } from 'tg.component/layout/BaseFormView';
 import { DashboardPage } from 'tg.component/layout/DashboardPage';
 import { Validation } from 'tg.constants/GlobalValidationSchema';
 import { LINKS, PARAMS } from 'tg.constants/links';
-import { components } from 'tg.service/apiSchema.generated';
-import { useApiMutation, useApiQuery } from 'tg.service/http/useQueryApi';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import { useApiMutation } from 'tg.service/http/useQueryApi';
+import { CreateProjectFormValues } from 'tg.views/projects/project/types';
+import {
+  useCanCreateProject,
+  usePreferredOrganization,
+} from 'tg.globalContext/helpers';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
 import { messageService } from 'tg.service/MessageService';
 
@@ -19,8 +22,13 @@ import { BaseLanguageSelect } from 'tg.views/projects/project/components/BaseLan
 import { CreateProjectLanguagesArrayField } from 'tg.views/projects/project/components/CreateProjectLanguagesArrayField';
 import { useGlobalActions } from 'tg.globalContext/GlobalContext';
 
-export type CreateProjectValueType =
-  components['schemas']['CreateProjectRequest'];
+const RefusalMessage: FunctionComponent<
+  React.PropsWithChildren<{ dataCy: string }>
+> = ({ dataCy, children }) => (
+  <Typography variant="body2" color="error" data-cy={dataCy}>
+    {children}
+  </Typography>
+);
 
 export const ProjectCreateView: FunctionComponent<
   React.PropsWithChildren<unknown>
@@ -34,21 +42,26 @@ export const ProjectCreateView: FunctionComponent<
     invalidatePrefix: '/v2/projects',
   });
   const { t } = useTranslate();
-  const { preferredOrganization, updatePreferredOrganization } =
-    usePreferredOrganization();
+  const { preferredOrganization } = usePreferredOrganization();
+  const { canCreateProject, isFetching } = useCanCreateProject();
 
-  const onSubmit = (values: CreateProjectValueType) => {
-    values.name = values.name.trim();
-    values.languages = values.languages.filter((l) => !!l);
+  const onSubmit = (values: CreateProjectFormValues) => {
+    if (!preferredOrganization) {
+      return;
+    }
     createProjectLoadable.mutate(
       {
         content: {
-          'application/json': values,
+          'application/json': {
+            ...values,
+            name: values.name.trim(),
+            languages: values.languages.filter((l) => !!l),
+            organizationId: preferredOrganization.id,
+          },
         },
       },
       {
         onSuccess(data) {
-          updatePreferredOrganization(values.organizationId);
           messageService.success(<T keyName="project_created_message" />);
           history.push(
             LINKS.PROJECT_DASHBOARD.build({ [PARAMS.PROJECT_ID]: data.id })
@@ -59,24 +72,30 @@ export const ProjectCreateView: FunctionComponent<
     );
   };
 
-  const organizationsLoadable = useApiQuery({
-    url: '/v2/organizations',
-    method: 'get',
-    query: {
-      size: 100,
-      filterCurrentUserOwner: true,
-    },
-  });
-
-  const initialValues: CreateProjectValueType = {
+  const initialValues: CreateProjectFormValues = {
     name: '',
     languages: [
       { tag: 'en', name: 'English', originalName: 'English', flagEmoji: '🇬🇧' },
     ],
-    organizationId: preferredOrganization?.id || 0,
     baseLanguageTag: 'en',
     icuPlaceholders: true,
   };
+
+  const refusalMessage = preferredOrganization ? (
+    <RefusalMessage dataCy="project-create-no-permission-message">
+      <T
+        keyName="project_create_no_permission_message"
+        defaultValue="You don't have permission to create a project in this organization."
+      />
+    </RefusalMessage>
+  ) : (
+    <RefusalMessage dataCy="project-create-no-organization-message">
+      <T
+        keyName="project_create_no_organization_message"
+        defaultValue="You are not a member of any organization."
+      />
+    </RefusalMessage>
+  );
 
   return (
     <DashboardPage>
@@ -85,13 +104,14 @@ export const ProjectCreateView: FunctionComponent<
         windowTitle={t('create_project_view')}
         title={t('create_project_view')}
         initialValues={initialValues}
-        loading={organizationsLoadable.isLoading}
         onSubmit={onSubmit}
         saveActionLoadable={createProjectLoadable}
         validationSchema={Validation.PROJECT_CREATION(t)}
-        switcher={<OrganizationSwitch ownedOnly />}
+        disabled={isFetching}
+        submitDisabledReason={!canCreateProject ? refusalMessage : undefined}
+        switcher={<OrganizationSwitch />}
       >
-        {(props: FormikProps<CreateProjectValueType>) => {
+        {(props: FormikProps<CreateProjectFormValues>) => {
           return (
             <Box>
               <Box sx={{ mb: 1 }}>

--- a/webapp/src/views/projects/project/ProjectCreateView.tsx
+++ b/webapp/src/views/projects/project/ProjectCreateView.tsx
@@ -12,23 +12,18 @@ import { LINKS, PARAMS } from 'tg.constants/links';
 import { useApiMutation } from 'tg.service/http/useQueryApi';
 import { CreateProjectFormValues } from 'tg.views/projects/project/types';
 import {
-  useCanCreateProject,
-  usePreferredOrganization,
+  useIsSwitchingOrganization,
+  usePreferredOrganizationResolution,
+  useProjectCreationRefusal,
 } from 'tg.globalContext/helpers';
+import { BoxLoading } from 'tg.component/common/BoxLoading';
+import { NoPermissionsView } from 'tg.component/common/NoPermissionsView';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
 import { messageService } from 'tg.service/MessageService';
 
 import { BaseLanguageSelect } from 'tg.views/projects/project/components/BaseLanguageSelect';
 import { CreateProjectLanguagesArrayField } from 'tg.views/projects/project/components/CreateProjectLanguagesArrayField';
 import { useGlobalActions } from 'tg.globalContext/GlobalContext';
-
-const RefusalMessage: FunctionComponent<
-  React.PropsWithChildren<{ dataCy: string }>
-> = ({ dataCy, children }) => (
-  <Typography variant="body2" color="error" data-cy={dataCy}>
-    {children}
-  </Typography>
-);
 
 export const ProjectCreateView: FunctionComponent<
   React.PropsWithChildren<unknown>
@@ -42,13 +37,25 @@ export const ProjectCreateView: FunctionComponent<
     invalidatePrefix: '/v2/projects',
   });
   const { t } = useTranslate();
-  const { preferredOrganization } = usePreferredOrganization();
-  const { canCreateProject, isFetching } = useCanCreateProject();
+  const creationRefusal = useProjectCreationRefusal();
+  const isSwitchingOrganization = useIsSwitchingOrganization();
+  const resolution = usePreferredOrganizationResolution();
+
+  if (resolution.status === 'resolving') {
+    return (
+      <DashboardPage>
+        <BoxLoading />
+      </DashboardPage>
+    );
+  }
+
+  if (resolution.status === 'missing') {
+    return <NoPermissionsView reason="no-organization" />;
+  }
+
+  const organizationId = resolution.organization.id;
 
   const onSubmit = (values: CreateProjectFormValues) => {
-    if (!preferredOrganization) {
-      return;
-    }
     createProjectLoadable.mutate(
       {
         content: {
@@ -56,7 +63,7 @@ export const ProjectCreateView: FunctionComponent<
             ...values,
             name: values.name.trim(),
             languages: values.languages.filter((l) => !!l),
-            organizationId: preferredOrganization.id,
+            organizationId,
           },
         },
       },
@@ -81,21 +88,37 @@ export const ProjectCreateView: FunctionComponent<
     icuPlaceholders: true,
   };
 
-  const refusalMessage = preferredOrganization ? (
-    <RefusalMessage dataCy="project-create-no-permission-message">
+  const switchingReason = (
+    <Typography variant="body2" data-cy="project-create-switching-message">
+      <T
+        keyName="switching_organization_message"
+        defaultValue="Switching organization…"
+      />
+    </Typography>
+  );
+
+  const refusalReason = (
+    <Typography
+      variant="body2"
+      color="error"
+      data-cy="project-create-no-permission-message"
+    >
       <T
         keyName="project_create_no_permission_message"
         defaultValue="You don't have permission to create a project in this organization."
       />
-    </RefusalMessage>
-  ) : (
-    <RefusalMessage dataCy="project-create-no-organization-message">
-      <T
-        keyName="project_create_no_organization_message"
-        defaultValue="You are not a member of any organization."
-      />
-    </RefusalMessage>
+    </Typography>
   );
+
+  const submitDisabledReason = () => {
+    if (isSwitchingOrganization) {
+      return switchingReason;
+    }
+    if (creationRefusal === 'not-owner-or-maintainer') {
+      return refusalReason;
+    }
+    return undefined;
+  };
 
   return (
     <DashboardPage>
@@ -107,8 +130,7 @@ export const ProjectCreateView: FunctionComponent<
         onSubmit={onSubmit}
         saveActionLoadable={createProjectLoadable}
         validationSchema={Validation.PROJECT_CREATION(t)}
-        disabled={isFetching}
-        submitDisabledReason={!canCreateProject ? refusalMessage : undefined}
+        submitDisabledReason={submitDisabledReason()}
         switcher={<OrganizationSwitch />}
       >
         {(props: FormikProps<CreateProjectFormValues>) => {

--- a/webapp/src/views/projects/project/components/CreateProjectLanguagesArrayField.tsx
+++ b/webapp/src/views/projects/project/components/CreateProjectLanguagesArrayField.tsx
@@ -5,12 +5,12 @@ import { Field, useFormikContext } from 'formik';
 
 import { CreateLanguagesField } from 'tg.component/languages/CreateLanguagesField';
 
-import { CreateProjectValueType } from '../ProjectCreateView';
+import { CreateProjectFormValues } from 'tg.views/projects/project/types';
 
 export const CreateProjectLanguagesArrayField: FC<
   React.PropsWithChildren<unknown>
 > = () => {
-  const formikContext = useFormikContext<CreateProjectValueType>();
+  const formikContext = useFormikContext<CreateProjectFormValues>();
 
   const languagesMeta = formikContext.getFieldMeta('languages');
 

--- a/webapp/src/views/projects/project/types.ts
+++ b/webapp/src/views/projects/project/types.ts
@@ -1,0 +1,6 @@
+import { CreateProjectRequest } from 'tg.service/apiSchemaTypes.generated';
+
+export type CreateProjectFormValues = Omit<
+  CreateProjectRequest,
+  'organizationId'
+>;

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/MachineTranslation/MachineTranslation.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/MachineTranslation/MachineTranslation.tsx
@@ -149,6 +149,12 @@ export const MachineTranslation: React.FC<
                   {t('machine_translation_upgrade_plan')}
                 </Button>
               )}
+              fallback={
+                <T
+                  keyName="machine_translation_ask_owner_to_upgrade"
+                  defaultValue="Ask an organization owner to upgrade the plan."
+                />
+              }
             />
           </StyledError>
         </OutOfCreditsWrapper>

--- a/webapp/src/views/projects/usePublicProjectsList.ts
+++ b/webapp/src/views/projects/usePublicProjectsList.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useHasCommunityContributions } from 'tg.globalContext/helpers';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { useLatchedSearchVisibility } from 'tg.views/projects/useLatchedSearchVisibility';
 
@@ -10,8 +11,12 @@ type Options = {
 export const usePublicProjectsList = ({ contributionFilter }: Options = {}) => {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
+  const hasCommunityContributions = useHasCommunityContributions();
+  const defaultToContributions = Boolean(
+    contributionFilter && hasCommunityContributions
+  );
   const [myContributionsOnly, setMyContributionsOnly] = useState(
-    Boolean(contributionFilter)
+    defaultToContributions
   );
 
   const loadable = useApiQuery({


### PR DESCRIPTION
Follow-up to #3808 (merged). That PR fixed organization permissions for public projects on the backend; this one fixes the frontend bootstrap that still left the target user stuck.

## Problem

A signed-in user with **no organization** — organization creation disabled on the server, or an SSO-provisioned account — was stuck on the "No permissions" page and could not open a public project, even from a direct link.

## Root cause

`RequirePreferredOrganization` wrapped the whole authenticated route tree, so `ProjectsRouter` never mounted. `ProjectContext` — the only thing that adopts the project's owning organization as the preferred one — therefore never ran.

## Fix

Move the `/projects` routes above the terminal gate and re-apply the gate to the `/projects/add` leaf inside `ProjectsRouter`: viewing a project is reachable without a preferred organization, creating one still requires it.

Supporting changes that fall out of the route move:

- `DashboardRouter` extracted from `RootRouter` so the gated and ungated arms are declared in one place, and `HelpMenu` has a single structural mount.
- `HelpMenu` guard changed from `!preferredOrganization` to `!user` — it must render for a signed-in user who has no organization, and must not render for anonymous visitors.
- `OrganizationSwitch` / `BaseProjectView` handle the no-preferred-organization state instead of rendering an empty switch or a dangling breadcrumb chevron. On `/community-projects` the surface label still renders; the dropdown (which would open onto an empty list) does not.
- Project creation permission consolidated behind one `useCanCreateProject`, mirroring the server rule in `OrganizationRoleService.checkUserCanCreateProject` (owner or maintainer of the preferred organization, or a server `ADMIN`). It is shared by the add button on the project list, that view's empty-state shortcut, and the submit button on `/projects/add`. A user parked on an organization they cannot create in reaches the form only by typing the URL — it now renders with the submit disabled and the organization switcher still usable, instead of accepting input that would 403 on submit.

  One behaviour change on the project list follows, outside the organization-less persona this PR is about: a `SUPPORTER` viewing an organization they are not a member of **loses** the add button and empty-state shortcut, because the server refuses them — `isAdmin()` is `role == ADMIN`, so their create always 403'd. Server admins are unaffected. `isAdminAccess` is left exactly as it was in `ProjectListView`: it drives the admin-access banner, which is a different question from who may create.
- The disabled submit is accompanied by an explanation, so the state is not silent. Two messages, picked by whether an organization is selected at all: `project_create_no_permission_message` names the organization, and `project_create_no_organization_message` covers the state where there is none to name (reachable because `RequirePreferredOrganization` passes an email-unverified user straight through). Without it this traded a late-but-explicit 403 for an early-and-silent dead button — worst for the organization-less user, who on a server with `userCanCreateOrganizations=false` also sees an empty switcher popover with its "add organization" entry hidden. Both come from one `submitDisabledReason` prop on `BaseFormView`, which renders the reason and disables the button, so the two cannot fall out of step.
- The organization switcher on `/projects/add` is no longer restricted to organizations the user owns. `filterCurrentUserOwner` maps to `roleType = OWNER` server-side, so a maintainer — who may create — could not reach their own organization from the page that had just told them to switch.
- `StandardForm` blocks submission itself when the submit is refused, rather than relying on the button's `disabled` attribute. Callers using `formId` with their own submit button bypass that attribute entirely, so the gate belongs on the Formik submit path.
- `ProjectCreateView` no longer keeps `organizationId` in Formik state, taking it from the preferred organization at submit time instead. `StandardForm` sets `enableReinitialize`, so an id in `initialValues` meant that using the organization switcher — now the prescribed way out of a disabled submit — reset every field the user had typed.
- Support-chat entitlement consolidated behind one `useHasSupportChat`, shared by `useChatwoot` and `useIntercom`, and made viewer-scoped: a community contributor parked on someone else's organization no longer inherits that organization's paid support widget. Previously `setChatwootAttributes` would have pushed the host organization's plan, subscription status and enabled features to Chatwoot on behalf of a non-member.
- `useIntercom` now shuts the messenger down when a booted session becomes de-entitled mid-navigation — reachable now that the preferred organization changes as a side effect of ordinary navigation.

Preferred organization stays synchronized with the selected project; that is deliberate, since organization settings and glossaries need a selected organization.

## Backend fix folded in

Reviewing the client rule surfaced a defect in `ProjectsController.createProject`. It looked the role up with `organizationRoleService.getType(dto.organizationId)` — the *throwing* accessor — to decide whether to grant a maintainer full access, and that call happens after `ProjectCreationService.createProject` has already committed its own transaction. `getType` raises `USER_IS_NOT_MEMBER_OF_ORGANIZATION` for a non-member, so a server `ADMIN` creating a project in an organization they do not belong to passed the permission check, had the project persisted, and *then* received a 403 — leaving it behind in a stranger's organization with nothing in the UI indicating it existed.

The lookup only needs the role, so it wants the nullable `findType`. Swapped, with a regression test asserting the create succeeds and that no full-access permission is granted. Unrelated to organization-less public-project access, but it is the rule the client mirrors, and mirroring a broken rule was the alternative.

## Tests

- Backend: two new cases in `PreferredOrganizationCommunityTest` covering an organization-less user adopting an organization via a public project, and failing to adopt one without public projects (7/7 pass). `ProjectsControllerCreateTest` gains a case pinning the `getType` → `findType` fix.
- Unit: `organizationEntitlement` pins the support-tier and limited-view rules (mutation-checked — dropping either support tier or the limited-view conjunct turns the suite red). `organizationRole` pins the role predicates the create rule is built from.
- E2E: `communityPreferredOrganization.cy.ts` extended with an organization-less persona (server configured with `userCanCreateOrganizations=false`) covering cold deep-link adoption, reload persistence, switch-failure resilience, community project listing, and the create-project/create-organization walls; plus a case asserting the create-project submit is disabled for an organization-less user after they adopt a foreign organization. A second case covers the member persona end to end: submit disabled on the foreign organization, typed input surviving an organization switch, submit re-enabled, and the created project landing in the switched-to organization. A third adds a `SUPPORTER` persona (`supporterCommunityUser`) who owns no organization and is a plain `MEMBER` of one. It is checked in both positions — parked on an organization it only supports, and switched to the one it belongs to — so the add button and the create submit stay refused in each. That combination is what makes the `ADMIN`-vs-`ADMIN`-or-`SUPPORTER` distinction fail loudly if it regresses, and because the user owns nothing, the switch itself only succeeds while the switcher is not restricted to owned organizations. A fourth persona (`dualOrgCommunityUser`) owns one organization and is a plain `MEMBER` of another — the only shape that can cross from may-create to may-not — and its case delays the preference PUT to assert the submit is blocked while the switch is still in flight, which is the window in which a stale answer would create the project in the organization being left.

## Notes for review

Support chat is now scoped to the viewer's own relationship with the organization, via the `limitedView` flag from `PrivateOrganizationModel`. Who keeps it:

| Viewer | `limitedView` | `activeCloudSubscription` | Chatwoot | Intercom |
|---|---|---|---|---|
| Organization member (any role) | `false` | present | yes | yes |
| Project-level member, no organization role | `false` | null | yes | no (also no on `main`) |
| Admin / supporter | `false` | present | yes | yes |
| Public-project viewer only | `true` | null | **no** (changed) | no |

`limitedView` is `!isSupporterOrAdmin && !canUserViewStrict`, and `canUserViewStrict` counts direct project permissions as well as organization roles — so the only group that loses support chat is a viewer whose *sole* access route is public-project visibility. Everyone who has the widget on `main` keeps it.

The Intercom column is not a change from this PR: `activeCloudSubscription` is nulled unless `isAtLeastMember` (organization role only), and it is populated only by the cloud billing module, so Intercom could never boot for below-member or self-hosted users. This PR makes `useIntercom`'s menu-entry condition match the boot condition it already had, which removes a menu entry that rendered but did nothing on self-hosted instances.

`limitedView` is applied to support chat only. QA checks, tasks and translation memory still follow the content owner's entitlement, which is the intended behaviour — those are properties of the project being translated, whereas support chat is about the viewer's own relationship with Tolgee.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Community “preferred organization” adoption now works reliably for org-less users through public projects, with preferences preserved across sessions.
  * Help/support UI now appears conditionally based on sign-in and support eligibility.
  * Project creation UI now reflects organization preference and permission rules more directly.
* **Bug Fixes**
  * Improved access control around viewing/adopting preferred organizations and preventing unauthorized adoption or repeated updates.
  * Organization switch and routing behavior were tightened when no preferred organization is available.
* **Tests**
  * Expanded Cypress coverage for community preferred-organization and org-less scenarios.
  * Added backend and UI entitlement/helper tests to validate edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
