### PR TITLE
fix: hard-delete project fails on FK constraints for imports, tasks and branch merges

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -14,7 +14,9 @@ import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
 import io.tolgee.development.testDataBuilder.data.MtSettingsTestData
 import io.tolgee.development.testDataBuilder.data.ProjectWithQaEntitiesTestData
 import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
+import io.tolgee.development.testDataBuilder.data.TaskTestData
 import io.tolgee.development.testDataBuilder.data.WebhooksTestData
+import io.tolgee.development.testDataBuilder.data.dataImport.ImportTestData
 import io.tolgee.dtos.BigMetaDto
 import io.tolgee.dtos.RelatedKeyDto
 import io.tolgee.fixtures.waitFor
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import java.util.Date
 
 @SpringBootTest
 class ProjectHardDeletingServiceTest : AbstractSpringTest() {
@@ -213,6 +216,35 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
             .singleResult as Number
         ).toLong()
       remaining.assert.isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun `deletes project with a soft-deleted import`() {
+    val testData = ImportTestData()
+    testData.importBuilder.self.deletedAt = Date()
+    testDataService.saveTestData(testData.root)
+
+    io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
+      projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+
+    executeInNewTransaction {
+      projectService.find(testData.projectBuilder.self.id).assert.isNull()
+    }
+  }
+
+  @Test
+  fun `deletes project with tasks`() {
+    val testData = TaskTestData()
+    testDataService.saveTestData(testData.root)
+
+    io.tolgee.util.executeInNewTransaction(platformTransactionManager) {
+      projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+
+    executeInNewTransaction {
+      projectService.find(testData.projectBuilder.self.id).assert.isNull()
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/dataImport/ImportRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/dataImport/ImportRepository.kt
@@ -34,6 +34,13 @@ interface ImportRepository : JpaRepository<Import, Long> {
 
   @Query(
     """
+    select i from Import i where i.project.id = :projectId
+  """,
+  )
+  fun findAllByProjectIdIncludingDeleted(projectId: Long): List<Import>
+
+  @Query(
+    """
     select distinct if.namespace from ImportFile if where if.importData.id = :importId
   """,
   )

--- a/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/dataImport/ImportService.kt
@@ -483,6 +483,9 @@ class ImportService(
 
   fun getAllByProject(projectId: Long) = this.importRepository.findAllByProjectId(projectId)
 
+  fun getAllByProjectIncludingDeleted(projectId: Long) =
+    this.importRepository.findAllByProjectIdIncludingDeleted(projectId)
+
   fun saveAllFileIssueParams(params: List<ImportFileIssueParam>): MutableList<ImportFileIssueParam> =
     importFileIssueParamRepository.saveAll(params)
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectHardDeletingService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectHardDeletingService.kt
@@ -88,9 +88,14 @@ class ProjectHardDeletingService(
         importSettingsService.deleteAllByProject(projectId)
       }
 
-      importService.getAllByProject(projectId).forEach {
+      // includes soft-deleted imports — their import_language/import_key rows still reference
+      // the project's languages/keys we are about to delete
+      importService.getAllByProjectIncludingDeleted(projectId).forEach {
         importService.hardDeleteImport(it)
       }
+
+      deleteTasks(projectId)
+      deleteBranchMergeChanges(projectId)
 
       // otherwise the project keeps referencing the language/namespace we are about to delete
       project.baseLanguage = null
@@ -211,6 +216,34 @@ class ProjectHardDeletingService(
         .setParameter("projectId", projectId)
         .executeUpdate()
     }
+  }
+
+  /**
+   * Tasks (EE) reference the project's languages, keys and the project itself, but no service
+   * removes them on project deletion. Delete them and their children with native SQL so the
+   * table set stays consistent even when the EE module is absent.
+   */
+  private fun deleteTasks(projectId: Long) {
+    val taskIds = "select id from task where project_id = :projectId"
+    executeByProjectId("delete from task_key where task_id in ($taskIds)", projectId)
+    executeByProjectId("delete from task_assignees where tasks_id in ($taskIds)", projectId)
+    executeByProjectId("update notification set linked_task_id = null where linked_task_id in ($taskIds)", projectId)
+    executeByProjectId("delete from task where project_id = :projectId", projectId)
+  }
+
+  private fun deleteBranchMergeChanges(projectId: Long) {
+    val keyIds = "select id from key where project_id = :projectId"
+    executeByProjectId(
+      "delete from branch_merge_change where source_key_id in ($keyIds) or target_key_id in ($keyIds)",
+      projectId,
+    )
+  }
+
+  private fun executeByProjectId(
+    sql: String,
+    projectId: Long,
+  ) {
+    entityManager.createNativeQuery(sql).setParameter("projectId", projectId).executeUpdate()
   }
 
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMPLETION)


### PR DESCRIPTION
Follow-up to #3810. After that fixed the `default_namespace` FK, the orphan-organization purge (`DeletedOrganizationProjectPurgeScheduler`) still fails one FK further along, and different orphaned projects hit different constraints. Confirmed in prod (Sentry `TOLGEE-BACKEND-3WB`, and current logs `DELETE FROM language ... violates FK on import_language`).

## Root cause — `hardDeleteProject` leaves child rows referencing the project's languages/keys

I audited every FK into the tables `hardDeleteProject` bulk-deletes (`language`, `key`, `namespace`). Most children are already handled (e.g. `languageService.deleteAllByProject` deletes translations, auto_translation_config, translation_suggestion, language_stats, language_qa_config). Three gaps remained:

1. **Soft-deleted imports** — `getAllByProject` filters `deletedAt is null`, so soft-deleted imports' `import_language` (`existing_language_id → language`) and `import_key` rows survive and block language/key deletion. Now uses `getAllByProjectIncludingDeleted`.
2. **Tasks** — only `task_key` was deleted, never the `task` entity itself (`task.language_id → language`, `task.project_id → project`). Now deletes `task_key`, `task_assignees`, unlinks `notification.linked_task_id`, then the task.
3. **Branch merge changes** — `branch_merge_change.{source,target}_key_id → key` were only cleared via `branchService` *after* key deletion. Now cleared before it.

Native SQL is used for the EE-owned `task`/`branch_merge_change` tables (they exist in the shared schema; matching the existing native deletes in `hardDeleteProject`/`LanguageService`).

## Impact

`hardDeleteProject` is used by the purge scheduler and by the async `OnProjectSoftDeleted` listener, so this also silently broke the normal hard-delete of any project with imports/tasks/branch-merges.

## Tests

`ProjectHardDeletingServiceTest`:
- `deletes project with a soft-deleted import`
- `deletes project with tasks`

Both reproduce the FK violation without the fix (verified) and pass with it; all existing hard-delete tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permanent project deletion to fully remove projects that contain previously deleted imports.
  - Project deletion now also cleans up associated tasks and branch merge data.
  - Prevented leftover project-related records from remaining after permanent deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->