### PR TITLE
ci: pin the billing release to the released platform commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,4 +111,4 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.TOLGEE_MACHINE_PAT }}" \
             https://api.github.com/repos/tolgee/billing/actions/workflows/test.yml/dispatches \
-            -d '{"ref":"main","inputs":{"release-version":"${{ steps.version.outputs.VERSION }}"}}'
+            -d '{"ref":"main","inputs":{"release-version":"${{ steps.version.outputs.VERSION }}","public-branch":"${{ github.sha }}"}}'


### PR DESCRIPTION
> Draft — opened for review of the approach. Verified the root cause empirically (below), but the change only exercises on a real release dispatch.

## Problem

When platform's release triggers the billing test/release workflow, it passes only `release-version` and leaves billing's `public-branch` input null. Each billing job (`Build backend`, `data:test`, e2e, …) then independently resolves platform **`main` HEAD** via `checkout-main`. If any commit merges to platform `main` **mid-run**, jobs split across two different platform commits → **stale-artifact skew**:

- `Build backend` compiles platform `main` at commit A and uploads the classes.
- A later test job checks out fresh test sources at commit B (A ≠ B) and runs them against A's compiled classes.

### Concrete example just now
A security fix adding HTML-escaping to notification emails (#3842) merged **between** `Build backend`'s checkout (09:04, pre-#3842) and `data:test`'s checkout (09:07, post-#3842) in a billing release run. `TaskEmailComposerTest` (added by #3842) ran against a `TaskEmailComposer` compiled **without** the escaping and failed on its raw-HTML assertions — even though the test passes cleanly against a consistent checkout:

```
TaskEmailComposerTest > escapes task name()     PASSED
TaskEmailComposerTest > escapes language name() PASSED
```
(run against current `main` locally)

## Fix

Pass `public-branch=${{ github.sha }}` in the billing dispatch. Billing's `checkout-main` already forwards `main-ref` straight to `actions/checkout`, which accepts a SHA — so **every** billing job pins to the exact commit platform released. This:
- removes the mid-run-merge race (all jobs use one commit),
- makes the billing image reproducible and consistent with the platform build (both build `github.sha`).

**No billing-side change needed** — the `public-branch` input and its wiring already exist.

## Scope note
This fixes the **platform-triggered** release path. A **manual** billing `test.yml` dispatch (leaving `public-branch` empty) still resolves `main` HEAD per job; for a manual run, pass `public-branch=<sha>` yourself, or we could later default it to a once-resolved SHA in billing.