### PR TITLE
fix: set correct MIME type on content delivery published files

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryConfigControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryConfigControllerTest.kt
@@ -2,14 +2,16 @@ package io.tolgee.api.v2.controllers.contentDelivery
 
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.batch.BatchJobConcurrentLauncher
-import io.tolgee.component.fileStorage.AzureBlobFileStorage
 import io.tolgee.component.fileStorage.AzureFileStorageFactory
 import io.tolgee.component.fileStorage.FileStorage
-import io.tolgee.component.fileStorage.S3FileStorage
 import io.tolgee.component.fileStorage.S3FileStorageFactory
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
+import io.tolgee.fixtures.CONTENT_DELIVERY_GENERATED_SLUG_PATTERN
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.assertPrunedSingleDirectory
+import io.tolgee.fixtures.assertStoredSingleFile
+import io.tolgee.fixtures.mockCreatedStorage
 import io.tolgee.service.contentDelivery.ContentDeliveryConfigService
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
@@ -18,11 +20,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.invocation.Invocation
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 
@@ -58,8 +55,8 @@ class ContentDeliveryConfigControllerTest : ProjectAuthControllerTest("/v2/proje
   @AfterEach
   fun after() {
     resetServerProperties()
+    testDataService.cleanTestData(testData.root)
     batchJobConcurrentLauncher.pause = false
-    tolgeeProperties.contentDelivery.storage.s3.bucketName = null
   }
 
   @Test
@@ -84,7 +81,7 @@ class ContentDeliveryConfigControllerTest : ProjectAuthControllerTest("/v2/proje
   @ProjectJWTAuthTestMethod
   fun `publishes to default server content delivery config`() {
     tolgeeProperties.contentDelivery.storage.s3.bucketName = "my-bucket"
-    val mocked = mockS3FileStorage()
+    val mocked = s3FileStorageFactory.mockCreatedStorage()
     performProjectAuthPost("content-delivery-configs/${testData.defaultServerContentDeliveryConfig.self.id}").andIsOk
     assertStored(mocked)
     assertPruned(mocked)
@@ -94,16 +91,16 @@ class ContentDeliveryConfigControllerTest : ProjectAuthControllerTest("/v2/proje
   @ProjectJWTAuthTestMethod
   fun `publishes to custom server content delivery config`() {
     tolgeeProperties.contentDelivery.storage.s3.bucketName = "my-bucket"
-    val mocked = mockS3FileStorage()
+    val mocked = s3FileStorageFactory.mockCreatedStorage()
     performProjectAuthPost("content-delivery-configs/${testData.s3ContentDeliveryConfigWithCustomSlug.self.id}").andIsOk
-    assertStored(mocked)
-    assertPruned(mocked)
+    assertStored(mocked, slugPattern = "my-slug")
+    assertPruned(mocked, slugPattern = "my-slug")
   }
 
   @Test
   @ProjectJWTAuthTestMethod
   fun `publishes to azure`() {
-    val mocked = mockAzureFileStorage()
+    val mocked = azureFileStorageFactory.mockCreatedStorage()
     performProjectAuthPost("content-delivery-configs/${testData.azureContentDeliveryConfig.self.id}").andIsOk
     assertStored(mocked)
     assertPruned(mocked)
@@ -113,63 +110,29 @@ class ContentDeliveryConfigControllerTest : ProjectAuthControllerTest("/v2/proje
   @ProjectJWTAuthTestMethod
   fun `publishes as zip when zip option is enabled`() {
     tolgeeProperties.contentDelivery.storage.s3.bucketName = "my-bucket"
-    val mocked = mockS3FileStorage()
+    val mocked = s3FileStorageFactory.mockCreatedStorage()
     performProjectAuthPost("content-delivery-configs/${testData.zipEnabledContentDeliveryConfig.self.id}").andIsOk
     assertStoredAsZip(mocked)
     assertPruned(mocked)
   }
 
-  private fun assertStored(mocked: FileStorage) {
-    mocked.getStoreFileInvocations().assert.hasSize(1)
-    getLastStoreFileInvocationPath(mocked)
-      .matches("[a-f0-9]{32}/en\\.json".toRegex())
-  }
+  private fun assertStored(
+    mocked: FileStorage,
+    slugPattern: String = CONTENT_DELIVERY_GENERATED_SLUG_PATTERN,
+  ) = mocked.assertStoredSingleFile("$slugPattern/en\\.json", "application/json")
 
-  private fun assertStoredAsZip(mocked: FileStorage) {
-    mocked.getStoreFileInvocations().assert.hasSize(1)
-    getLastStoreFileInvocationPath(mocked)
-      .matches("[a-f0-9]{32}/translations\\.zip".toRegex())
-  }
+  private fun assertStoredAsZip(mocked: FileStorage) =
+    mocked.assertStoredSingleFile("$CONTENT_DELIVERY_GENERATED_SLUG_PATTERN/translations\\.zip", "application/zip")
 
-  private fun getLastStoreFileInvocationPath(mocked: FileStorage): String =
-    (mocked.getStoreFileInvocations().single().arguments[0] as String)
-
-  private fun assertPruned(mocked: FileStorage) {
-    mocked.getPruneDirectoryInvocations().assert.hasSize(1)
-    (mocked.getPruneDirectoryInvocations().single().arguments[0] as String)
-      .matches("[a-f0-9]{32}".toRegex())
-  }
-
-  private fun FileStorage.getInvocations(): List<Invocation> = Mockito.mockingDetails(this).invocations.toList()
-
-  private fun FileStorage.getStoreFileInvocations(): List<Invocation> {
-    return getInvocations().filter { it.method.name == "storeFile" }
-  }
-
-  private fun FileStorage.getPruneDirectoryInvocations(): List<Invocation> {
-    return getInvocations().filter { it.method.name == "pruneDirectory" }
-  }
+  private fun assertPruned(
+    mocked: FileStorage,
+    slugPattern: String = CONTENT_DELIVERY_GENERATED_SLUG_PATTERN,
+  ) = mocked.assertPrunedSingleDirectory(slugPattern)
 
   private fun resetServerProperties() {
     tolgeeProperties.contentDelivery.storage.s3
       .clear()
     tolgeeProperties.contentDelivery.storage.azure
       .clear()
-  }
-
-  private fun mockS3FileStorage(): S3FileStorage {
-    val mockedFileStorage = mock<S3FileStorage>()
-    doAnswer {
-      mockedFileStorage
-    }.whenever(s3FileStorageFactory).create(any())
-    return mockedFileStorage
-  }
-
-  private fun mockAzureFileStorage(): AzureBlobFileStorage {
-    val mockedFileStorage = mock<AzureBlobFileStorage>()
-    doAnswer {
-      mockedFileStorage
-    }.whenever(azureFileStorageFactory).create(any())
-    return mockedFileStorage
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryContentTypeTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/contentDelivery/ContentDeliveryContentTypeTest.kt
@@ -1,0 +1,79 @@
+package io.tolgee.api.v2.controllers.contentDelivery
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.batch.BatchJobConcurrentLauncher
+import io.tolgee.component.fileStorage.AzureFileStorageFactory
+import io.tolgee.development.testDataBuilder.data.ContentDeliveryContentTypeTestData
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.getStoreFileCalls
+import io.tolgee.fixtures.mockCreatedStorage
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+
+class ContentDeliveryContentTypeTest : ProjectAuthControllerTest("/v2/projects/") {
+  lateinit var testData: ContentDeliveryContentTypeTestData
+
+  @Autowired
+  @MockitoSpyBean
+  private lateinit var azureFileStorageFactory: AzureFileStorageFactory
+
+  @Autowired
+  private lateinit var batchJobConcurrentLauncher: BatchJobConcurrentLauncher
+
+  @BeforeEach
+  fun setup() {
+    batchJobConcurrentLauncher.pause = true
+    testData = ContentDeliveryContentTypeTestData()
+    projectSupplier = { testData.projectBuilder.self }
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    Mockito.reset(azureFileStorageFactory)
+  }
+
+  @AfterEach
+  fun after() {
+    testDataService.cleanTestData(testData.root)
+    batchJobConcurrentLauncher.pause = false
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `publishes each file with its own content type`() {
+    val mocked = azureFileStorageFactory.mockCreatedStorage()
+
+    performProjectAuthPost(
+      "content-delivery-configs/${testData.appleContentDeliveryConfig.self.id}",
+    ).andIsOk
+
+    val stored = mocked.getStoreFileCalls()
+    stored.assert.hasSize(2)
+    stored
+      .single { it.path.endsWith(".strings") }
+      .contentType.assert
+      .isEqualTo("text/plain; charset=UTF-8")
+    stored
+      .single { it.path.endsWith(".stringsdict") }
+      .contentType.assert
+      .isEqualTo("application/xml")
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `publishes without a content type when the template renders the extension unseparated`() {
+    val mocked = azureFileStorageFactory.mockCreatedStorage()
+
+    performProjectAuthPost(
+      "content-delivery-configs/${testData.unrecoverableExtensionContentDeliveryConfig.self.id}",
+    ).andIsOk
+
+    val stored = mocked.getStoreFileCalls()
+    stored.assert.hasSize(2)
+    stored.forEach { it.contentType.assert.isNull() }
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/automation/AutomationCachingTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/automation/AutomationCachingTest.kt
@@ -12,6 +12,7 @@ import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
 import jakarta.persistence.EntityManagerFactory
 import org.hibernate.SessionFactory
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -43,6 +44,11 @@ class AutomationCachingTest : ProjectAuthControllerTest("/v2/projects/") {
     this.projectSupplier = { testData.projectBuilder.self }
     cacheManager.getCache(Caches.AUTOMATIONS)!!.clear()
     entityManagerFactory.unwrap(SessionFactory::class.java).statistics.isStatisticsEnabled = true
+  }
+
+  @AfterEach
+  fun after() {
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/automation/AutomationIntegrationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/automation/AutomationIntegrationTest.kt
@@ -7,20 +7,20 @@ import io.tolgee.component.contentDelivery.cachePurging.ContentDeliveryCachePurg
 import io.tolgee.component.enabledFeaturesProvider.EnabledFeaturesProvider
 import io.tolgee.component.fileStorage.FileStorage
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
+import io.tolgee.fixtures.CONTENT_DELIVERY_GENERATED_SLUG_PATTERN
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.assertPrunedSingleDirectory
+import io.tolgee.fixtures.assertStoredSingleFile
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.service.contentDelivery.ContentDeliveryConfigService
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.invocation.Invocation
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -50,19 +50,26 @@ class AutomationIntegrationTest : ProjectAuthControllerTest("/v2/projects/") {
   @Autowired
   lateinit var contentDeliveryConfigService: ContentDeliveryConfigService
 
+  lateinit var testData: ContentDeliveryConfigTestData
+
+  @BeforeEach
+  fun setup() {
+    currentDateProvider.forcedDate = currentDateProvider.date
+    testData = ContentDeliveryConfigTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    this.projectSupplier = { testData.projectBuilder.self }
+  }
+
   @AfterEach
   fun after() {
     currentDateProvider.forcedDate = null
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test
   @ProjectJWTAuthTestMethod
   fun `publishes to Content Delivery`() {
-    currentDateProvider.forcedDate = currentDateProvider.date
-    val testData = ContentDeliveryConfigTestData()
-    testDataService.saveTestData(testData.root)
-    userAccount = testData.user
-    this.projectSupplier = { testData.projectBuilder.self }
     fileStorageMock = mock()
     doReturn(fileStorageMock).whenever(contentDeliveryFileStorageProvider).getContentStorageWithDefaultClient()
     purgingMock = mock()
@@ -87,18 +94,13 @@ class AutomationIntegrationTest : ProjectAuthControllerTest("/v2/projects/") {
 
   private fun verifyContentDeliveryPublish() {
     waitForNotThrowing(timeout = 2000) {
-      verify(fileStorageMock, times(1)).storeFile(any(), any())
-      val storeFileInvocations =
-        fileStorageInvocations.filter { it.method.name == "storeFile" }
-      storeFileInvocations.assert.hasSize(1)
-      val pruneDirectoryInvocations =
-        fileStorageInvocations.filter { it.method.name == "pruneDirectory" }
-      pruneDirectoryInvocations.assert.hasSize(1)
+      fileStorageMock.assertStoredSingleFile(
+        "$CONTENT_DELIVERY_GENERATED_SLUG_PATTERN/en\\.json",
+        "application/json",
+      )
+      fileStorageMock.assertPrunedSingleDirectory(CONTENT_DELIVERY_GENERATED_SLUG_PATTERN)
     }
   }
-
-  private val fileStorageInvocations: MutableCollection<Invocation>
-    get() = Mockito.mockingDetails(fileStorageMock).invocations
 
   private fun modifyTranslationData() {
     performProjectAuthPost(

--- a/backend/app/src/test/kotlin/io/tolgee/automation/ContentDeliveryBranchAutopushTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/automation/ContentDeliveryBranchAutopushTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.component.fileStorage.FileStorage
 import io.tolgee.constants.Feature
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigBranchingTestData
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.getStoreFileCalls
 import io.tolgee.fixtures.waitForNotThrowing
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
 import io.tolgee.testing.assert
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -48,7 +50,7 @@ class ContentDeliveryBranchAutopushTest : ProjectAuthControllerTest("/v2/project
 
   @BeforeEach
   fun setup() {
-    doReturn(arrayOf(Feature.BRANCHING)).whenever(enabledFeaturesProvider).get(org.mockito.kotlin.any())
+    doReturn(arrayOf(Feature.BRANCHING)).whenever(enabledFeaturesProvider).get(any())
 
     currentDateProvider.forcedDate = currentDateProvider.date
     testData = ContentDeliveryConfigBranchingTestData()
@@ -69,6 +71,7 @@ class ContentDeliveryBranchAutopushTest : ProjectAuthControllerTest("/v2/project
   @AfterEach
   fun after() {
     currentDateProvider.forcedDate = null
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test
@@ -115,14 +118,7 @@ class ContentDeliveryBranchAutopushTest : ProjectAuthControllerTest("/v2/project
 
   private fun waitForStoreFileCalls(expectedCount: Int) {
     waitForNotThrowing(timeout = 3000, pollTime = 200) {
-      storeFileInvocations.assert.hasSize(expectedCount)
+      fileStorageMock.getStoreFileCalls().assert.hasSize(expectedCount)
     }
   }
-
-  private val storeFileInvocations
-    get() =
-      Mockito
-        .mockingDetails(fileStorageMock)
-        .invocations
-        .filter { it.method.name == "storeFile" }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
@@ -6,15 +6,17 @@ package io.tolgee.component.fileStorage
 
 import com.azure.core.http.rest.PagedIterable
 import com.azure.core.util.BinaryData
+import com.azure.core.util.Context
 import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.models.BlobItem
+import com.azure.storage.blob.options.BlobParallelUploadOptions
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -25,6 +27,7 @@ class FileStorageAzureTest {
   private lateinit var containerClientMock: BlobContainerClient
   private val filePath = "/hello/hello/en.json"
   private val content = "hello"
+  private val contentBytes = content.toByteArray(Charsets.UTF_8)
   private lateinit var blobClientMock: BlobClient
 
   @BeforeEach
@@ -35,7 +38,7 @@ class FileStorageAzureTest {
     whenever(containerClientMock.getBlobClient(eq(filePath))).then { blobClientMock }
     val binaryDataMock = mock<BinaryData>()
     whenever(blobClientMock.downloadContent()).thenReturn(binaryDataMock)
-    whenever(binaryDataMock.toBytes()).thenReturn(content.toByteArray(Charsets.UTF_8))
+    whenever(binaryDataMock.toBytes()).thenReturn(contentBytes)
   }
 
   @Test
@@ -44,7 +47,7 @@ class FileStorageAzureTest {
       .readFile(filePath)
       .toString(Charsets.UTF_8)
       .assert
-      .isEqualTo("hello")
+      .isEqualTo(content)
     verifyGetsClient()
   }
 
@@ -56,21 +59,26 @@ class FileStorageAzureTest {
   }
 
   @Test
-  fun testStoreFile() {
-    val bytes = content.toByteArray(Charsets.UTF_8)
-    azureFs.storeFile(filePath, bytes)
-    verify(blobClientMock, times(1)).upload(any<BinaryData>(), eq(true))
-    val binaryData =
-      Mockito
-        .mockingDetails(blobClientMock)
-        .invocations
-        .single()
-        .arguments[0] as BinaryData
-    binaryData
-      .toBytes()
-      .toString(Charsets.UTF_8)
-      .assert
-      .isEqualTo(content)
+  fun `stores file without a content type`() {
+    azureFs.storeFile(filePath, contentBytes)
+
+    val options = captureUploadOptions()
+    options.uploadedContent().assert.isEqualTo(content)
+    options.headers.assert.isNull()
+    options.assertOverwriteAllowed()
+    verifyGetsClient()
+  }
+
+  @Test
+  fun `stores file with content type`() {
+    azureFs.storeFile(filePath, contentBytes, "application/json")
+
+    val options = captureUploadOptions()
+    options.uploadedContent().assert.isEqualTo(content)
+    options.headers
+      ?.contentType.assert
+      .isEqualTo("application/json")
+    options.assertOverwriteAllowed()
     verifyGetsClient()
   }
 
@@ -100,5 +108,25 @@ class FileStorageAzureTest {
 
   private fun verifyGetsClient() {
     verify(containerClientMock, times(1)).getBlobClient(eq(filePath))
+  }
+
+  private fun captureUploadOptions(): BlobParallelUploadOptions {
+    val captor = argumentCaptor<BlobParallelUploadOptions>()
+    verify(blobClientMock, times(1)).uploadWithResponse(captor.capture(), eq(null), eq(Context.NONE))
+    return captor.firstValue
+  }
+
+  private fun BlobParallelUploadOptions.uploadedContent() =
+    BinaryData
+      .fromFlux(this.dataFlux)
+      .block()!!
+      .toBytes()
+      .toString(Charsets.UTF_8)
+
+  private fun BlobParallelUploadOptions.assertOverwriteAllowed() {
+    this.requestConditions
+      ?.ifNoneMatch.assert
+      .describedAs("an ifNoneMatch condition would make republishing fail with BlobAlreadyExists")
+      .isNull()
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageFsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageFsTest.kt
@@ -44,7 +44,7 @@ class FileStorageFsTest : AbstractFileStorageServiceTest() {
   @Test
   fun testStoreFile() {
     val filePath = "aaa/aaaa/aaa.txt"
-    fileStorage.storeFile("aaa/aaaa/aaa.txt", "hello".toByteArray(charset("UTF-8")))
+    fileStorage.storeFile(filePath, "hello".toByteArray(charset("UTF-8")))
     val file = File("${tolgeeProperties.fileStorage.fsDataPath}/$filePath")
     assertThat(file).exists()
     assertThat(file).hasContent("hello")

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageS3Test.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageS3Test.kt
@@ -13,8 +13,13 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.model.S3Exception
 
 @ContextRecreatingTest
@@ -36,6 +41,8 @@ class FileStorageS3Test : AbstractFileStorageServiceTest() {
       endpoint = "http://localhost:29090"
       signingRegion = "dummy_signing_region"
     }
+
+  private val testFileBytes = testFileContent.toByteArray(Charsets.UTF_8)
 
   val s3 by lazy {
     S3ClientProvider(
@@ -63,8 +70,7 @@ class FileStorageS3Test : AbstractFileStorageServiceTest() {
   @Test
   fun testGetFile() {
     s3.putObject({ req -> req.bucket(BUCKET_NAME).key(testFilePath) }, RequestBody.fromString(testFileContent))
-    val fileByteContent = testFileContent.toByteArray(charset("UTF-8"))
-    assertThat(createFileStorage().readFile(testFilePath)).isEqualTo(fileByteContent)
+    assertThat(createFileStorage().readFile(testFilePath)).isEqualTo(testFileBytes)
   }
 
   @Test
@@ -81,15 +87,47 @@ class FileStorageS3Test : AbstractFileStorageServiceTest() {
 
   @Test
   fun testStoreFile() {
-    createFileStorage().storeFile(testFilePath, testFileContent.toByteArray(charset("UTF-8")))
-    assertThat(
-      s3.getObject { req -> req.bucket(BUCKET_NAME).key(testFilePath) }.readAllBytes(),
-    ).isEqualTo(testFileContent.toByteArray())
+    createFileStorage().storeFile(testFilePath, testFileBytes)
+    assertThat(getStoredObject().readAllBytes()).isEqualTo(testFileBytes)
+  }
+
+  @Test
+  fun `does not set a content type on the put request when none is given`() {
+    val spiedS3 = Mockito.spy(s3)
+    S3FileStorage(bucketName = BUCKET_NAME, path = null, s3 = spiedS3)
+      .storeFile("test/content-type/none.txt", testFileBytes)
+
+    val captor = argumentCaptor<PutObjectRequest>()
+    verify(spiedS3).putObject(captor.capture(), any<RequestBody>())
+    assertThat(captor.firstValue.contentType()).isNull()
+  }
+
+  @Test
+  fun `stores file with content type`() {
+    createFileStorage().storeFile(
+      "test/content-type/json.txt",
+      testFileBytes,
+      "application/json",
+    )
+    val stored = getStoredObject("test/content-type/json.txt")
+    assertThat(stored.readAllBytes()).isEqualTo(testFileBytes)
+    assertThat(stored.response().contentType()).isEqualTo("application/json")
+  }
+
+  @Test
+  fun `stores file with charset parameterised content type`() {
+    createFileStorage().storeFile(
+      "test/content-type/text.txt",
+      testFileBytes,
+      "text/plain; charset=UTF-8",
+    )
+    val stored = getStoredObject("test/content-type/text.txt")
+    assertThat(stored.response().contentType()).isEqualTo("text/plain; charset=UTF-8")
   }
 
   @Test
   fun testPruneDirectory() {
-    createFileStorage().storeFile(testFilePath, testFileContent.toByteArray(charset("UTF-8")))
+    createFileStorage().storeFile(testFilePath, testFileBytes)
     createFileStorage().pruneDirectory("test")
     assertThat(createFileStorage().fileExists(testFilePath)).isEqualTo(false)
   }
@@ -103,14 +141,13 @@ class FileStorageS3Test : AbstractFileStorageServiceTest() {
   @Test
   fun `stores files to path by config`() {
     val storage = s3FileStorageFactory.create(defaultProperties.copy(path = "content/path"))
-    storage.storeFile(
-      testFilePath,
-      testFileContent.toByteArray(charset("UTF-8")),
-    )
+    storage.storeFile(testFilePath, testFileBytes)
     assertThat(
       s3.getObject { req -> req.bucket(BUCKET_NAME).key("content/path/$testFilePath") }.readAllBytes(),
-    ).isEqualTo(testFileContent.toByteArray())
+    ).isEqualTo(testFileBytes)
   }
+
+  private fun getStoredObject(key: String = testFilePath) = s3.getObject { req -> req.bucket(BUCKET_NAME).key(key) }
 
   fun createFileStorage(): S3FileStorage {
     return s3FileStorageFactory.create(defaultProperties)

--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -127,6 +127,7 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
   @Test
   fun `deletes project with Content Delivery Configs`() {
     val testData = ContentDeliveryConfigTestData()
+    testDataToClean = testData
     testDataService.saveTestData(testData.root)
     executeInNewRepeatableTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())

--- a/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryFileStorageProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryFileStorageProvider.kt
@@ -74,11 +74,7 @@ class ContentDeliveryFileStorageProvider(
   }
 
   private fun bypassForTesting(): FileStorage? {
-    if (tolgeeProperties.internal.e3eContentStorageBypassOk == null) {
-      return null
-    }
-
-    val shouldBeOk = tolgeeProperties.internal.e3eContentStorageBypassOk!!
+    val shouldBeOk = tolgeeProperties.internal.e3eContentStorageBypassOk ?: return null
 
     if (shouldBeOk) {
       return okFileStorage
@@ -99,6 +95,7 @@ class ContentDeliveryFileStorageProvider(
         override fun storeFile(
           storageFilePath: String,
           bytes: ByteArray,
+          contentType: String?,
         ) {
         }
 
@@ -121,6 +118,7 @@ class ContentDeliveryFileStorageProvider(
         override fun storeFile(
           storageFilePath: String,
           bytes: ByteArray,
+          contentType: String?,
         ) {
           throw FileStoreException("Bypassed storage put exception", "test", IllegalStateException())
         }

--- a/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryUploader.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/contentDelivery/ContentDeliveryUploader.kt
@@ -5,10 +5,12 @@ import io.tolgee.component.contentDelivery.cachePurging.ContentDeliveryCachePurg
 import io.tolgee.component.fileStorage.FileStorage
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
+import io.tolgee.formats.resolveExportContentType
 import io.tolgee.model.contentDelivery.ContentDeliveryConfig
 import io.tolgee.service.contentDelivery.ContentDeliveryConfigService
 import io.tolgee.service.export.ExportService
 import io.tolgee.util.Logging
+import io.tolgee.util.formatPathsForLog
 import io.tolgee.util.logger
 import org.springframework.stereotype.Component
 import java.io.ByteArrayOutputStream
@@ -34,15 +36,23 @@ class ContentDeliveryUploader(
       files = createZipArchive(files)
     }
 
-    val withFullPaths = files.mapKeys { "${config.slug}/${it.key}" }
     pruneIfNeeded(config, storage)
-    storeToStorage(withFullPaths, storage)
+    storeToStorage(config, files, storage)
     purgeCacheIfConfigured(config, files.keys)
 
     config.lastPublished = currentDateProvider.date
-    config.lastPublishedFiles = files.map { it.key }.toList()
+    config.lastPublishedFiles = files.keys.toList()
     contentDeliveryConfigService.save(config)
   }
+
+  private fun getStorage(contentDeliveryConfig: ContentDeliveryConfig) =
+    contentDeliveryConfig.contentStorage
+      ?.let {
+        contentDeliveryFileStorageProvider.getStorage(
+          config = it.storageConfig ?: throw IllegalStateException("No storage config stored"),
+        )
+      }
+      ?: contentDeliveryFileStorageProvider.getContentStorageWithDefaultClient()
 
   private fun createZipArchive(files: Map<String, InputStream>): Map<String, InputStream> {
     val zipFileName = "translations.zip"
@@ -73,6 +83,44 @@ class ContentDeliveryUploader(
     }
   }
 
+  private fun storeToStorage(
+    config: ContentDeliveryConfig,
+    files: Map<String, InputStream>,
+    storage: FileStorage,
+  ) {
+    val pathsWithoutContentType = mutableListOf<String>()
+
+    files.forEach { (path, stream) ->
+      val contentType = resolveExportContentType(config.format, config.zip, path)
+      if (contentType == null) {
+        pathsWithoutContentType.add(path)
+      }
+      storage.storeFile(
+        storageFilePath = "${config.slug}/$path",
+        bytes = stream.readBytes(),
+        contentType = contentType,
+      )
+    }
+
+    logUnresolvedContentTypes(config, pathsWithoutContentType)
+  }
+
+  private fun logUnresolvedContentTypes(
+    config: ContentDeliveryConfig,
+    pathsWithoutContentType: List<String>,
+  ) {
+    if (pathsWithoutContentType.isEmpty()) {
+      return
+    }
+    logger.warn(
+      "Content delivery config {} ({}) publishes {} file(s) without a content type: {}",
+      config.id,
+      config.format,
+      pathsWithoutContentType.size,
+      formatPathsForLog(pathsWithoutContentType),
+    )
+  }
+
   private fun purgeCacheIfConfigured(
     contentDeliveryConfig: ContentDeliveryConfig,
     paths: Set<String>,
@@ -84,25 +132,4 @@ class ContentDeliveryUploader(
       }
     }
   }
-
-  private fun storeToStorage(
-    withFullPaths: Map<String, InputStream>,
-    storage: FileStorage,
-  ) {
-    withFullPaths.forEach {
-      storage.storeFile(
-        storageFilePath = it.key,
-        bytes = it.value.readBytes(),
-      )
-    }
-  }
-
-  private fun getStorage(contentDeliveryConfig: ContentDeliveryConfig) =
-    contentDeliveryConfig.contentStorage
-      ?.let {
-        contentDeliveryFileStorageProvider.getStorage(
-          config = it.storageConfig ?: throw IllegalStateException("No storage config stored"),
-        )
-      }
-      ?: contentDeliveryFileStorageProvider.getContentStorageWithDefaultClient()
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
@@ -5,8 +5,11 @@
 package io.tolgee.component.fileStorage
 
 import com.azure.core.util.BinaryData
+import com.azure.core.util.Context
 import com.azure.storage.blob.BlobContainerClient
+import com.azure.storage.blob.models.BlobHttpHeaders
 import com.azure.storage.blob.models.ListBlobsOptions
+import com.azure.storage.blob.options.BlobParallelUploadOptions
 import io.tolgee.exceptions.FileStoreException
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 
@@ -24,7 +27,6 @@ open class AzureBlobFileStorage(
   override fun deleteFile(storageFilePath: String) {
     try {
       client.getBlobClient(storageFilePath).delete()
-      return
     } catch (e: Exception) {
       throw FileStoreException("Can not delete file using Azure Blob!", storageFilePath, e)
     }
@@ -33,14 +35,15 @@ open class AzureBlobFileStorage(
   override fun storeFile(
     storageFilePath: String,
     bytes: ByteArray,
+    contentType: String?,
   ) {
     try {
-      val client = client.getBlobClient(storageFilePath)
-      client.upload(BinaryData.fromBytes(bytes), true)
+      val options = BlobParallelUploadOptions(BinaryData.fromBytes(bytes))
+      contentType?.let { options.setHeaders(BlobHttpHeaders().setContentType(it)) }
+      client.getBlobClient(storageFilePath).uploadWithResponse(options, null, Context.NONE)
     } catch (e: Exception) {
       throw FileStoreException("Can not store file using Azure Blob!", storageFilePath, e)
     }
-    return
   }
 
   override fun fileExists(storageFilePath: String): Boolean {

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/FileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/FileStorage.kt
@@ -10,6 +10,7 @@ interface FileStorage {
   fun storeFile(
     storageFilePath: String,
     bytes: ByteArray,
+    contentType: String? = null,
   )
 
   fun fileExists(storageFilePath: String): Boolean

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/LocalFileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/LocalFileStorage.kt
@@ -32,6 +32,7 @@ class LocalFileStorage(
   override fun storeFile(
     storageFilePath: String,
     bytes: ByteArray,
+    contentType: String?,
   ) {
     val file = getLocalFile(storageFilePath)
     try {

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/S3FileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/S3FileStorage.kt
@@ -29,7 +29,6 @@ open class S3FileStorage(
   override fun deleteFile(storageFilePath: String) {
     try {
       s3.deleteObject { b -> b.bucket(bucketName).key("$canonicalPath$storageFilePath") }
-      return
     } catch (e: Exception) {
       throw FileStoreException("Can not delete file using s3 bucket!", storageFilePath, e)
     }
@@ -38,17 +37,19 @@ open class S3FileStorage(
   override fun storeFile(
     storageFilePath: String,
     bytes: ByteArray,
+    contentType: String?,
   ) {
-    val byteArrayInputStream = ByteArrayInputStream(bytes)
     try {
       s3.putObject(
-        { b -> b.bucket(bucketName).key("$canonicalPath$storageFilePath") },
-        RequestBody.fromInputStream(byteArrayInputStream, bytes.size.toLong()),
+        { b ->
+          b.bucket(bucketName).key("$canonicalPath$storageFilePath")
+          contentType?.let { b.contentType(it) }
+        },
+        RequestBody.fromInputStream(ByteArrayInputStream(bytes), bytes.size.toLong()),
       )
     } catch (e: Exception) {
       throw FileStoreException("Can not store file using s3 bucket!", storageFilePath, e)
     }
-    return
   }
 
   override fun fileExists(storageFilePath: String): Boolean {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ContentDeliveryContentTypeTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ContentDeliveryContentTypeTestData.kt
@@ -1,0 +1,49 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.formats.ExportFormat
+import io.tolgee.model.contentDelivery.AzureContentStorageConfig
+
+class ContentDeliveryContentTypeTestData :
+  BaseTestData(
+    userName = "content_type_username",
+    projectName = "content_type_project",
+  ) {
+  val azureContentStorage =
+    projectBuilder.addContentStorage {
+      this.azureContentStorageConfig =
+        AzureContentStorageConfig(this).apply {
+          connectionString = "fake"
+          containerName = "fake"
+        }
+    }
+
+  val appleContentDeliveryConfig =
+    projectBuilder.addContentDeliveryConfig {
+      contentStorage = azureContentStorage.self
+      name = "Apple"
+      format = ExportFormat.APPLE_STRINGS_STRINGSDICT
+    }
+
+  val unrecoverableExtensionContentDeliveryConfig =
+    projectBuilder.addContentDeliveryConfig {
+      contentStorage = azureContentStorage.self
+      name = "Apple with unrecoverable extension"
+      format = ExportFormat.APPLE_STRINGS_STRINGSDICT
+      fileStructureTemplate = "{languageTag}{extension}"
+    }
+
+  val keyForcingStringsFile =
+    projectBuilder.addKey("key") {
+      addTranslation("en", "Hello")
+    }
+
+  val keyForcingStringsdictFile =
+    projectBuilder
+      .addKey {
+        name = "plural key"
+        isPlural = true
+        pluralArgName = "count"
+      }.build {
+        addTranslation("en", "{count, plural, one {I am one} other {I am other}}")
+      }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/appleFormatConstants.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/appleFormatConstants.kt
@@ -3,3 +3,6 @@ package io.tolgee.formats.apple
 const val APPLE_FILE_ORIGINAL_CUSTOM_KEY = "_appleXliffFileOriginal"
 const val APPLE_PLURAL_PROPERTY_CUSTOM_KEY = "_appleXliffPropertyName"
 const val APPLE_CORRESPONDING_STRINGS_FILE_ORIGINAL = "_appleXliffStringsFileOriginal"
+
+const val APPLE_STRINGS_EXTENSION = "strings"
+const val APPLE_STRINGSDICT_EXTENSION = "stringsdict"

--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/getAppleExportPathContentType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/out/getAppleExportPathContentType.kt
@@ -1,0 +1,43 @@
+package io.tolgee.formats.apple.out
+
+import io.tolgee.formats.apple.APPLE_STRINGSDICT_EXTENSION
+import io.tolgee.formats.apple.APPLE_STRINGS_EXTENSION
+
+private val APPLE_CONTENT_TYPES =
+  mapOf(
+    APPLE_STRINGSDICT_EXTENSION to "application/xml",
+    APPLE_STRINGS_EXTENSION to "text/plain",
+  )
+
+private val APPLE_EXTENSION_ANYWHERE_REGEX =
+  (
+    "(?<![A-Za-z0-9])" +
+      "(?:${Regex.escape(APPLE_STRINGSDICT_EXTENSION)}|${Regex.escape(APPLE_STRINGS_EXTENSION)})" +
+      "(?![A-Za-z0-9])"
+  ).toRegex()
+
+fun getAppleExportPathContentType(exportRelativePath: String): String? {
+  val segments = exportRelativePath.split('/')
+  val fileName = segments.last()
+
+  fileName.appleContentTypeFromDotSegments()?.let { return it }
+  fileName.appleContentTypeFromWordAnywhere()?.let { return it }
+
+  val directoriesNearestFirst = segments.dropLast(1).asReversed()
+  val directoryMatches = directoriesNearestFirst.mapNotNull { it.appleContentTypeFromDotSegments() }.distinct()
+  if (directoryMatches.size > 1) {
+    return null
+  }
+
+  return directoryMatches.singleOrNull()
+    ?: directoriesNearestFirst.firstNotNullOfOrNull { it.appleContentTypeFromWordAnywhere() }
+}
+
+private fun String.appleContentTypeFromDotSegments(): String? =
+  this.split('.').asReversed().firstNotNullOfOrNull { APPLE_CONTENT_TYPES[it] }
+
+private fun String.appleContentTypeFromWordAnywhere(): String? =
+  APPLE_EXTENSION_ANYWHERE_REGEX
+    .findAll(this)
+    .lastOrNull()
+    ?.let { APPLE_CONTENT_TYPES[it.value] }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/resolveExportContentType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/resolveExportContentType.kt
@@ -1,0 +1,37 @@
+package io.tolgee.formats
+
+import io.tolgee.formats.apple.out.getAppleExportPathContentType
+import io.tolgee.util.nullIfEmpty
+
+private const val ZIP_CONTENT_TYPE = "application/zip"
+private const val UTF_8_CHARSET_SUFFIX = "; charset=UTF-8"
+private const val TEXT_TYPE_PREFIX = "text/"
+
+fun resolveExportContentType(
+  format: ExportFormat,
+  zip: Boolean,
+  exportRelativePath: String,
+): String? {
+  if (zip) {
+    return ZIP_CONTENT_TYPE
+  }
+
+  return rawMediaType(format, exportRelativePath)?.withCharsetIfText()
+}
+
+private fun rawMediaType(
+  format: ExportFormat,
+  exportRelativePath: String,
+): String? {
+  if (format == ExportFormat.APPLE_STRINGS_STRINGSDICT) {
+    return getAppleExportPathContentType(exportRelativePath)
+  }
+  return format.mediaType.nullIfEmpty
+}
+
+private fun String.withCharsetIfText(): String {
+  if (!this.startsWith(TEXT_TYPE_PREFIX)) {
+    return this
+  }
+  return this + UTF_8_CHARSET_SUFFIX
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/export/FileExporterFactory.kt
@@ -4,6 +4,8 @@ import io.tolgee.component.CurrentDateProvider
 import io.tolgee.dtos.IExportParams
 import io.tolgee.dtos.cacheable.LanguageDto
 import io.tolgee.formats.ExportFormat
+import io.tolgee.formats.apple.APPLE_STRINGSDICT_EXTENSION
+import io.tolgee.formats.apple.APPLE_STRINGS_EXTENSION
 import io.tolgee.formats.apple.out.AppleStringsStringsdictExporter
 import io.tolgee.formats.apple.out.AppleXcstringsExporter
 import io.tolgee.formats.apple.out.AppleXliffExporter
@@ -139,8 +141,8 @@ class FileExporterFactory(
           data,
           exportParams,
           projectIcuPlaceholdersSupport,
-          stringsFilePathProvider = getFilePathProvider(exportParams, data, "strings"),
-          stringsdictFilePathProvider = getFilePathProvider(exportParams, data, "stringsdict"),
+          stringsFilePathProvider = getFilePathProvider(exportParams, data, APPLE_STRINGS_EXTENSION),
+          stringsdictFilePathProvider = getFilePathProvider(exportParams, data, APPLE_STRINGSDICT_EXTENSION),
         )
       }
 

--- a/backend/data/src/main/kotlin/io/tolgee/util/formatPathsForLog.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/formatPathsForLog.kt
@@ -1,0 +1,17 @@
+package io.tolgee.util
+
+private const val MAX_LOGGED_PATHS = 3
+private const val MAX_LOGGED_PATH_LENGTH = 200
+private val LOG_UNSAFE_CHARACTERS_REGEX = "[\\p{C}\\u2028\\u2029]".toRegex()
+
+/** Paths may be user-authored, so they are scrubbed of non-printables and truncated before reaching a log. */
+fun formatPathsForLog(paths: List<String>): String {
+  val shown =
+    paths
+      .take(MAX_LOGGED_PATHS)
+      .joinToString { it.replace(LOG_UNSAFE_CHARACTERS_REGEX, "_").take(MAX_LOGGED_PATH_LENGTH) }
+  if (paths.size <= MAX_LOGGED_PATHS) {
+    return shown
+  }
+  return "$shown and ${paths.size - MAX_LOGGED_PATHS} more"
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/ResolveExportContentTypeTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/ResolveExportContentTypeTest.kt
@@ -1,0 +1,90 @@
+package io.tolgee.unit.formats
+
+import io.tolgee.formats.ExportFormat
+import io.tolgee.formats.resolveExportContentType
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+
+class ResolveExportContentTypeTest {
+  @Test
+  fun `resolves plain formats from the enum media type`() {
+    resolve(ExportFormat.JSON, "en.json").assert.isEqualTo("application/json")
+    resolve(ExportFormat.XLIFF, "en.xliff").assert.isEqualTo("application/x-xliff+xml")
+  }
+
+  @Test
+  fun `appends utf-8 charset to text types only`() {
+    resolve(ExportFormat.CSV, "en.csv").assert.isEqualTo("text/csv; charset=UTF-8")
+    resolve(ExportFormat.PROPERTIES, "en.properties").assert.isEqualTo("text/plain; charset=UTF-8")
+    resolve(ExportFormat.YAML, "en.yaml").assert.isEqualTo("application/x-yaml")
+    resolve(ExportFormat.PO, "en.po").assert.isEqualTo("text/x-gettext-translation; charset=UTF-8")
+    resolve(ExportFormat.RESX_ICU, "en.resx").assert.isEqualTo("text/microsoft-resx; charset=UTF-8")
+  }
+
+  @Test
+  fun `ignores apple extensions in the path for non apple formats`() {
+    resolve(ExportFormat.ANDROID_XML, "values-en/strings.xml").assert.isEqualTo("application/xml")
+    resolve(ExportFormat.COMPOSE_XML, "values-en/strings.xml").assert.isEqualTo("application/xml")
+    resolve(ExportFormat.JSON, "strings/en.json").assert.isEqualTo("application/json")
+  }
+
+  @Test
+  fun `resolves every format to zip when zipped`() {
+    ExportFormat.entries.forEach {
+      resolve(it, "translations.zip", zip = true)
+        .assert
+        .describedAs("format %s", it)
+        .isEqualTo("application/zip")
+    }
+  }
+
+  @Test
+  fun `resolves every format to its declared content type`() {
+    val expected =
+      mapOf(
+        ExportFormat.JSON to "application/json",
+        ExportFormat.JSON_TOLGEE to "application/json",
+        ExportFormat.JSON_I18NEXT to "application/json",
+        ExportFormat.XLIFF to "application/x-xliff+xml",
+        ExportFormat.APPLE_XLIFF to "application/x-xliff+xml",
+        ExportFormat.PO to "text/x-gettext-translation; charset=UTF-8",
+        ExportFormat.APPLE_STRINGS_STRINGSDICT to "text/plain; charset=UTF-8",
+        ExportFormat.ANDROID_XML to "application/xml",
+        ExportFormat.COMPOSE_XML to "application/xml",
+        ExportFormat.FLUTTER_ARB to "application/json",
+        ExportFormat.PROPERTIES to "text/plain; charset=UTF-8",
+        ExportFormat.YAML_RUBY to "application/x-yaml",
+        ExportFormat.YAML to "application/x-yaml",
+        ExportFormat.CSV to "text/csv; charset=UTF-8",
+        ExportFormat.RESX_ICU to "text/microsoft-resx; charset=UTF-8",
+        ExportFormat.XLSX to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ExportFormat.APPLE_XCSTRINGS to "application/json",
+        ExportFormat.ANDROID_SDK to "application/json",
+        ExportFormat.APPLE_SDK to "application/json",
+      )
+
+    expected.keys.assert
+      .describedAs("every ExportFormat needs an expected content type")
+      .containsExactlyInAnyOrderElementsOf(ExportFormat.entries)
+    ExportFormat.entries.forEach {
+      resolve(it, pathFor(it)).assert.describedAs("format %s", it).isEqualTo(expected[it])
+    }
+  }
+
+  private fun pathFor(format: ExportFormat): String {
+    if (format == APPLE) {
+      return "en.lproj/Localizable.strings"
+    }
+    return "en.${format.extension}"
+  }
+
+  private fun resolve(
+    format: ExportFormat,
+    path: String,
+    zip: Boolean = false,
+  ) = resolveExportContentType(format, zip, path)
+
+  companion object {
+    private val APPLE = ExportFormat.APPLE_STRINGS_STRINGSDICT
+  }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/GetAppleExportPathContentTypeTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/apple/out/GetAppleExportPathContentTypeTest.kt
@@ -1,0 +1,110 @@
+package io.tolgee.unit.formats.apple.out
+
+import io.tolgee.formats.apple.out.getAppleExportPathContentType
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+
+class GetAppleExportPathContentTypeTest {
+  @Test
+  fun `resolves apple strings and stringsdict by extension`() {
+    appleContentType("en.lproj/Localizable.strings").assert.isEqualTo("text/plain")
+    appleContentType("en.lproj/Localizable.stringsdict").assert.isEqualTo("application/xml")
+  }
+
+  @Test
+  fun `prefers the file name over a directory segment carrying a separator`() {
+    appleContentType("a.strings/Localizable.stringsdict").assert.isEqualTo("application/xml")
+    appleContentType("a.stringsdict/Localizable.strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `resolves nothing when the path carries no apple extension`() {
+    appleContentType("en.lproj/Localizable").assert.isNull()
+  }
+
+  @Test
+  fun `resolves apple extension when the template puts a suffix after it`() {
+    appleContentType("en.strings.txt").assert.isEqualTo("text/plain")
+    appleContentType("en.lproj/Localizable.stringsdict.bak").assert.isEqualTo("application/xml")
+  }
+
+  @Test
+  fun `resolves apple extension when the separator before it is not a letter`() {
+    appleContentType("en_strings").assert.isEqualTo("text/plain")
+    appleContentType("en_stringsdict").assert.isEqualTo("application/xml")
+  }
+
+  @Test
+  fun `does not resolve an apple extension that is part of a longer word`() {
+    appleContentType("mystrings").assert.isNull()
+    appleContentType("strings2").assert.isNull()
+    appleContentType("v2strings").assert.isNull()
+    appleContentType("stringsdictionary").assert.isNull()
+  }
+
+  @Test
+  fun `matches the apple extension case-sensitively`() {
+    appleContentType("Strings").assert.isNull()
+  }
+
+  @Test
+  fun `resolves apple extension from a directory segment`() {
+    appleContentType("strings/en").assert.isEqualTo("text/plain")
+    appleContentType("stringsdict/en").assert.isEqualTo("application/xml")
+  }
+
+  @Test
+  fun `refuses to guess when two directories are both an exact extension`() {
+    appleContentType("strings/stringsdict/en").assert.isNull()
+    appleContentType("stringsdict/strings/en").assert.isNull()
+  }
+
+  @Test
+  fun `prefers a whole directory segment over a namespace merely containing the word`() {
+    appleContentType("stringsdict/ios-strings/en").assert.isEqualTo("application/xml")
+    appleContentType("strings/my-stringsdict-ns/en").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `resolves a separator-less extension rendered into a directory`() {
+    appleContentType("en_strings/Localizable").assert.isEqualTo("text/plain")
+    appleContentType("en_stringsdict/Localizable").assert.isEqualTo("application/xml")
+  }
+
+  @Test
+  fun `prefers the file name's own extension over a directory named like one`() {
+    appleContentType("strings/en_stringsdict").assert.isEqualTo("application/xml")
+    appleContentType("stringsdict/en_strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `prefers the file name over directory segments`() {
+    appleContentType("stringsdict/en.lproj/Localizable.strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `prefers a dot-delimited extension over a separator-less one in the same file name`() {
+    appleContentType("en_strings.stringsdict").assert.isEqualTo("application/xml")
+    appleContentType("en_stringsdict.strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `resolves the last apple extension within a separator-less segment`() {
+    appleContentType("en_strings_stringsdict").assert.isEqualTo("application/xml")
+    appleContentType("en_stringsdict_strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `resolves the last apple extension among dot-separated parts`() {
+    appleContentType("en.strings.stringsdict").assert.isEqualTo("application/xml")
+    appleContentType("en.stringsdict.strings").assert.isEqualTo("text/plain")
+  }
+
+  @Test
+  fun `resolves apple extension from a directory segment carrying a separator`() {
+    appleContentType("en.strings/Localizable").assert.isEqualTo("text/plain")
+    appleContentType("Localizable.stringsdict/en").assert.isEqualTo("application/xml")
+  }
+
+  private fun appleContentType(exportRelativePath: String) = getAppleExportPathContentType(exportRelativePath)
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/util/FormatPathsForLogTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/util/FormatPathsForLogTest.kt
@@ -1,0 +1,32 @@
+package io.tolgee.unit.util
+
+import io.tolgee.testing.assert
+import io.tolgee.util.formatPathsForLog
+import org.junit.jupiter.api.Test
+
+class FormatPathsForLogTest {
+  @Test
+  fun `scrubs characters that would forge log lines`() {
+    formatPathsForLog(listOf("en\r\nWARN faked\tline.strings"))
+      .assert
+      .isEqualTo("en__WARN faked_line.strings")
+  }
+
+  @Test
+  fun `caps each path rather than the joined result`() {
+    val formatted = formatPathsForLog(List(3) { "a".repeat(500) })
+    formatted.assert.hasSize(3 * 200 + 2 * ", ".length)
+  }
+
+  @Test
+  fun `lists at most three paths and counts the rest`() {
+    formatPathsForLog(listOf("a", "b", "c", "d", "e"))
+      .assert
+      .isEqualTo("a, b, c and 2 more")
+  }
+
+  @Test
+  fun `lists every path when there are no more than three`() {
+    formatPathsForLog(listOf("a", "b")).assert.isEqualTo("a, b")
+  }
+}

--- a/backend/development/src/main/kotlin/io/tolgee/util/InMemoryFileStorage.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/util/InMemoryFileStorage.kt
@@ -34,6 +34,7 @@ class InMemoryFileStorage : FileStorage {
   override fun storeFile(
     storageFilePath: String,
     bytes: ByteArray,
+    contentType: String?,
   ) {
     files[storageFilePath] = bytes
   }

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/contentDeliverySlug.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/contentDeliverySlug.kt
@@ -1,0 +1,3 @@
+package io.tolgee.fixtures
+
+const val CONTENT_DELIVERY_GENERATED_SLUG_PATTERN = "[a-f0-9]{32}"

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/fileStorageFactoryMocking.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/fileStorageFactoryMocking.kt
@@ -1,0 +1,22 @@
+package io.tolgee.fixtures
+
+import io.tolgee.component.fileStorage.AzureBlobFileStorage
+import io.tolgee.component.fileStorage.AzureFileStorageFactory
+import io.tolgee.component.fileStorage.S3FileStorage
+import io.tolgee.component.fileStorage.S3FileStorageFactory
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+fun S3FileStorageFactory.mockCreatedStorage(): S3FileStorage {
+  val mockedFileStorage = mock<S3FileStorage>()
+  doAnswer { mockedFileStorage }.whenever(this).create(any())
+  return mockedFileStorage
+}
+
+fun AzureFileStorageFactory.mockCreatedStorage(): AzureBlobFileStorage {
+  val mockedFileStorage = mock<AzureBlobFileStorage>()
+  doAnswer { mockedFileStorage }.whenever(this).create(any())
+  return mockedFileStorage
+}

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/fileStorageMockInspection.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/fileStorageMockInspection.kt
@@ -1,0 +1,45 @@
+package io.tolgee.fixtures
+
+import io.tolgee.component.fileStorage.FileStorage
+import io.tolgee.testing.assert
+import org.mockito.Mockito
+import org.mockito.invocation.Invocation
+
+data class StoredFileCall(
+  val path: String,
+  val contentType: String?,
+)
+
+fun FileStorage.assertStoredSingleFile(
+  pathPattern: String,
+  contentType: String?,
+) {
+  val calls = getStoreFileCalls()
+  calls.assert.describedAs("storeFile calls").hasSize(1)
+  val stored = calls.single()
+  stored.path.assert.matches(pathPattern)
+  stored.contentType.assert.isEqualTo(contentType)
+}
+
+fun FileStorage.assertPrunedSingleDirectory(pathPattern: String) {
+  val pruned = getPrunedDirectories()
+  pruned.assert.describedAs("pruneDirectory calls").hasSize(1)
+  pruned.single().assert.matches(pathPattern)
+}
+
+fun FileStorage.getStoreFileCalls(): List<StoredFileCall> =
+  getInvocations()
+    .filter { it.method.name == "storeFile" }
+    .map { invocation ->
+      StoredFileCall(
+        path = invocation.getArgument(0),
+        contentType = invocation.getArgument(2),
+      )
+    }
+
+fun FileStorage.getPrunedDirectories(): List<String> =
+  getInvocations()
+    .filter { it.method.name == "pruneDirectory" }
+    .map { invocation -> invocation.getArgument(0) }
+
+private fun FileStorage.getInvocations(): List<Invocation> = Mockito.mockingDetails(this).invocations.toList()

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigBranchingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigBranchingTest.kt
@@ -54,8 +54,9 @@ class ContentDeliveryConfigBranchingTest : ProjectAuthControllerTest("/v2/projec
 
   @AfterEach
   fun after() {
-    batchJobConcurrentLauncher.pause = false
     enabledFeaturesProvider.forceEnabled = null
+    testDataService.cleanTestData(testData.root)
+    batchJobConcurrentLauncher.pause = false
   }
 
   @Test

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigControllerEeTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentDeliveryConfigControllerEeTest.kt
@@ -2,20 +2,23 @@ package io.tolgee.ee.api.v2.controllers
 
 import io.tolgee.ProjectAuthControllerTest
 import io.tolgee.batch.BatchJobConcurrentLauncher
-import io.tolgee.component.fileStorage.AzureBlobFileStorage
 import io.tolgee.component.fileStorage.AzureFileStorageFactory
 import io.tolgee.component.fileStorage.FileStorage
-import io.tolgee.component.fileStorage.S3FileStorage
 import io.tolgee.component.fileStorage.S3FileStorageFactory
 import io.tolgee.constants.Feature
 import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.fixtures.CONTENT_DELIVERY_GENERATED_SLUG_PATTERN
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andHasErrorMessage
 import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.assertPrunedSingleDirectory
+import io.tolgee.fixtures.assertStoredSingleFile
+import io.tolgee.fixtures.getPrunedDirectories
 import io.tolgee.fixtures.isValidId
+import io.tolgee.fixtures.mockCreatedStorage
 import io.tolgee.fixtures.node
 import io.tolgee.service.contentDelivery.ContentDeliveryConfigService
 import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
@@ -24,11 +27,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import org.mockito.invocation.Invocation
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.web.servlet.ResultActions
@@ -73,8 +71,9 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
   @AfterEach
   fun after() {
     resetServerProperties()
-    batchJobConcurrentLauncher.pause = false
     enabledFeaturesProvider.forceEnabled = null
+    testDataService.cleanTestData(testData.root)
+    batchJobConcurrentLauncher.pause = false
   }
 
   @Test
@@ -112,7 +111,7 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
   @Test
   @ProjectJWTAuthTestMethod
   fun `creates content delivery config with auto publish`() {
-    val mock = mockAzureFileStorage()
+    val mock = azureFileStorageFactory.mockCreatedStorage()
     var id: Long? = null
     performProjectAuthPost(
       "content-delivery-configs",
@@ -139,7 +138,7 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
   @Test
   @ProjectJWTAuthTestMethod
   fun `creates content delivery config without pruning`() {
-    val mock = mockAzureFileStorage()
+    val mock = azureFileStorageFactory.mockCreatedStorage()
     performProjectAuthPost(
       "content-delivery-configs",
       mapOf(
@@ -206,7 +205,7 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
   @Test
   @ProjectJWTAuthTestMethod
   fun `publishes to s3`() {
-    val mocked = mockS3FileStorage()
+    val mocked = s3FileStorageFactory.mockCreatedStorage()
     performProjectAuthPost("content-delivery-configs/${testData.s3ContentDeliveryConfig.self.id}")
     assertStored(mocked)
     assertPruned(mocked)
@@ -258,7 +257,7 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
     performProjectAuthPut(
       "content-delivery-configs/${testData.s3ContentDeliveryConfigWithCustomSlug.self.id}",
       mapOf("name" to "S3", "contentStorageId" to testData.s3ContentStorage.self.id),
-    ).andAssertThatJson { node("slug").isString.matches("[a-f0-9]{32}") }
+    ).andAssertThatJson { node("slug").isString.matches(CONTENT_DELIVERY_GENERATED_SLUG_PATTERN) }
   }
 
   @Test
@@ -304,30 +303,14 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
       ),
     )
 
-  private fun assertStored(mocked: FileStorage) {
-    mocked.getStoreFileInvocations().assert.hasSize(1)
-    (mocked.getStoreFileInvocations().single().arguments[0] as String)
-      .matches("[a-f0-9]{32}/en\\.json".toRegex())
-  }
+  private fun assertStored(mocked: FileStorage) =
+    mocked.assertStoredSingleFile("$CONTENT_DELIVERY_GENERATED_SLUG_PATTERN/en\\.json", "application/json")
 
-  private fun assertPruned(mocked: FileStorage) {
-    mocked.getPruneDirectoryInvocations().assert.hasSize(1)
-    (mocked.getPruneDirectoryInvocations().single().arguments[0] as String)
-      .matches("[a-f0-9]{32}".toRegex())
-  }
+  private fun assertPruned(mocked: FileStorage) =
+    mocked.assertPrunedSingleDirectory(CONTENT_DELIVERY_GENERATED_SLUG_PATTERN)
 
   private fun assertNotPruned(mocked: FileStorage) {
-    mocked.getPruneDirectoryInvocations().assert.hasSize(0)
-  }
-
-  private fun FileStorage.getInvocations(): List<Invocation> = Mockito.mockingDetails(this).invocations.toList()
-
-  private fun FileStorage.getStoreFileInvocations(): List<Invocation> {
-    return getInvocations().filter { it.method.name == "storeFile" }
-  }
-
-  private fun FileStorage.getPruneDirectoryInvocations(): List<Invocation> {
-    return getInvocations().filter { it.method.name == "pruneDirectory" }
+    mocked.getPrunedDirectories().assert.isEmpty()
   }
 
   private fun resetServerProperties() {
@@ -335,21 +318,5 @@ class ContentDeliveryConfigControllerEeTest : ProjectAuthControllerTest("/v2/pro
       .clear()
     tolgeeProperties.contentDelivery.storage.azure
       .clear()
-  }
-
-  private fun mockS3FileStorage(): S3FileStorage {
-    val mockedFileStorage = mock<S3FileStorage>()
-    doAnswer {
-      mockedFileStorage
-    }.whenever(s3FileStorageFactory).create(any())
-    return mockedFileStorage
-  }
-
-  private fun mockAzureFileStorage(): AzureBlobFileStorage {
-    val mockedFileStorage = mock<AzureBlobFileStorage>()
-    doAnswer {
-      mockedFileStorage
-    }.whenever(azureFileStorageFactory).create(any())
-    return mockedFileStorage
   }
 }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentStorageControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/ContentStorageControllerTest.kt
@@ -58,8 +58,9 @@ class ContentStorageControllerTest : ProjectAuthControllerTest("/v2/projects/") 
   }
 
   @AfterEach
-  fun clenup() {
+  fun cleanup() {
     enabledFeaturesProvider.forceEnabled = setOf()
+    testDataService.cleanTestData(testData.root)
   }
 
   @Test


### PR DESCRIPTION
Fixes #2504.

## Problem

Files published by Content Delivery to S3-compatible and Azure Blob storage were stored without a `Content-Type`, so both services fall back to `application/octet-stream`. CDNs in front of those buckets (Front Door, CloudFront, Cloud CDN) then skip their default caching and compression rules, and browsers download the files instead of rendering them. Reported for Azure, then confirmed on S3 and GCS in the issue thread.

## Fix

The content type is resolved per published file and passed into the upload request itself (`putObject` / `uploadWithResponse`), so no extra round trip.

- Source of truth is `ExportFormat.mediaType` — the same value the export download endpoint already sends — so the two cannot drift.
- Two cases the format alone cannot express: a zipped publish is `application/zip`, and `APPLE_STRINGS_STRINGSDICT` emits both `.strings` and `.stringsdict` from one format whose enum `mediaType` is blank.
- `; charset=UTF-8` is appended to `text/*` only. Those files are now *rendered* rather than downloaded, so without it a browser falls back to a locale-derived encoding and accented/CJK translations render as mojibake — which the CDN would then cache. JSON and XML define their own encoding detection; binary types must not carry a charset.

### Apple path resolution

`fileStructureTemplate` only has to *contain* `{extension}`, not place it anywhere particular, so the placeholder can render into a directory (`strings/en`), carry a suffix (`Localizable.stringsdict.bak`) or sit against another character (`en_strings`). Candidates are ranked: file name before directories, exact dot-segment before a fuzzy word match. Two equally exact directory segments resolve to *nothing* rather than a guess, since a wrong Content-Type is worse than none.

The resolver is given the export-relative path, never the user-controlled slug. A publish that cannot recover the extension keeps today's behaviour and logs a warning naming the config, format and paths (scrubbed of non-printables, since templates are user-authored).

GCS users are covered by the S3 path, which is what its interoperability endpoint speaks.

## Tests

- `ResolveExportContentTypeTest` — exhaustive `ExportFormat` → expected table, asserted complete against `ExportFormat.entries` so a new format forces an explicit decision.
- `GetAppleExportPathContentTypeTest` — 17 cases covering the template shapes above, the ranking, and the refusal to guess.
- `ContentDeliveryContentTypeTest` — end-to-end publish of an Apple config, asserting `.strings` and `.stringsdict` reach storage with different content types, plus the degradation case.
- `FileStorageS3Test` / `FileStorageAzureTest` — content type is really sent, and is absent when none is given; the Azure upload keeps overwrite semantics (`ifNoneMatch` unset), so republishing still works.

Also adds the `cleanTestData` teardown the project's test-data rule requires to the content-delivery test classes; without it those suites were order-dependent and failed a different subset of cases per run.

## Deliberately out of scope

- **`V2ExportController` still derives its own header.** Routing the download endpoint through this resolver would add `; charset=UTF-8` to public response headers and start emitting a type for single-file Apple downloads — a user-visible API change that belongs in its own PR.
- **`AzureBlobFileStorage.fileExists` returns `true` unconditionally** (it discards `exists()` and catches an AWS exception type Azure never throws). Real bug, unrelated to MIME types; worth a separate `fix:` with its own test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content-delivery exports now apply appropriate content types, including UTF-8 text, ZIP archives, and Apple `.strings`/`.stringsdict` files.
  * Apple export paths are analyzed to determine the correct content type, including nested directories and filename extensions.
  * Cloud storage uploads now preserve content-type metadata for Azure Blob Storage and Amazon S3.

* **Bug Fixes**
  * Improved handling of generated storage paths and custom content-delivery slugs.
  * Added safer, clearer logging for files whose content type cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->