### PR TITLE
fix: restore Jackson 2 handling of absent numeric fields

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebConfiguration.kt
@@ -79,6 +79,7 @@ class WebConfiguration(
   fun objectMapper(): JsonMapper {
     return jacksonMapperBuilder()
       .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
       .enable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS)
       .build()
   }

--- a/backend/app/src/test/kotlin/io/tolgee/unit/WebConfigurationObjectMapperTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/WebConfigurationObjectMapperTest.kt
@@ -1,0 +1,38 @@
+package io.tolgee.unit
+
+import io.tolgee.configuration.WebConfiguration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+class WebConfigurationObjectMapperTest {
+  class WithPrimitives(
+    val count: Long,
+    val flag: Boolean,
+  )
+
+  private val objectMapper = WebConfiguration(mock(), mock()).objectMapper()
+
+  @Test
+  fun `leaves absent primitives at their default instead of failing`() {
+    val parsed = objectMapper.readValue("""{}""", WithPrimitives::class.java)
+
+    assertThat(parsed.count).isEqualTo(0)
+    assertThat(parsed.flag).isFalse()
+  }
+
+  @Test
+  fun `still binds primitives that are present`() {
+    val parsed = objectMapper.readValue("""{"count": 7, "flag": true}""", WithPrimitives::class.java)
+
+    assertThat(parsed.count).isEqualTo(7)
+    assertThat(parsed.flag).isTrue()
+  }
+
+  @Test
+  fun `ignores unknown properties`() {
+    val parsed = objectMapper.readValue("""{"count": 7, "flag": true, "surprise": "x"}""", WithPrimitives::class.java)
+
+    assertThat(parsed.count).isEqualTo(7)
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/AnthropicApiServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/AnthropicApiServiceTest.kt
@@ -151,6 +151,21 @@ class AnthropicApiServiceTest {
   }
 
   @Test
+  fun `parses response omitting output_tokens`() {
+    val config = createConfig(format = "json_schema")
+    val params = createParams(shouldOutputJson = true)
+    val restTemplate =
+      stubLlmRestTemplate(
+        """{"content": [{"type": "text", "text": "Ahoj svet"}], "usage": {"input_tokens": 10}}""",
+      )
+
+    val result = service.translate(params, config, restTemplate)
+
+    assertThat(result.usage?.inputTokens).isEqualTo(10)
+    assertThat(result.usage?.outputTokens).isEqualTo(0)
+  }
+
+  @Test
   fun `omits output_config when shouldOutputJson is false`() {
     val config = createConfig(format = "json_schema")
     val params = createParams(shouldOutputJson = false)

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/GoogleAiApiServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/GoogleAiApiServiceTest.kt
@@ -1,0 +1,83 @@
+package io.tolgee.ee.unit
+
+import io.tolgee.configuration.tolgee.machineTranslation.LlmProviderInterface
+import io.tolgee.dtos.LlmParams
+import io.tolgee.ee.component.llm.GoogleAiApiService
+import io.tolgee.exceptions.LlmEmptyResponseException
+import io.tolgee.model.enums.LlmProviderPriority
+import io.tolgee.model.enums.LlmProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class GoogleAiApiServiceTest {
+  private lateinit var service: GoogleAiApiService
+
+  @BeforeEach
+  fun setUp() {
+    service = GoogleAiApiService()
+  }
+
+  @Test
+  fun `parses response omitting candidatesTokenCount`() {
+    val restTemplate =
+      stubLlmRestTemplate(
+        """
+        {
+          "candidates": [{"content": {"role": "model", "parts": [{"text": "Ahoj svet"}]}, "finishReason": "STOP"}],
+          "usageMetadata": {"promptTokenCount": 10, "totalTokenCount": 10}
+        }
+        """.trimIndent(),
+      )
+
+    val result = service.translate(createParams(), createConfig(), restTemplate)
+
+    assertThat(result.response).isEqualTo("Ahoj svet")
+    assertThat(result.usage?.inputTokens).isEqualTo(10)
+    assertThat(result.usage?.outputTokens).isEqualTo(0)
+  }
+
+  @Test
+  fun `throws empty response when the part carries no text`() {
+    val restTemplate =
+      stubLlmRestTemplate(
+        """{"candidates": [{"content": {"parts": [{}]}}], "usageMetadata": {"promptTokenCount": 10}}""",
+      )
+
+    assertThatThrownBy { service.translate(createParams(), createConfig(), restTemplate) }
+      .isInstanceOf(LlmEmptyResponseException::class.java)
+  }
+
+  private fun createConfig(): LlmProviderInterface {
+    return object : LlmProviderInterface {
+      override var name = "test-google"
+      override var type = LlmProviderType.GOOGLE_AI
+      override var priority: LlmProviderPriority? = LlmProviderPriority.HIGH
+      override var apiKey: String? = "test-key"
+      override var apiUrl: String? = "https://generativelanguage.googleapis.com"
+      override var model: String? = "gemini-2.0-flash"
+      override var format: String? = null
+      override var deployment: String? = null
+      override var reasoningEffort: String? = null
+      override var maxTokens: Long = 1000
+      override var tokenPriceInCreditsInput: Double? = null
+      override var tokenPriceInCreditsOutput: Double? = null
+      override var attempts: List<Int>? = null
+    }
+  }
+
+  private fun createParams(): LlmParams {
+    return LlmParams(
+      messages =
+        listOf(
+          LlmParams.Companion.LlmMessage(
+            type = LlmParams.Companion.LlmMessageType.TEXT,
+            text = "Translate 'hello' to Czech",
+          ),
+        ),
+      shouldOutputJson = true,
+      priority = LlmProviderPriority.HIGH,
+    )
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/OpenaiApiServiceTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/OpenaiApiServiceTest.kt
@@ -1,0 +1,113 @@
+package io.tolgee.ee.unit
+
+import io.tolgee.configuration.tolgee.machineTranslation.LlmProviderInterface
+import io.tolgee.dtos.LlmParams
+import io.tolgee.ee.component.llm.OpenaiApiService
+import io.tolgee.exceptions.LlmEmptyResponseException
+import io.tolgee.model.enums.LlmProviderPriority
+import io.tolgee.model.enums.LlmProviderType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OpenaiApiServiceTest {
+  private lateinit var service: OpenaiApiService
+
+  @BeforeEach
+  fun setUp() {
+    service = OpenaiApiService()
+  }
+
+  @Test
+  fun `parses response omitting prediction token details`() {
+    val restTemplate =
+      stubLlmRestTemplate(
+        """
+        {
+          "id": "gen-123",
+          "provider": "OpenRouter",
+          "model": "openai/gpt-4o",
+          "object": "chat.completion",
+          "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "Ahoj svet"}}],
+          "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "prompt_tokens_details": {"cached_tokens": 2},
+            "completion_tokens_details": {"reasoning_tokens": 0}
+          }
+        }
+        """.trimIndent(),
+      )
+
+    val result = service.translate(createParams(), createConfig(), restTemplate)
+
+    assertThat(result.response).isEqualTo("Ahoj svet")
+    assertThat(result.usage?.inputTokens).isEqualTo(10)
+    assertThat(result.usage?.outputTokens).isEqualTo(5)
+    assertThat(result.usage?.cachedTokens).isEqualTo(2)
+  }
+
+  @Test
+  fun `parses response omitting token details objects entirely`() {
+    val restTemplate =
+      stubLlmRestTemplate(
+        """
+        {
+          "choices": [{"message": {"role": "assistant", "content": "Ahoj svet"}}],
+          "usage": {"prompt_tokens": 10, "completion_tokens": 5}
+        }
+        """.trimIndent(),
+      )
+
+    val result = service.translate(createParams(), createConfig(), restTemplate)
+
+    assertThat(result.response).isEqualTo("Ahoj svet")
+    assertThat(result.usage?.inputTokens).isEqualTo(10)
+    assertThat(result.usage?.cachedTokens).isNull()
+  }
+
+  @Test
+  fun `throws empty response when the message carries no content`() {
+    val restTemplate =
+      stubLlmRestTemplate(
+        """{"choices": [{"message": {"role": "assistant"}}], "usage": {"prompt_tokens": 10}}""",
+      )
+
+    assertThatThrownBy { service.translate(createParams(), createConfig(), restTemplate) }
+      .isInstanceOf(LlmEmptyResponseException::class.java)
+  }
+
+  private fun createConfig(): LlmProviderInterface {
+    return object : LlmProviderInterface {
+      override var name = "test-openai"
+      override var type = LlmProviderType.OPENAI
+      override var priority: LlmProviderPriority? = LlmProviderPriority.HIGH
+      override var apiKey: String? = "test-key"
+      override var apiUrl: String? = "https://openrouter.ai/api"
+      override var model: String? = "openai/gpt-4o"
+      override var format: String? = "json_schema"
+      override var deployment: String? = null
+      override var reasoningEffort: String? = null
+      override var maxTokens: Long = 1000
+      override var tokenPriceInCreditsInput: Double? = null
+      override var tokenPriceInCreditsOutput: Double? = null
+      override var attempts: List<Int>? = null
+    }
+  }
+
+  private fun createParams(): LlmParams {
+    return LlmParams(
+      messages =
+        listOf(
+          LlmParams.Companion.LlmMessage(
+            type = LlmParams.Companion.LlmMessageType.TEXT,
+            text = "Translate 'hello' to Czech",
+          ),
+        ),
+      shouldOutputJson = true,
+      priority = LlmProviderPriority.HIGH,
+    )
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/StubLlmRestTemplate.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/unit/StubLlmRestTemplate.kt
@@ -1,0 +1,79 @@
+package io.tolgee.ee.unit
+
+import io.tolgee.configuration.WebConfiguration
+import org.mockito.kotlin.mock
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.client.ClientHttpRequest
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.ClientHttpResponse
+import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
+import org.springframework.web.client.RestTemplate
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.URI
+
+/**
+ * Builds a [RestTemplate] answering every request with [responseJson], deserializing through the
+ * application's own `JsonMapper` — the LLM services get theirs from the Spring-configured
+ * `RestTemplateBuilder`, so a stub on plain defaults would not exercise the same Jackson settings.
+ */
+fun stubLlmRestTemplate(responseJson: String): RestTemplate {
+  val factory =
+    ClientHttpRequestFactory { uri, httpMethod ->
+      StubClientHttpRequest(uri, httpMethod, responseJson)
+    }
+
+  val restTemplate = RestTemplate(factory)
+  restTemplate.messageConverters.replaceAll {
+    if (it is JacksonJsonHttpMessageConverter) JacksonJsonHttpMessageConverter(applicationJsonMapper) else it
+  }
+  return restTemplate
+}
+
+private val applicationJsonMapper = WebConfiguration(mock(), mock()).objectMapper()
+
+private class StubClientHttpRequest(
+  private val uri: URI,
+  private val httpMethod: HttpMethod,
+  private val responseJson: String,
+) : ClientHttpRequest {
+  private val outputStream = ByteArrayOutputStream()
+  private val headers = HttpHeaders()
+
+  override fun getMethod() = httpMethod
+
+  override fun getURI() = uri
+
+  override fun getHeaders() = headers
+
+  override fun getBody(): OutputStream = outputStream
+
+  override fun getAttributes(): MutableMap<String, Any> = mutableMapOf()
+
+  override fun execute(): ClientHttpResponse = StubClientHttpResponse(responseJson)
+}
+
+private class StubClientHttpResponse(
+  private val body: String,
+) : ClientHttpResponse {
+  private val headers =
+    HttpHeaders().apply {
+      contentType = MediaType.APPLICATION_JSON
+    }
+
+  override fun getStatusCode() = HttpStatus.OK
+
+  override fun getHeaders() = headers
+
+  override fun getBody(): InputStream = ByteArrayInputStream(body.toByteArray())
+
+  override fun close() {}
+
+  @Deprecated("Deprecated in Java")
+  override fun getStatusText() = "OK"
+}


### PR DESCRIPTION
## Problem

After the Spring Boot 4 upgrade (#3804) moved the JSON stack from Jackson 2 to Jackson 3, AI translation through OpenAI-compatible providers fails while parsing an otherwise successful response:

```
Error while extracting response for type
[class io.tolgee.ee.component.llm.OpenaiApiService$Companion$ResponseBody]
and content type [application/json]

Caused by: tools.jackson.databind.exc.MismatchedInputException:
Missing required creator property 'accepted_prediction_tokens'
```

OpenRouter (used as an `OPENAI` provider) omits `accepted_prediction_tokens` and `rejected_prediction_tokens` from `completion_tokens_details` when those metrics don't apply. Both are non-nullable `Long` creator properties on `OpenaiApiService.ResponseBody`.

## Cause

Jackson 3 enables `DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES` by default. A merely *absent* number is now a hard failure; Jackson 2 left it at `0`.

Verified directly against the project's Jackson 3:

| Case | Result |
|---|---|
| `FAIL_ON_NULL_FOR_PRIMITIVES` default | `true` |
| missing `val x: Long` | `MismatchedInputException: Missing required creator property 'x'` |
| missing `val x: Long`, feature disabled | OK, `x = 0` ← Jackson 2 behavior |

This is not specific to the LLM services — it reaches every DTO with a non-nullable numeric creator property, and third-party APIs omit optional counters routinely.

## Fix

Disable the feature on the application `JsonMapper`, restoring pre-upgrade behavior. The migration shouldn't change app behavior; anything that genuinely needs stricter binding is a separate change.

It has to be configured on the mapper itself rather than via `spring.jackson.deserialization.fail-on-null-for-primitives`. The bean is hand-built with `jacksonMapperBuilder()` and backs off Boot's auto-configuration through `@ConditionalOnMissingBean`, so the property never applies to it — confirmed with an `ApplicationContextRunner` probe:

| Setup | Result |
|---|---|
| Boot auto-config, no property | fails |
| Boot auto-config + property | OK, `0` |
| **+ the app's `@Primary JsonMapper`** | **fails — property ignored** |

## Alternative considered

Defaulting the affected fields per DTO (`val accepted_prediction_tokens: Long? = null`). Rejected as the primary fix: it only patches the DTOs we happen to know about, and the regression is systemic. The mapper setting restores the documented pre-upgrade semantics in one place.

## Scope

Missing non-nullable **object** properties (e.g. `usage`, `message`) still fail, through the Kotlin module's null check rather than this feature. That behaved identically under Jackson 2, so it's deliberately out of scope.

## Tests

- `WebConfigurationObjectMapperTest` — pins the behavior at the source: absent primitives keep their default, present values still bind, unknown properties still ignored.
- `OpenaiApiServiceTest` — the reported OpenRouter payload, end to end.
- `GoogleAiApiServiceTest`, `AnthropicApiServiceTest` — same regression on their own numeric fields (`candidatesTokenCount`, `output_tokens`).
- `StubLlmRestTemplate` — shared stub that deserializes through the application's own mapper. The LLM services get their `RestTemplate` from the Spring-configured `RestTemplateBuilder`, so a stub on Jackson defaults wouldn't exercise the shipped settings.

## Verification

17 unit tests green, `ktlintCheck` clean. Integration suites not run locally — left to CI.

Fixes #3856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with AI provider responses that omit optional token usage details.
  - Missing primitive values now safely use appropriate defaults instead of causing parsing failures.
  - Added clearer handling for responses containing no usable text.
  - Unknown response fields are ignored for improved forward compatibility.

- **Reliability**
  - Strengthened validation and parsing across supported AI integrations, helping prevent failures when provider response formats vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->