### PR TITLE
fix: default isBatch on the legacy translate endpoint under Jackson 3

### DIFF
--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/LegacyTolgeeTranslateRequest.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/LegacyTolgeeTranslateRequest.kt
@@ -9,7 +9,7 @@ data class LegacyTolgeeTranslateRequest(
   val targetTag: String,
   val metadata: Metadata?,
   val formality: Formality?,
-  val isBatch: Boolean,
+  val isBatch: Boolean = false,
   val pluralForms: Map<String, String>? = null,
   val pluralFormExamples: Map<String, String>? = null,
 ) {


### PR DESCRIPTION
## Problem

The public legacy endpoint `POST /v2/public/translator/translate` (deserializing into `LegacyTolgeeTranslateRequest`) started rejecting requests that **omit** `isBatch` after the Spring Boot 4 upgrade (#3804) moved the JSON stack from Jackson 2 to Jackson 3 (`tools.jackson`):

```
request_parse_error (HTTP 400)
Missing required creator property 'isBatch' (index 6)
```

## Cause

`LegacyTolgeeTranslateRequest.isBatch` is a non-nullable `Boolean` with **no default value**, i.e. a required creator property.

- **Jackson 2** tolerated a missing non-nullable Boolean creator property and left it at the Kotlin/JVM default (`false`).
- **Jackson 3** enforces required creator properties strictly, so any legacy client that doesn't send `isBatch` is now rejected.

The field is **not** renamed — `{"isBatch": …}` binds correctly when present (verified directly against the Spring-configured `tools.jackson.databind.json.JsonMapper`: `{"isBatch":true}` → `isBatch=true`). The failure is purely the *absence* of a required value; the error message looks the same whether a required key is missing or misnamed, which is easy to misread.

## Fix

Give `isBatch` a default of `false`, so an omitted value is treated as "not a batch request" — restoring the pre-upgrade behavior. No `@JsonProperty` / rename handling is needed.

## Notes

Surfaced by the billing `EeTolgeeTranslatorControllerTest` suite (its controller is in the billing repo, using this platform DTO). The cases that omit `isBatch` began failing once those tests could actually run against Jackson 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when processing legacy translation requests by correctly recognizing the batch-processing option.
  * Requests that omit this option now default to non-batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->