### PR TITLE
chore: make buildx optional

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -34,7 +34,8 @@ ENV HEALTHCHECK_PORT=8080 \
 COPY BOOT-INF/lib /app/lib
 COPY META-INF /app/META-INF
 COPY BOOT-INF/classes /app
-COPY --chmod=755 cmd.sh /app
+COPY cmd.sh /app
+RUN chmod 755 /app/cmd.sh
 
 # Download OpenTelemetry Java agent for distributed tracing
 # When OTEL_JAVAAGENT_ENABLED=true, cmd.sh will use this agent

--- a/docker/app/Dockerfile.slim
+++ b/docker/app/Dockerfile.slim
@@ -23,7 +23,8 @@ ENV HEALTHCHECK_PORT=8080 \
 COPY BOOT-INF/lib /app/lib
 COPY META-INF /app/META-INF
 COPY BOOT-INF/classes /app
-COPY --chmod=755 cmd.sh /app
+COPY cmd.sh /app
+RUN chmod 755 /app/cmd.sh
 
 # Download OpenTelemetry Java agent for distributed tracing
 # When OTEL_JAVAAGENT_ENABLED=true, cmd.sh will use this agent

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -25,8 +25,7 @@ tasks.register('docker', Exec) {
     workingDir dockerPath
     commandLine "docker", "build", ".",
         "-t", "tolgee/tolgee",
-        "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}",
-        "--cache-from", "type=registry,ref=tolgee/tolgee:latest"
+        "--build-arg", "OTEL_AGENT_VERSION=${opentelemetryJavaagentVersion}"
 }
 
 // Builds the slim Docker image, tagged as tolgee/tolgee:slim.


### PR DESCRIPTION
TLDR: We don't use the docker cache anymore anyway. The cache param requires buildx. Removing it makes e2e tests work with plain Podman setup.


## Problem

The local `docker` Gradle task passed `--cache-from type=registry,ref=tolgee/tolgee:latest`. That is BuildKit-only syntax — a Docker CLI without the buildx plugin falls back to the legacy builder, which parses the value as an image reference and aborts:

```
Error response from daemon: failed to parse query parameter 'cachefrom':
  "[\"type=registry\",\"ref=tolgee/tolgee:latest\"]": invalid repo "type=registry":
  must contain registry and repository: invalid reference format
```

This makes `./gradlew docker` unusable on buildx-less setups (e.g. Podman behind the docker CLI), and takes the local e2e chain with it, since `runDockerE2e` → `tagDockerLocal` → `docker`. There is no workaround short of editing the build file locally.

## The flag was importing nothing anyway

A registry cache can only be imported if the publishing build exported one. Nothing does:

- `DOCKER_CACHE_TO` is read by `dockerPublish`, but it is never set — it appears only in `gradle/docker.gradle` itself, in no workflow in this repo and none in `billing`.
- The published `tolgee/tolgee:latest` image config carries no `moby.buildkit.cache.v0` entry and no cache labels (checked directly against the Docker Hub registry API).

So the import was a no-op even on a fully BuildKit-capable machine, and the layers it could theoretically have served are pinned base layers already in the local layer cache, while everything below `COPY BOOT-INF/lib` changes on every build.

## Change

Delete the flag. One line.

The task is now structurally identical to `dockerSlim`, which has never carried a cache flag: one deterministic single-arch local build, the same command on every machine, working on buildx and legacy builders alike, with no environment sniffing.

If a registry cache is wanted later, the honest way is to set `DOCKER_CACHE_TO` on the publishing build first, then drive the import from the `DOCKER_CACHE_FROM` env var `dockerPublish` already supports — opt-in, so it can never break a legacy-builder machine.

## CI and multi-arch are unaffected

`dockerPublish` and the `release`, `prerelease-alpha` and `preview` workflows still use buildx, so published images remain multi-arch (`linux/arm64,linux/amd64`). `setup-env` keeps `setup-qemu-action` / `setup-buildx-action`.

Note the `docker` task is not only a local task, and it is well covered by CI:

- This repo's `test.yml` runs `./gradlew runE2e`, which reaches it through `runE2e` → `runDockerE2e` → `tagDockerLocal` → `docker` (`gradle/e2e.gradle`), so every E2E shard builds the image with this command line.
- `billing`'s `release.yml` and `deploy-preview.yml` both run `./gradlew docker` to build the EE image.

All of those runners have buildx, so they exercised the flag before and exercise its absence now. Since the cache import was a no-op there too, dropping it costs them nothing and saves a failed Docker Hub manifest fetch.

## Verification

Against Docker CLI 29.7.2 talking to Podman 5.8.4 (legacy builder, no buildx):

- Reproduced the original failure standalone.
- `./gradlew docker` → `BUILD SUCCESSFUL`, image tagged `tolgee/tolgee`.
- Confirmed Podman's builder accepts the `COPY --chmod=755` used in both Dockerfiles, so no Dockerfile changes were needed.
- Full CI green, 41/41, on this revision — including all 15 E2E shards, which build the image via the changed task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Updated local Docker builds to rely on the image tag and OpenTelemetry build argument without the registry cache option.
- Improved Docker image build compatibility by applying executable permissions to the application startup script in a separate build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->