### PR TITLE
chore: raise ee-test JVM heap to 8G to avoid OOM under Spring Boot 4

### DIFF
--- a/ee/backend/tests/build.gradle
+++ b/ee/backend/tests/build.gradle
@@ -29,7 +29,7 @@ allOpen {
 
 tasks.named('test', Test) {
     useJUnitPlatform()
-    maxHeapSize = "4096m"
+    maxHeapSize = "8192m"
     rootProject.setTestRetry(it)
 }
 


### PR DESCRIPTION
## Problem

`ee-test:test` intermittently fails with `java.lang.OutOfMemoryError` (Java heap), surfacing as flaky failures in whichever test class happens to be loading a Spring context when the heap fills — e.g. `QaCheckFinalizationTest`, `QaCheckRunnerServiceTest`. The tests pass in isolation; only the full suite OOMs.

## Cause

The `ee-test` suite runs all ~984 tests in a single JVM with `maxHeapSize = "4096m"`, and caches Spring test contexts (`spring.test.context.cache` default cap = 32). ee-test has many distinct `@SpringBootTest`/`@MockitoBean` configurations, so a large number of distinct contexts get cached. Spring Boot 4 contexts are heavier than SB3's, so 32 cached contexts now intermittently exceed the 4G heap — the `OutOfMemoryError` is thrown by the JVM (heap exhausted), not an OS OOM-kill. Memory config was not changed by the SB4 migration; the same 4G heap now holds heavier contexts.

## Fix

Raise the forked test-JVM heap `4096m → 8192m`. GitHub `ubuntu-24.04` runners have ~16G, and during the test task only this one forked JVM plus the gradle process and the Postgres/Redis containers are running, so 8G is safe headroom with no OS memory pressure.

If OOM recurs even at 8G, the follow-up would be to cap `spring.test.context.cache.maxSize` (fewer retained contexts) or shard `ee-test` — but a heap bump is the minimal first step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the memory available during test execution to improve reliability for memory-intensive test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->