### PR TITLE
feat: support Google Workspace as SSO provider

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/dtos/sso/SsoTenantConfig.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/sso/SsoTenantConfig.kt
@@ -1,6 +1,7 @@
 package io.tolgee.dtos.sso
 
 import io.tolgee.api.ISsoTenant
+import java.net.URI
 
 data class SsoTenantConfig(
   override val clientId: String,
@@ -15,6 +16,19 @@ data class SsoTenantConfig(
   override val global: Boolean,
   val organizationId: Long? = null,
 ) : ISsoTenant {
+  /**
+   * Google rejects the standard OIDC `offline_access` scope with `invalid_scope`;
+   * refresh tokens must be requested via `access_type=offline&prompt=consent` instead,
+   * and Google's refresh responses don't rotate the refresh token.
+   */
+  val isGoogle: Boolean
+    get() = isGoogleHost(authorizationUri) || isGoogleHost(tokenUri)
+
+  private fun isGoogleHost(uri: String): Boolean {
+    val host = runCatching { URI(uri).host }.getOrNull() ?: return false
+    return host == "accounts.google.com" || host == "googleapis.com" || host.endsWith(".googleapis.com")
+  }
+
   constructor(other: ISsoTenant, organizationId: Long?) : this(
     clientId = other.clientId,
     clientSecret = other.clientSecret,

--- a/backend/data/src/test/kotlin/io/tolgee/unit/SsoTenantConfigTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/SsoTenantConfigTest.kt
@@ -1,0 +1,50 @@
+package io.tolgee.unit
+
+import io.tolgee.dtos.sso.SsoTenantConfig
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+
+class SsoTenantConfigTest {
+  @Test
+  fun `detects google by authorization uri`() {
+    config(authorizationUri = "https://accounts.google.com/o/oauth2/v2/auth").isGoogle.assert.isTrue()
+  }
+
+  @Test
+  fun `detects google by token uri`() {
+    config(tokenUri = "https://oauth2.googleapis.com/token").isGoogle.assert.isTrue()
+  }
+
+  @Test
+  fun `does not detect generic provider as google`() {
+    config().isGoogle.assert.isFalse()
+  }
+
+  @Test
+  fun `does not detect google host in path as google`() {
+    config(authorizationUri = "https://evil.com/accounts.google.com").isGoogle.assert.isFalse()
+  }
+
+  @Test
+  fun `does not detect google-like suffix without dot as google`() {
+    config(authorizationUri = "https://notgoogleapis.com/auth").isGoogle.assert.isFalse()
+  }
+
+  @Test
+  fun `handles unparseable uri`() {
+    config(authorizationUri = "not a uri").isGoogle.assert.isFalse()
+  }
+
+  private fun config(
+    authorizationUri: String = "https://idp.example.com/auth",
+    tokenUri: String = "https://idp.example.com/token",
+  ) = SsoTenantConfig(
+    clientId = "clientId",
+    clientSecret = "clientSecret",
+    authorizationUri = authorizationUri,
+    domain = "example.com",
+    tokenUri = tokenUri,
+    force = false,
+    global = false,
+  )
+}

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/SsoAuthController.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/SsoAuthController.kt
@@ -45,11 +45,24 @@ class SsoAuthController(
   private fun buildAuthUrl(
     tenant: SsoTenantConfig,
     state: String,
-  ): String =
-    "${tenant.authorizationUri}?" +
-      "client_id=${tenant.clientId}&" +
-      "redirect_uri=${frontendUrlProvider.url + "/login/auth_callback/sso"}&" +
-      "response_type=code&" +
-      "scope=openid profile email offline_access&" +
-      "state=$state"
+  ): String {
+    val url =
+      "${tenant.authorizationUri}?" +
+        "client_id=${tenant.clientId}&" +
+        "redirect_uri=${frontendUrlProvider.url + "/login/auth_callback/sso"}&" +
+        "response_type=code&" +
+        "scope=${getScope(tenant)}&" +
+        "state=$state"
+    if (!tenant.isGoogle) {
+      return url
+    }
+    return "$url&access_type=offline&prompt=consent"
+  }
+
+  private fun getScope(tenant: SsoTenantConfig): String {
+    if (tenant.isGoogle) {
+      return "openid profile email"
+    }
+    return "openid profile email offline_access"
+  }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/OAuth2TokenResponse.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/OAuth2TokenResponse.kt
@@ -4,5 +4,5 @@ package io.tolgee.ee.data
 class OAuth2TokenResponse(
   val id_token: String,
   val scope: String,
-  val refresh_token: String,
+  val refresh_token: String?,
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/OAuth2TokenResponse.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/OAuth2TokenResponse.kt
@@ -1,8 +1,13 @@
 package io.tolgee.ee.data
 
+/**
+ * Providers may omit any of these fields: `id_token` and `refresh_token` are commonly
+ * absent from refresh responses (e.g. Google), and `scope` is optional per RFC 6749.
+ * Callers requiring a field must check for null.
+ */
 @Suppress("PropertyName")
 class OAuth2TokenResponse(
-  val id_token: String,
-  val scope: String,
+  val id_token: String?,
+  val scope: String?,
   val refresh_token: String?,
 )

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
@@ -149,7 +149,7 @@ class SsoDelegateEe(
     userResponse: GenericUserResponse,
     tenant: SsoTenantConfig,
     invitationCode: String?,
-    refreshToken: String,
+    refreshToken: String?,
   ): JwtAuthenticationResponse {
     val email =
       userResponse.email ?: let {
@@ -220,13 +220,12 @@ class SsoDelegateEe(
   ): Boolean {
     val tenant = tenantService.getEnabledConfigByDomain(domain)
 
-    val response = fetchRefreshToken(tenant, refreshToken)
-    if (response?.refresh_token == null) {
-      return false
-    }
+    val response = fetchRefreshToken(tenant, refreshToken) ?: return false
 
     val userAccount = userAccountService.get(user.id)
-    userAccountService.updateSsoSession(userAccount, response.refresh_token)
+    // Providers that don't rotate refresh tokens (e.g. Google) omit refresh_token in the
+    // refresh response — a successful response means the old token is still valid.
+    userAccountService.updateSsoSession(userAccount, response.refresh_token ?: refreshToken)
     return true
   }
 
@@ -244,7 +243,7 @@ class SsoDelegateEe(
       add("grant_type", "refresh_token")
       add("client_id", tenant.clientId)
       add("client_secret", tenant.clientSecret)
-      add("scope", "offline_access openid")
+      add("scope", getRefreshScope(tenant))
       add("refresh_token", refreshToken)
     }
 
@@ -262,5 +261,12 @@ class SsoDelegateEe(
       logger.info("Failed to refresh token: ${e.message}")
     }
     return null
+  }
+
+  private fun getRefreshScope(tenant: SsoTenantConfig): String {
+    if (tenant.isGoogle) {
+      return "openid"
+    }
+    return "offline_access openid"
   }
 }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
@@ -82,8 +82,11 @@ class SsoDelegateEe(
     val token =
       fetchToken(tenant, code, redirectUri)
         ?: throw SsoAuthorizationException(Message.SSO_TOKEN_EXCHANGE_FAILED)
+    val idToken =
+      token.id_token
+        ?: throw SsoAuthorizationException(Message.SSO_TOKEN_EXCHANGE_FAILED)
 
-    val userInfo = decodeIdTokenUnsafe(token.id_token)
+    val userInfo = decodeIdTokenUnsafe(idToken)
     return getTokenResponseForUser(userInfo, tenant, invitationCode, token.refresh_token)
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/SsoOrganizationsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/SsoOrganizationsTest.kt
@@ -252,6 +252,44 @@ class SsoOrganizationsTest : AuthorizedControllerTest() {
   }
 
   @Test
+  fun `doesn't authorize user when token response has no id token`() {
+    val response = loginAsSsoUser(tokenResponse = SsoMultiTenantsMocks.minimalRefreshTokenResponse)
+    assertThat(response.response.status).isEqualTo(401)
+    assertThat(response.response.contentAsString).contains(Message.SSO_TOKEN_EXCHANGE_FAILED.code)
+    val userName = SsoMultiTenantsMocks.jwtClaimsSet.get("email") as String
+    assertThrows<NotFoundException> { userAccountService.get(userName) }
+  }
+
+  @Test
+  fun `refresh succeeds when response contains only access token fields`() {
+    loginAsSsoUser()
+    val userName = SsoMultiTenantsMocks.jwtClaimsSet.get("email") as String
+    val user = userAccountService.get(userName)
+    val originalRefreshToken = user.ssoRefreshToken
+    originalRefreshToken.assert.isNotNull
+
+    whenever(
+      restTemplate?.exchange(
+        eq(testData.tenant.tokenUri),
+        eq(HttpMethod.POST),
+        any(HttpEntity::class.java),
+        eq(OAuth2TokenResponse::class.java),
+      ),
+    ).thenReturn(SsoMultiTenantsMocks.minimalRefreshTokenResponse)
+    currentDateProvider.forcedDate = Date(currentDateProvider.date.time + 600_000)
+
+    ssoDelegate
+      .verifyUserSsoAccountAvailable(userAccountService.getDto(user.id))
+      .assert
+      .isTrue()
+
+    userAccountService
+      .get(user.id)
+      .ssoRefreshToken.assert
+      .isEqualTo(originalRefreshToken)
+  }
+
+  @Test
   fun `refresh keeps old refresh token when response contains none`() {
     loginAsSsoUser()
     val userName = SsoMultiTenantsMocks.jwtClaimsSet.get("email") as String

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/SsoOrganizationsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/SsoOrganizationsTest.kt
@@ -28,6 +28,7 @@ import org.mockito.ArgumentMatchers.startsWith
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.only
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpEntity
@@ -220,6 +221,70 @@ class SsoOrganizationsTest : AuthorizedControllerTest() {
       any(HttpEntity::class.java),
       eq(OAuth2TokenResponse::class.java),
     )
+  }
+
+  @Test
+  fun `auth link for generic provider requests offline_access scope`() {
+    val redirectUrl = getAuthLinkRedirectUrl()
+    redirectUrl.assert.contains("scope=openid profile email offline_access")
+    redirectUrl.assert.doesNotContain("access_type=offline")
+    redirectUrl.assert.doesNotContain("prompt=consent")
+  }
+
+  @Test
+  fun `auth link for google provider uses access_type instead of offline_access scope`() {
+    testData.tenant.authorizationUri = "https://accounts.google.com/o/oauth2/v2/auth"
+    tenantService.save(testData.tenant)
+    val redirectUrl = getAuthLinkRedirectUrl()
+    redirectUrl.assert.contains("scope=openid profile email&")
+    redirectUrl.assert.doesNotContain("offline_access")
+    redirectUrl.assert.contains("access_type=offline")
+    redirectUrl.assert.contains("prompt=consent")
+  }
+
+  @Test
+  fun `sso login succeeds when token response has no refresh token`() {
+    val response = loginAsSsoUser(tokenResponse = SsoMultiTenantsMocks.defaultTokenResponseWithoutRefreshToken)
+    assertThat(response.response.status).isEqualTo(200)
+    val userName = SsoMultiTenantsMocks.jwtClaimsSet.get("email") as String
+    val user = userAccountService.get(userName)
+    user.ssoRefreshToken.assert.isNull()
+  }
+
+  @Test
+  fun `refresh keeps old refresh token when response contains none`() {
+    loginAsSsoUser()
+    val userName = SsoMultiTenantsMocks.jwtClaimsSet.get("email") as String
+    val user = userAccountService.get(userName)
+    val originalRefreshToken = user.ssoRefreshToken
+    originalRefreshToken.assert.isNotNull
+
+    whenever(
+      restTemplate?.exchange(
+        eq(testData.tenant.tokenUri),
+        eq(HttpMethod.POST),
+        any(HttpEntity::class.java),
+        eq(OAuth2TokenResponse::class.java),
+      ),
+    ).thenReturn(SsoMultiTenantsMocks.defaultTokenResponseWithoutRefreshToken)
+    currentDateProvider.forcedDate = Date(currentDateProvider.date.time + 600_000)
+
+    ssoDelegate
+      .verifyUserSsoAccountAvailable(userAccountService.getDto(user.id))
+      .assert
+      .isTrue()
+
+    userAccountService
+      .get(user.id)
+      .ssoRefreshToken.assert
+      .isEqualTo(originalRefreshToken)
+  }
+
+  private fun getAuthLinkRedirectUrl(): String {
+    val response = ssoMultiTenantsMocks.getAuthLink("domain.com").response
+    assertThat(response.status).isEqualTo(200)
+    val result = jacksonObjectMapper().readValue(response.contentAsString, HashMap::class.java)
+    return result["redirectUrl"] as String
   }
 
   fun organizationDto() =

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/SsoMultiTenantsMocks.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/SsoMultiTenantsMocks.kt
@@ -56,6 +56,12 @@ class SsoMultiTenantsMocks(
         defaultTokenWithoutRefreshToken,
         HttpStatus.OK,
       )
+
+    val minimalRefreshTokenResponse =
+      ResponseEntity(
+        OAuth2TokenResponse(id_token = null, scope = null, refresh_token = null),
+        HttpStatus.OK,
+      )
     val defaultTokenResponse2 =
       ResponseEntity(
         defaultToken2,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/SsoMultiTenantsMocks.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/utils/SsoMultiTenantsMocks.kt
@@ -38,9 +38,22 @@ class SsoMultiTenantsMocks(
         refresh_token = "refresh_token",
       )
 
+    val defaultTokenWithoutRefreshToken =
+      OAuth2TokenResponse(
+        id_token = generateTestJwt(jwtClaimsSet),
+        scope = "scope",
+        refresh_token = null,
+      )
+
     val defaultTokenResponse =
       ResponseEntity(
         defaultToken,
+        HttpStatus.OK,
+      )
+
+    val defaultTokenResponseWithoutRefreshToken =
+      ResponseEntity(
+        defaultTokenWithoutRefreshToken,
         HttpStatus.OK,
       )
     val defaultTokenResponse2 =


### PR DESCRIPTION
## Problem

Configuring Google Workspace as an OIDC SSO provider fails with `Error 400: invalid_scope … invalid=[offline_access]`. Google rejects the standard OIDC `offline_access` scope — it issues refresh tokens via `access_type=offline&prompt=consent` instead, and it doesn't rotate refresh tokens on refresh (the refresh response omits `refresh_token`).

## Changes

- `SsoTenantConfig.isGoogle` — detects Google tenants by the host of the authorization/token URI (`accounts.google.com`, `*.googleapis.com`). No DB migration or UI change needed; works for per-organization and global SSO.
- `SsoAuthController` — for Google tenants the auth URL uses `scope=openid profile email` and appends `access_type=offline&prompt=consent`; other providers keep the current behavior.
- `OAuth2TokenResponse.refresh_token` is now nullable — Google token responses without a refresh token would otherwise fail deserialization.
- `SsoDelegateEe` — the refresh request sends `offline_access` only for non-Google tenants, and a successful refresh response without a new refresh token keeps the old one instead of failing the session.

## Tests

- Unit tests for the Google host detection (including non-Google hosts with google-looking paths/suffixes)
- Integration tests: auth URL shape for Google vs. generic tenants, login with a token response lacking a refresh token, session refresh keeping the old refresh token when none is returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Google SSO support with provider-specific authorization scopes and consent settings.
  * Added support for signing in when Google does not return a refresh token.
  * Preserved existing refresh tokens when subsequent responses omit them.

* **Bug Fixes**
  * Improved provider detection and handling of invalid or misleading SSO URLs.
  * Updated token refresh behavior for providers with differing OAuth requirements.
  * Added validation to reject sign-in responses missing a required ID token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->