### PR TITLE
fix: hard-delete project fails on branch merge, snapshot and content delivery FKs

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/project/ProjectHardDeletingServiceTest.kt
@@ -10,8 +10,10 @@ import io.tolgee.batch.data.BatchJobType
 import io.tolgee.batch.request.DeleteKeysRequest
 import io.tolgee.development.testDataBuilder.data.BaseTestData
 import io.tolgee.development.testDataBuilder.data.BatchJobsTestData
+import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigBranchingTestData
 import io.tolgee.development.testDataBuilder.data.ContentDeliveryConfigTestData
 import io.tolgee.development.testDataBuilder.data.MtSettingsTestData
+import io.tolgee.development.testDataBuilder.data.ProjectImportTargetTestData
 import io.tolgee.development.testDataBuilder.data.ProjectWithQaEntitiesTestData
 import io.tolgee.development.testDataBuilder.data.SuggestionsTestData
 import io.tolgee.development.testDataBuilder.data.TaskTestData
@@ -130,6 +132,32 @@ class ProjectHardDeletingServiceTest : AbstractSpringTest() {
     testDataService.saveTestData(testData.root)
     executeInNewRepeatableTransaction(platformTransactionManager) {
       projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+  }
+
+  @Test
+  fun `deletes project with content delivery configs on branches`() {
+    val testData = ContentDeliveryConfigBranchingTestData()
+    testDataService.saveTestData(testData.root)
+    executeInNewRepeatableTransaction(platformTransactionManager) {
+      projectHardDeletingService.hardDeleteProject(testData.projectBuilder.self.refresh())
+    }
+
+    executeInNewTransaction {
+      projectService.find(testData.projectBuilder.self.id).assert.isNull()
+    }
+  }
+
+  @Test
+  fun `deletes project with branch merges and snapshots`() {
+    val testData = ProjectImportTargetTestData()
+    testDataService.saveTestData(testData.root)
+    executeInNewRepeatableTransaction(platformTransactionManager) {
+      projectHardDeletingService.hardDeleteProject(testData.targetProject.refresh())
+    }
+
+    executeInNewTransaction {
+      projectService.find(testData.targetProject.id).assert.isNull()
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportTargetTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportTargetTestData.kt
@@ -15,7 +15,8 @@ import io.tolgee.model.key.Key
  * branch merge/snapshot rows hanging off them), plus a separate sibling project in the same organization
  * whose content must stay completely untouched (blast-radius isolation). The merge/snapshot rows exist so
  * the clear-in-place FK ordering is exercised — they FK key/branch with no DB cascade, so the wipe must
- * delete them before keys/branches or it FK-violates.
+ * delete them before keys/branches or it FK-violates. ProjectHardDeletingServiceTest covers the same
+ * ordering with these rows, so dropping them silently guts that test too.
  */
 class ProjectImportTargetTestData :
   BaseTestData(userName = "import-target-owner", projectName = "import-target-project") {

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchMergeChangeRepositoryOss.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchMergeChangeRepositoryOss.kt
@@ -12,4 +12,15 @@ interface BranchMergeChangeRepositoryOss : JpaRepository<BranchMergeChange, Long
   @Modifying
   @Query("delete from BranchMergeChange bmc where bmc.sourceKey.id in :ids or bmc.targetKey.id in :ids")
   fun deleteBySourceOrTargetIds(ids: Collection<Long>)
+
+  @Modifying
+  @Query(
+    """
+    delete from BranchMergeChange bmc where bmc.branchMerge.id in (
+      select bm.id from BranchMerge bm
+      where bm.sourceBranch.project.id = :projectId or bm.targetBranch.project.id = :projectId
+    )
+  """,
+  )
+  fun deleteAllByProjectId(projectId: Long)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchMergeRepositoryOss.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchMergeRepositoryOss.kt
@@ -1,0 +1,20 @@
+package io.tolgee.repository.branching
+
+import io.tolgee.model.branching.BranchMerge
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface BranchMergeRepositoryOss : JpaRepository<BranchMerge, Long> {
+  @Modifying
+  @Query(
+    """
+    delete from BranchMerge bm
+    where bm.sourceBranch.id in (select b.id from Branch b where b.project.id = :projectId)
+      or bm.targetBranch.id in (select b.id from Branch b where b.project.id = :projectId)
+    """,
+  )
+  fun deleteAllByProjectId(projectId: Long)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchRepositoryOss.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/BranchRepositoryOss.kt
@@ -2,6 +2,7 @@ package io.tolgee.repository.branching
 
 import io.tolgee.model.branching.Branch
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
@@ -39,6 +40,15 @@ interface BranchRepositoryOss : JpaRepository<Branch, Long> {
     """,
   )
   fun findDefaultByProjectId(projectId: Long): Branch?
+
+  @Modifying
+  @Query(
+    """
+    update Branch b set b.originBranch = null
+    where b.originBranch.id in (select origin.id from Branch origin where origin.project.id = :projectId)
+    """,
+  )
+  fun detachOriginReferencesByProjectId(projectId: Long)
 
   fun deleteAllByProjectId(projectId: Long)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/KeyMetaSnapshotRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/KeyMetaSnapshotRepository.kt
@@ -1,0 +1,19 @@
+package io.tolgee.repository.branching
+
+import io.tolgee.model.branching.snapshot.KeyMetaSnapshot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface KeyMetaSnapshotRepository : JpaRepository<KeyMetaSnapshot, Long> {
+  @Modifying
+  @Query(
+    """
+    delete from KeyMetaSnapshot kms
+    where kms.keySnapshot.id in (select ks.id from KeySnapshot ks where ks.project.id = :projectId)
+    """,
+  )
+  fun deleteAllByProjectId(projectId: Long)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/KeySnapshotRepositoryOss.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/KeySnapshotRepositoryOss.kt
@@ -1,0 +1,14 @@
+package io.tolgee.repository.branching
+
+import io.tolgee.model.branching.snapshot.KeySnapshot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface KeySnapshotRepositoryOss : JpaRepository<KeySnapshot, Long> {
+  @Modifying
+  @Query("delete from KeySnapshot ks where ks.project.id = :projectId")
+  fun deleteAllByProjectId(projectId: Long)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/branching/TranslationSnapshotRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/branching/TranslationSnapshotRepository.kt
@@ -1,0 +1,19 @@
+package io.tolgee.repository.branching
+
+import io.tolgee.model.branching.snapshot.TranslationSnapshot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TranslationSnapshotRepository : JpaRepository<TranslationSnapshot, Long> {
+  @Modifying
+  @Query(
+    """
+    delete from TranslationSnapshot ts
+    where ts.keySnapshot.id in (select ks.id from KeySnapshot ks where ks.project.id = :projectId)
+    """,
+  )
+  fun deleteAllByProjectId(projectId: Long)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/contentDelivery/ContentDeliveryConfigRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/contentDelivery/ContentDeliveryConfigRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
@@ -64,4 +65,8 @@ interface ContentDeliveryConfigRepository : JpaRepository<ContentDeliveryConfig,
     projectId: Long,
     branchId: Long,
   ): List<ContentDeliveryConfig>
+
+  @Modifying
+  @Query("update ContentDeliveryConfig c set c.branch = null where c.project.id = :projectId")
+  fun detachBranchByProjectId(projectId: Long)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/AbstractBranchMergeService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/AbstractBranchMergeService.kt
@@ -1,11 +1,21 @@
 package io.tolgee.service.branching
 
 import io.tolgee.repository.branching.BranchMergeChangeRepositoryOss
+import io.tolgee.repository.branching.BranchMergeRepositoryOss
 
 abstract class AbstractBranchMergeService(
   protected open val branchMergeChangeRepositoryOss: BranchMergeChangeRepositoryOss,
+  protected open val branchMergeRepositoryOss: BranchMergeRepositoryOss,
 ) : BranchMergeService {
   override fun deleteChangesByKeyIds(keyIds: Collection<Long>) {
     branchMergeChangeRepositoryOss.deleteBySourceOrTargetIds(keyIds)
+  }
+
+  override fun deleteChangesByProjectId(projectId: Long) {
+    branchMergeChangeRepositoryOss.deleteAllByProjectId(projectId)
+  }
+
+  override fun deleteMergesByProjectId(projectId: Long) {
+    branchMergeRepositoryOss.deleteAllByProjectId(projectId)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/AbstractBranchService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/AbstractBranchService.kt
@@ -4,10 +4,18 @@ import io.tolgee.constants.Message
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.model.branching.Branch
 import io.tolgee.repository.branching.BranchRepositoryOss
+import io.tolgee.repository.branching.KeyMetaSnapshotRepository
+import io.tolgee.repository.branching.KeySnapshotRepositoryOss
+import io.tolgee.repository.branching.TranslationSnapshotRepository
+import io.tolgee.repository.contentDelivery.ContentDeliveryConfigRepository
 
 abstract class AbstractBranchService(
   protected open val branchRepository: BranchRepositoryOss,
   protected open val branchMergeService: BranchMergeService,
+  protected open val contentDeliveryConfigRepository: ContentDeliveryConfigRepository,
+  protected open val keySnapshotRepository: KeySnapshotRepositoryOss,
+  protected open val translationSnapshotRepository: TranslationSnapshotRepository,
+  protected open val keyMetaSnapshotRepository: KeyMetaSnapshotRepository,
 ) : BranchService {
   override fun getActiveBranch(
     projectId: Long,
@@ -35,10 +43,19 @@ abstract class AbstractBranchService(
     return branchRepository.findDefaultByProjectId(projectId)
   }
 
+  /**
+   * Everything referencing the project's branches goes first — none of those FKs has an `ON DELETE`
+   * action. Keys, imports, tasks and language stats also FK branch, so the caller still has to remove
+   * those before calling this.
+   */
   override fun deleteAllByProjectId(projectId: Long) {
+    contentDeliveryConfigRepository.detachBranchByProjectId(projectId)
+    branchMergeService.deleteChangesByProjectId(projectId)
+    translationSnapshotRepository.deleteAllByProjectId(projectId)
+    keyMetaSnapshotRepository.deleteAllByProjectId(projectId)
+    keySnapshotRepository.deleteAllByProjectId(projectId)
+    branchMergeService.deleteMergesByProjectId(projectId)
+    branchRepository.detachOriginReferencesByProjectId(projectId)
     return branchRepository.deleteAllByProjectId(projectId)
-  }
-
-  override fun deleteBranchMergeChangesByKeyIds(keyIds: Set<Long>) {
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchMergeService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchMergeService.kt
@@ -2,4 +2,8 @@ package io.tolgee.service.branching
 
 interface BranchMergeService {
   fun deleteChangesByKeyIds(keyIds: Collection<Long>)
+
+  fun deleteChangesByProjectId(projectId: Long)
+
+  fun deleteMergesByProjectId(projectId: Long)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchMergeServiceOssStub.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchMergeServiceOssStub.kt
@@ -1,9 +1,11 @@
 package io.tolgee.service.branching
 
 import io.tolgee.repository.branching.BranchMergeChangeRepositoryOss
+import io.tolgee.repository.branching.BranchMergeRepositoryOss
 import org.springframework.stereotype.Service
 
 @Service
 class BranchMergeServiceOssStub(
   branchMergeChangeRepository: BranchMergeChangeRepositoryOss,
-) : AbstractBranchMergeService(branchMergeChangeRepository)
+  branchMergeRepository: BranchMergeRepositoryOss,
+) : AbstractBranchMergeService(branchMergeChangeRepository, branchMergeRepository)

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchService.kt
@@ -126,6 +126,4 @@ interface BranchService {
   fun enableBranchingOnProject(projectId: Long)
 
   fun deleteAllByProjectId(projectId: Long)
-
-  fun deleteBranchMergeChangesByKeyIds(keyIds: Set<Long>)
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchServiceOssStub.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/branching/BranchServiceOssStub.kt
@@ -11,6 +11,10 @@ import io.tolgee.model.branching.Branch
 import io.tolgee.model.branching.BranchMerge
 import io.tolgee.model.enums.BranchKeyMergeChangeType
 import io.tolgee.repository.branching.BranchRepositoryOss
+import io.tolgee.repository.branching.KeyMetaSnapshotRepository
+import io.tolgee.repository.branching.KeySnapshotRepositoryOss
+import io.tolgee.repository.branching.TranslationSnapshotRepository
+import io.tolgee.repository.contentDelivery.ContentDeliveryConfigRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -19,7 +23,18 @@ import org.springframework.stereotype.Service
 class BranchServiceOssStub(
   branchRepository: BranchRepositoryOss,
   branchMergeService: BranchMergeService,
-) : AbstractBranchService(branchRepository, branchMergeService) {
+  contentDeliveryConfigRepository: ContentDeliveryConfigRepository,
+  keySnapshotRepository: KeySnapshotRepositoryOss,
+  translationSnapshotRepository: TranslationSnapshotRepository,
+  keyMetaSnapshotRepository: KeyMetaSnapshotRepository,
+) : AbstractBranchService(
+    branchRepository,
+    branchMergeService,
+    contentDeliveryConfigRepository,
+    keySnapshotRepository,
+    translationSnapshotRepository,
+    keyMetaSnapshotRepository,
+  ) {
   override fun getBranches(
     projectId: Long,
     page: Pageable,

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyService.kt
@@ -526,6 +526,7 @@ class KeyService(
     keyMetaService.deleteAllByProject(projectId)
     screenshotService.deleteAllByProject(projectId)
     taskKeyRepository.deleteAllByKeyProjectId(projectId)
+    branchMergeService.deleteChangesByProjectId(projectId)
 
     entityManager
       .createQuery("""delete from Key where project.id = :projectId""")

--- a/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectContentClearer.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectContentClearer.kt
@@ -73,8 +73,6 @@ class ProjectContentClearer(
     val projectId = project.id
 
     clearTasks(projectId)
-    // branch_merge_change FKs key (no cascade) — must go before keys, and before its branch_merge parent.
-    deleteBranchMergeChanges(projectId)
     clearImports(projectId)
     translationMemoryManagementService.deleteAllByProject(projectId)
 
@@ -99,8 +97,6 @@ class ProjectContentClearer(
     entityManager.clear()
 
     bigMetaService.deleteAllByProjectId(projectId)
-    detachKeptConfigFromBranches(projectId)
-    deleteBranchMergesAndSnapshots(projectId)
     branchService.deleteAllByProjectId(projectId)
     projectQaConfigRepository.deleteAllByProjectId(projectId)
 
@@ -121,16 +117,6 @@ class ProjectContentClearer(
     jpqlUpdate("DELETE FROM Task t WHERE t.project.id = :projectId", projectId)
   }
 
-  private fun deleteBranchMergeChanges(projectId: Long) {
-    nativeUpdate(
-      "DELETE FROM branch_merge_change WHERE branch_merge_id IN (" +
-        "SELECT bm.id FROM branch_merge bm WHERE " +
-        "bm.source_branch_id IN (SELECT id FROM branch WHERE project_id = :projectId) OR " +
-        "bm.target_branch_id IN (SELECT id FROM branch WHERE project_id = :projectId))",
-      projectId,
-    )
-  }
-
   private fun clearImports(projectId: Long) {
     // Imports FK both branch and language (no cascade) and are transient upload state, never transferred.
     importService.getAllByProject(projectId).forEach { importService.hardDeleteImport(it) }
@@ -141,41 +127,6 @@ class ProjectContentClearer(
     // TranslationSuggestionServiceOssImpl.deleteAllByProject is a no-op on OSS, so the languageService
     // cascade won't remove suggestions here — delete them explicitly or they leak into the mirror import.
     jpqlUpdate("DELETE FROM TranslationSuggestion ts WHERE ts.project.id = :projectId", projectId)
-  }
-
-  private fun detachKeptConfigFromBranches(projectId: Long) {
-    // content_delivery_config is kept (project-level config, not content) but its nullable branch FK would
-    // block the branch wipe; detach it. A re-import recreates branches, so a branch-pinned delivery config
-    // falls back to the default branch — acceptable for a wipe-and-replace.
-    nativeUpdate(
-      "UPDATE content_delivery_config SET branch_id = NULL WHERE project_id = :projectId",
-      projectId,
-    )
-  }
-
-  private fun deleteBranchMergesAndSnapshots(projectId: Long) {
-    // Snapshot and merge rows FK branch (no DB cascade), so they must go before the branch rows. Mirrors
-    // the table relationships in the EE branch-scoped BranchCleanupService.
-    nativeUpdate(
-      "DELETE FROM branch_translation_snapshot WHERE key_snapshot_id IN " +
-        "(SELECT id FROM branch_key_snapshot WHERE project_id = :projectId)",
-      projectId,
-    )
-    nativeUpdate(
-      "DELETE FROM branch_key_meta_snapshot WHERE key_snapshot_id IN " +
-        "(SELECT id FROM branch_key_snapshot WHERE project_id = :projectId)",
-      projectId,
-    )
-    nativeUpdate("DELETE FROM branch_key_snapshot WHERE project_id = :projectId", projectId)
-    nativeUpdate(
-      "DELETE FROM branch_merge WHERE " +
-        "source_branch_id IN (SELECT id FROM branch WHERE project_id = :projectId) OR " +
-        "target_branch_id IN (SELECT id FROM branch WHERE project_id = :projectId)",
-      projectId,
-    )
-    // Detach the branch self-reference so the entity-based branch delete below can't FK-violate on an
-    // origin branch that happens to be removed first (the FK has no DB-level ON DELETE).
-    nativeUpdate("UPDATE branch SET origin_branch_id = NULL WHERE project_id = :projectId", projectId)
   }
 
   /**

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/branching/BranchMergeRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/branching/BranchMergeRepository.kt
@@ -2,12 +2,12 @@ package io.tolgee.ee.repository.branching
 
 import io.tolgee.dtos.queryResults.branching.BranchMergeView
 import io.tolgee.model.branching.BranchMerge
+import io.tolgee.repository.branching.BranchMergeRepositoryOss
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface BranchMergeRepository : JpaRepository<BranchMerge, Long> {
+interface BranchMergeRepository : BranchMergeRepositoryOss {
   @Query(
     """
       select bm from BranchMerge bm 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/branching/KeySnapshotRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/branching/KeySnapshotRepository.kt
@@ -1,12 +1,12 @@
 package io.tolgee.ee.repository.branching
 
 import io.tolgee.model.branching.snapshot.KeySnapshot
+import io.tolgee.repository.branching.KeySnapshotRepositoryOss
 import org.springframework.data.jpa.repository.EntityGraph
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface KeySnapshotRepository : JpaRepository<KeySnapshot, Long> {
+interface KeySnapshotRepository : KeySnapshotRepositoryOss {
   @EntityGraph(attributePaths = ["translations", "keyMetaSnapshot"])
   fun findAllByBranchId(branchId: Long): List<KeySnapshot>
 

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchMergeService.kt
@@ -45,7 +45,7 @@ class BranchMergeService(
   @Lazy
   private val languageService: LanguageService,
   private val metrics: Metrics,
-) : AbstractBranchMergeService(branchMergeChangeRepository),
+) : AbstractBranchMergeService(branchMergeChangeRepository, branchMergeRepository),
   Logging {
   @Transactional
   fun dryRun(branchMerge: BranchMerge) {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/branching/BranchServiceImpl.kt
@@ -11,6 +11,7 @@ import io.tolgee.dtos.request.branching.DryRunMergeBranchRequest
 import io.tolgee.dtos.request.branching.ResolveAllBranchMergeConflictsRequest
 import io.tolgee.dtos.request.branching.ResolveBranchMergeConflictRequest
 import io.tolgee.ee.repository.branching.BranchRepository
+import io.tolgee.ee.repository.branching.KeySnapshotRepository
 import io.tolgee.ee.service.TaskService
 import io.tolgee.ee.service.qa.QaRecheckService
 import io.tolgee.events.OnBranchSoftDeleted
@@ -22,6 +23,9 @@ import io.tolgee.model.UserAccount
 import io.tolgee.model.branching.Branch
 import io.tolgee.model.branching.BranchMerge
 import io.tolgee.model.enums.BranchKeyMergeChangeType
+import io.tolgee.repository.branching.KeyMetaSnapshotRepository
+import io.tolgee.repository.branching.TranslationSnapshotRepository
+import io.tolgee.repository.contentDelivery.ContentDeliveryConfigRepository
 import io.tolgee.security.authentication.AuthenticationFacade
 import io.tolgee.service.branching.AbstractBranchService
 import io.tolgee.service.branching.BranchCopyService
@@ -41,6 +45,10 @@ class BranchServiceImpl(
   override val branchRepository: BranchRepository,
   override val branchMergeService: BranchMergeService,
   private val entityManager: EntityManager,
+  override val contentDeliveryConfigRepository: ContentDeliveryConfigRepository,
+  override val keySnapshotRepository: KeySnapshotRepository,
+  override val translationSnapshotRepository: TranslationSnapshotRepository,
+  override val keyMetaSnapshotRepository: KeyMetaSnapshotRepository,
   private val branchCopyService: BranchCopyService,
   private val branchSnapshotService: BranchSnapshotService,
   private val taskService: TaskService,
@@ -51,7 +59,14 @@ class BranchServiceImpl(
   private val metrics: Metrics,
   @Lazy
   private val qaRecheckService: QaRecheckService,
-) : AbstractBranchService(branchRepository, branchMergeService) {
+) : AbstractBranchService(
+    branchRepository,
+    branchMergeService,
+    contentDeliveryConfigRepository,
+    keySnapshotRepository,
+    translationSnapshotRepository,
+    keyMetaSnapshotRepository,
+  ) {
   override fun getBranches(
     projectId: Long,
     page: Pageable,


### PR DESCRIPTION
## Problem

The orphan-project purge scheduler (`DeletedOrganizationProjectPurgeScheduler` → `ProjectHardDeletingService.hardDeleteProject`) keeps failing in production, so projects of deleted organizations pile up (`deleted_at` set on the org, projects never removed). The scheduler processes projects in a batch, so a single bad project aborts the whole run.

Sentry showed:

```
update or delete on table "branch" violates foreign key constraint
"FK5jtc226unswiodyqp8r4isds6" on table "content_delivery_config"
  at io.tolgee.service.project.ProjectHardDeletingService.hardDeleteProject
```

Rather than fix that one constraint, I audited every FK into `branch` and `key` in `schema.xml`. All are non-deferrable with no `ON DELETE` action, and four were unhandled — fixing only the reported one would have left the scheduler dying on the next project.

## Fix

Deleting a project's branches is what breaks, so **`BranchService.deleteAllByProjectId` now clears everything that references them** before removing the branch rows:

| Constraint | Problem |
|---|---|
| `content_delivery_config.branch_id → branch` | never detached (the config itself is project-level: the hard delete removes it later, the mirror import keeps it) |
| `branch_merge.{source,target}_branch_id → branch` | never deleted |
| `branch_key_snapshot.branch_id → branch` (+ `branch_translation_snapshot` / `branch_key_meta_snapshot` children) | never deleted. `branch_key_snapshot.project_id → project` also blocked the final project-row delete |
| `branch.origin_branch_id → branch` (self-FK) | `deleteAllByProjectId` is a derived delete issuing one `DELETE` per row in unspecified order |

Keys, imports, tasks and language stats also FK `branch`; those stay the caller's job, since they are deleted by their own services well before branches.

Separately, `branch_merge_change` FKs `key`. Both the single- and multi-key delete paths already cleared it via `BranchMergeService.deleteChangesByKeyIds`; only `KeyService.deleteAllByProject` didn't. It now does the same by project — fixing every caller of it, not just the hard delete.

**`ProjectHardDeletingService` is unchanged.** Its original call ordering was always fine; the referencing rows simply weren't being cleared. `ProjectContentClearer` only loses code — the three private helpers it had grown for this same FK chain are gone, absorbed into the branch service.

`BranchService.deleteBranchMergeChangesByKeyIds` was a no-op that nothing overrode and nothing called — apparently the hook intended for this cleanup, never wired up. Removed (verified unused across all Tolgee repos; billing compiles clean against this branch).

## Where the queries live

Each delete is a project-scoped query on the repository that owns the entity it removes, so `AbstractBranchService` holds no SQL and needs no `EntityManager`:

| Entity | Repository |
|---|---|
| `BranchMergeChange` | `BranchMergeChangeRepositoryOss` (existing) |
| `BranchMerge` | `BranchMergeRepositoryOss` (new OSS base) |
| `KeySnapshot` | `KeySnapshotRepositoryOss` (new OSS base) |
| `TranslationSnapshot`, `KeyMetaSnapshot` | own repositories (new) |
| `ContentDeliveryConfig`, `Branch` | existing repositories |

`BranchMerge` and `KeySnapshot` previously had EE-only repositories, which OSS can't reach — the EE ones now extend the new OSS bases, matching how `BranchMergeChangeRepository` and `BranchRepository` already work. The two snapshot children get their own repositories rather than methods on `KeySnapshotRepositoryOss`, following `KeyComment` / `KeyCodeReference` (also owned children with `cascade = ALL`). Bulk JPQL bypasses those cascade mappings, which is why the child deletes are explicit — the same reason EE's `BranchSnapshotService` deletes them explicitly too.

## Tests

`ProjectHardDeletingServiceTest`:
- `deletes project with content delivery configs on branches` — `ContentDeliveryConfigBranchingTestData`
- `deletes project with branch merges and snapshots` — `ProjectImportTargetTestData`, which carries merge, snapshot and origin-branch rows

Both reproduce the FK violation without the fix (verified by reverting and re-running: `PSQLException`) and pass with it. The export/import suite and the `clear strategy` policy guard cover the shared `ProjectContentClearer` path.

## Supersedes #3832

#3832 covered the same purge path. Its soft-deleted-import and task gaps have since landed on `main` via #3804 (`ImportService.deleteAllByProject` now queries including-deleted; `AbstractTaskService.deleteAllByProjectId` clears notifications, `task_assignees` and `task_key`). Its only surviving piece — the `branch_merge_change` cleanup — is included here, so #3832 is closed.
