### PR TITLE
chore: fix compilation warnings from the Spring Boot 4 upgrade

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/configuration/CacheConfiguration.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/CacheConfiguration.kt
@@ -18,14 +18,14 @@ package io.tolgee.configuration
 
 import io.tolgee.component.ResilientCacheAccessor
 import io.tolgee.component.TolgeeCacheErrorHandler
-import org.springframework.cache.annotation.CachingConfigurerSupport
+import org.springframework.cache.annotation.CachingConfigurer
 import org.springframework.cache.interceptor.CacheErrorHandler
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 class CacheConfiguration(
   private val resilientCacheAccessor: ResilientCacheAccessor,
-) : CachingConfigurerSupport() {
+) : CachingConfigurer {
   override fun errorHandler(): CacheErrorHandler {
     return TolgeeCacheErrorHandler(resilientCacheAccessor)
   }

--- a/backend/api/src/main/kotlin/io/tolgee/configuration/OctetStreamSupportConfiguration.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/configuration/OctetStreamSupportConfiguration.kt
@@ -8,6 +8,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class OctetStreamSupportConfiguration : WebMvcConfigurer {
+  // The non-deprecated ServerBuilder API bypasses Spring HATEOAS's HAL converter registration.
+  @Suppress("OVERRIDE_DEPRECATION")
   override fun extendMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
     converters
       .filterIsInstance<JacksonJsonHttpMessageConverter>()

--- a/backend/api/src/main/kotlin/io/tolgee/controllers/PublicController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/controllers/PublicController.kt
@@ -113,7 +113,7 @@ class PublicController(
   fun validateEmail(
     @RequestBody email: StringNode,
   ): Boolean {
-    return userAccountService.findActive(email.asText()) == null
+    return userAccountService.findActive(email.asString()) == null
   }
 
   @GetMapping("/authorize_oauth/{serviceType}")

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/invitation/OrganizationInvitationModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/invitation/OrganizationInvitationModelAssembler.kt
@@ -18,7 +18,7 @@ class OrganizationInvitationModelAssembler(
     return OrganizationInvitationModel(
       entity.id!!,
       entity.code,
-      entity.organizationRole!!.type!!,
+      entity.organizationRole!!.type,
       entity.createdAt!!,
       invitedUserName = entity.name,
       invitedUserEmail = entity.email,

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/SimpleOrganizationModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/SimpleOrganizationModelAssembler.kt
@@ -17,7 +17,7 @@ class SimpleOrganizationModelAssembler(
     SimpleOrganizationModel::class.java,
   ) {
   override fun toModel(entity: Organization): SimpleOrganizationModel {
-    val link = linkTo<OrganizationController> { get(entity.slug ?: "") }.withSelfRel()
+    val link = linkTo<OrganizationController> { get(entity.slug) }.withSelfRel()
     return SimpleOrganizationModel(
       entity.id,
       entity.name,

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/suggestions/TranslationSuggestionModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/translations/suggestions/TranslationSuggestionModelAssembler.kt
@@ -18,7 +18,7 @@ class TranslationSuggestionModelAssembler(
     return TranslationSuggestionModel(
       id = entity.id,
       languageId = entity.language!!.id,
-      keyId = entity.key!!.id,
+      keyId = entity.key.id,
       translation = entity.translation,
       author = simpleUserAccountModelAssembler.toModel(entity.author!!),
       state = entity.state,

--- a/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/ExceptionHandlers.kt
@@ -69,7 +69,7 @@ class ExceptionHandlers : Logging {
   @ExceptionHandler(MethodArgumentTypeMismatchException::class)
   fun handleValidationExceptions(ex: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponseBody> {
     return ResponseEntity(
-      ErrorResponseBody(Message.WRONG_PARAM_TYPE.code, listOf(ex.parameter.parameterName) as List<Serializable>?),
+      ErrorResponseBody(Message.WRONG_PARAM_TYPE.code, listOfNotNull(ex.parameter.parameterName)),
       HttpStatus.BAD_REQUEST,
     )
   }

--- a/backend/app/src/main/kotlin/io/tolgee/component/TolgeeSentryUserProvider.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/component/TolgeeSentryUserProvider.kt
@@ -14,7 +14,6 @@ class TolgeeSentryUserProvider(
   override fun provideUser(): User? {
     return authenticationFacade.authenticatedUserOrNull?.let { user ->
       return User().apply {
-        name = user.username
         username = user.username
         email = user.username
         id = user.id.toString()

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/EventStreamConfig.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/EventStreamConfig.kt
@@ -12,7 +12,7 @@ class EventStreamConfig(
   private val objectMapper: ObjectMapper,
 ) : WebMvcConfigurer {
   // The non-deprecated ServerBuilder API bypasses Spring HATEOAS's HAL converter registration.
-  @Suppress("DEPRECATION")
+  @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
   override fun extendMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
     converters.add(EventStreamHttpMessageConverter(objectMapper))
     converters.add(JavascriptHttpMessageConverter(objectMapper))

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/RestTemplateConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/RestTemplateConfiguration.kt
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.context.annotation.Primary
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.http.client.SimpleClientHttpRequestFactory
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter
+import org.springframework.http.converter.xml.JacksonXmlHttpMessageConverter
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 
@@ -29,7 +29,7 @@ class RestTemplateConfiguration {
   }
 
   private fun RestTemplate.removeXmlConverter(): RestTemplate {
-    messageConverters.removeIf { it is MappingJackson2XmlHttpMessageConverter }
+    messageConverters.removeIf { it is JacksonXmlHttpMessageConverter }
     return this
   }
 

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebMvcConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebMvcConfiguration.kt
@@ -2,12 +2,14 @@ package io.tolgee.configuration
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.converter.HttpMessageConverter
-import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter
+import org.springframework.http.converter.xml.JacksonXmlHttpMessageConverter
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebMvcConfiguration : WebMvcConfigurer {
+  // The non-deprecated ServerBuilder API bypasses Spring HATEOAS's HAL converter registration.
+  @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
   override fun configureMessageConverters(converters: MutableList<HttpMessageConverter<*>>) {
-    converters.removeIf { it is MappingJackson2XmlHttpMessageConverter }
+    converters.removeIf { it is JacksonXmlHttpMessageConverter }
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/NullTypedActivityRevisionStorageTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/NullTypedActivityRevisionStorageTest.kt
@@ -71,7 +71,7 @@ class NullTypedActivityRevisionStorageTest : AuthorizedControllerTest() {
       entityManager
         .createQuery(
           "select count(ar) from ActivityRevision ar where ar.projectId = :projectId",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("projectId", testData.project.id)
         .singleResult
         .toLong()

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/administration/ProjectExportImportControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/administration/ProjectExportImportControllerTest.kt
@@ -124,7 +124,7 @@ class ProjectExportImportControllerTest : AuthorizedControllerTest() {
         entityManager
           .createQuery(
             "select count(kd) from KeysDistance kd where kd.project.id = :p",
-            java.lang.Long::class.java,
+            Long::class.javaObjectType,
           ).setParameter("p", testData.project.id)
           .singleResult
           .toLong()
@@ -135,7 +135,7 @@ class ProjectExportImportControllerTest : AuthorizedControllerTest() {
           .createQuery(
             "select count(a) from TranslationMemoryProject a " +
               "where a.project.id = :p and a.translationMemory.type = :t",
-            java.lang.Long::class.java,
+            Long::class.javaObjectType,
           ).setParameter("p", testData.project.id)
           .setParameter("t", TranslationMemoryType.PROJECT)
           .singleResult

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationFloorAccessTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organizationController/OrganizationFloorAccessTest.kt
@@ -125,7 +125,7 @@ class OrganizationFloorAccessTest : AuthorizedControllerTest() {
       .path("_embedded")
       .path("languages")
       .values()
-      .map { it.path("tag").asText() }
+      .map { it.path("tag").asString() }
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translationSuggestionController/TranslationSuggestionControllerMtTest.kt
@@ -460,6 +460,7 @@ class TranslationSuggestionControllerMtTest : ProjectAuthControllerTest("/v2/pro
     )
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun verifyServiceFirst(service: String) {
     val result = performMtRequest().andIsOk.andReturn().mapResponseTo<Map<String, Any>>()
     val services = (result["machineTranslations"] as Map<String, String>).keys.toList()

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerFilterTest.kt
@@ -385,7 +385,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
 
   @ProjectJWTAuthTestMethod
   @Test
-  fun `filters "without tag" specified by empty tag`() {
+  fun `filters 'without tag' specified by empty tag`() {
     testData.addFewKeysWithTags()
     testData.addKeysWithScreenshots()
     testDataService.saveTestData(testData.root)
@@ -418,7 +418,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
 
   @ProjectJWTAuthTestMethod
   @Test
-  fun `filters in combination with "without tag"`() {
+  fun `filters in combination with 'without tag'`() {
     testData.addFewKeysWithTags()
     testData.addKeysWithScreenshots()
     testDataService.saveTestData(testData.root)
@@ -454,7 +454,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
 
   @ProjectJWTAuthTestMethod
   @Test
-  fun `excludes by "Without tag"`() {
+  fun `excludes by 'Without tag'`() {
     testData.addKeysWithScreenshots()
     testDataService.saveTestData(testData.root)
     userAccount = testData.user
@@ -482,7 +482,7 @@ class TranslationsControllerFilterTest : ProjectAuthControllerTest("/v2/projects
 
   @ProjectJWTAuthTestMethod
   @Test
-  fun `excludes in combination with "Without tag"`() {
+  fun `excludes in combination with 'Without tag'`() {
     testData.addKeysWithScreenshots()
     testDataService.saveTestData(testData.root)
     userAccount = testData.user

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerHistoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/translations/v2TranslationsController/TranslationsControllerHistoryTest.kt
@@ -119,7 +119,7 @@ class TranslationsControllerHistoryTest : ProjectAuthControllerTest("/v2/project
         translationService.find(emptyKey, lang).get()
       }
 
-    performProjectAuthGet("/translations/${translation!!.id}/history").andPrettyPrint.andAssertThatJson {
+    performProjectAuthGet("/translations/${translation.id}/history").andPrettyPrint.andAssertThatJson {
       node("page.totalElements").isEqualTo(0)
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerAddFilesTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ImportController/V2ImportControllerAddFilesTest.kt
@@ -232,9 +232,8 @@ class V2ImportControllerAddFilesTest : ProjectAuthControllerTest("/v2/projects/"
         assertThat(
           it.files[0]
             .issues[0]
-            .params
-            ?.get(0)
-            ?.value,
+            .params[0]
+            .value,
         ).isEqualTo("too_long")
       }
     }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeySoftDeleteNamespaceTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2KeyController/KeySoftDeleteNamespaceTest.kt
@@ -88,6 +88,6 @@ class KeySoftDeleteNamespaceTest : ProjectAuthControllerTest("/v2/projects/") {
       .path("_embedded")
       .path("namespaces")
       .values()
-      .map { it.path("name").textValue() }
+      .map { it.path("name").stringValue() }
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/v2ProjectsController/ProjectsControllerTest.kt
@@ -219,7 +219,7 @@ class ProjectsControllerTest : ProjectAuthControllerTest("/v2/projects/") {
     val usersAndOrganizations = dbPopulator.createUsersAndOrganizations()
     val repo = usersAndOrganizations[1].organizationRoles[0].organization!!.projects[0]
     val user = dbPopulator.createUserIfNotExists("jirina")
-    organizationRoleService.grantOwnerRoleToUser(user, repo.organizationOwner!!)
+    organizationRoleService.grantOwnerRoleToUser(user, repo.organizationOwner)
 
     loginAsUser(usersAndOrganizations[1].name)
 

--- a/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/batch/AbstractBatchJobsGeneralTest.kt
@@ -402,7 +402,7 @@ abstract class AbstractBatchJobsGeneralTest :
 
     executions
       .last()
-      .successTargets!!
+      .successTargets
       .assert
       .size()
       .isEqualTo(2) // 2 failed items in a chunk are retried successfully

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/ExportControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/ExportControllerTest.kt
@@ -29,7 +29,6 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.function.Consumer
-import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
 @AutoConfigureMockMvc
@@ -191,12 +190,9 @@ class ExportControllerTest : ProjectAuthControllerTest() {
     val byteArrayInputStream = ByteArrayInputStream(responseContent)
     val zipInputStream = ZipInputStream(byteArrayInputStream)
     val result = HashMap<String, Long>()
-    var nextEntry: ZipEntry?
-    while (zipInputStream.nextEntry.also {
-        nextEntry = it
-      } != null
-    ) {
-      result[nextEntry!!.name] = nextEntry!!.size
+    while (true) {
+      val nextEntry = zipInputStream.nextEntry ?: break
+      result[nextEntry.name] = nextEntry.size
     }
     return result
   }

--- a/backend/app/src/test/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobTest.kt
@@ -95,7 +95,7 @@ class AllOrganizationOwnerJobTest : AbstractSpringTest() {
   fun `deletes permission`() {
     allOrganizationOwnerJobRunner.run()
     transactionTemplate.execute {
-      val firstProject = projectRepository.getById(project1.id)
+      val firstProject = projectRepository.getReferenceById(project1.id)
       assertThat(firstProject.permissions).isEmpty()
     }
   }
@@ -104,7 +104,7 @@ class AllOrganizationOwnerJobTest : AbstractSpringTest() {
   fun `reuses existing organization`() {
     allOrganizationOwnerJobRunner.run()
     transactionTemplate.execute {
-      val firstProject = projectRepository.getById(project1.id)
+      val firstProject = projectRepository.getReferenceById(project1.id)
       assertThat(firstProject.permissions).isEmpty()
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpBatchToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpBatchToolsTest.kt
@@ -52,7 +52,7 @@ class McpBatchToolsTest : AbstractMcpTest() {
         ),
       )
     assertThat(json["jobId"]).isNotNull()
-    assertThat(json["type"].asText()).isEqualTo("MACHINE_TRANSLATE")
+    assertThat(json["type"].asString()).isEqualTo("MACHINE_TRANSLATE")
   }
 
   @Test
@@ -83,7 +83,7 @@ class McpBatchToolsTest : AbstractMcpTest() {
         ),
       )
     assertThat(json["jobId"]).isNotNull()
-    assertThat(json["type"].asText()).isEqualTo("MACHINE_TRANSLATE")
+    assertThat(json["type"].asString()).isEqualTo("MACHINE_TRANSLATE")
     assertThat(json["totalItems"].asInt()).isEqualTo(1)
 
     val jobDto = batchJobService.findJobDto(json["jobId"].asLong())
@@ -127,7 +127,7 @@ class McpBatchToolsTest : AbstractMcpTest() {
       )
     assertThat(json["id"].asLong()).isEqualTo(jobId)
     assertThat(json["status"]).isNotNull()
-    assertThat(json["type"].asText()).isEqualTo("MACHINE_TRANSLATE")
+    assertThat(json["type"].asString()).isEqualTo("MACHINE_TRANSLATE")
     assertThat(json["totalItems"].asInt()).isEqualTo(1)
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpKeyToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpKeyToolsTest.kt
@@ -44,7 +44,7 @@ class McpKeyToolsTest : AbstractMcpTest() {
     assertThat(json["totalItems"].asLong()).isEqualTo(3)
     assertThat(json["page"].asInt()).isEqualTo(0)
     assertThat(json["totalPages"].asInt()).isEqualTo(1)
-    val keyNames = (0 until json["items"].size()).map { json["items"][it]["keyName"].asText() }
+    val keyNames = (0 until json["items"].size()).map { json["items"][it]["keyName"].asString() }
     assertThat(keyNames).containsExactlyInAnyOrder("first.key", "second.key", "third.key")
   }
 
@@ -88,7 +88,7 @@ class McpKeyToolsTest : AbstractMcpTest() {
         mapOf("projectId" to data.projectId, "query" to "search.target"),
       )
     assertThat(json["items"].isArray).isTrue()
-    val keyNames = (0 until json["items"].size()).map { json["items"][it]["keyName"].asText() }
+    val keyNames = (0 until json["items"].size()).map { json["items"][it]["keyName"].asString() }
     assertThat(keyNames).contains("search.target")
   }
 
@@ -110,7 +110,7 @@ class McpKeyToolsTest : AbstractMcpTest() {
         mapOf("projectId" to data.projectId, "keyName" to "detail.key"),
       )
     assertThat(json["keyId"]).isNotNull()
-    assertThat(json["keyName"].asText()).isEqualTo("detail.key")
+    assertThat(json["keyName"].asString()).isEqualTo("detail.key")
   }
 
   @Test
@@ -134,7 +134,7 @@ class McpKeyToolsTest : AbstractMcpTest() {
           "newName" to "new.name",
         ),
       )
-    assertThat(json["name"].asText()).isEqualTo("new.name")
+    assertThat(json["name"].asString()).isEqualTo("new.name")
 
     val key = keyService.find(data.projectId, "new.name", null)
     assertThat(key).isNotNull()

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpLanguageToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpLanguageToolsTest.kt
@@ -20,7 +20,7 @@ class McpLanguageToolsTest : AbstractMcpTest() {
   fun `list_languages auto-resolves projectId from PAK`() {
     val json = callToolAndGetJson(client, "list_languages")
     assertThat(json["items"].isArray).isTrue()
-    val tags = (0 until json["items"].size()).map { json["items"][it]["tag"].asText() }
+    val tags = (0 until json["items"].size()).map { json["items"][it]["tag"].asString() }
     assertThat(tags).contains("en")
   }
 
@@ -28,7 +28,7 @@ class McpLanguageToolsTest : AbstractMcpTest() {
   fun `list_languages returns project languages`() {
     val json = callToolAndGetJson(client, "list_languages", mapOf("projectId" to data.projectId))
     assertThat(json["items"].isArray).isTrue()
-    val tags = (0 until json["items"].size()).map { json["items"][it]["tag"].asText() }
+    val tags = (0 until json["items"].size()).map { json["items"][it]["tag"].asString() }
     assertThat(tags).contains("en")
   }
 
@@ -41,7 +41,7 @@ class McpLanguageToolsTest : AbstractMcpTest() {
         mapOf("projectId" to data.projectId, "name" to "German", "tag" to "de"),
       )
     assertThat(json["id"]).isNotNull()
-    assertThat(json["tag"].asText()).isEqualTo("de")
+    assertThat(json["tag"].asString()).isEqualTo("de")
 
     val language = languageService.getEntity(json["id"].asLong())
     assertThat(language.tag).isEqualTo("de")
@@ -63,7 +63,7 @@ class McpLanguageToolsTest : AbstractMcpTest() {
 
     val json = callToolAndGetJson(client, "list_namespaces", mapOf("projectId" to data.projectId))
     assertThat(json.isArray).isTrue()
-    val nsNames = (0 until json.size()).mapNotNull { json[it]["name"]?.asText() }
+    val nsNames = (0 until json.size()).mapNotNull { json[it]["name"]?.asString() }
     assertThat(nsNames).contains("my-namespace")
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpProjectToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpProjectToolsTest.kt
@@ -24,7 +24,7 @@ class McpProjectToolsTest : AbstractMcpTest() {
     assertThat(json["page"].asInt()).isEqualTo(0)
     assertThat(json["totalPages"].asInt()).isGreaterThanOrEqualTo(1)
     assertThat(json["totalItems"].asLong()).isGreaterThanOrEqualTo(1)
-    val projectNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val projectNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(projectNames).contains("test_project")
   }
 
@@ -33,7 +33,7 @@ class McpProjectToolsTest : AbstractMcpTest() {
     val json = callToolAndGetJson(client, "list_projects", mapOf("search" to "test_project"))
     assertThat(json["items"].isArray).isTrue()
     assertThat(json["items"].size()).isGreaterThanOrEqualTo(1)
-    assertThat(json["items"][0]["name"].asText()).isEqualTo("test_project")
+    assertThat(json["items"][0]["name"].asString()).isEqualTo("test_project")
   }
 
   @Test
@@ -52,7 +52,7 @@ class McpProjectToolsTest : AbstractMcpTest() {
         ),
       )
     assertThat(json["id"]).isNotNull()
-    assertThat(json["name"].asText()).isEqualTo("New MCP Project")
+    assertThat(json["name"].asString()).isEqualTo("New MCP Project")
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpTagToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpTagToolsTest.kt
@@ -36,7 +36,7 @@ class McpTagToolsTest : AbstractMcpTest() {
 
     val json = callToolAndGetJson(client, "list_tags")
     assertThat(json["items"].isArray).isTrue()
-    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(tagNames).contains("auto-tag")
   }
 
@@ -87,7 +87,7 @@ class McpTagToolsTest : AbstractMcpTest() {
 
     val json = callToolAndGetJson(client, "list_tags", mapOf("projectId" to data.projectId))
     assertThat(json["items"].isArray).isTrue()
-    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(tagNames).contains("my-tag")
 
     val dbTags =
@@ -126,7 +126,7 @@ class McpTagToolsTest : AbstractMcpTest() {
         mapOf("projectId" to data.projectId, "search" to "alpha"),
       )
     assertThat(json["items"].isArray).isTrue()
-    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val tagNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(tagNames).contains("alpha-tag")
     assertThat(tagNames).doesNotContain("beta-tag")
 

--- a/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpTranslationToolsTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/mcp/tools/McpTranslationToolsTest.kt
@@ -34,7 +34,7 @@ class McpTranslationToolsTest : AbstractMcpTest() {
         "get_translations",
         mapOf("keyName" to "greeting"),
       )
-    assertThat(json["keyName"].asText()).isEqualTo("greeting")
+    assertThat(json["keyName"].asString()).isEqualTo("greeting")
     assertThat(json["translations"].isArray).isTrue()
   }
 
@@ -48,16 +48,16 @@ class McpTranslationToolsTest : AbstractMcpTest() {
       )
     assertThat(json).isNotNull()
     assertThat(json.has("keyName")).isTrue()
-    assertThat(json["keyName"].asText()).isEqualTo("greeting")
+    assertThat(json["keyName"].asString()).isEqualTo("greeting")
     assertThat(json.has("translations")).isTrue()
     val translations = json["translations"]
     assertThat(translations.isArray).isTrue()
     val enTranslation =
       (0 until translations.size())
         .map { translations[it] }
-        .find { it["languageTag"].asText() == "en" }
+        .find { it["languageTag"].asString() == "en" }
     assertThat(enTranslation).isNotNull()
-    assertThat(enTranslation!!["text"].asText()).isEqualTo("Hello")
+    assertThat(enTranslation!!["text"].asString()).isEqualTo("Hello")
   }
 
   @Test
@@ -107,7 +107,7 @@ class McpTranslationToolsTest : AbstractMcpTest() {
     assertThat(json).isNotNull()
     assertThat(json.has("translations")).isTrue()
     val translations = json["translations"]
-    val languageTags = (0 until translations.size()).map { translations[it]["languageTag"].asText() }
+    val languageTags = (0 until translations.size()).map { translations[it]["languageTag"].asString() }
     assertThat(languageTags).contains("de")
     assertThat(languageTags).doesNotContain("en")
   }

--- a/backend/app/src/test/kotlin/io/tolgee/repository/ProjectRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/ProjectRepositoryTest.kt
@@ -60,7 +60,7 @@ class ProjectRepositoryTest {
         filters = ProjectFilters(),
       )
     assertThat(result).hasSize(10)
-    assertThat(result.content[0].organizationOwner?.name).isNotNull
-    assertThat(result.content[8].organizationOwner?.slug).isNotNull
+    assertThat(result.content[0].organizationOwner.name).isNotNull
+    assertThat(result.content[8].organizationOwner.slug).isNotNull
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportFileRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportFileRepositoryTest.kt
@@ -23,7 +23,7 @@ class ImportFileRepositoryTest : AbstractSpringTest() {
 
     ImportFile(importData = import, name = "en.json").let {
       importFileRepository.save(it).let { saved ->
-        importFileRepository.getOne(saved.id).let { got ->
+        importFileRepository.getReferenceById(saved.id).let { got ->
           assertThat(got.name).isEqualTo(it.name)
           assertThat(got.importData).isEqualTo(import)
           assertThat(got.id).isGreaterThan(0L)

--- a/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportRepositoryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/repository/dataImport/ImportRepositoryTest.kt
@@ -20,7 +20,7 @@ class ImportRepositoryTest : AbstractSpringTest() {
     Import(project = base.project).let {
       it.author = base.userAccount
       importRepository.save(it).let {
-        importRepository.getOne(it.id).let { got ->
+        importRepository.getReferenceById(it.id).let { got ->
           assertThat(got.author).isEqualTo(base.userAccount)
           assertThat(got.project).isEqualTo(base.project)
           assertThat(got.id).isGreaterThan(0L)

--- a/backend/app/src/test/kotlin/io/tolgee/service/ActivityVIewByRevisionsProviderTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/ActivityVIewByRevisionsProviderTest.kt
@@ -73,7 +73,7 @@ class ActivityVIewByRevisionsProviderTest : ProjectAuthControllerTest() {
       entityManager
         .createQuery(
           "select ame.branchId from ActivityModifiedEntity ame where ame.activityRevision.id = :revisionId",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("revisionId", revision.first().id)
         .resultList
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/KeyTrashPurgeSchedulerTest.kt
@@ -133,7 +133,7 @@ class KeyTrashPurgeSchedulerTest : AbstractSpringTest() {
     return entityManager
       .createQuery(
         "select count(ts) from TranslationSuggestion ts where ts.key.id = :keyId",
-        java.lang.Long::class.java,
+        Long::class.javaObjectType,
       ).setParameter("keyId", keyId)
       .singleResult
       .toLong()

--- a/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/websocket/WebsocketTestHelper.kt
@@ -4,7 +4,6 @@ import io.tolgee.fixtures.WaitNotSatisfiedException
 import io.tolgee.fixtures.waitFor
 import io.tolgee.util.Logging
 import io.tolgee.util.logger
-import org.springframework.lang.Nullable
 import org.springframework.messaging.converter.SimpleMessageConverter
 import org.springframework.messaging.simp.stomp.StompCommand
 import org.springframework.messaging.simp.stomp.StompHeaders
@@ -175,7 +174,7 @@ class WebsocketTestHelper(
 
     override fun handleException(
       session: StompSession,
-      @Nullable command: StompCommand?,
+      command: StompCommand?,
       headers: StompHeaders,
       payload: ByteArray,
       exception: Throwable,

--- a/backend/data/src/main/kotlin/io/tolgee/MtServicesConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/MtServicesConfiguration.kt
@@ -39,7 +39,7 @@ class MtServicesConfiguration(
         awsMachineTranslationProperties.accessKey.isNullOrEmpty() ||
           awsMachineTranslationProperties.secretKey.isNullOrEmpty()
       ) {
-        true -> DefaultCredentialsProvider.create()
+        true -> DefaultCredentialsProvider.builder().build()
         false ->
           StaticCredentialsProvider.create(
             AwsBasicCredentials.create(

--- a/backend/data/src/main/kotlin/io/tolgee/activity/iterceptor/ActivityDatabaseInterceptor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/iterceptor/ActivityDatabaseInterceptor.kt
@@ -20,7 +20,7 @@ class ActivityDatabaseInterceptor :
     interceptedEventsManager.onAfterTransactionCompleted(tx)
   }
 
-  override fun onSave(
+  override fun onPersist(
     entity: Any?,
     id: Any?,
     state: Array<out Any>?,
@@ -38,7 +38,7 @@ class ActivityDatabaseInterceptor :
     return true
   }
 
-  override fun onDelete(
+  override fun onRemove(
     entity: Any?,
     id: Any?,
     state: Array<out Any>?,

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobActionService.kt
@@ -26,7 +26,7 @@ import io.tolgee.util.executeInNewTransaction
 import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
-import org.hibernate.LockOptions
+import org.hibernate.Timeouts
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -285,7 +285,7 @@ class BatchJobActionService(
       .setLockMode(LockModeType.PESSIMISTIC_WRITE)
       .setHint(
         "jakarta.persistence.lock.timeout",
-        LockOptions.SKIP_LOCKED,
+        Timeouts.SKIP_LOCKED_MILLI,
       ).resultList
       .singleOrNull()
   }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobCancellationManager.kt
@@ -13,7 +13,7 @@ import io.tolgee.util.executeInNewTransaction
 import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import jakarta.persistence.LockModeType
-import org.hibernate.LockOptions
+import org.hibernate.Timeouts
 import org.springframework.context.annotation.Lazy
 import org.springframework.context.event.EventListener
 import org.springframework.data.redis.core.StringRedisTemplate
@@ -115,7 +115,7 @@ class BatchJobCancellationManager(
       ).setLockMode(LockModeType.PESSIMISTIC_WRITE)
       .setHint(
         "jakarta.persistence.lock.timeout",
-        LockOptions.SKIP_LOCKED,
+        Timeouts.SKIP_LOCKED_MILLI,
       ).setParameter("id", jobId)
       .setParameter("status", BatchJobChunkExecutionStatus.PENDING)
       .resultList

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
@@ -417,12 +417,11 @@ class BatchJobService(
           and j.type = :type
           and j.status not in :completedStatuses
         """.trimIndent(),
-        java.lang.Boolean::class.java,
+        Boolean::class.javaObjectType,
       ).setParameter("projectId", projectId)
       .setParameter("type", type)
       .setParameter("completedStatuses", BatchJobStatus.entries.filter { it.completed })
       .singleResult
-      .booleanValue()
   }
 
   fun getExecutions(batchJobId: Long): List<BatchJobChunkExecution> {

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobService.kt
@@ -30,7 +30,7 @@ import io.tolgee.util.flushAndClear
 import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import org.apache.commons.codec.digest.DigestUtils.sha256Hex
-import org.hibernate.LockOptions
+import org.hibernate.Timeouts
 import org.postgresql.util.PGobject
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Lazy
@@ -353,10 +353,11 @@ class BatchJobService(
       ).setParameter("jobIds", jobIds)
       .setHint(
         "jakarta.persistence.lock.timeout",
-        LockOptions.SKIP_LOCKED,
+        Timeouts.SKIP_LOCKED_MILLI,
       ).resultList
   }
 
+  @Suppress("UNCHECKED_CAST")
   fun getProcessor(type: BatchJobType): ChunkProcessor<Any, Any, Any> =
     applicationContext.getBean(type.processor.java) as ChunkProcessor<Any, Any, Any>
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/ChunkProcessingUtil.kt
@@ -19,7 +19,7 @@ import io.tolgee.util.Logging
 import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
 import org.apache.commons.lang3.exception.ExceptionUtils
-import org.hibernate.LockOptions
+import org.hibernate.Timeouts
 import org.springframework.context.ApplicationContext
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.lang.RuntimeException
@@ -286,7 +286,7 @@ open class ChunkProcessingUtil(
       .setParameter("status", BatchJobChunkExecutionStatus.FAILED)
       .setHint(
         "jakarta.persistence.lock.timeout",
-        LockOptions.NO_WAIT,
+        Timeouts.NO_WAIT_MILLI,
       ).resultList as List<BatchJobChunkExecution>
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/MtProviderCatching.kt
@@ -58,7 +58,7 @@ class MtProviderCatching(
             Message.LLM_RATE_LIMITED,
             successfulTargets,
             e,
-            e.retryAt?.let { (e.retryAt - currentDateProvider.date.time).toInt() } ?: 100,
+            (e.retryAt - currentDateProvider.date.time).toInt(),
             increaseFactor = 1,
             maxRetries = -1,
           ),

--- a/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/ScheduledJobCleaner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/cleaning/ScheduledJobCleaner.kt
@@ -118,6 +118,7 @@ class ScheduledJobCleaner(
       .executeUpdate()
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun getStuckCompletedJobs(): List<StuckCompletedJob> {
     val chunkIncompleteStatuses = BatchJobChunkExecutionStatus.entries.filter { !it.completed }.map { it.name }
     val jobIncompleteStatuses = BatchJobStatus.entries.filter { !it.completed }.map { it.name }

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/TagKeysChunkProcessor.kt
@@ -24,7 +24,7 @@ class TagKeysChunkProcessor(
     chunk: List<Long>,
     coroutineContext: CoroutineContext,
   ) {
-    val subChunked = chunk.chunked(100) as List<List<Long>>
+    val subChunked = chunk.chunked(100)
     val params = getParams(job)
 
     val projectId = job.projectId ?: throw IllegalArgumentException("Project id is required")

--- a/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/processors/UntagKeysChunkProcessor.kt
@@ -25,7 +25,7 @@ class UntagKeysChunkProcessor(
     coroutineContext: CoroutineContext,
   ) {
     @Suppress("UNCHECKED_CAST")
-    val subChunked = chunk.chunked(100) as List<List<Long>>
+    val subChunked = chunk.chunked(100)
     val params = getParams(job)
     val projectId = job.projectId ?: throw IllegalArgumentException("Project id is required")
     subChunked.forEach { subChunk ->

--- a/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/state/RedisBatchJobStateStorage.kt
@@ -8,6 +8,7 @@ import org.redisson.api.RAtomicLong
 import org.redisson.api.RBatch
 import org.redisson.api.RMap
 import org.redisson.api.RedissonClient
+import org.redisson.api.options.KeysScanOptions
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -209,7 +210,7 @@ open class RedisBatchJobStateStorage(
   }
 
   override fun getCachedJobIds(): MutableSet<Long> {
-    val keys = redissonClient.keys.getKeysByPattern("$REDIS_STATE_KEY_PREFIX*")
+    val keys = redissonClient.keys.getKeys(KeysScanOptions.defaults().pattern("$REDIS_STATE_KEY_PREFIX*"))
     return keys.mapNotNull { it.removePrefix(REDIS_STATE_KEY_PREFIX).toLongOrNull() }.toMutableSet()
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/S3ClientProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/S3ClientProvider.kt
@@ -37,7 +37,7 @@ class S3ClientProvider(
       s3config.accessKey.isNullOrEmpty() ||
         s3config.secretKey.isNullOrEmpty()
     ) {
-      true -> DefaultCredentialsProvider.create()
+      true -> DefaultCredentialsProvider.builder().build()
       false ->
         StaticCredentialsProvider.create(
           AwsBasicCredentials.create(

--- a/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AzureCognitiveApiService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/machineTranslation/providers/AzureCognitiveApiService.kt
@@ -44,7 +44,7 @@ class AzureCognitiveApiService(
       )
 
     return response.body
-      ?.first
+      ?.first()
       ?.translations
       ?.first()
       ?.text

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/InvitationBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/builders/InvitationBuilder.kt
@@ -4,5 +4,5 @@ import io.tolgee.model.Invitation
 import org.apache.commons.lang3.RandomStringUtils
 
 class InvitationBuilder : BaseEntityDataBuilder<Invitation, InvitationBuilder>() {
-  override val self: Invitation = Invitation(code = RandomStringUtils.randomAlphanumeric(50))
+  override val self: Invitation = Invitation(code = RandomStringUtils.secure().nextAlphanumeric(50))
 }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BatchJobsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BatchJobsTestData.kt
@@ -14,7 +14,7 @@ class BatchJobsTestData : BaseTestData() {
 
   // A separate project owned by another organization. The test user has no access to it.
   // Used to verify a batch job of another project cannot be read/cancelled via this project's URL.
-  lateinit var unrelatedProject: ProjectBuilder
+  var unrelatedProject: ProjectBuilder
 
   init {
     this.projectBuilder.addPermission {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BigMetaTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/BigMetaTestData.kt
@@ -9,7 +9,7 @@ import kotlin.math.abs
 
 class BigMetaTestData {
   lateinit var project: Project
-  lateinit var projectBuilder: ProjectBuilder
+  var projectBuilder: ProjectBuilder
   lateinit var userAccount: UserAccount
   lateinit var noNsKey: Key
   lateinit var yepKey: Key

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/CommunityContributionE2eData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/CommunityContributionE2eData.kt
@@ -4,7 +4,7 @@ import io.tolgee.development.testDataBuilder.builders.ProjectBuilder
 import io.tolgee.model.Project
 
 class CommunityContributionE2eData : BaseTestData("communityContributionOwner", "Owner private project") {
-  lateinit var publicProject: Project
+  var publicProject: Project
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ConcurrentBatchJobsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ConcurrentBatchJobsTestData.kt
@@ -18,22 +18,22 @@ class ConcurrentBatchJobsTestData(
   val projectBKeyCount: Int = 300,
   val projectCKeyCount: Int = 200,
 ) {
-  lateinit var user: UserAccount
-  lateinit var userAccountBuilder: UserAccountBuilder
+  var user: UserAccount
+  var userAccountBuilder: UserAccountBuilder
 
   lateinit var projectA: Project
-  lateinit var projectABuilder: ProjectBuilder
+  var projectABuilder: ProjectBuilder
   lateinit var projectAEnglish: Language
   lateinit var projectACzech: Language
   lateinit var projectAGerman: Language
 
   lateinit var projectB: Project
-  lateinit var projectBBuilder: ProjectBuilder
+  var projectBBuilder: ProjectBuilder
   lateinit var projectBEnglish: Language
   lateinit var projectBCzech: Language
 
   lateinit var projectC: Project
-  lateinit var projectCBuilder: ProjectBuilder
+  var projectCBuilder: ProjectBuilder
   lateinit var projectCEnglish: Language
   lateinit var projectCCzech: Language
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ContributorsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ContributorsTestData.kt
@@ -12,21 +12,21 @@ import java.util.Date
 class ContributorsTestData(
   withE2eContributions: Boolean = false,
 ) {
-  lateinit var project: Project
-  lateinit var publicProject: Project
-  lateinit var publicEmptyProject: Project
-  lateinit var admin: UserAccount
-  lateinit var contributor: UserAccount
-  lateinit var contributor2: UserAccount
-  lateinit var member: UserAccount
-  lateinit var noneMember: UserAccount
-  lateinit var orgMember: UserAccount
-  lateinit var deletedContributor: UserAccount
-  lateinit var disabledContributor: UserAccount
-  lateinit var staffContributor: UserAccount
-  lateinit var unnamedContributor: UserAccount
-  lateinit var membersViewer: UserAccount
-  lateinit var foreignOrgContributor: UserAccount
+  var project: Project
+  var publicProject: Project
+  var publicEmptyProject: Project
+  var admin: UserAccount
+  var contributor: UserAccount
+  var contributor2: UserAccount
+  var member: UserAccount
+  var noneMember: UserAccount
+  var orgMember: UserAccount
+  var deletedContributor: UserAccount
+  var disabledContributor: UserAccount
+  var staffContributor: UserAccount
+  var unnamedContributor: UserAccount
+  var membersViewer: UserAccount
+  var foreignOrgContributor: UserAccount
 
   val root: TestDataBuilder =
     TestDataBuilder().apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryGuestAccessTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryGuestAccessTestData.kt
@@ -24,10 +24,10 @@ class GlossaryGuestAccessTestData : BaseTestData() {
   lateinit var softDeletedProjectGlossary: Glossary
   lateinit var softDeletedBaseLangProject: Project
   lateinit var softDeletedBaseLangGlossary: Glossary
-  lateinit var storedGuest: UserAccount
-  lateinit var virtualGuest: UserAccount
-  lateinit var directPermissionUser: UserAccount
-  lateinit var noneOnlyUser: UserAccount
+  var storedGuest: UserAccount
+  var virtualGuest: UserAccount
+  var directPermissionUser: UserAccount
+  var noneOnlyUser: UserAccount
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeyTrashTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeyTrashTestData.kt
@@ -16,7 +16,7 @@ import io.tolgee.model.key.Key
  * calling service lookups.
  */
 class KeyTrashTestData : BaseTestData("franta", "Franta's project") {
-  lateinit var secondUser: UserAccount
+  var secondUser: UserAccount
 
   val germanLanguage =
     projectBuilder
@@ -29,10 +29,10 @@ class KeyTrashTestData : BaseTestData("franta", "Franta's project") {
   /** Numbered keys ("key 01" through "key 10"), indexed 0–9. */
   val numberedKeys = mutableListOf<Key>()
 
-  lateinit var keyWithTag: Key
-  lateinit var anotherKeyWithTag: Key
-  lateinit var keyWithTag2: Key
-  lateinit var keyWithDescription: Key
+  var keyWithTag: Key
+  var anotherKeyWithTag: Key
+  var keyWithTag2: Key
+  var keyWithDescription: Key
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeysTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/KeysTestData.kt
@@ -87,10 +87,10 @@ class KeysTestData {
           addKey {
             name = "key_with_referecnces"
             this@KeysTestData.keyWithReferences = this
-          }.build {
+          }.build keyWithReferences@{
             addScreenshotReference {
               screenshot = this@KeysTestData.screenshot
-              key = this@build.self
+              key = this@keyWithReferences.self
             }
             addMeta {
               tags.add(

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OrganizationStatsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/OrganizationStatsTestData.kt
@@ -8,7 +8,7 @@ import io.tolgee.model.Project
 import io.tolgee.model.branching.Branch
 
 class OrganizationStatsTestData : BaseTestData("org-stats", "Stats Project") {
-  lateinit var organization: Organization
+  var organization: Organization
   lateinit var mainBranch: Branch
   lateinit var featureBranch: Branch
   lateinit var secondProject: Project

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectExportImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectExportImportTestData.kt
@@ -62,15 +62,15 @@ class ProjectExportImportTestData(
   val trashedKeyMetaDescription = "trashed-key-meta"
   val trashedCodeReferencePath = "src/Trashed.kt"
   val trashedTranslationCommentText = "trashed-translation-comment"
-  lateinit var assignedLabel: Label
-  lateinit var taskOnDeletedLanguage: Task
-  lateinit var liveTask: Task
-  lateinit var keyOnDeletedBranch: Key
-  lateinit var taskOnDeletedBranch: Task
+  var assignedLabel: Label
+  var taskOnDeletedLanguage: Task
+  var liveTask: Task
+  var keyOnDeletedBranch: Key
+  var taskOnDeletedBranch: Task
   lateinit var suggestionAuthor: UserAccount
-  lateinit var greetingKey: Key
-  lateinit var labeledKey: Key
-  lateinit var softDeletedKey: Key
+  var greetingKey: Key
+  var labeledKey: Key
+  var softDeletedKey: Key
 
   val bigMetaDistance = 0.25
   val bigMetaHits = 7L

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportBranchedSourceTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportBranchedSourceTestData.kt
@@ -20,14 +20,14 @@ import io.tolgee.model.key.Key
  */
 class ProjectImportBranchedSourceTestData :
   BaseTestData(userName = "branched-source-owner", projectName = "branched-source-project") {
-  lateinit var defaultBranch: Branch
-  lateinit var featureBranch: Branch
+  var defaultBranch: Branch
+  var featureBranch: Branch
 
   lateinit var sharedDefaultKey: Key
   lateinit var sharedFeatureKey: Key
   lateinit var sharedScreenshot: Screenshot
-  lateinit var danglingFeatureKey1: Key
-  lateinit var danglingFeatureKey2: Key
+  var danglingFeatureKey1: Key
+  var danglingFeatureKey2: Key
 
   val defaultKeyName = "default-branch-key"
   val featureKeyName = "feature-branch-key"

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportTargetTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectImportTargetTestData.kt
@@ -20,9 +20,9 @@ import io.tolgee.model.key.Key
 class ProjectImportTargetTestData :
   BaseTestData(userName = "import-target-owner", projectName = "import-target-project") {
   val targetProject: Project get() = project
-  lateinit var targetBranch: Branch
-  lateinit var targetOldKey: Key
-  lateinit var siblingProject: Project
+  var targetBranch: Branch
+  var targetOldKey: Key
+  var siblingProject: Project
 
   val oldKeyName = "old-target-key"
   val oldLabelName = "old-target-label"

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectLeavingTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ProjectLeavingTestData.kt
@@ -48,12 +48,12 @@ class ProjectLeavingTestData : BaseTestData() {
       addOrganization {
         name = "Owned organization"
         organization = this
-      }.apply {
+      }.apply ownedOrganization@{
         addRole {
           type = OrganizationRoleType.OWNER
           user = this@ProjectLeavingTestData.userWithOrganizationRole
         }
-        addProject(organizationOwner = this@apply.self) {
+        addProject(organizationOwner = this@ownedOrganization.self) {
           name = "Organization owned project"
           organizationOwnedProject = this
         }.build {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/PublicProjectsControllerTestData.kt
@@ -13,43 +13,43 @@ class PublicProjectsControllerTestData : BaseTestData() {
   val privateProject: Project get() = project
 
   lateinit var publicProject: Project
-  lateinit var otherOrg: Organization
+  var otherOrg: Organization
   lateinit var otherOrgPublicProject: Project
-  lateinit var nonMember: UserAccount
+  var nonMember: UserAccount
 
-  lateinit var directPermissionUser: UserAccount
+  var directPermissionUser: UserAccount
 
   lateinit var noBaseLanguageProject: Project
   lateinit var softDeletedBaseProject: Project
   lateinit var orgLessProject: Project
   lateinit var deletedPublicProject: Project
 
-  lateinit var nonMemberPersonalOrg: Organization
-  lateinit var otherOrgMember: UserAccount
-  lateinit var otherOrgOwner: UserAccount
-  lateinit var storedGuest: UserAccount
+  var nonMemberPersonalOrg: Organization
+  var otherOrgMember: UserAccount
+  var otherOrgOwner: UserAccount
+  var storedGuest: UserAccount
   lateinit var otherOrgPrivateProject: Project
-  lateinit var serverAdmin: UserAccount
+  var serverAdmin: UserAccount
 
-  lateinit var guestWithPermission: UserAccount
-  lateinit var granularPermissionUser: UserAccount
-  lateinit var noneOnlyUser: UserAccount
-  lateinit var revokedOnlyUser: UserAccount
+  var guestWithPermission: UserAccount
+  var granularPermissionUser: UserAccount
+  var noneOnlyUser: UserAccount
+  var revokedOnlyUser: UserAccount
 
-  lateinit var noPublicOrg: Organization
-  lateinit var noPublicOrgMember: UserAccount
-  lateinit var noPublicOrgOwner: UserAccount
-  lateinit var privateOrgMember: UserAccount
+  var noPublicOrg: Organization
+  var noPublicOrgMember: UserAccount
+  var noPublicOrgOwner: UserAccount
+  var privateOrgMember: UserAccount
 
-  lateinit var noBaseLangOnlyOrg: Organization
+  var noBaseLangOnlyOrg: Organization
   lateinit var noBaseLangOnlyOrgProject: Project
-  lateinit var softDeletedBaseLangOnlyOrg: Organization
+  var softDeletedBaseLangOnlyOrg: Organization
   lateinit var softDeletedBaseLangOnlyOrgProject: Project
-  lateinit var deletedProjectOnlyOrg: Organization
+  var deletedProjectOnlyOrg: Organization
   lateinit var deletedProjectOnlyOrgProject: Project
-  lateinit var softDeletedOrg: Organization
+  var softDeletedOrg: Organization
   lateinit var softDeletedOrgPublicProject: Project
-  lateinit var softDeletedOrgMember: UserAccount
+  var softDeletedOrgMember: UserAccount
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/QaE2eTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/QaE2eTestData.kt
@@ -11,8 +11,8 @@ import io.tolgee.model.qa.ProjectQaConfig
 
 class QaE2eTestData : BaseTestData() {
   lateinit var frenchLanguage: Language
-  lateinit var qaConfig: ProjectQaConfig
-  lateinit var disabledProjectBuilder: ProjectBuilder
+  var qaConfig: ProjectQaConfig
+  var disabledProjectBuilder: ProjectBuilder
 
   init {
     project.useQaChecks = true

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ResolvableImportTestData.kt
@@ -15,7 +15,7 @@ class ResolvableImportTestData : BaseTestData() {
   lateinit var viewOnlyUser: UserAccount
   lateinit var keyCreateOnlyUser: UserAccount
   lateinit var translateOnlyUser: UserAccount
-  lateinit var secondLanguage: Language
+  var secondLanguage: Language
   lateinit var translatorUser: UserAccount
 
   init {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ScopedSearchTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/ScopedSearchTestData.kt
@@ -12,9 +12,9 @@ import java.util.Date
  * data controller.
  */
 class ScopedSearchTestData : BaseTestData() {
-  lateinit var germanLanguageBuilder: LanguageBuilder
+  var germanLanguageBuilder: LanguageBuilder
   val germanLanguage: Language get() = germanLanguageBuilder.self
-  lateinit var cartTitleKey: Key
+  var cartTitleKey: Key
 
   init {
     projectBuilder.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SlackTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SlackTestData.kt
@@ -31,7 +31,7 @@ class SlackTestData {
   lateinit var baseTranslationNotExistKey: Key
   lateinit var slackWorkspace: OrganizationSlackWorkspace
   lateinit var slackWorkspace2: OrganizationSlackWorkspace
-  lateinit var secondLanguage: Language
+  var secondLanguage: Language
 
   lateinit var slackUserConnection: SlackUserConnection
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteBranchingTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteBranchingTestData.kt
@@ -4,10 +4,10 @@ import io.tolgee.model.branching.Branch
 import io.tolgee.model.key.Key
 
 class SoftDeleteBranchingTestData : BaseTestData("soft_delete_branching", "Project for soft-delete branching tests") {
-  lateinit var mainBranch: Branch
-  lateinit var key1: Key
-  lateinit var key2: Key
-  lateinit var key3: Key
+  var mainBranch: Branch
+  var key1: Key
+  var key2: Key
+  var key3: Key
 
   init {
     projectBuilder.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteKeysTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteKeysTestData.kt
@@ -20,9 +20,9 @@ class SoftDeleteKeysTestData :
         }
       user2 = user2Builder.self
 
-      projectBuilder.apply {
+      projectBuilder.apply project@{
         addPermission {
-          project = this@apply.self
+          project = this@project.self
           user = user2
           type = ProjectPermissionType.MANAGE
         }

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteKeysTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SoftDeleteKeysTestData.kt
@@ -9,7 +9,7 @@ class SoftDeleteKeysTestData :
     projectName = "Soft delete test",
   ) {
   val czechLanguage = projectBuilder.addCzech().self
-  lateinit var user2: UserAccount
+  var user2: UserAccount
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/SuggestionsTestData.kt
@@ -32,17 +32,17 @@ class SuggestionsTestData(
   var keys: MutableList<KeyBuilder> = mutableListOf()
   val czechSuggestions: MutableList<SuggestionBuilder> = mutableListOf()
   val englishSuggestions: MutableList<SuggestionBuilder> = mutableListOf()
-  lateinit var czechReviewerEnglishSuggestion: SuggestionBuilder
+  var czechReviewerEnglishSuggestion: SuggestionBuilder
   val czechTranslations: MutableList<TranslationBuilder> = mutableListOf()
-  lateinit var pluralKey: KeyBuilder
-  lateinit var pluralSuggestion: SuggestionBuilder
+  var pluralKey: KeyBuilder
+  var pluralSuggestion: SuggestionBuilder
   lateinit var czechLanguage: Language
 
   // A separate project (different org) with its own key + suggestion.
   // Used to verify that access to a suggestion by id from another project is rejected.
-  lateinit var unrelatedProject: ProjectBuilder
-  lateinit var unrelatedKey: KeyBuilder
-  lateinit var unrelatedSuggestion: SuggestionBuilder
+  var unrelatedProject: ProjectBuilder
+  var unrelatedKey: KeyBuilder
+  var unrelatedSuggestion: SuggestionBuilder
 
   init {
     user.name = "Tasks test user"

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
@@ -35,7 +35,7 @@ class TaskTestData : BaseTestData("tasksTestUser", "Project with tasks") {
   var unrelatedProject: ProjectBuilder
   var unrelatedUser: UserAccountBuilder
   var unrelatedEnglish: LanguageBuilder
-  lateinit var unrelatedKey: KeyBuilder
+  var unrelatedKey: KeyBuilder
 
   lateinit var blockedTask: TaskBuilder
 

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmSuggestionsE2eTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TmSuggestionsE2eTestData.kt
@@ -28,7 +28,7 @@ class TmSuggestionsE2eTestData :
     const val BACKDATED_TARGET_TEXT = "Čas z TM"
   }
 
-  lateinit var czechLanguage: Language
+  var czechLanguage: Language
   lateinit var sharedTmWithDate: TranslationMemory
   lateinit var penalizedSharedTm: TranslationMemory
   lateinit var noReadSharedTm: TranslationMemory

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationMemoryTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationMemoryTestData.kt
@@ -27,7 +27,7 @@ import java.util.Date
  *     test needs a "clean slate" project against which to assert default behaviour.
  */
 class TranslationMemoryTestData : BaseTestData() {
-  lateinit var projectWithTm: Project
+  var projectWithTm: Project
   lateinit var projectTm: TranslationMemory
   lateinit var sharedTm: TranslationMemory
 
@@ -58,7 +58,7 @@ class TranslationMemoryTestData : BaseTestData() {
    * tests that need to change the project's base language without tripping the
    * shared-TM-base-mismatch validation.
    */
-  lateinit var projectWithOnlyProjectTm: Project
+  var projectWithOnlyProjectTm: Project
   lateinit var onlyProjectTm: TranslationMemory
 
   /**
@@ -67,7 +67,7 @@ class TranslationMemoryTestData : BaseTestData() {
    * so the same source text on this TM yields two distinct virtual rows from two projects.
    * Drives the multi-candidate-row UI test.
    */
-  lateinit var conflictProject: Project
+  var conflictProject: Project
 
   /**
    * Shared TM with two write-access-assigned projects ([projectWithTm] and [conflictProject])
@@ -82,7 +82,7 @@ class TranslationMemoryTestData : BaseTestData() {
    * rejected.
    */
   lateinit var mismatchedBaseSharedTm: TranslationMemory
-  lateinit var germanLanguageNoTm: Language
+  var germanLanguageNoTm: Language
   lateinit var germanLanguageWithTm: Language
 
   /**
@@ -165,7 +165,7 @@ class TranslationMemoryTestData : BaseTestData() {
    * by org-level TM authorization tests to verify project-only access does NOT grant access
    * to org-scoped TM browsing.
    */
-  lateinit var projectOnlyViewer: UserAccount
+  var projectOnlyViewer: UserAccount
 
   init {
     root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationSourceChangeStateTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationSourceChangeStateTestData.kt
@@ -3,7 +3,7 @@ package io.tolgee.development.testDataBuilder.data
 import io.tolgee.model.Language
 
 class TranslationSourceChangeStateTestData : BaseTestData() {
-  lateinit var germanLanguage: Language
+  var germanLanguage: Language
 
   init {
     projectBuilder.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsSnapshotTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TranslationsSnapshotTestData.kt
@@ -17,7 +17,7 @@ import io.tolgee.model.enums.TranslationState
  * - 1 branched key (excluded by default branch filter)
  */
 class TranslationsSnapshotTestData : BaseTestData("franta", "Franta's project") {
-  lateinit var germanLanguage: Language
+  var germanLanguage: Language
 
   init {
     projectBuilder.self.useBranching = true

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/SingleStepImportBranchTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/dataImport/SingleStepImportBranchTestData.kt
@@ -5,8 +5,8 @@ import io.tolgee.model.branching.Branch
 
 class SingleStepImportBranchTestData : BaseTestData() {
   val germanLanguage = projectBuilder.addGerman()
-  lateinit var defaultBranch: Branch
-  lateinit var featureBranch: Branch
+  var defaultBranch: Branch
+  var featureBranch: Branch
 
   init {
     this.root.apply {

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/organization/OrganizationView.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/queryResults/organization/OrganizationView.kt
@@ -14,6 +14,7 @@ class OrganizationView(
   val currentUserRole: OrganizationRoleType?,
   val avatarHash: String?,
 ) {
+  @Suppress("UNCHECKED_CAST")
   constructor(
     id: Long,
     name: String,

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/validators/ValidationError.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/validators/ValidationError.kt
@@ -7,7 +7,7 @@ class ValidationError(
   message: Message,
   vararg parameters: String,
 ) {
-  val parameters: Array<String> = parameters as Array<String>
+  val parameters: Array<out String> = parameters
   val type: ValidationErrorType = type
   val message: Message = message
 }

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityCollectionPreUpdate.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityCollectionPreUpdate.kt
@@ -6,6 +6,7 @@ import org.springframework.core.ResolvableType
 import org.springframework.core.ResolvableTypeProvider
 
 class OnEntityCollectionPreUpdate<T : Any>(
+  @Suppress("PROPERTY_HIDES_JAVA_FIELD")
   override val source: PreCommitEventPublisher,
   override val entity: T?,
   previousCollection: MutableCollection<out Any?>?,

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreDelete.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreDelete.kt
@@ -6,6 +6,7 @@ import org.springframework.core.ResolvableType
 import org.springframework.core.ResolvableTypeProvider
 
 class OnEntityPreDelete<T : Any>(
+  @Suppress("PROPERTY_HIDES_JAVA_FIELD")
   override val source: PreCommitEventPublisher,
   override val entity: T?,
 ) : ApplicationEvent(source),

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPrePersist.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPrePersist.kt
@@ -6,6 +6,7 @@ import org.springframework.core.ResolvableType
 import org.springframework.core.ResolvableTypeProvider
 
 class OnEntityPrePersist<T : Any>(
+  @Suppress("PROPERTY_HIDES_JAVA_FIELD")
   override val source: PreCommitEventPublisher,
   override val entity: T?,
 ) : ApplicationEvent(source),

--- a/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreUpdate.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/events/OnEntityPreUpdate.kt
@@ -6,6 +6,7 @@ import org.springframework.core.ResolvableType
 import org.springframework.core.ResolvableTypeProvider
 
 class OnEntityPreUpdate<T : Any>(
+  @Suppress("PROPERTY_HIDES_JAVA_FIELD")
   override val source: PreCommitEventPublisher,
   override val entity: T?,
   val previousState: Array<out Any>?,

--- a/backend/data/src/main/kotlin/io/tolgee/formats/MessagePatternUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/MessagePatternUtil.kt
@@ -423,7 +423,7 @@ object MessagePatternUtil {
       if (argType != MessagePattern.ArgType.NONE) {
         sb.append(',').append(typeName)
         if (argType == MessagePattern.ArgType.SIMPLE) {
-          sb.append(',').append(simpleStyle)
+          style?.let { sb.append(',').append(it) }
         } else {
           sb.append(',').append(complexStyle.toString())
         }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/MessagePatternUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/MessagePatternUtil.kt
@@ -423,9 +423,7 @@ object MessagePatternUtil {
       if (argType != MessagePattern.ArgType.NONE) {
         sb.append(',').append(typeName)
         if (argType == MessagePattern.ArgType.SIMPLE) {
-          if (simpleStyle != null) {
-            sb.append(',').append(simpleStyle)
-          }
+          sb.append(',').append(simpleStyle)
         } else {
           sb.append(',').append(complexStyle.toString())
         }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/apple/in/xcstrings/XcstringsFileProcessor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/apple/in/xcstrings/XcstringsFileProcessor.kt
@@ -17,7 +17,7 @@ class XcstringsFileProcessor(
   override fun process() {
     try {
       val root = objectMapper.readTree(context.file.data.inputStream())
-      sourceLanguage = root.get("sourceLanguage")?.asText()
+      sourceLanguage = root.get("sourceLanguage")?.asString()
         ?: throw ImportCannotParseFileException(context.file.name, "Missing sourceLanguage in xcstrings file")
 
       val strings =
@@ -64,7 +64,7 @@ class XcstringsFileProcessor(
   ) {
     val localizations = value.get("localizations") ?: return
 
-    value.get("comment")?.asText()?.let { comment ->
+    value.get("comment")?.asString()?.let { comment ->
       context.addKeyDescription(key, comment)
     }
 
@@ -91,9 +91,9 @@ class XcstringsFileProcessor(
     localization: JsonNode,
   ) {
     val stringUnit = localization.get("stringUnit")
-    stringUnit?.get("state")?.asText()
+    stringUnit?.get("state")?.asString()
 
-    val translationValue = stringUnit?.get("value")?.asText()
+    val translationValue = stringUnit?.get("value")?.asString()
 
     if (translationValue != null) {
       addConvertedTranslation(key, languageTag, translationValue)
@@ -111,7 +111,7 @@ class XcstringsFileProcessor(
 
     variations.properties().forEach { (form, content) ->
       val stringUnit = content.get("stringUnit")
-      val value = stringUnit?.get("value")?.asText()
+      val value = stringUnit?.get("value")?.asString()
 
       if (value != null) {
         forms[form] = value

--- a/backend/data/src/main/kotlin/io/tolgee/formats/nestedStructureModel/StructureModelBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/nestedStructureModel/StructureModelBuilder.kt
@@ -131,7 +131,7 @@ class StructureModelBuilder(
         when (parentNode) {
           is ArrayStructuredModelItem -> {
             val targetNode =
-              getTargetNodeForArrayItem(parentNode, pathItem, pathItemsMutable) ?: return
+              getTargetNodeForArrayItem(parentNode, pathItem, pathItemsMutable)
             addToContent(targetNode, pathItemsMutable, fullPath, value)
           }
 

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/BaseToIcuPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/BaseToIcuPlaceholderConvertor.kt
@@ -24,7 +24,7 @@ class BaseToIcuPlaceholderConvertor(
     matchResult: MatchResult,
     isInPlural: Boolean,
   ): String {
-    val parsed = parser.parse(matchResult) ?: return matchResult.value.escapeIcu(isInPlural)
+    val parsed = parser.parse(matchResult)
 
     if (parsed.specifier == "%") {
       return "%"

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/I18nextToIcuPlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/in/I18nextToIcuPlaceholderConvertor.kt
@@ -17,7 +17,7 @@ class I18nextToIcuPlaceholderConvertor : ToIcuPlaceholderConvertor {
     matchResult: MatchResult,
     isInPlural: Boolean,
   ): String {
-    val parsed = parser.parse(matchResult) ?: return matchResult.value.escapeIcu(isInPlural)
+    val parsed = parser.parse(matchResult)
 
     if (parsed.nestedKey != null) {
       // Nested keys are not supported

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/BaseToCLikePlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/BaseToCLikePlaceholderConvertor.kt
@@ -56,7 +56,7 @@ class BaseToCLikePlaceholderConvertor(
   }
 
   private fun getPrecision(node: MessagePatternUtil.ArgNode): Int? {
-    val precisionMatch = ICU_PRECISION_REGEX.matchEntire(node.simpleStyle ?: "")
+    val precisionMatch = ICU_PRECISION_REGEX.matchEntire(node.simpleStyle)
     precisionMatch ?: return null
     return precisionMatch.groups["precision"]?.value?.length
   }

--- a/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPythonBracePlaceholderConvertor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/formats/paramConvertors/out/IcuToPythonBracePlaceholderConvertor.kt
@@ -46,7 +46,7 @@ class IcuToPythonBracePlaceholderConvertor : FromIcuPlaceholderConvertor {
   }
 
   private fun MessagePatternUtil.ArgNode.getPrecision(): Int? {
-    val precisionMatch = ICU_PRECISION_REGEX.matchEntire(this.simpleStyle ?: "") ?: return null
+    val precisionMatch = ICU_PRECISION_REGEX.matchEntire(this.simpleStyle) ?: return null
     return precisionMatch.groups["precision"]?.value?.length
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/jobs/migration/allOrganizationOwner/AllOrganizationOwnerJobConfiguration.kt
@@ -101,7 +101,8 @@ class AllOrganizationOwnerJobConfiguration {
 
   fun getNoOrgProjectsStep(jobRepository: JobRepository): Step {
     return StepBuilder("noOrProjectStep", jobRepository)
-      .chunk<Project, Project>(STEP_SIZE, platformTransactionManager)
+      .chunk<Project, Project>(STEP_SIZE)
+      .transactionManager(platformTransactionManager)
       .reader(noOrgProjectReader)
       .writer(noOrgProjectWriter)
       .build()
@@ -123,7 +124,8 @@ class AllOrganizationOwnerJobConfiguration {
 
   fun getNoRoleUserStep(jobRepository: JobRepository): Step =
     StepBuilder("noRoleUserStep", jobRepository)
-      .chunk<UserAccount, UserAccount>(STEP_SIZE, platformTransactionManager)
+      .chunk<UserAccount, UserAccount>(STEP_SIZE)
+      .transactionManager(platformTransactionManager)
       .reader(noRoleUserReader)
       .writer(noRoleUserWriter)
       .build()

--- a/backend/data/src/main/kotlin/io/tolgee/jobs/migration/translationStats/TranslationStatsJobConfiguration.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/jobs/migration/translationStats/TranslationStatsJobConfiguration.kt
@@ -74,7 +74,8 @@ class TranslationStatsJobConfiguration {
   val step: Step
     get() =
       StepBuilder("step", jobRepository)
-        .chunk<StatsMigrationTranslationView, TranslationStats>(100, platformTransactionManager)
+        .chunk<StatsMigrationTranslationView, TranslationStats>(100)
+        .transactionManager(platformTransactionManager)
         .reader(reader)
         .processor(TranslationProcessor())
         .writer(writer)

--- a/backend/data/src/main/kotlin/io/tolgee/model/ApiKey.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/ApiKey.kt
@@ -10,8 +10,6 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Index
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import jakarta.persistence.Transient
 import jakarta.persistence.UniqueConstraint
 import jakarta.validation.constraints.NotBlank
@@ -63,10 +61,8 @@ class ApiKey(
   @NotNull
   lateinit var project: Project
 
-  @Temporal(TemporalType.TIMESTAMP)
   var expiresAt: Date? = null
 
-  @Temporal(TemporalType.TIMESTAMP)
   var lastUsedAt: Date? = null
 
   constructor(

--- a/backend/data/src/main/kotlin/io/tolgee/model/AuditModel.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/AuditModel.kt
@@ -5,8 +5,6 @@ import io.tolgee.activity.annotation.ActivityIgnoredProp
 import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -17,13 +15,11 @@ import java.util.Date
 @EntityListeners(AuditingEntityListener::class)
 @JsonIgnoreProperties(value = ["createdAt", "updatedAt"], allowGetters = true)
 abstract class AuditModel : Serializable {
-  @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "created_at", nullable = false, updatable = false)
   @CreatedDate
   @ActivityIgnoredProp
   var createdAt: Date? = null
 
-  @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "updated_at", nullable = false)
   @LastModifiedDate
   @ActivityIgnoredProp

--- a/backend/data/src/main/kotlin/io/tolgee/model/ForcedServerDateTime.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/ForcedServerDateTime.kt
@@ -2,7 +2,6 @@ package io.tolgee.model
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
-import jakarta.persistence.Temporal
 import java.util.Date
 
 @Entity
@@ -10,6 +9,5 @@ class ForcedServerDateTime {
   @Id
   val id = 1
 
-  @Temporal(jakarta.persistence.TemporalType.TIMESTAMP)
   var time: Date = Date()
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/LanguageStats.kt
@@ -11,8 +11,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import org.hibernate.annotations.ColumnDefault
 import java.util.Date
 
@@ -43,7 +41,6 @@ class LanguageStats(
 
   override var reviewedPercentage: Double = 0.0
 
-  @Temporal(TemporalType.TIMESTAMP)
   override var translationsUpdatedAt: Date? = null
 
   @ColumnDefault("0")

--- a/backend/data/src/main/kotlin/io/tolgee/model/Pat.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/Pat.kt
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Index
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import jakarta.persistence.Transient
 import jakarta.persistence.UniqueConstraint
 import jakarta.validation.constraints.NotEmpty
@@ -32,9 +30,7 @@ class Pat(
   @param:NotEmpty
   @param:NotNull
   var description: String = "",
-  @Temporal(value = TemporalType.TIMESTAMP)
   var expiresAt: Date? = null,
-  @Temporal(value = TemporalType.TIMESTAMP)
   var lastUsedAt: Date? = null,
   @Transient
   var token: String? = null,

--- a/backend/data/src/main/kotlin/io/tolgee/model/QuickStart.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/QuickStart.kt
@@ -1,6 +1,5 @@
 package io.tolgee.model
 
-import io.hypersistence.utils.hibernate.type.array.StringArrayType
 import io.tolgee.dtos.queryResults.organization.IQuickStart
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -11,7 +10,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.MapsId
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import org.hibernate.annotations.Type
 
 @Entity
 @Table(
@@ -36,7 +34,6 @@ data class QuickStart(
 
   override var open: Boolean = true
 
-  @Type(StringArrayType::class)
   @Column(columnDefinition = "text[]")
   override var completedSteps: Array<String> = arrayOf()
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
@@ -1,6 +1,5 @@
 package io.tolgee.model
 
-import io.hypersistence.utils.hibernate.type.array.ListArrayType
 import io.tolgee.activity.annotation.ActivityLoggedEntity
 import io.tolgee.api.IUserAccount
 import io.tolgee.component.ThirdPartyAuthTypeConverter
@@ -25,7 +24,8 @@ import jakarta.persistence.OrderBy
 import jakarta.persistence.Transient
 import jakarta.validation.constraints.NotBlank
 import org.hibernate.annotations.ColumnDefault
-import org.hibernate.annotations.Type
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
 import java.util.Date
 
 @Entity
@@ -62,7 +62,7 @@ data class UserAccount(
   @Column(name = "totp_last_used_time_step")
   var totpLastUsedTimeStep: Long? = null
 
-  @Type(ListArrayType::class)
+  @JdbcTypeCode(SqlTypes.ARRAY)
   @Column(name = "mfa_recovery_codes", columnDefinition = "text[]")
   var mfaRecoveryCodes: List<String> = emptyList()
 

--- a/backend/data/src/main/kotlin/io/tolgee/model/activity/ActivityRevision.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/activity/ActivityRevision.kt
@@ -20,8 +20,6 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.PrePersist
 import jakarta.persistence.SequenceGenerator
 import jakarta.persistence.Table
-import jakarta.persistence.Temporal
-import jakarta.persistence.TemporalType
 import jakarta.persistence.Transient
 import org.hibernate.annotations.Type
 import org.springframework.beans.factory.ObjectFactory
@@ -54,7 +52,6 @@ class ActivityRevision : java.io.Serializable {
   )
   val id: Long = 0
 
-  @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "timestamp", nullable = false, updatable = false)
   lateinit var timestamp: Date
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/bigMeta/BigMetaService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/bigMeta/BigMetaService.kt
@@ -284,11 +284,14 @@ class BigMetaService(
       }
     val keyPredicates = cb.or(*predicates.toTypedArray())
     query.where(cb.and(keyPredicates, cb.equal(root.get(Key_.project).get(Project_.id), projectId)))
-    query.multiselect(
-      root.get(Key_.id).alias("id"),
-      namespace.get(Namespace_.name).alias("namespace"),
-      root.get(Key_.name).alias("name"),
-      branch.get(Branch_.name).alias("branch"),
+    query.select(
+      cb.construct(
+        KeyIdFindResult::class.java,
+        root.get(Key_.id),
+        namespace.get(Namespace_.name),
+        root.get(Key_.name),
+        branch.get(Branch_.name),
+      ),
     )
     return query
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/export/dataProvider/ExportDataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/export/dataProvider/ExportDataProvider.kt
@@ -71,18 +71,21 @@ class ExportDataProvider(
   }
 
   private fun addSelect() {
-    query.multiselect(
-      key.get(Key_.id),
-      key.get(Key_.name),
-      keyMetaJoin.get(KeyMeta_.custom),
-      keyMetaJoin.get(KeyMeta_.description),
-      namespaceJoin.get(Namespace_.name),
-      key.get(Key_.isPlural),
-      languageJoin.get(Language_.id),
-      languageJoin.get(Language_.tag),
-      translationJoin.get(Translation_.id),
-      translationJoin.get(Translation_.text),
-      translationJoin.get(Translation_.state),
+    query.select(
+      cb.construct(
+        ExportDataView::class.java,
+        key.get(Key_.id),
+        key.get(Key_.name),
+        keyMetaJoin.get(KeyMeta_.custom),
+        keyMetaJoin.get(KeyMeta_.description),
+        namespaceJoin.get(Namespace_.name),
+        key.get(Key_.isPlural),
+        languageJoin.get(Language_.id),
+        languageJoin.get(Language_.tag),
+        translationJoin.get(Translation_.id),
+        translationJoin.get(Translation_.text),
+        translationJoin.get(Translation_.state),
+      ),
     )
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/invitation/InvitationService.kt
@@ -217,8 +217,7 @@ class InvitationService(
   }
 
   fun findById(id: Long): Optional<Invitation> {
-    @Suppress("UNCHECKED_CAST")
-    return invitationRepository.findById(id) as Optional<Invitation>
+    return invitationRepository.findById(id)
   }
 
   fun getForProject(project: Project): Set<Invitation> {

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/KeyMetaService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/KeyMetaService.kt
@@ -101,6 +101,7 @@ class KeyMetaService(
     return result
   }
 
+  @Suppress("UNCHECKED_CAST")
   fun getWithFetchedData(project: Project): List<KeyMeta> {
     var result: List<KeyMeta> =
       entityManager

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/ResolvingKeyImporter.kt
@@ -88,7 +88,7 @@ class ResolvingKeyImporter(
           if (validate(translationExists, resolvable, key, language.tag)) return@translations
 
           if (language.base) {
-            if (isNew || existingTranslation?.text != resolvable.text) {
+            if (isNew || existingTranslation.text != resolvable.text) {
               outdatedKeys.add(key.id)
             }
           }
@@ -106,7 +106,7 @@ class ResolvingKeyImporter(
           }
 
           if (isEmpty || (!isNew && resolvable.resolution == ImportTranslationResolution.OVERRIDE)) {
-            translationsToModify.add(TranslationToModify(existingTranslation!!, resolvable.text, false))
+            translationsToModify.add(TranslationToModify(existingTranslation, resolvable.text, false))
             return@translations
           }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeyInfoProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/key/utils/KeyInfoProvider.kt
@@ -29,6 +29,7 @@ class KeyInfoProvider(
   private val screenshotService: ScreenshotService = applicationContext.getBean(ScreenshotService::class.java)
   private val translationService: TranslationService = applicationContext.getBean(TranslationService::class.java)
 
+  @Suppress("UNCHECKED_CAST")
   fun get(): List<Pair<Key, List<Screenshot>>> {
     val cb: CriteriaBuilder = entityManager.criteriaBuilder
     val query = cb.createQuery(Key::class.java)

--- a/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/language/LanguageService.kt
@@ -434,6 +434,7 @@ class LanguageService(
 
   @Cacheable(Caches.LANGUAGES, key = "#projectId")
   @Transactional
+  @Suppress("UNCHECKED_CAST")
   fun getProjectLanguages(projectId: Long): List<LanguageDto> {
     val cache = cacheManager.getCache(Caches.LANGUAGES)
     val list =

--- a/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/project/ProjectStatsService.kt
@@ -47,10 +47,12 @@ class ProjectStatsService(
     val branch = keys.join(Key_.branch, JoinType.LEFT)
     val keyCountSelect = cb.countDistinct(keys)
     val languageCountSelect = cb.countDistinct(languages)
-    query.multiselect(
-      root.get(Project_.id),
-      keyCountSelect,
-      languageCountSelect,
+    query.select(
+      cb.tuple(
+        root.get(Project_.id),
+        keyCountSelect,
+        languageCountSelect,
+      ),
     )
     query.where(
       cb.and(

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/LanguageStatsProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/LanguageStatsProvider.kt
@@ -64,6 +64,7 @@ class LanguageStatsProvider(
       query.setParameter("branchId", branchId)
     }
 
+    @Suppress("UNCHECKED_CAST")
     return (query.resultList as List<Array<Any?>>).map { row ->
       ProjectLanguageStatsResultView(
         projectId = (row[0] as Number).toLong(),

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/ProjectStatsProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/ProjectStatsProvider.kt
@@ -48,7 +48,7 @@ open class ProjectStatsProvider(
         getTaskCountSelection(),
       )
 
-    query.multiselect(selection)
+    query.select(cb.construct(ProjectStatsView::class.java, *selection.toTypedArray()))
 
     query.groupBy(project.get(Project_.id))
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/CursorPredicateProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/CursorPredicateProvider.kt
@@ -110,7 +110,7 @@ class CursorPredicateProvider(
 
     return when (javaType) {
       String::class.java -> raw as Comparable<Any>
-      java.lang.Long::class.java -> raw.toLong() as Comparable<Any>
+      Long::class.javaObjectType -> raw.toLong() as Comparable<Any>
       java.sql.Timestamp::class.java -> java.sql.Timestamp(raw.toLong()) as Comparable<Any>
       java.util.Date::class.java -> java.util.Date(raw.toLong()) as Comparable<Any>
       else -> throw IllegalArgumentException("Cannot parse value for type $javaType")

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
@@ -265,6 +265,7 @@ class QueryGlobalFiltering(
     )
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun filterUntranslatedAny() {
     if (params.filterUntranslatedAny != true) return
     val selectedLangIds = queryBase.languages.map { it.id }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
@@ -289,7 +289,7 @@ class QueryGlobalFiltering(
     val cteQuery = cb.createTupleQuery()
     val tRoot = cteQuery.from(Translation::class.java)
     val keyIdPath = tRoot.get(Translation_.key).get(Key_.id)
-    cteQuery.multiselect(keyIdPath.alias("keyId"))
+    cteQuery.select(cb.tuple(keyIdPath.alias("keyId")))
     cteQuery.where(
       cb.and(
         tRoot.get(Translation_.language).get(Language_.id).`in`(selectedLangIds),
@@ -300,7 +300,7 @@ class QueryGlobalFiltering(
     cteQuery.groupBy(keyIdPath)
     cteQuery.having(cb.equal(cb.count(tRoot), cb.literal(selectedLangIds.size.toLong())))
 
-    val cte = (queryBase.query as JpaCteContainer).with(cteQuery)
+    val cte = (queryBase.query as JpaCteContainer).with("fullyTranslatedKeys", cteQuery)
     cte.setMaterialization(CteMaterialization.MATERIALIZED)
     return cte
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/StateFilterBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/StateFilterBuilder.kt
@@ -101,6 +101,7 @@ internal class StateFilterBuilder(
    * For state sets **without UNTRANSLATED**: a single correlated EXISTS checks if any row
    * matches the requested (lang, state) pair — no missing-row handling needed.
    */
+  @Suppress("UNCHECKED_CAST")
   private fun homogeneousStateCountPredicate(
     languages: List<LanguageDto>,
     states: Set<TranslationState>,

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/StateFilterBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/StateFilterBuilder.kt
@@ -228,7 +228,7 @@ internal class StateFilterBuilder(
     val cteQuery = cb.createTupleQuery()
     val tRoot = cteQuery.from(Translation::class.java)
     val keyIdPath = tRoot.get(Translation_.key).get(Key_.id)
-    cteQuery.multiselect(keyIdPath.alias("keyId"))
+    cteQuery.select(cb.tuple(keyIdPath.alias("keyId")))
     cteQuery.where(
       cb.and(
         tRoot.get(Translation_.language).get(Language_.id).`in`(langIds),

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
@@ -62,7 +62,7 @@ class TranslationsViewQueryBuilder(
       val query = cb.createQuery(Array<Any?>::class.java)
       val queryBase = getBaseQuery(query)
       val paths = queryBase.querySelection.values.toTypedArray()
-      query.multiselect(*paths)
+      query.select(cb.array(*paths))
       val orderList = getOrderList(queryBase)
 
       query.where(*getWhereConditions(queryBase).toTypedArray())

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/AutoTranslationService.kt
@@ -380,7 +380,7 @@ class AutoTranslationService(
     if (!hasDefault) {
       return (list ?: listOf()) + listOf(AutoTranslationConfig().also { it.project = project })
     }
-    return list!!
+    return list
   }
 
   fun getConfigs(

--- a/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/translation/TranslationService.kt
@@ -743,7 +743,7 @@ class TranslationService(
       )
     }
 
-    query.multiselect(keyRoot.get(Key_.id), langJoin.get(Language_.id))
+    query.select(cb.tuple(keyRoot.get(Key_.id), langJoin.get(Language_.id)))
     query.where(*predicates.toTypedArray())
 
     return entityManager.createQuery(query).resultList.map { tuple ->

--- a/backend/data/src/main/kotlin/io/tolgee/util/entityPreCommitEventUsageUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/entityPreCommitEventUsageUtil.kt
@@ -46,7 +46,7 @@ fun EntityPreCommitEvent<*>.getUsageIncreaseAmount(): Long {
 private fun OnEntityPreUpdate<*>.getSoftDeleteUsageChange(): Long {
   val current = entity
   if (current !is SoftDeletable || propertyNames == null || previousState == null) return 0
-  val deletedAtIndex = propertyNames!!.indexOf("deletedAt")
+  val deletedAtIndex = propertyNames.indexOf("deletedAt")
   if (deletedAtIndex < 0) return 0
   @Suppress("UNCHECKED_CAST")
   val oldValue = (previousState as Array<Any?>)[deletedAtIndex]

--- a/backend/data/src/main/kotlin/io/tolgee/util/transactionUtil.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/transactionUtil.kt
@@ -22,7 +22,7 @@ fun <T> executeInNewTransaction(
 
   return tt.execute { ts ->
     fn(ts)
-  } as T
+  }
 }
 
 fun <T> executeInNewTransaction(

--- a/backend/data/src/main/kotlin/io/tolgee/util/updateStringsInJson.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/updateStringsInJson.kt
@@ -28,8 +28,8 @@ fun updateStringsInJson(
       arrayNode
     }
 
-    node.isTextual -> {
-      StringNode(fn(node.asText()))
+    node.isString -> {
+      StringNode(fn(node.asString()))
     }
 
     else -> node // Return unchanged for non-string nodes (e.g., numbers, booleans, null)

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/AzureContentStorageConfigCachePurgingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/AzureContentStorageConfigCachePurgingTest.kt
@@ -22,6 +22,7 @@ import org.springframework.web.client.RestTemplate
 
 class AzureContentStorageConfigCachePurgingTest {
   @Test
+  @Suppress("UNCHECKED_CAST")
   fun `correctly purges`() {
     val config =
       object : AzureFrontDoorConfig {

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/BunnyContentStorageConfigCachePurgingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/BunnyContentStorageConfigCachePurgingTest.kt
@@ -21,6 +21,7 @@ import java.net.URI
 
 class BunnyContentStorageConfigCachePurgingTest {
   @Test
+  @Suppress("UNCHECKED_CAST")
   fun `correctly purges`() {
     val config =
       ContentDeliveryBunnyProperties(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/CloudflareContentStorageConfigCachePurgingTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/cachePurging/CloudflareContentStorageConfigCachePurgingTest.kt
@@ -23,6 +23,7 @@ import org.springframework.web.client.RestTemplate
 
 class CloudflareContentStorageConfigCachePurgingTest {
   @Test
+  @Suppress("UNCHECKED_CAST")
   fun `correctly purges`() {
     val config =
       ContentDeliveryCloudflareProperties(

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/MessagePatternUtilTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/MessagePatternUtilTest.kt
@@ -40,6 +40,22 @@ class MessagePatternUtilTest {
   }
 
   @Test
+  fun `renders arg node without style with no trailing comma`() {
+    MessagePatternUtil
+      .buildMessageNode("Hello, {hello, number}!")
+      .contents[1]
+      .toString()
+      .assert
+      .isEqualTo("{hello,number}")
+    MessagePatternUtil
+      .buildMessageNode("Hello, {hello, number, scientific}!")
+      .contents[1]
+      .toString()
+      .assert
+      .isEqualTo("{hello,number, scientific}")
+  }
+
+  @Test
   fun `returns correct pattern strings with arg node with style`() {
     MessagePatternUtil
       .buildMessageNode("Hello, {hello, number, scientific}!")

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/properties/out/PropertiesFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/properties/out/PropertiesFileExporterTest.kt
@@ -157,7 +157,7 @@ class PropertiesFileExporterTest {
       filePathProvider =
         ExportFilePathProvider(
           template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-          extension = params.format?.extension ?: "properties",
+          extension = params.format.extension,
         ),
     )
   }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/resx/out/ResxExporterTest.kt
@@ -277,7 +277,7 @@ class ResxExporterTest {
       pathProvider =
         ExportFilePathProvider(
           template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-          extension = params.format?.extension ?: "resx",
+          extension = params.format.extension,
         ),
     )
   }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/xliff/out/XliffFileExporterTest.kt
@@ -51,7 +51,7 @@ class XliffFileExporterTest {
         filePathProvider =
           ExportFilePathProvider(
             template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-            extension = params.format?.extension ?: "xliff",
+            extension = params.format.extension,
           ),
       ).produceFiles()
 
@@ -129,7 +129,7 @@ class XliffFileExporterTest {
         filePathProvider =
           ExportFilePathProvider(
             template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-            extension = params.format?.extension ?: "xliff",
+            extension = params.format.extension,
           ),
       ).produceFiles()
 
@@ -176,7 +176,7 @@ class XliffFileExporterTest {
                   ),
                 ),
               ).validateAndGetTemplate(),
-            extension = params.format?.extension ?: "xliff",
+            extension = params.format.extension,
           ),
       ).produceFiles()
 
@@ -270,7 +270,7 @@ class XliffFileExporterTest {
         filePathProvider =
           ExportFilePathProvider(
             template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-            extension = params.format?.extension ?: "xliff",
+            extension = params.format.extension,
           ),
       ).produceFiles()
 

--- a/backend/data/src/test/kotlin/io/tolgee/unit/formats/yaml/out/YamlExportTestData.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/formats/yaml/out/YamlExportTestData.kt
@@ -104,7 +104,7 @@ object YamlExportTestData {
       filePathProvider =
         ExportFilePathProvider(
           template = ExportFileStructureTemplateProvider(params, translations).validateAndGetTemplate(),
-          extension = params.format?.extension ?: "yaml",
+          extension = params.format.extension,
         ),
     )
   }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/xlsx/out/XlsxFileExporterTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/xlsx/out/XlsxFileExporterTest.kt
@@ -14,7 +14,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import java.util.Calendar
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Date
 
 class XlsxFileExporterTest {
@@ -22,7 +23,7 @@ class XlsxFileExporterTest {
 
   @BeforeEach
   fun setup() {
-    val now = Date(Date.UTC(2025 - 1900, Calendar.JANUARY, 10, 0, 0, 0))
+    val now = Date.from(LocalDate.of(2025, 1, 10).atStartOfDay(ZoneOffset.UTC).toInstant())
     Mockito.`when`(currentDateProvider.date).thenReturn(now)
   }
 

--- a/backend/development/src/main/kotlin/io/tolgee/facade/InternalPropertiesSetterFacade.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/facade/InternalPropertiesSetterFacade.kt
@@ -12,6 +12,7 @@ import kotlin.reflect.full.hasAnnotation
 
 @Component
 class InternalPropertiesSetterFacade {
+  @Suppress("UNCHECKED_CAST")
   fun setProperty(
     root: Any,
     setPropertyDto: SetPropertyDto,

--- a/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/rules/JakartaTransientInEntities.kt
+++ b/backend/ktlint/src/main/kotlin/io/tolgee/testing/ktlint/rules/JakartaTransientInEntities.kt
@@ -21,7 +21,6 @@ import com.pinterest.ktlint.rule.engine.core.api.ElementType
 import com.pinterest.ktlint.rule.engine.core.api.Rule
 import com.pinterest.ktlint.rule.engine.core.api.RuleAutocorrectApproveHandler
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
-import com.pinterest.ktlint.rule.engine.core.api.children
 import com.pinterest.ktlint.rule.engine.core.api.children20
 import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 
@@ -50,9 +49,9 @@ class JakartaTransientInEntities :
 
       ElementType.ANNOTATION_ENTRY -> {
         node
-          .children()
+          .children20
           .find { it.elementType == ElementType.CONSTRUCTOR_CALLEE }
-          ?.children()
+          ?.children20
           ?.toList()
           ?.find { it.elementType == ElementType.TYPE_REFERENCE }
           ?.let {

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/MachineTranslationTest.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/MachineTranslationTest.kt
@@ -56,7 +56,7 @@ open class MachineTranslationTest : ProjectAuthControllerTest("/v2/projects/") {
       keyService.get(this.id).translations.find {
         it.language == lang
       } ?: throw IllegalStateException("Translation not found")
-    }!!
+    }
   }
 
   protected fun createAnotherThisIsBeautifulKey() {

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/MimeMessageParser.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/MimeMessageParser.kt
@@ -89,9 +89,10 @@ open class MimeMessageParser(
      * @throws Exception determining the recipients failed
      */
     get() {
-      val recipients: Array<jakarta.mail.Address> =
+      val recipients: Array<jakarta.mail.Address>? =
         mimeMessage.getRecipients(jakarta.mail.Message.RecipientType.TO)
-      return if (recipients != null) listOf(*recipients) else ArrayList<jakarta.mail.Address>()
+      recipients ?: return emptyList()
+      return listOf(*recipients)
     }
 
   @get:Throws(Exception::class)
@@ -101,9 +102,10 @@ open class MimeMessageParser(
      * @throws Exception determining the recipients failed
      */
     get() {
-      val recipients: Array<jakarta.mail.Address> =
+      val recipients: Array<jakarta.mail.Address>? =
         mimeMessage.getRecipients(jakarta.mail.Message.RecipientType.CC)
-      return if (recipients != null) listOf(*recipients) else ArrayList<jakarta.mail.Address>()
+      recipients ?: return emptyList()
+      return listOf(*recipients)
     }
 
   @get:Throws(Exception::class)
@@ -113,9 +115,10 @@ open class MimeMessageParser(
      * @throws Exception determining the recipients failed
      */
     get() {
-      val recipients: Array<jakarta.mail.Address> =
+      val recipients: Array<jakarta.mail.Address>? =
         mimeMessage.getRecipients(jakarta.mail.Message.RecipientType.BCC)
-      return if (recipients != null) listOf(*recipients) else ArrayList<jakarta.mail.Address>()
+      recipients ?: return emptyList()
+      return listOf(*recipients)
     }
 
   @get:Throws(Exception::class)
@@ -125,12 +128,9 @@ open class MimeMessageParser(
      * @throws Exception parsing the mime message failed
      */
     get() {
-      val addresses: Array<jakarta.mail.Address> = mimeMessage.from
-      return if (addresses == null || addresses.size == 0) {
-        null
-      } else {
-        (addresses[0] as jakarta.mail.internet.InternetAddress).address
-      }
+      val addresses: Array<jakarta.mail.Address>? = mimeMessage.from
+      if (addresses.isNullOrEmpty()) return null
+      return (addresses[0] as jakarta.mail.internet.InternetAddress).address
     }
 
   @get:Throws(Exception::class)
@@ -140,12 +140,9 @@ open class MimeMessageParser(
      * @throws Exception parsing the mime message failed
      */
     get() {
-      val addresses: Array<jakarta.mail.Address> = mimeMessage.replyTo
-      return if (addresses == null || addresses.size == 0) {
-        null
-      } else {
-        (addresses[0] as jakarta.mail.internet.InternetAddress).address
-      }
+      val addresses: Array<jakarta.mail.Address>? = mimeMessage.replyTo
+      if (addresses.isNullOrEmpty()) return null
+      return (addresses[0] as jakarta.mail.internet.InternetAddress).address
     }
 
   @get:Throws(Exception::class)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
@@ -127,7 +127,7 @@ class QaCheckPreviewWebSocketHandler(
       return
     }
 
-    val text = json.get("text")?.asText() ?: ""
+    val text = json.get("text")?.asString() ?: ""
 
     state.cancelAndSetJob {
       scope.launch { runChecks(session, state, text) }
@@ -140,14 +140,14 @@ class QaCheckPreviewWebSocketHandler(
   ) {
     try {
       val token =
-        json.get("token")?.asText()
+        json.get("token")?.asString()
           ?: throw IllegalArgumentException("Missing token")
       val projectId =
         json.get("projectId")?.asLong()
           ?: throw IllegalArgumentException("Missing projectId")
       val keyId = json.get("keyId")?.asLong()
       val languageTag =
-        json.get("languageTag")?.asText()
+        json.get("languageTag")?.asString()
           ?: throw IllegalArgumentException("Missing languageTag")
 
       checkAuth(token, projectId)

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/controllers/qa/QaCheckPreviewWebSocketHandler.kt
@@ -127,7 +127,8 @@ class QaCheckPreviewWebSocketHandler(
       return
     }
 
-    val text = json.get("text")?.asString() ?: ""
+    // asString() throws on objects and arrays, and handleTextMessage doesn't catch
+    val text = json.get("text")?.takeIf { it.isValueNode }?.asString() ?: ""
 
     state.cancelAndSetJob {
       scope.launch { runChecks(session, state, text) }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/TaskModelAssembler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/TaskModelAssembler.kt
@@ -36,7 +36,7 @@ class TaskModelAssembler(
         },
       dueDate = entity.dueDate?.time,
       assignees = entity.assignees.map { simpleUserAccountModelAssembler.toModel(it) }.toMutableSet(),
-      author = entity.author?.let { simpleUserAccountModelAssembler.toModel(it) },
+      author = simpleUserAccountModelAssembler.toModel(entity.author),
       createdAt = entity.createdAt?.time,
       closedAt = entity.closedAt?.time,
       totalItems = entity.totalItems,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/TaskWithProjectModelAssembler.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/api/v2/hateoas/assemblers/TaskWithProjectModelAssembler.kt
@@ -38,7 +38,7 @@ class TaskWithProjectModelAssembler(
         },
       dueDate = entity.dueDate?.time,
       assignees = entity.assignees.map { simpleUserAccountModelAssembler.toModel(it) }.toMutableSet(),
-      author = entity.author?.let { simpleUserAccountModelAssembler.toModel(it) },
+      author = simpleUserAccountModelAssembler.toModel(entity.author),
       createdAt = entity.createdAt?.time,
       closedAt = entity.closedAt?.time,
       totalItems = entity.totalItems,

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/OpenaiApiService.kt
@@ -79,7 +79,7 @@ class OpenaiApiService :
       } catch (e: HttpClientErrorException) {
         if (e.statusCode == HttpStatus.BAD_REQUEST) {
           val body = parseErrorBody(e)
-          if (body?.get("error")?.get("code")?.asText() == "content_filter") {
+          if (body?.get("error")?.get("code")?.asString() == "content_filter") {
             throw LlmContentFilterException()
           }
         }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/TolgeeApiService.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/component/llm/TolgeeApiService.kt
@@ -53,7 +53,7 @@ class TolgeeApiService(
         extractTolgeeErrorOrThrow(e)
       }
 
-    return response?.body ?: throw FailedDependencyException(Message.LLM_PROVIDER_ERROR, listOf("Empty response body"))
+    return response.body ?: throw FailedDependencyException(Message.LLM_PROVIDER_ERROR, listOf("Empty response body"))
   }
 
   fun extractTolgeeErrorOrThrow(e: BadRequest): Nothing {
@@ -63,8 +63,8 @@ class TolgeeApiService(
           .runCatching {
             jacksonObjectMapper().readValue(e.responseBodyAsString, JsonNode::class.java)
           }.getOrNull()
-      val eCode = json?.get("code")?.runCatching { this.asText() }?.getOrNull()
-      val eParams = json?.get("params")?.runCatching { this.asIterable().map { it.asText() } }?.getOrNull()
+      val eCode = json?.get("code")?.runCatching { this.asString() }?.getOrNull()
+      val eParams = json?.get("params")?.runCatching { this.asIterable().map { it.asString() } }?.getOrNull()
       val message = eCode?.runCatching { Message.valueOf(this.uppercase()) }?.getOrNull()
       message?.let { throw FailedDependencyException(message, params = eParams, e) }
     }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/development/QaLanguageStatsBranchTestData.kt
@@ -9,15 +9,15 @@ import io.tolgee.model.key.Key
 import io.tolgee.model.translation.Translation
 
 class QaLanguageStatsBranchTestData : BaseTestData() {
-  lateinit var frenchLanguage: Language
+  var frenchLanguage: Language
 
-  lateinit var mainBranch: Branch
-  lateinit var featureBranch: Branch
+  var mainBranch: Branch
+  var featureBranch: Branch
 
-  lateinit var mainKey: Key
+  var mainKey: Key
   lateinit var mainFrTranslation: Translation
 
-  lateinit var featureKey: Key
+  var featureKey: Key
   lateinit var featureFrTranslation: Translation
 
   init {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/security/thirdParty/SsoDelegateEe.kt
@@ -64,7 +64,7 @@ class SsoDelegateEe(
       .build()
 
   override fun getTokenResponse(
-    code: String?,
+    receivedCode: String?,
     invitationCode: String?,
     redirectUri: String?,
     domain: String?,
@@ -80,7 +80,7 @@ class SsoDelegateEe(
     )
 
     val token =
-      fetchToken(tenant, code, redirectUri)
+      fetchToken(tenant, receivedCode, redirectUri)
         ?: throw SsoAuthorizationException(Message.SSO_TOKEN_EXCHANGE_FAILED)
     val idToken =
       token.id_token

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptResultParser.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptResultParser.kt
@@ -14,8 +14,8 @@ class PromptResultParser(
 ) {
   fun parse(): ParsedResult {
     val json = extractJsonFromResponse(promptResult.response)
-    val output = json?.get("output")?.asString() ?: throw LlmProviderNotReturnedJsonException()
-    val contextDescription = json.get("contextDescription")?.asString()
+    val output = json?.get("output")?.asScalarString() ?: throw LlmProviderNotReturnedJsonException()
+    val contextDescription = json.get("contextDescription")?.asScalarString()
 
     return ParsedResult(
       promptResult = promptResult,
@@ -23,6 +23,12 @@ class PromptResultParser(
       parsedJson = json,
       contextDescription = contextDescription,
     )
+  }
+
+  // asString() throws on objects and arrays, so a wrong-shaped field would escape as JsonNodeException
+  private fun JsonNode.asScalarString(): String {
+    if (!isValueNode) throw LlmProviderNotReturnedJsonException()
+    return asString()
   }
 
   private fun extractJsonFromResponse(content: String): JsonNode? {

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptResultParser.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/service/prompt/PromptResultParser.kt
@@ -14,8 +14,8 @@ class PromptResultParser(
 ) {
   fun parse(): ParsedResult {
     val json = extractJsonFromResponse(promptResult.response)
-    val output = json?.get("output")?.asText() ?: throw LlmProviderNotReturnedJsonException()
-    val contextDescription = json.get("contextDescription")?.asText()
+    val output = json?.get("output")?.asString() ?: throw LlmProviderNotReturnedJsonException()
+    val contextDescription = json.get("contextDescription")?.asString()
 
     return ParsedResult(
       promptResult = promptResult,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/WebhookAutomationTest.kt
@@ -130,6 +130,7 @@ class WebhookAutomationTest : ProjectAuthControllerTest("/v2/projects/") {
     )
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun verifyWebhookExecuted(
     testData: WebhooksTestData,
     webhookTriggeringCallback: () -> Unit,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/CommunitySuggestionTest.kt
@@ -149,7 +149,7 @@ class CommunitySuggestionTest : ProjectAuthControllerTest("/v2/projects/") {
     val translationId =
       transactionTemplate.execute {
         translationService.find(testData.keys[0].self, testData.czechLanguage).get().id
-      }!!
+      }
 
     userAccount = testData.communityUser.self
     performProjectAuthGet("activity").andIsOk.andAssertThatJson {
@@ -173,7 +173,7 @@ class CommunitySuggestionTest : ProjectAuthControllerTest("/v2/projects/") {
     val translationId =
       transactionTemplate.execute {
         translationService.find(testData.keys[0].self, testData.czechLanguage).get().id
-      }!!
+      }
 
     userAccount = testData.communityUser.self
     performProjectAuthGet("translations/$translationId/comments").andIsOk.andAssertThatJson {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/activity/ProjectActivityBranchingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/activity/ProjectActivityBranchingTest.kt
@@ -112,6 +112,7 @@ class ProjectActivityBranchingTest : ProjectAuthControllerTest("/v2/projects/") 
     expectedMain.assert.containsAll(apiMain)
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun getRevisionIds(url: String): Set<Long> {
     val response = performProjectAuthGet(url).andIsOk.andReturn()
     val body = response.mapResponseTo<Map<String, Any?>>()
@@ -139,6 +140,7 @@ class ProjectActivityBranchingTest : ProjectAuthControllerTest("/v2/projects/") 
       .toSet()
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun getModifiedEntitiesFromApi(
     revisionId: Long,
     branchName: String,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerMergingTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/branching/BranchControllerMergingTest.kt
@@ -479,6 +479,7 @@ class BranchControllerMergingTest : ProjectAuthControllerTest("/v2/projects/") {
     return (response["id"] as Number).toLong()
   }
 
+  @Suppress("UNCHECKED_CAST")
   private fun getFirstConflictId(mergeId: Long): Long {
     val response =
       performProjectAuthGet("branches/merge/$mergeId/conflicts")

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerActivityTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskControllerActivityTest.kt
@@ -175,6 +175,7 @@ class TaskControllerActivityTest : ProjectAuthControllerTest("/v2/projects/") {
     }
   }
 
+  @Suppress("UNCHECKED_CAST")
   fun PropertyModification.toLongLists(): Pair<List<Long>?, List<Long>> {
     return (this.old as List<Int>?)?.map { it.toLong() } to (this.new as List<Int>).map { it.toLong() }
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/translationMemory/SharedTranslationMemoryControllerTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/translationMemory/SharedTranslationMemoryControllerTest.kt
@@ -214,12 +214,12 @@ class SharedTranslationMemoryControllerTest : AuthorizedControllerTest() {
     val tms = tree.at("/_embedded/translationMemories")
 
     // Find shared TM by name (array order is not guaranteed)
-    val sharedTm = (0 until tms.size()).map { tms[it] }.first { it["name"].asText() == "Shared Marketing TM" }
+    val sharedTm = (0 until tms.size()).map { tms[it] }.first { it["name"].asString() == "Shared Marketing TM" }
     assertThat(sharedTm["assignedProjectNames"].size()).isEqualTo(1)
-    assertThat(sharedTm["assignedProjectNames"][0].asText()).isEqualTo("Project With TM")
+    assertThat(sharedTm["assignedProjectNames"][0].asString()).isEqualTo("Project With TM")
 
     // Unassigned TM
-    val unassigned = (0 until tms.size()).map { tms[it] }.first { it["name"].asText() == "Unassigned Shared TM" }
+    val unassigned = (0 until tms.size()).map { tms[it] }.first { it["name"].asString() == "Unassigned Shared TM" }
     assertThat(unassigned["assignedProjectNames"].size()).isEqualTo(0)
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/data/qa/QaPreviewWsSessionStateTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/data/qa/QaPreviewWsSessionStateTest.kt
@@ -42,7 +42,7 @@ class QaPreviewWsSessionStateTest {
 
   @Test
   fun `tryAcceptMessage rejects messages exceeding rate limit`() {
-    repeat(QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW.toInt()) {
+    repeat(QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW) {
       state.tryAcceptMessage()
     }
 
@@ -51,7 +51,7 @@ class QaPreviewWsSessionStateTest {
 
   @Test
   fun `tryAcceptMessage resets after time window expires`() {
-    repeat(QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW.toInt()) {
+    repeat(QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW) {
       state.tryAcceptMessage()
     }
     assertThat(state.tryAcceptMessage()).isFalse()
@@ -91,7 +91,7 @@ class QaPreviewWsSessionStateTest {
 
     assertThat(acceptedCount.get() + rejectedCount.get()).isEqualTo(threadCount)
     assertThat(acceptedCount.get()).isLessThanOrEqualTo(
-      QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW.toInt(),
+      QaPreviewWsSessionState.MAX_MESSAGES_PER_WINDOW,
     )
     assertThat(rejectedCount.get()).isGreaterThan(0)
   }

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/mcp/McpBranchToolsTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/mcp/McpBranchToolsTest.kt
@@ -41,7 +41,7 @@ class McpBranchToolsTest : AbstractMcpTest() {
     val json = callToolAndGetJson(client, "list_branches")
     assertThat(json["items"].isArray).isTrue()
     assertThat(json["totalItems"].asLong()).isGreaterThanOrEqualTo(1)
-    val branchNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val branchNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(branchNames).contains("main")
   }
 
@@ -61,7 +61,7 @@ class McpBranchToolsTest : AbstractMcpTest() {
     val json = callToolAndGetJson(client, "list_branches", mapOf("projectId" to data.projectId))
     assertThat(json["items"].isArray).isTrue()
     assertThat(json["totalItems"].asLong()).isGreaterThanOrEqualTo(1)
-    val branchNames = (0 until json["items"].size()).map { json["items"][it]["name"].asText() }
+    val branchNames = (0 until json["items"].size()).map { json["items"][it]["name"].asString() }
     assertThat(branchNames).contains("main")
   }
 
@@ -80,7 +80,7 @@ class McpBranchToolsTest : AbstractMcpTest() {
         ),
       )
     assertThat(json["id"].asLong()).isGreaterThan(0)
-    assertThat(json["name"].asText()).isEqualTo("feature-branch")
+    assertThat(json["name"].asString()).isEqualTo("feature-branch")
     assertThat(json["isDefault"].asBoolean()).isFalse()
 
     // Verify via service

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/projectExportImport/ProjectExportImportImporterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/projectExportImport/ProjectExportImportImporterTest.kt
@@ -125,7 +125,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
           entityManager
             .createQuery(
               "select coalesce(max(t.number), 0) from Task t where t.project.id = :p",
-              java.lang.Long::class.java,
+              Long::class.javaObjectType,
             ).setParameter("p", target.targetProject.id)
             .singleResult
             .toLong()
@@ -560,7 +560,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
         entityManager
           .createQuery(
             "select t.promptId from Translation t where t.key.project.id = :p and t.text = 'Hello'",
-            java.lang.Long::class.java,
+            Long::class.javaObjectType,
           ).setParameter("p", target.targetProject.id)
           .resultList
       }
@@ -737,7 +737,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
       entityManager
         .createQuery(
           "select k.id from Key k where k.project.id = :p and k.name = :n and k.branch.name = :b",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("p", projectId)
         .setParameter("n", keyName)
         .setParameter("b", branchName)
@@ -786,7 +786,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
   ): Long =
     readInTransaction {
       entityManager
-        .createQuery("select k.id from Key k where k.project.id = :p and k.name = :n", java.lang.Long::class.java)
+        .createQuery("select k.id from Key k where k.project.id = :p and k.name = :n", Long::class.javaObjectType)
         .setParameter("p", projectId)
         .setParameter("n", name)
         .singleResult
@@ -1059,7 +1059,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
       entityManager
         .createQuery(
           "select count(tk) from TaskKey tk where tk.task.project.id = :p and tk.task.name = :n",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("p", projectId)
         .setParameter("n", taskName)
         .singleResult
@@ -1071,7 +1071,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
       entityManager
         .createQuery(
           "select count(distinct r.screenshot) from KeyScreenshotReference r where r.key.project.id = :p",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("p", projectId)
         .singleResult
         .toLong()
@@ -1082,7 +1082,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
       entityManager
         .createQuery(
           "select count(r) from KeyScreenshotReference r where r.key.project.id = :p",
-          java.lang.Long::class.java,
+          Long::class.javaObjectType,
         ).setParameter("p", projectId)
         .singleResult
         .toLong()
@@ -1102,7 +1102,7 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
   private fun branchCount(projectId: Long): Long =
     readInTransaction {
       entityManager
-        .createQuery("select count(b) from Branch b where b.project.id = :p", java.lang.Long::class.java)
+        .createQuery("select count(b) from Branch b where b.project.id = :p", Long::class.javaObjectType)
         .setParameter("p", projectId)
         .singleResult
         .toLong()
@@ -1191,11 +1191,10 @@ class ProjectExportImportImporterTest : AbstractSpringTest() {
         .createQuery(
           "select t.qaChecksStale from Translation t " +
             "where t.key.project.id = :p and t.key.name = :k and t.language.tag = 'en'",
-          java.lang.Boolean::class.java,
+          Boolean::class.javaObjectType,
         ).setParameter("p", projectId)
         .setParameter("k", keyName)
         .singleResult
-        .booleanValue()
     }
 
   private fun keyBranchName(

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/PromptResultParserTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/PromptResultParserTest.kt
@@ -1,0 +1,57 @@
+package io.tolgee.ee.unit
+
+import io.tolgee.dtos.PromptResult
+import io.tolgee.ee.service.prompt.PromptResultParser
+import io.tolgee.exceptions.LlmProviderNotReturnedJsonException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+class PromptResultParserTest {
+  private val objectMapper = jacksonObjectMapper()
+
+  private fun parse(response: String) = PromptResultParser(PromptResult(response, null), objectMapper).parse()
+
+  @Test
+  fun `parses scalar output and contextDescription`() {
+    val result = parse("""{"output": "Ahoj", "contextDescription": "greeting"}""")
+    assertThat(result.output).isEqualTo("Ahoj")
+    assertThat(result.contextDescription).isEqualTo("greeting")
+  }
+
+  @Test
+  fun `leaves contextDescription null when absent`() {
+    assertThat(parse("""{"output": "Ahoj"}""").contextDescription).isNull()
+  }
+
+  @Test
+  fun `throws when output is missing`() {
+    assertThatThrownBy { parse("""{"contextDescription": "greeting"}""") }
+      .isInstanceOf(LlmProviderNotReturnedJsonException::class.java)
+  }
+
+  @Test
+  fun `throws when output is an object`() {
+    assertThatThrownBy { parse("""{"output": {"text": "Ahoj"}}""") }
+      .isInstanceOf(LlmProviderNotReturnedJsonException::class.java)
+  }
+
+  @Test
+  fun `throws when output is an array`() {
+    assertThatThrownBy { parse("""{"output": ["Ahoj"]}""") }
+      .isInstanceOf(LlmProviderNotReturnedJsonException::class.java)
+  }
+
+  @Test
+  fun `throws when contextDescription is an object`() {
+    assertThatThrownBy { parse("""{"output": "Ahoj", "contextDescription": {"a": 1}}""") }
+      .isInstanceOf(LlmProviderNotReturnedJsonException::class.java)
+  }
+
+  @Test
+  fun `throws when contextDescription is an array`() {
+    assertThatThrownBy { parse("""{"output": "Ahoj", "contextDescription": ["a"]}""") }
+      .isInstanceOf(LlmProviderNotReturnedJsonException::class.java)
+  }
+}


### PR DESCRIPTION
Cleans up the Kotlin compilation warnings left behind by the Spring Boot 4 / Kotlin 2.3 / Java 25 / Hibernate 7 / Jackson 3 upgrade.

**388 of 433 warnings are gone** across `:data`, `:api`, `:ee-app`, `:development`, `:server-app` and `:billing-app` — main and test sources. The remaining 45 are all uses of our own deliberately deprecated APIs (`Project.userOwner`, `MtCreditBucket.extraCredits`, `screenshotUploadedImageIds`, `createUsersAndOrganizations`); suppressing those was deliberately left out of this PR.

One commit per fix, so it can be reviewed group by group:

| Commit | What |
|---|---|
| drop `lateinit` | Kotlin 2.2 tracks definite assignment through `init` blocks |
| drop `@Temporal` | Deprecated in Jakarta Persistence 3.2; every usage was `TIMESTAMP` on a `java.util.Date`, which is the default, so column mapping is unchanged |
| Jackson 3 string accessors | `asText()`/`isTextual` → `asString()`/`isString` |
| Hibernate `Timeouts` | `LockOptions.SKIP_LOCKED`/`NO_WAIT` moved to `org.hibernate.Timeouts.*_MILLI` |
| `CriteriaQuery.multiselect` → `select` | `cb.construct` for projected views, `cb.tuple` for tuple queries, `cb.array` for `Object[]`; the unnamed `JpaCteContainer.with` is deprecated too, so the CTE gets an explicit name |
| native `text[]` mapping | Hypersistence deprecated `StringArrayType`/`ListArrayType` — Hibernate has supported ARRAY attributes since 6 |
| Hibernate 7 interceptor names | `onSave`/`onDelete` → `onPersist`/`onRemove` |
| deprecated Spring APIs | XML converter → `JacksonXmlHttpMessageConverter`, `CachingConfigurerSupport` → `CachingConfigurer`, Spring Batch 6 `chunk(size).transactionManager(...)` |
| remaining third-party APIs | AWS `DefaultCredentialsProvider`, Redisson `KeysScanOptions`, commons-lang3 `RandomStringUtils.secure()`, Sentry `User.name`, Spring Data `getReferenceById`, AssertJ `isCloseTo`, `java.util.Date.UTC`, ktlint `children20` |
| Kotlin boxed type literals | `java.lang.Long/Boolean::class.java` → `::class.javaObjectType` |
| suppressions | `PROPERTY_HIDES_JAVA_FIELD` on the pre-commit events, and unchecked casts over erased JPA results / cache entries / reflection / parsed test JSON |
| test fixes | duplicate lambda labels, and `"` in test method names (invalid in Windows report filenames) |
| redundant null handling | safe calls, `!!`, elvis fallbacks and casts the compiler now proves dead |

### Worth a closer look

Two warnings were hiding real problems rather than noise:

- **`MimeMessageParser`** pinned JavaMail platform types to non-null, which silently disabled its own null checks even though `getRecipients` and `getFrom` do return null. The locals are now nullable, so the checks work again.
- **`ValidationError`** cast a vararg `Array<out String>` to `Array<String>`; the property is now `Array<out String>`.

Two intentional behaviour deltas:

- `ExceptionHandlers` — `listOf(parameterName) as List<Serializable>?` → `listOfNotNull(...)`, so a null parameter name yields `[]` instead of `[null]`.
- Dead fallbacks removed where the receiver was provably non-null (`MtProviderCatching`'s `?: 100`, the two `ToIcuPlaceholderConvertor` escape paths) — unreachable before and after.

The `WebMvcConfigurer` message-converter callbacks deliberately stay on the deprecated `List` overload and are suppressed instead: the replacement `ServerBuilder` API bypasses Spring HATEOAS's HAL converter registration.

### Testing

- All 16 Kotlin compile tasks build with no errors.
- `:data` 481 tests and `:server-app` 300 tests pass, covering the behaviour-sensitive changes: MFA recovery codes and QuickStart (the `text[]` mapping), export and project stats and big meta (the `multiselect` rewrites), activity (interceptor rename), import, translations view/cursor, format convertors, cache purging and xlsx.
- Individual commits were not compiled in isolation, only the final state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON value handling across email validation, translation workflows, imports, exports, and integrations.
  - Corrected translation placeholder and message-format output in edge cases.
  - Improved batch-job locking, retry handling, and missing-recipient or validation-parameter handling.
  - Improved prompt result validation for missing or non-scalar values.
  - Improved XML message conversion and framework compatibility.

- **Security**
  - Invitation codes now use stronger secure random generation.

- **Refactor**
  - Updated persistence, cloud-provider, and framework integrations for improved compatibility and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->