### PR TITLE
feat: community projects "My contributions only" toggle and switcher entry

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/InitialDataController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/InitialDataController.kt
@@ -13,6 +13,7 @@ import io.tolgee.hateoas.userAccount.PrivateUserAccountModelAssembler
 import io.tolgee.openApiDocs.OpenApiHideFromPublicDocs
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.TenantService
+import io.tolgee.service.contributor.ProjectContributorService
 import io.tolgee.service.security.UserPreferencesService
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
@@ -40,6 +41,7 @@ class InitialDataController(
   private val publicSsoTenantModelAssembler: PublicSsoTenantModelAssembler,
   private val qaCheckCategoryModelAssembler: QaCheckCategoryModelAssembler,
   private val eeSubscriptionProvider: EeSubscriptionProvider?,
+  private val projectContributorService: ProjectContributorService,
 ) : IController {
   @GetMapping(value = [""])
   @Operation(summary = "Get initial data", description = "Returns initial data required by the UI to load")
@@ -61,6 +63,7 @@ class InitialDataController(
       data.languageTag = userPreferencesService.find(userAccount.id)?.language
       data.announcement = announcementController.getLatest()
       data.eeSubscription = getEeSubscriptionModel()
+      data.hasCommunityContributions = projectContributorService.hasCommunityContributions(userAccount.id)
     }
 
     return data

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/PublicProjectsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/PublicProjectsController.kt
@@ -37,8 +37,9 @@ class PublicProjectsController(
   fun getAllPublicWithStatistics(
     @ParameterObject @SortDefault("name") pageable: Pageable,
     @RequestParam("search") search: String?,
+    @RequestParam("filterContributed", defaultValue = "false") filterContributed: Boolean,
   ): PagedModel<ProjectWithStatsModel> {
-    val projects = projectService.findAllPublicPaged(pageable, search)
+    val projects = projectService.findAllPublicPaged(pageable, search, filterContributed)
     return projectWithStatsFacade.getPagedModelWithStats(projects)
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/initialData/InitialDataModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/initialData/InitialDataModel.kt
@@ -18,4 +18,5 @@ class InitialDataModel(
   var announcement: AnnouncementDto? = null,
   var eeSubscription: InitialDataEeSubscriptionModel? = null,
   var qaCheckCategories: List<QaCheckCategoryModel>? = null,
+  var hasCommunityContributions: Boolean = false,
 )

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/InitialDataControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/InitialDataControllerTest.kt
@@ -17,6 +17,7 @@ class InitialDataControllerTest : AuthorizedControllerTest() {
       node("serverConfiguration.authentication").isEqualTo(true)
       node("userInfo.name").isEqualTo("admin")
       node("preferredOrganization.name").isEqualTo("admin")
+      node("hasCommunityContributions").isEqualTo(false)
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PublicProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PublicProjectsControllerTest.kt
@@ -4,18 +4,25 @@ import io.tolgee.development.testDataBuilder.data.PublicProjectsControllerTestDa
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.node
+import io.tolgee.model.activity.ActivityRevision
+import io.tolgee.service.contributor.ProjectContributorService
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import java.util.Date
 
 @SpringBootTest
 @AutoConfigureMockMvc
 class PublicProjectsControllerTest : AuthorizedControllerTest() {
   private lateinit var testData: PublicProjectsControllerTestData
+
+  @Autowired
+  private lateinit var projectContributorService: ProjectContributorService
 
   @BeforeEach
   fun setup() {
@@ -25,6 +32,7 @@ class PublicProjectsControllerTest : AuthorizedControllerTest() {
 
   @AfterEach
   fun cleanup() {
+    currentDateProvider.forcedDate = null
     testDataService.cleanTestData(testData.root)
   }
 
@@ -190,6 +198,64 @@ class PublicProjectsControllerTest : AuthorizedControllerTest() {
     projectService.hasPublicProjects(testData.softDeletedBaseLangOnlyOrg.id).assert.isFalse()
     projectService.hasPublicProjects(testData.deletedProjectOnlyOrg.id).assert.isFalse()
     projectService.hasPublicProjects(testData.softDeletedOrg.id).assert.isFalse()
+  }
+
+  @Test
+  fun `filterContributed lists only public projects the user contributed to as a non-member`() {
+    recordActivity(testData.publicProject.id, testData.nonMember.id)
+
+    userAccount = testData.nonMember
+    performAuthGet("/v2/public/projects/with-stats?filterContributed=true").andIsOk.andAssertThatJson {
+      node("_embedded.projects") {
+        isArray.hasSize(1)
+        node("[0].id").isEqualTo(testData.publicProject.id)
+      }
+    }
+  }
+
+  @Test
+  fun `filterContributed excludes a contributed project the user is a member of`() {
+    recordActivity(testData.publicProject.id, testData.user.id)
+
+    userAccount = testData.user
+    performAuthGet("/v2/public/projects/with-stats?filterContributed=true").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun `filterContributed returns nothing to an anonymous visitor`() {
+    recordActivity(testData.publicProject.id, testData.nonMember.id)
+
+    performGet("/v2/public/projects/with-stats?filterContributed=true").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun `hasCommunityContributions is true for a non-member contributor, false for a member`() {
+    recordActivity(testData.publicProject.id, testData.nonMember.id)
+    recordActivity(testData.publicProject.id, testData.user.id)
+
+    projectContributorService.hasCommunityContributions(testData.nonMember.id).assert.isTrue()
+    projectContributorService.hasCommunityContributions(testData.user.id).assert.isFalse()
+  }
+
+  private fun recordActivity(
+    projectId: Long,
+    authorId: Long?,
+    at: Date = Date(1_600_000_000_000),
+  ) {
+    currentDateProvider.forcedDate = at
+    executeInNewTransaction {
+      entityManager.persist(
+        ActivityRevision().apply {
+          this.projectId = projectId
+          this.authorId = authorId
+        },
+      )
+      entityManager.flush()
+    }
   }
 
   private fun baseLanguageId(projectId: Long): Long? =

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PublicProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/PublicProjectsControllerTest.kt
@@ -224,6 +224,17 @@ class PublicProjectsControllerTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `filterContributed excludes a contributed project the user is a direct-permission member of`() {
+    recordActivity(testData.otherOrgPublicProject.id, testData.directPermissionUser.id)
+
+    userAccount = testData.directPermissionUser
+    performAuthGet("/v2/public/projects/with-stats?filterContributed=true").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+    projectContributorService.hasCommunityContributions(testData.directPermissionUser.id).assert.isFalse()
+  }
+
+  @Test
   fun `filterContributed returns nothing to an anonymous visitor`() {
     recordActivity(testData.publicProject.id, testData.nonMember.id)
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/CommunityContributionE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/CommunityContributionE2eData.kt
@@ -1,0 +1,29 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.model.Project
+
+class CommunityContributionE2eData : BaseTestData("communityContributionOwner", "Owner private project") {
+  lateinit var publicProject: Project
+
+  init {
+    root.apply {
+      publicProject =
+        addProject(organizationOwner = userAccountBuilder.defaultOrganizationBuilder.self) {
+          name = "Contributed public project"
+          public = true
+        }.build {
+          addBaseLanguage()
+        }.self
+    }
+  }
+
+  private fun ProjectBuilder.addBaseLanguage() {
+    addLanguage {
+      name = "English"
+      tag = "en"
+      originalName = "English"
+      this@addBaseLanguage.self.baseLanguage = this
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -1,11 +1,17 @@
 package io.tolgee.development.testDataBuilder.data
 
 import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
+import io.tolgee.model.Project
+import io.tolgee.model.UserAccount
 
 class PublicProjectsE2eData(
   count: Int = 6,
   includeForeignOrgProject: Boolean = true,
 ) : BaseTestData("publicProjectsUser", "Private project") {
+  // publicProjectsUser is a non-member of this project — the seed target for a community contribution.
+  var outsiderProject: Project? = null
+  val contributingUser: UserAccount = userAccountBuilder.self
+
   init {
     root.apply {
       val communityUserBuilder =
@@ -15,12 +21,13 @@ class PublicProjectsE2eData(
         }
 
       if (includeForeignOrgProject) {
-        addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
-          name = "Community Outsider"
-          public = true
-        }.build {
-          addBaseLanguage()
-        }
+        outsiderProject =
+          addProject(organizationOwner = communityUserBuilder.defaultOrganizationBuilder.self) {
+            name = "Community Outsider"
+            public = true
+          }.build {
+            addBaseLanguage()
+          }.self
       }
 
       listOf("Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta").take(count).forEach { suffix ->

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsE2eData.kt
@@ -8,7 +8,6 @@ class PublicProjectsE2eData(
   count: Int = 6,
   includeForeignOrgProject: Boolean = true,
 ) : BaseTestData("publicProjectsUser", "Private project") {
-  // publicProjectsUser is a non-member of this project — the seed target for a community contribution.
   var outsiderProject: Project? = null
   val contributingUser: UserAccount = userAccountBuilder.self
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
@@ -32,22 +32,16 @@ interface ProjectContributorRepository : Repository<ProjectContributor, ProjectC
     pageable: Pageable,
   ): Page<ProjectContributorView>
 
-  // Structurally mirrors the mine-only filter in ProjectRepository.findAllPublic so the switcher gate
-  // and the community-page listing cannot silently diverge — edit both together.
   @Query(
     """
       select count(r) > 0 from Project r
       left join r.baseLanguage bl
       left join r.organizationOwner o
-      left join Permission p on p.project = r and p.user.id = :userId
-      left join OrganizationRole role on role.organization = o and role.user.id = :userId
+      left join Permission p on p.project = r and p.user.id = :userAccountId
+      left join OrganizationRole role on role.organization = o and role.user.id = :userAccountId
       where ${ProjectRepository.PUBLIC_PROJECT_VISIBILITY}
-        and p is null and role is null
-        and exists (
-          select 1 from ProjectContributor pc
-          where pc.projectId = r.id and pc.userId = :userId
-        )
+        and ${ProjectRepository.NON_MEMBER_CONTRIBUTOR_FILTER}
     """,
   )
-  fun hasNonMemberPublicContribution(userId: Long): Boolean
+  fun hasNonMemberPublicContribution(userAccountId: Long): Boolean
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
@@ -31,4 +31,23 @@ interface ProjectContributorRepository : Repository<ProjectContributor, ProjectC
     projectId: Long,
     pageable: Pageable,
   ): Page<ProjectContributorView>
+
+  // Membership exclusion (`p is null and orl is null`) must match the mine-only filter in
+  // ProjectRepository.findAllPublic — the switcher entry and the community page share this predicate.
+  @Query(
+    """
+      select count(pc) > 0
+      from ProjectContributor pc
+      join Project r on r.id = pc.projectId
+      left join r.baseLanguage bl
+      left join r.organizationOwner o
+      left join Permission p on p.project = r and p.user.id = :userId
+      left join OrganizationRole orl on orl.organization = o and orl.user.id = :userId
+      where pc.userId = :userId
+        and ${ProjectRepository.PUBLIC_PROJECT_VISIBILITY}
+        and p is null
+        and orl is null
+    """,
+  )
+  fun hasNonMemberPublicContribution(userId: Long): Boolean
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectContributorRepository.kt
@@ -32,21 +32,21 @@ interface ProjectContributorRepository : Repository<ProjectContributor, ProjectC
     pageable: Pageable,
   ): Page<ProjectContributorView>
 
-  // Membership exclusion (`p is null and orl is null`) must match the mine-only filter in
-  // ProjectRepository.findAllPublic — the switcher entry and the community page share this predicate.
+  // Structurally mirrors the mine-only filter in ProjectRepository.findAllPublic so the switcher gate
+  // and the community-page listing cannot silently diverge — edit both together.
   @Query(
     """
-      select count(pc) > 0
-      from ProjectContributor pc
-      join Project r on r.id = pc.projectId
+      select count(r) > 0 from Project r
       left join r.baseLanguage bl
       left join r.organizationOwner o
       left join Permission p on p.project = r and p.user.id = :userId
-      left join OrganizationRole orl on orl.organization = o and orl.user.id = :userId
-      where pc.userId = :userId
-        and ${ProjectRepository.PUBLIC_PROJECT_VISIBILITY}
-        and p is null
-        and orl is null
+      left join OrganizationRole role on role.organization = o and role.user.id = :userId
+      where ${ProjectRepository.PUBLIC_PROJECT_VISIBILITY}
+        and p is null and role is null
+        and exists (
+          select 1 from ProjectContributor pc
+          where pc.projectId = r.id and pc.userId = :userId
+        )
     """,
   )
   fun hasNonMemberPublicContribution(userId: Long): Boolean

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -57,6 +57,7 @@ interface ProjectRepository : JpaRepository<Project, Long> {
         and o.deletedAt is null
         """
 
+    /** Embedding query must expose the `r`, `p` (Permission), `role` (OrganizationRole) aliases and bind `:userAccountId` — see [findAllPublic]. */
     const val NON_MEMBER_CONTRIBUTOR_FILTER = """
         p is null and role is null
         and exists (

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -57,6 +57,14 @@ interface ProjectRepository : JpaRepository<Project, Long> {
         and o.deletedAt is null
         """
 
+    const val NON_MEMBER_CONTRIBUTOR_FILTER = """
+        p is null and role is null
+        and exists (
+            select 1 from ProjectContributor pc
+            where pc.projectId = r.id and pc.userId = :userAccountId
+        )
+        """
+
     /** `r.deletedAt`/`o.deletedAt` sit top-level so they also guard the permission branch, which [PUBLIC_PROJECT_VISIBILITY] does not. */
     const val BELOW_MEMBER_ACCESSIBLE_PROJECT = """
         (
@@ -136,16 +144,7 @@ interface ProjectRepository : JpaRepository<Project, Long> {
             :search is null or (lower(r.name) like lower(concat('%', cast(:search as text), '%'))
             or lower(o.name) like lower(concat('%', cast(:search as text),'%')))
         )
-        and (
-            :filterContributed = false
-            or (
-                p is null and role is null
-                and exists (
-                    select 1 from ProjectContributor pc
-                    where pc.projectId = r.id and pc.userId = :userAccountId
-                )
-            )
-        )
+        and (:filterContributed = false or ($NON_MEMBER_CONTRIBUTOR_FILTER))
     """,
   )
   fun findAllPublic(

--- a/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/ProjectRepository.kt
@@ -136,12 +136,23 @@ interface ProjectRepository : JpaRepository<Project, Long> {
             :search is null or (lower(r.name) like lower(concat('%', cast(:search as text), '%'))
             or lower(o.name) like lower(concat('%', cast(:search as text),'%')))
         )
+        and (
+            :filterContributed = false
+            or (
+                p is null and role is null
+                and exists (
+                    select 1 from ProjectContributor pc
+                    where pc.projectId = r.id and pc.userId = :userAccountId
+                )
+            )
+        )
     """,
   )
   fun findAllPublic(
     userAccountId: Long,
     pageable: Pageable,
     @Param("search") search: String? = null,
+    @Param("filterContributed") filterContributed: Boolean = false,
   ): Page<ProjectView>
 
   @Query(

--- a/backend/data/src/main/kotlin/io/tolgee/service/contributor/ProjectContributorService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/contributor/ProjectContributorService.kt
@@ -19,6 +19,10 @@ class ProjectContributorService(
     return projectContributorRepository.findContributors(projectId, withTotalOrder(pageable))
   }
 
+  fun hasCommunityContributions(userId: Long): Boolean {
+    return projectContributorRepository.hasNonMemberPublicContribution(userId)
+  }
+
   private fun withTotalOrder(pageable: Pageable): Pageable {
     val orders = pageable.sort.filter { it.property in ALLOWED_SORT_PROPERTIES }.toMutableList()
     if (orders.isEmpty()) {

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectService.kt
@@ -483,9 +483,10 @@ class ProjectService(
   fun findAllPublicPaged(
     pageable: Pageable,
     search: String?,
+    filterContributed: Boolean = false,
   ): Page<ProjectWithLanguagesView> {
     val userAccountId = authenticationFacade.authenticatedUserOrNull?.id ?: NO_USER_ID
-    val projects = projectRepository.findAllPublic(userAccountId, pageable, search)
+    val projects = projectRepository.findAllPublic(userAccountId, pageable, search, filterContributed)
     return projects.map { ProjectWithLanguagesView.fromProjectView(it, null) }
   }
 

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
@@ -14,21 +14,23 @@ class CommunityContributionE2eDataController : AbstractE2eDataController() {
   private lateinit var entityManager: EntityManager
 
   @Autowired
-  private lateinit var userAccountLookup: UserAccountService
+  private lateinit var userAccountService: UserAccountService
 
-  private lateinit var currentTestData: CommunityContributionE2eData
+  private var currentTestData: CommunityContributionE2eData? = null
 
   override val testData: TestDataBuilder
     get() {
-      currentTestData = CommunityContributionE2eData()
-      return currentTestData.root
+      val data = CommunityContributionE2eData()
+      currentTestData = data
+      return data.root
     }
 
   override fun afterTestDataStored(data: TestDataBuilder) {
-    val adminId = userAccountLookup.findActive(ADMIN_USERNAME)?.id ?: return
+    val testData = currentTestData ?: return
+    val adminId = userAccountService.findActive(ADMIN_USERNAME)?.id ?: return
     entityManager.persist(
       ActivityRevision().apply {
-        projectId = currentTestData.publicProject.id
+        projectId = testData.publicProject.id
         authorId = adminId
       },
     )

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
@@ -16,21 +16,19 @@ class CommunityContributionE2eDataController : AbstractE2eDataController() {
   @Autowired
   private lateinit var userAccountLookup: UserAccountService
 
-  private lateinit var data: CommunityContributionE2eData
+  private lateinit var currentTestData: CommunityContributionE2eData
 
   override val testData: TestDataBuilder
     get() {
-      data = CommunityContributionE2eData()
-      return data.root
+      currentTestData = CommunityContributionE2eData()
+      return currentTestData.root
     }
 
-  // Seed a contribution by the seeded platform admin (the default e2e login user) on a public project it
-  // is not a member of, so the gated "Community translation" switcher entry renders for that user.
   override fun afterTestDataStored(data: TestDataBuilder) {
     val adminId = userAccountLookup.findActive(ADMIN_USERNAME)?.id ?: return
     entityManager.persist(
       ActivityRevision().apply {
-        projectId = this@CommunityContributionE2eDataController.data.publicProject.id
+        projectId = currentTestData.publicProject.id
         authorId = adminId
       },
     )

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/CommunityContributionE2eDataController.kt
@@ -1,0 +1,43 @@
+package io.tolgee.controllers.internal.e2eData
+
+import io.tolgee.controllers.internal.InternalController
+import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
+import io.tolgee.development.testDataBuilder.data.CommunityContributionE2eData
+import io.tolgee.model.activity.ActivityRevision
+import io.tolgee.service.security.UserAccountService
+import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Autowired
+
+@InternalController(["internal/e2e-data/community-contribution"])
+class CommunityContributionE2eDataController : AbstractE2eDataController() {
+  @Autowired
+  private lateinit var entityManager: EntityManager
+
+  @Autowired
+  private lateinit var userAccountLookup: UserAccountService
+
+  private lateinit var data: CommunityContributionE2eData
+
+  override val testData: TestDataBuilder
+    get() {
+      data = CommunityContributionE2eData()
+      return data.root
+    }
+
+  // Seed a contribution by the seeded platform admin (the default e2e login user) on a public project it
+  // is not a member of, so the gated "Community translation" switcher entry renders for that user.
+  override fun afterTestDataStored(data: TestDataBuilder) {
+    val adminId = userAccountLookup.findActive(ADMIN_USERNAME)?.id ?: return
+    entityManager.persist(
+      ActivityRevision().apply {
+        projectId = this@CommunityContributionE2eDataController.data.publicProject.id
+        authorId = adminId
+      },
+    )
+    entityManager.flush()
+  }
+
+  companion object {
+    private const val ADMIN_USERNAME = "admin"
+  }
+}

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
@@ -18,26 +18,20 @@ class PublicProjectsE2eDataController(
   @Autowired
   private lateinit var entityManager: EntityManager
 
-  private lateinit var data: PublicProjectsE2eData
+  private lateinit var currentTestData: PublicProjectsE2eData
 
-  // Each access builds a fresh graph (save assigns ids) and captures the instance so
-  // afterTestDataStored can read the just-persisted "Community Outsider" project to seed a contribution.
   override val testData: TestDataBuilder
     get() {
-      data = PublicProjectsE2eData()
-      return data.root
+      currentTestData = PublicProjectsE2eData()
+      return currentTestData.root
     }
 
-  // The community page reads contributions, not memberships. publicProjectsUser owns the "Community *"
-  // projects (a member of those), so it only qualifies as a contributor on the foreign-org project it
-  // is not a member of — seed one activity revision there so the mine-only view and the switcher entry
-  // have something to show.
   override fun afterTestDataStored(data: TestDataBuilder) {
-    val project = this.data.outsiderProject ?: return
+    val project = currentTestData.outsiderProject ?: return
     entityManager.persist(
       ActivityRevision().apply {
         projectId = project.id
-        authorId = this@PublicProjectsE2eDataController.data.contributingUser.id
+        authorId = currentTestData.contributingUser.id
       },
     )
     entityManager.flush()

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
@@ -18,20 +18,22 @@ class PublicProjectsE2eDataController(
   @Autowired
   private lateinit var entityManager: EntityManager
 
-  private lateinit var currentTestData: PublicProjectsE2eData
+  private var currentTestData: PublicProjectsE2eData? = null
 
   override val testData: TestDataBuilder
     get() {
-      currentTestData = PublicProjectsE2eData()
-      return currentTestData.root
+      val data = PublicProjectsE2eData()
+      currentTestData = data
+      return data.root
     }
 
   override fun afterTestDataStored(data: TestDataBuilder) {
-    val project = currentTestData.outsiderProject ?: return
+    val testData = currentTestData ?: return
+    val project = testData.outsiderProject ?: return
     entityManager.persist(
       ActivityRevision().apply {
         projectId = project.id
-        authorId = currentTestData.contributingUser.id
+        authorId = testData.contributingUser.id
       },
     )
     entityManager.flush()

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/e2eData/PublicProjectsE2eDataController.kt
@@ -5,6 +5,9 @@ import io.tolgee.data.StandardTestDataResult
 import io.tolgee.data.service.TestDataGeneratingService
 import io.tolgee.development.testDataBuilder.builders.TestDataBuilder
 import io.tolgee.development.testDataBuilder.data.PublicProjectsE2eData
+import io.tolgee.model.activity.ActivityRevision
+import jakarta.persistence.EntityManager
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.bind.annotation.GetMapping
 
@@ -12,8 +15,33 @@ import org.springframework.web.bind.annotation.GetMapping
 class PublicProjectsE2eDataController(
   private val generatingService: TestDataGeneratingService,
 ) : AbstractE2eDataController() {
+  @Autowired
+  private lateinit var entityManager: EntityManager
+
+  private lateinit var data: PublicProjectsE2eData
+
+  // Each access builds a fresh graph (save assigns ids) and captures the instance so
+  // afterTestDataStored can read the just-persisted "Community Outsider" project to seed a contribution.
   override val testData: TestDataBuilder
-    get() = PublicProjectsE2eData().root
+    get() {
+      data = PublicProjectsE2eData()
+      return data.root
+    }
+
+  // The community page reads contributions, not memberships. publicProjectsUser owns the "Community *"
+  // projects (a member of those), so it only qualifies as a contributor on the foreign-org project it
+  // is not a member of — seed one activity revision there so the mine-only view and the switcher entry
+  // have something to show.
+  override fun afterTestDataStored(data: TestDataBuilder) {
+    val project = this.data.outsiderProject ?: return
+    entityManager.persist(
+      ActivityRevision().apply {
+        projectId = project.id
+        authorId = this@PublicProjectsE2eDataController.data.contributingUser.id
+      },
+    )
+    entityManager.flush()
+  }
 
   @GetMapping(value = ["/generate-few"])
   @Transactional

--- a/e2e/cypress/common/apiCalls/testData/testData.ts
+++ b/e2e/cypress/common/apiCalls/testData/testData.ts
@@ -21,6 +21,10 @@ export const ssoOrganizationsLoginTestData = generateTestDataObject(
 
 export const organizationTestData = generateTestDataObject('organizations');
 
+export const communityContributionData = generateTestDataObject(
+  'community-contribution'
+);
+
 export const organizationNewTestData =
   generateTestDataObject('organization-new');
 

--- a/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
+++ b/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
@@ -142,6 +142,17 @@ describe('Community projects navigation', () => {
     }).should('be.visible');
   });
 
+  it('does not offer the community entry for a user with no contributions', () => {
+    communityContributionData.clean();
+    visitProjects();
+    openSwitch();
+    gcy('switch-popover-item').should('exist');
+    gcyAdvanced({
+      value: 'switch-popover-footer-action',
+      action: 'organization-switch-community',
+    }).should('not.exist');
+  });
+
   it('shows the empty state and hides search when there are no contributions', () => {
     publicProjectsData.clean();
     communityContributionData.clean();

--- a/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
+++ b/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
@@ -29,8 +29,6 @@ describe('Community projects navigation', () => {
     setBypassSeatCountCheck(true);
     login();
     communityContributionData.clean();
-    // Seeds a contribution by the admin login user on a public project it is not a member of, so the
-    // gated "Community translation" switcher entry renders.
     communityContributionData.generateStandard();
     organizationTestData.clean({ timeout: 120000 });
     organizationTestData.generate().then((res) => {
@@ -146,7 +144,6 @@ describe('Community projects navigation', () => {
 
   it('shows the empty state and hides search when there are no contributions', () => {
     publicProjectsData.clean();
-    // Default-on shows the admin's contributions; clear the seeded one so the list is genuinely empty.
     communityContributionData.clean();
     visitCommunity();
     waitForGlobalLoading();
@@ -211,11 +208,11 @@ describe('Community projects email-verification gate', () => {
 describe('Community projects list content', () => {
   beforeEach(() => {
     publicProjectsData.clean();
+    communityContributionData.clean();
     publicProjectsData.generateStandard();
     login('publicProjectsUser');
     cy.visit(`${HOST}/community-projects`);
     waitForGlobalLoading();
-    // These tests assert the full public listing, which is the toggle-off state.
     disableMyContributions();
   });
 
@@ -254,11 +251,11 @@ describe('Community projects list content', () => {
 describe('Community projects search threshold', () => {
   beforeEach(() => {
     publicProjectsData.clean();
+    communityContributionData.clean();
     publicProjectsData.generateFew();
     login('publicProjectsUser');
     cy.visit(`${HOST}/community-projects`);
     waitForGlobalLoading();
-    // The threshold applies to the full public listing, which is the toggle-off state.
     disableMyContributions();
   });
 
@@ -275,6 +272,7 @@ describe('Community projects search threshold', () => {
 describe('Community projects "My contributions only" toggle', () => {
   beforeEach(() => {
     publicProjectsData.clean();
+    communityContributionData.clean();
     publicProjectsData.generateStandard();
     login('publicProjectsUser');
     cy.visit(`${HOST}/community-projects`);
@@ -287,8 +285,6 @@ describe('Community projects "My contributions only" toggle', () => {
 
   it('defaults on and lists only public projects the user contributed to as a non-member', () => {
     gcy('community-my-contributions-toggle').find('input').should('be.checked');
-    // publicProjectsUser owns the "Community *" projects (a member of those); it only contributed to
-    // "Community Outsider", owned by another org.
     gcy('dashboard-projects-list-item').should('have.length', 1);
     cy.contains('Community Outsider').should('be.visible');
     cy.contains('Community Alpha').should('not.exist');

--- a/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
+++ b/e2e/cypress/e2e/projects/communityProjectsNavigation.cy.ts
@@ -10,11 +10,17 @@ import {
   setBypassSeatCountCheck,
 } from '../../common/apiCalls/common';
 import {
+  communityContributionData,
   organizationTestData,
   publicProjectsData,
 } from '../../common/apiCalls/testData/testData';
 import { gcy, gcyAdvanced, switchToOrganization } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
+
+const disableMyContributions = () => {
+  gcy('community-my-contributions-toggle').click();
+  waitForGlobalLoading();
+};
 
 describe('Community projects navigation', () => {
   let organizationData: Record<string, { slug: string }>;
@@ -22,6 +28,10 @@ describe('Community projects navigation', () => {
   beforeEach(() => {
     setBypassSeatCountCheck(true);
     login();
+    communityContributionData.clean();
+    // Seeds a contribution by the admin login user on a public project it is not a member of, so the
+    // gated "Community translation" switcher entry renders.
+    communityContributionData.generateStandard();
     organizationTestData.clean({ timeout: 120000 });
     organizationTestData.generate().then((res) => {
       organizationData = res.body as any;
@@ -31,6 +41,7 @@ describe('Community projects navigation', () => {
 
   afterEach(() => {
     organizationTestData.clean();
+    communityContributionData.clean();
     setBypassSeatCountCheck(false);
   });
 
@@ -50,10 +61,7 @@ describe('Community projects navigation', () => {
     cy.waitForDom();
   };
 
-  // TODO: the "Community translation" switcher entry is currently disabled (it will return once
-  // contributor tracking lands in a future pitch). Re-enable these five skipped tests — the ones
-  // that drive `switch-popover-footer-action` — when the button is added back.
-  it.skip('navigates to the community page via the dropdown entry (mouse)', () => {
+  it('navigates to the community page via the dropdown entry (mouse)', () => {
     openSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
@@ -62,7 +70,7 @@ describe('Community projects navigation', () => {
     cy.location('pathname').should('eq', '/community-projects');
   });
 
-  it.skip('navigates to the community page via the dropdown entry (keyboard)', () => {
+  it('navigates to the community page via the dropdown entry (keyboard)', () => {
     openSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
@@ -113,7 +121,7 @@ describe('Community projects navigation', () => {
       .should('be.visible');
   });
 
-  it.skip('highlights no org row while on the community page but still offers the community entry', () => {
+  it('highlights no org row while on the community page but still offers the community entry', () => {
     visitCommunity();
     openSwitch();
     gcy('switch-popover-item').should('exist');
@@ -124,7 +132,7 @@ describe('Community projects navigation', () => {
     }).should('be.visible');
   });
 
-  it.skip('offers the community entry from a switcher outside the projects pages', () => {
+  it('offers the community entry from a switcher outside the projects pages', () => {
     cy.visit(
       `${HOST}/organizations/${organizationData['Tolgee'].slug}/members`
     );
@@ -136,8 +144,10 @@ describe('Community projects navigation', () => {
     }).should('be.visible');
   });
 
-  it('shows the empty state and hides search when there are no public projects', () => {
+  it('shows the empty state and hides search when there are no contributions', () => {
     publicProjectsData.clean();
+    // Default-on shows the admin's contributions; clear the seeded one so the list is genuinely empty.
+    communityContributionData.clean();
     visitCommunity();
     waitForGlobalLoading();
     gcy('community-projects-view').should('be.visible');
@@ -146,7 +156,7 @@ describe('Community projects navigation', () => {
     gcy('global-list-search').should('not.exist');
   });
 
-  it.skip('closes the popover on Escape from the footer entry', () => {
+  it('closes the popover on Escape from the footer entry', () => {
     openSwitch();
     gcyAdvanced({
       value: 'switch-popover-footer-action',
@@ -205,6 +215,8 @@ describe('Community projects list content', () => {
     login('publicProjectsUser');
     cy.visit(`${HOST}/community-projects`);
     waitForGlobalLoading();
+    // These tests assert the full public listing, which is the toggle-off state.
+    disableMyContributions();
   });
 
   afterEach(() => {
@@ -246,6 +258,8 @@ describe('Community projects search threshold', () => {
     login('publicProjectsUser');
     cy.visit(`${HOST}/community-projects`);
     waitForGlobalLoading();
+    // The threshold applies to the full public listing, which is the toggle-off state.
+    disableMyContributions();
   });
 
   afterEach(() => {
@@ -255,6 +269,36 @@ describe('Community projects search threshold', () => {
   it('hides the search field at or below the project threshold', () => {
     gcy('dashboard-projects-list-item').should('have.length', 5);
     gcy('global-list-search').should('not.exist');
+  });
+});
+
+describe('Community projects "My contributions only" toggle', () => {
+  beforeEach(() => {
+    publicProjectsData.clean();
+    publicProjectsData.generateStandard();
+    login('publicProjectsUser');
+    cy.visit(`${HOST}/community-projects`);
+    waitForGlobalLoading();
+  });
+
+  afterEach(() => {
+    publicProjectsData.clean();
+  });
+
+  it('defaults on and lists only public projects the user contributed to as a non-member', () => {
+    gcy('community-my-contributions-toggle').find('input').should('be.checked');
+    // publicProjectsUser owns the "Community *" projects (a member of those); it only contributed to
+    // "Community Outsider", owned by another org.
+    gcy('dashboard-projects-list-item').should('have.length', 1);
+    cy.contains('Community Outsider').should('be.visible');
+    cy.contains('Community Alpha').should('not.exist');
+  });
+
+  it('lists all public projects once toggled off', () => {
+    disableMyContributions();
+    gcy('dashboard-projects-list-item').should('have.length', 7);
+    cy.contains('Community Alpha').should('be.visible');
+    cy.contains('Community Outsider').should('be.visible');
   });
 });
 

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -146,6 +146,7 @@ declare namespace DataCy {
         "comment-menu-needs-resolution": true;
         "comment-resolve": true;
         "comment-text": true;
+        "community-my-contributions-toggle": true;
         "community-projects-view": true;
         "community-translation-banner": true;
         "community-translation-item": true;

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -7,7 +7,10 @@ import { OrganizationItem } from './OrganizationItem';
 import { CommunityTranslationItem } from './CommunityTranslationItem';
 import { useHistory } from 'react-router-dom';
 import { LINKS } from 'tg.constants/links';
-import { usePreferredOrganization } from 'tg.globalContext/helpers';
+import {
+  useHasCommunityContributions,
+  usePreferredOrganization,
+} from 'tg.globalContext/helpers';
 import { OrganizationPopover } from './OrganizationPopover';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
@@ -42,6 +45,7 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
   const [isOpen, setIsOpen] = useState(false);
   const { preferredOrganization, updatePreferredOrganization } =
     usePreferredOrganization();
+  const hasCommunityContributions = useHasCommunityContributions();
   const history = useHistory();
 
   const handleClose = () => {
@@ -87,6 +91,11 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
         anchorEl={anchorEl.current!}
         onAddNew={handleCreateNewOrg}
         communitySelected={isCommunitySurface}
+        onCommunityNavigate={
+          hasCommunityContributions
+            ? () => history.push(LINKS.COMMUNITY_PROJECTS.build())
+            : undefined
+        }
       />
     </Box>
   );

--- a/webapp/src/globalContext/helpers.tsx
+++ b/webapp/src/globalContext/helpers.tsx
@@ -10,6 +10,9 @@ export const useUser = () => useGlobalContext((c) => c.initialData.userInfo);
 export const useIsEmailVerified = () =>
   useGlobalContext((c) => c.isEmailVerified);
 
+export const useHasCommunityContributions = () =>
+  useGlobalContext((c) => Boolean(c.initialData.hasCommunityContributions));
+
 export const useEmailAwaitingVerification = () =>
   useGlobalContext((c) => c.initialData.userInfo?.emailAwaitingVerification);
 

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -3748,6 +3748,7 @@ export interface components {
       announcement?: components["schemas"]["AnnouncementDto"];
       authInfo?: components["schemas"]["AuthInfoModel"];
       eeSubscription?: components["schemas"]["InitialDataEeSubscriptionModel"];
+      hasCommunityContributions: boolean;
       languageTag?: string;
       preferredOrganization?: components["schemas"]["PrivateOrganizationModel"];
       qaCheckCategories?: components["schemas"]["QaCheckCategoryModel"][];
@@ -25271,6 +25272,7 @@ export interface operations {
         /** Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
         sort?: string[];
         search?: string;
+        filterContributed?: boolean;
       };
     };
     responses: {

--- a/webapp/src/views/projects/CommunityProjectsView.tsx
+++ b/webapp/src/views/projects/CommunityProjectsView.tsx
@@ -12,6 +12,7 @@ import { useIsEmailVerified } from 'tg.globalContext/helpers';
 import { ProjectsList } from 'tg.views/projects/ProjectsList';
 import { CommunityTranslationBanner } from 'tg.views/projects/public/CommunityTranslationBanner';
 import { usePublicProjectsList } from 'tg.views/projects/usePublicProjectsList';
+import { MyContributionsToggle } from 'tg.views/projects/MyContributionsToggle';
 import { CriticalUsageCircle } from 'tg.ee';
 
 // Flex column so the full-width banner keeps its content height — the surrounding grid layouts
@@ -25,8 +26,14 @@ const StyledContent = styled('div')`
 const CommunityProjects = () => {
   const { t } = useTranslate();
   const history = useHistory();
-  const { loadable, showSearch, onSearch, onPageChange } =
-    usePublicProjectsList();
+  const {
+    loadable,
+    showSearch,
+    onSearch,
+    onPageChange,
+    myContributionsOnly,
+    onToggleMyContributions,
+  } = usePublicProjectsList({ contributionFilter: true });
 
   return (
     <DashboardPage>
@@ -48,6 +55,12 @@ const CommunityProjects = () => {
         allCentered
         hideChildrenOnLoading={false}
         customButtons={[<CriticalUsageCircle key="usage" />]}
+        addComponent={
+          <MyContributionsToggle
+            checked={myContributionsOnly}
+            onChange={onToggleMyContributions}
+          />
+        }
         loading={loadable.isFetching}
       >
         <StyledContent>

--- a/webapp/src/views/projects/MyContributionsToggle.tsx
+++ b/webapp/src/views/projects/MyContributionsToggle.tsx
@@ -1,0 +1,30 @@
+import { FormControlLabel, Switch } from '@mui/material';
+import { useTranslate } from '@tolgee/react';
+
+type Props = {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+};
+
+export const MyContributionsToggle: React.FC<Props> = ({
+  checked,
+  onChange,
+}) => {
+  const { t } = useTranslate();
+
+  return (
+    <FormControlLabel
+      labelPlacement="start"
+      data-cy="community-my-contributions-toggle"
+      control={
+        <Switch
+          size="small"
+          color="primary"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+      }
+      label={t('community_my_contributions_toggle', 'My contributions only')}
+    />
+  );
+};

--- a/webapp/src/views/projects/usePublicProjectsList.ts
+++ b/webapp/src/views/projects/usePublicProjectsList.ts
@@ -3,9 +3,16 @@ import { useState } from 'react';
 import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { useLatchedSearchVisibility } from 'tg.views/projects/useLatchedSearchVisibility';
 
-export const usePublicProjectsList = () => {
+type Options = {
+  // Opt-in: only the community page exposes the "My contributions only" filter. The public homepage
+  // view shares this hook and must keep listing every public project.
+  contributionFilter?: boolean;
+};
+
+export const usePublicProjectsList = ({ contributionFilter }: Options = {}) => {
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState('');
+  const [myContributionsOnly, setMyContributionsOnly] = useState(true);
 
   const loadable = useApiQuery({
     url: '/v2/public/projects/with-stats',
@@ -15,6 +22,7 @@ export const usePublicProjectsList = () => {
       size: 20,
       search,
       sort: ['name,asc'],
+      filterContributed: contributionFilter ? myContributionsOnly : undefined,
     },
     options: {
       keepPreviousData: true,
@@ -31,5 +39,18 @@ export const usePublicProjectsList = () => {
     setPage(0);
   };
 
-  return { loadable, showSearch, search, onSearch, onPageChange: setPage };
+  const onToggleMyContributions = (value: boolean) => {
+    setMyContributionsOnly(value);
+    setPage(0);
+  };
+
+  return {
+    loadable,
+    showSearch,
+    search,
+    onSearch,
+    onPageChange: setPage,
+    myContributionsOnly,
+    onToggleMyContributions,
+  };
 };

--- a/webapp/src/views/projects/usePublicProjectsList.ts
+++ b/webapp/src/views/projects/usePublicProjectsList.ts
@@ -4,8 +4,6 @@ import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { useLatchedSearchVisibility } from 'tg.views/projects/useLatchedSearchVisibility';
 
 type Options = {
-  // Opt-in: only the community page exposes the "My contributions only" filter. The public homepage
-  // view shares this hook and must keep listing every public project.
   contributionFilter?: boolean;
 };
 


### PR DESCRIPTION
Part 3 of the Community Contributors pitch (#3806) — the `/community-projects` page. Merges into the integration branch `jirikuchynka/community-contributors` (#3819), not `main`.

## What this adds

- **"My contributions only" toggle** on `/community-projects`, **default on**. On, it lists public projects the user contributed to but is **not a member of**; off lists every public project. It sits where the add button renders on the normal projects list (the header's right slot, next to the search field).
- **Re-wired "Community translation" org-switcher entry.** It appears exactly for users with at least one contribution in a currently-public project they are not a member of — i.e. exactly when the community page has something to show them.
- **Re-enabled the five skipped switcher-navigation e2e tests.**

## How it works

- The toggle drives a new opt-in `filterContributed` param on `GET /v2/public/projects/with-stats`. The predicate reuses Scope A's `project_contributor` table (`EXISTS` a contribution) plus a member-exclusion that mirrors the per-project contributor list, so the page and the switcher agree. The param is opt-in per caller, so the public homepage listing (which shares the hook) is unchanged.
- The switcher entry is gated on a new `InitialDataModel.hasCommunityContributions` boolean — a cheap `EXISTS` over the `project_contributor` `user_id` index, computed per authenticated user and piggybacked on the already-cached `initial-data` payload the switcher reads (no extra request, available on every page).

## Tests

- Backend: `filterContributed` listing (non-member contributor only; member-owned excluded; anonymous empty) and the `hasCommunityContributions` boolean, in `PublicProjectsControllerTest`; `InitialDataControllerTest` asserts the field is wired.
- E2E: the 5 switcher-nav tests re-enabled (seed a contribution for the `admin` login user via a small dedicated e2e-data set); existing list/threshold tests flip the toggle off (they assert the all-public view); new tests cover the default-on mine-only behavior.

## Known limitation (accepted, per pitch scope)

A contributor with no organization of their own won't see the switcher entry — the org popover renders nothing without a preferred organization.

## Translations

The `community_my_contributions_toggle` key ("My contributions only") is created in the Tolgee project (id 1), tagged `draft: community-projects-page`. No screenshot uploaded yet.
