### PR TITLE
fix: strip structural newlines from plural source in AI translator prompt

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PromptTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PromptTestData.kt
@@ -28,6 +28,7 @@ class PromptTestData : BaseTestData() {
   lateinit var chinese: LanguageBuilder
   lateinit var keys: MutableList<KeyBuilder>
   lateinit var keyWithoutTranslations: KeyBuilder
+  lateinit var pluralKey: KeyBuilder
   lateinit var customPrompt: PromptBuilder
   lateinit var llmProvider: LlmProviderBuilder
   lateinit var unrelatedLlmProvider: LlmProviderBuilder
@@ -227,6 +228,25 @@ class PromptTestData : BaseTestData() {
   fun addKeyWithoutTranslations() {
     promptProject.build {
       keyWithoutTranslations = addKey("Key without translations") {}
+    }
+  }
+
+  fun addPluralKey() {
+    promptProject.build {
+      pluralKey =
+        addKey("Plural key") {}.also {
+          it.self.isPlural = true
+          it.self.pluralArgName = "count"
+          addTranslation {
+            key = it.self
+            language = english.self
+            text =
+              "{count, plural,\n" +
+              "one {Listing spreadsheet sheets}\n" +
+              "other {Listing sheets in # spreadsheets}\n" +
+              "}"
+          }
+        }
     }
   }
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptVariablesHelper.kt
@@ -10,6 +10,8 @@ import io.tolgee.ee.component.PromptLazyMap.Companion.Variable
 import io.tolgee.ee.service.glossary.GlossaryTermService
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.formats.DEFAULT_PLURAL_ARGUMENT_NAME
+import io.tolgee.formats.getPluralForms
+import io.tolgee.formats.toIcuPluralString
 import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 import io.tolgee.service.key.KeyService
@@ -193,10 +195,15 @@ class PromptVariablesHelper(
 
     result.add(Variable("languageName", language?.name))
     result.add(Variable("languageTag", language?.tag))
-    result.add(Variable("translation", PromptHandlebarsHelper.escapeJson(translation?.text)))
+    result.add(Variable("translation", PromptHandlebarsHelper.escapeJson(singleLinePlural(translation?.text))))
     result.add(Variable("languageNote", language?.aiTranslatorPromptDescription ?: ""))
     result.add(cjkVariable(language?.tag))
     return result
+  }
+
+  private fun singleLinePlural(text: String?): String? {
+    val forms = getPluralForms(text) ?: return text
+    return forms.forms.toIcuPluralString(optimize = false, addNewLines = false, argName = forms.argName)
   }
 
   private fun getPluralVariables(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/PromptControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/PromptControllerTest.kt
@@ -26,6 +26,7 @@ class PromptControllerTest : ProjectAuthControllerTest("/v2/projects/") {
   fun setup() {
     testData = PromptTestData()
     testData.addKeyWithoutTranslations()
+    testData.addPluralKey()
     testDataService.saveTestData(testData.root)
     llmProperties.enabled = true
     llmProperties.providers =
@@ -302,6 +303,27 @@ class PromptControllerTest : ProjectAuthControllerTest("/v2/projects/") {
       ),
     ).andIsOk.andAssertThatJson {
       node("prompt").isString.contains("bare=[] object=[]")
+    }
+  }
+
+  @Test
+  fun `renders a plural source translation as a single line without literal newlines`() {
+    performAuthPost(
+      "/v2/projects/${testData.promptProject.self.id}/prompts/run",
+      PromptRunDto(
+        template = "{{fragment.translationInfo}}",
+        keyId = testData.pluralKey.self.id,
+        targetLanguageId = testData.czech.self.id,
+        provider = "default",
+        basicPromptOptions = null,
+      ),
+    ).andIsOk.andAssertThatJson {
+      node("prompt").isString.doesNotContain("""\n""")
+      node("prompt")
+        .isString
+        .contains(
+          "{count, plural, one {Listing spreadsheet sheets} other {Listing sheets in # spreadsheets}}",
+        )
     }
   }
 


### PR DESCRIPTION
## Problem

The AI translator (the `PROMPT` machine-translation service) mangles ICU plural keys by injecting literal `\n` sequences. A source uploaded as:

```
{count, plural, one {Listing spreadsheet sheets} other {Listing sheets in # spreadsheets} }
```

comes back stored as:

```
{count, plural,\none {Listing spreadsheet sheets}\nother {Listing sheets in # spreadsheets}\n}
```

## Root cause

1. Saved plurals are stored **multi-line** — `FormsToIcuPluralConvertor` serializes with `addNewLines = true`, so `translation.text` for a plural contains real newlines (after `plural,` and between forms). This is a purely cosmetic storage/editor convention; ICU treats that whitespace as insignificant.
2. When the default prompt is built, `source.translation` is JSON-escaped via `escapeJson` (`PromptVariablesHelper`), which converts those **real newlines into the two-character literal `\n`**.
3. The escaped value is dropped into the **prose** `translationInfo` fragment — `Translate "{{source.translation}}" from …` — not a JSON block. `escapeJson` was intended for values embedded inside JSON in custom prompts, so it's the wrong transform here.
4. The model faithfully reproduces the literal `\n`, and they survive re-parsing into the stored translation.

## Fix

Normalize the translation to **single-line ICU before escaping**, using the same `optimize = false` / `addNewLines = false` round-trip the exporters (`FlutterArbFileExporter`, `IcuToGenericFormatMessageConvertor`) already use. Flat (non-plural) translations pass through untouched. This keeps the `escapeJson` contract intact, so custom prompts embedding `{{source.translation}}` in JSON are unaffected.

`optimize = false` is deliberate: it preserves the exact forms and order the user authored (optimizing would drop forms whose text equals `other` and reorder them, changing what the model sees).

## Scope / known limitation

This removes the **structural** newlines from Tolgee's plural serializer — the reported bug. A genuine newline that is part of a form's message *content* (e.g. `one {Line one⏎Line two}`) is still JSON-escaped to literal `\n` in the prose fragment, since that lives inside the form body. That's a broader `escapeJson`-in-prose issue affecting flat translations too; the principled fix (not escaping in the prose `translationInfo` fragment) changes the custom-prompt contract and is intentionally out of scope here.

Existing translations already corrupted in the DB are unaffected and need re-translating.

## Tests

- Added `PromptTestData.addPluralKey()` — a plural key stored in the multi-line form from the report.
- Added a `PromptControllerTest` regression test asserting the rendered prompt contains single-line ICU and no literal `\n`.
- Full `PromptControllerTest` suite passes (18/18), including the pre-existing `escapeJson` / `translationInfo` escaping tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plural translations in prompt data.
  * Plural source text is now formatted as a single-line ICU plural expression, preventing unwanted line breaks in translation information.

* **Tests**
  * Added coverage verifying that plural translations render correctly and contain the expected ICU formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->