### PR TITLE
fix: exclude soft-deleted keys from the keys/info endpoint

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerInfoTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerInfoTest.kt
@@ -80,4 +80,29 @@ class KeyControllerInfoTest : ProjectAuthControllerTest("/v2/projects/") {
         }.andPrettyPrint
     }
   }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `excludes soft-deleted (trashed) keys`() {
+    val deletedKey = keyService.get(testData.project.id, "key-1", null)
+    keyService.softDeleteMultiple(listOf(deletedKey.id), testData.user)
+
+    performProjectAuthPost(
+      "keys/info",
+      mapOf(
+        "keys" to
+          listOf(
+            mapOf("name" to "key-1"),
+            mapOf("name" to "key-2"),
+          ),
+        "languageTags" to listOf("de"),
+      ),
+    ).andIsOk
+      .andAssertThatJson {
+        node("_embedded.keys") {
+          isArray.hasSize(1)
+          node("[0].name").isEqualTo("key-2")
+        }
+      }
+  }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerInfoTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeyControllerInfoTest.kt
@@ -8,6 +8,7 @@ import io.tolgee.fixtures.andPrettyPrint
 import io.tolgee.fixtures.generateImage
 import io.tolgee.fixtures.node
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -29,6 +30,11 @@ class KeyControllerInfoTest : ProjectAuthControllerTest("/v2/projects/") {
       userAccount = testData.user
       uploadedImageId = imageUploadService.store(generateImage(), userAccount!!, null).id
     }
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeyInfoProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeyInfoProvider.kt
@@ -63,7 +63,9 @@ class KeyInfoProvider(
 
     val keyPredicates = cb.or(*predicates.toTypedArray())
 
-    query.where(cb.and(keyPredicates, branchPredicate))
+    val notDeletedPredicate = cb.isNull(root.get(Key_.deletedAt))
+
+    query.where(cb.and(keyPredicates, branchPredicate, notDeletedPredicate))
     query.orderBy(cb.asc(namespace.get(Namespace_.name)), cb.asc(root.get(Key_.name)))
 
     val result = entityManager.createQuery(query).resultList


### PR DESCRIPTION
Fixes #3817

`POST /v2/projects/{projectId}/keys/info` returns soft-deleted ("trashed") keys along with their translations for as long as they sit in the trash (the 7-day purge window), breaking the endpoint's documented contract ("If key is not found, it's not included in the response"). `Key` is `SoftDeletable` with no global soft-delete filter, so every query has to add `deletedAt IS NULL` itself — and `KeyInfoProvider.get()` (behind `KeyService.getKeysInfo()`) builds its Criteria `WHERE` from key name / namespace / branch only, omitting that predicate. The authoritative read paths all include it; the parallel Criteria query in `ExportDataProvider.filterDeletedKeys()` does exactly `cb.isNull(key.get(Key_.deletedAt))`. This adds the same predicate to `KeyInfoProvider`, so trashed keys stop leaking from `keys/info` (matching `/translations` and `/keys`). Looks like a regression from key archiving (#3486).

Adds a regression test to `KeyControllerInfoTest`: soft-delete a key via `keyService.softDeleteMultiple`, then `POST keys/info` for both the deleted key and a live sibling and assert only the live one comes back.

Ran locally against the auto-started Postgres (`./gradlew :server-app:test --tests "*KeyControllerInfoTest"`, JDK 21) — the new test and the existing `returns the data` case both pass. The full suite runs in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Key information results now exclude keys that have been moved to trash.
  * Only active (non-deleted) keys are returned when requesting key details for selected language tags.
* **Tests**
  * Improved key controller tests by adding automatic post-test cleanup to ensure stored test data doesn’t affect subsequent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->