### PR TITLE
fix: escape task and language names in notification emails

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/service/notification/TaskEmailComposer.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/notification/TaskEmailComposer.kt
@@ -5,6 +5,7 @@ import io.tolgee.model.notifications.Notification
 import io.tolgee.model.task.Task
 import io.tolgee.util.I18n
 import org.springframework.stereotype.Component
+import org.springframework.web.util.HtmlUtils
 
 @Component
 class TaskEmailComposer(
@@ -33,7 +34,7 @@ class TaskEmailComposer(
   private fun taskLink(task: Task): String {
     return """
         |<a href="${taskUrl(task)}">
-        |  ${taskName(task.name)} #${task.number} (${task.language.name})
+        |  ${HtmlUtils.htmlEscape(taskName(task.name))} #${task.number} (${HtmlUtils.htmlEscape(task.language.name)})
         |</a>
       """.trimMargin()
   }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/TaskEmailComposerTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/TaskEmailComposerTest.kt
@@ -1,10 +1,8 @@
 package io.tolgee.unit
 
 import io.tolgee.component.FrontendUrlProvider
-import io.tolgee.model.Language
+import io.tolgee.development.testDataBuilder.data.TaskTestData
 import io.tolgee.model.notifications.Notification
-import io.tolgee.model.notifications.NotificationType
-import io.tolgee.model.task.Task
 import io.tolgee.service.notification.TaskEmailComposer
 import io.tolgee.testing.assert
 import io.tolgee.util.I18n
@@ -40,16 +38,12 @@ class TaskEmailComposerTest {
     taskName: String = "Translate",
     languageName: String = "English",
   ): Notification {
-    val task =
-      Task().apply {
-        this.name = taskName
-        this.number = 1L
-        this.language = Language().apply { this.name = languageName }
-      }
-
-    return Notification().apply {
-      this.type = NotificationType.TASK_ASSIGNED
-      this.linkedTask = task
+    val testData = TaskTestData()
+    testData.addNotifications()
+    testData.translateTask.self.apply {
+      name = taskName
+      language.name = languageName
     }
+    return testData.taskNotification.self
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/TaskEmailComposerTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/TaskEmailComposerTest.kt
@@ -1,0 +1,55 @@
+package io.tolgee.unit
+
+import io.tolgee.component.FrontendUrlProvider
+import io.tolgee.model.Language
+import io.tolgee.model.notifications.Notification
+import io.tolgee.model.notifications.NotificationType
+import io.tolgee.model.task.Task
+import io.tolgee.service.notification.TaskEmailComposer
+import io.tolgee.testing.assert
+import io.tolgee.util.I18n
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class TaskEmailComposerTest {
+  private val frontendUrlProvider =
+    mock<FrontendUrlProvider> {
+      on { getTaskUrl(any(), any()) } doReturn "https://app.tolgee.io/task"
+      on { getMyTasksUrl() } doReturn "https://app.tolgee.io/my-tasks"
+    }
+
+  private val composer = TaskEmailComposer(frontendUrlProvider, I18n())
+
+  @Test
+  fun `escapes task name`() {
+    val email = composer.composeEmail(notification(taskName = "<h1>pwned</h1>"))
+    email.assert.doesNotContain("<h1>pwned</h1>")
+    email.assert.contains("&lt;h1&gt;pwned&lt;/h1&gt;")
+  }
+
+  @Test
+  fun `escapes language name`() {
+    val email = composer.composeEmail(notification(languageName = """<a href="https://evil.example">English</a>"""))
+    email.assert.doesNotContain("""<a href="https://evil.example">""")
+    email.assert.contains("&lt;a href=&quot;https://evil.example&quot;&gt;")
+  }
+
+  private fun notification(
+    taskName: String = "Translate",
+    languageName: String = "English",
+  ): Notification {
+    val task =
+      Task().apply {
+        this.name = taskName
+        this.number = 1L
+        this.language = Language().apply { this.name = languageName }
+      }
+
+    return Notification().apply {
+      this.type = NotificationType.TASK_ASSIGNED
+      this.linkedTask = task
+    }
+  }
+}


### PR DESCRIPTION
## Context

Triaging an external report claiming stored HTML injection in the signup verification email. That specific claim does not hold — the verification email contains no user-supplied name, and every template variable already goes through `#strings.escapeXml` (covered by `EmailServiceTest.it is not vulnerable to injection`).

Reviewing the surrounding code did turn up a genuine unescaped sink, which this PR fixes.

## The issue

`TaskEmailComposer` builds the notification email body as raw HTML and interpolates two user-supplied values without escaping:

- `task.name`
- `task.language.name`

That string is passed to `EmailParams.text`, which lands in the `default` template's `content` variable — the one variable deliberately injected as raw HTML (`dangerouslyInjectValueAsHtmlWithoutSanitization`). So a project member who names a task `<h1><a href="https://evil.example">…</a></h1>` gets that markup rendered in the task notification email received by everyone else on the project.

Severity is low: it requires project access, reaches only project members, and email clients do not execute script. It is the same class as the invitation-name bug fixed in #1898 — cosmetic markup injection into a transactional email, useful only for making phishing content look native.

## The fix

Escape both values with `HtmlUtils.htmlEscape` at the interpolation site, matching what `InvitationEmailSender` already does.

`taskName()` stays plain text — it is also called from the billing repo, which escapes at its own interpolation site (see tolgee/billing PR). The two changes are independent; either can merge first.

## Tests

New `TaskEmailComposerTest` asserts both values come out escaped. Verified it fails against the unpatched composer and passes with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-assignment email security by safely escaping task and language names in email links.
  * Prevented special characters in names from being interpreted as HTML.

* **Tests**
  * Added coverage to verify correct escaping in task notification emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->