### PR TITLE
feat: apps domain model & schema (apps alpha 1/7)

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
@@ -139,13 +139,9 @@ data class UserAccount(
   var isDemo: Boolean = false
 
   /**
-   * Whether this account is an app install acting as itself rather than a person — see
-   * [io.tolgee.model.apps.AppInstall.principal].
-   *
-   * It is a live, enabled account so that everything resolving the current principal to a row keeps
-   * working, which is precisely why it must be filtered out of every query that counts or lists
-   * people: seats, the administration user list, the sign-in lookups, and the migration job that
-   * hands an organization to every user without one.
+   * An app install acting as itself rather than a person — see
+   * [io.tolgee.model.apps.AppInstall.principal]. Must be filtered out of every query that counts
+   * or lists people (seats, user listings, sign-in lookups, the org-backfill job).
    */
   @Column(name = "is_app_principal", nullable = false)
   @ColumnDefault("false")

--- a/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/UserAccount.kt
@@ -138,6 +138,19 @@ data class UserAccount(
   @ColumnDefault("false")
   var isDemo: Boolean = false
 
+  /**
+   * Whether this account is an app install acting as itself rather than a person — see
+   * [io.tolgee.model.apps.AppInstall.principal].
+   *
+   * It is a live, enabled account so that everything resolving the current principal to a row keeps
+   * working, which is precisely why it must be filtered out of every query that counts or lists
+   * people: seats, the administration user list, the sign-in lookups, and the migration job that
+   * hands an organization to every user without one.
+   */
+  @Column(name = "is_app_principal", nullable = false)
+  @ColumnDefault("false")
+  var isAppPrincipal: Boolean = false
+
   @OneToMany(mappedBy = "userAccount", fetch = FetchType.LAZY, orphanRemoval = true)
   var slackUserConnection: MutableList<SlackUserConnection> = mutableListOf()
 

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
@@ -1,8 +1,8 @@
 package io.tolgee.model.apps
 
+import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
 import io.tolgee.model.Organization
 import io.tolgee.model.StandardAuditModel
-import io.tolgee.model.UserAccount
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -14,13 +14,13 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.ColumnDefault
+import org.hibernate.annotations.Type
 import java.util.Date
 
 /**
- * A published app, registered once and installed by any number of organizations. Its credentials
- * are the app's only long-lived ones: the token endpoint exchanges them plus an install id for the
- * short-lived tokens that reach an organization's data, so revoking them — which stamps
- * [tokensInvalidBefore] — cuts the app off everywhere at once.
+ * A published app, registered once per server and installed by any number of organizations. The
+ * registering organization owns it: it holds the app-level credentials and can remove the app from
+ * every organization that installed it.
  */
 @Entity
 @Table(
@@ -31,117 +31,86 @@ import java.util.Date
   ],
   indexes = [
     Index(columnList = "organization_id"),
-    Index(columnList = "author_id"),
   ],
 )
 class App : StandardAuditModel() {
-  /**
-   * The organization that registered the app and owns it: it holds the app-level credentials,
-   * rotates them, and can take the app off every organization that installed it. Every app has one —
-   * a server admin publishing a first-party app registers it under an organization it controls, the
-   * same way GitHub Apps are owned by a vendor account rather than by nobody.
-   */
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   lateinit var organization: Organization
 
-  /**
-   * Whether every organization on the server may install this app, not only the owner. Set by a
-   * server admin — it is how a first-party or vetted app is offered server-wide. Each organization
-   * that installs it still gets its own install, so tokens and uninstalls stay per-tenant.
-   */
-  @Column(name = "available_to_all_organizations", nullable = false)
+  /** Whether a server admin offered the app to every organization, not only the owner. */
+  @Column(nullable = false)
   @ColumnDefault("false")
   var availableToAllOrganizations: Boolean = false
 
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  lateinit var author: UserAccount
-
-  /** The `id` declared in the manifest. Unique across the whole server. */
-  @Column(name = "app_id", nullable = false)
+  /** The `id` declared in the manifest. */
+  @Column(nullable = false)
   lateinit var appId: String
 
   @Column(nullable = false)
   lateinit var manifestUrl: String
 
-  /**
-   * The scopes the manifest currently requests, comma-joined — refreshed on registration and by the
-   * periodic manifest check. Diffed against each install's granted scopes to tell an organization
-   * that the app is asking for more than it consented to. Null until the manifest was first read.
-   */
-  @Column(name = "manifest_scopes", columnDefinition = "TEXT")
-  var manifestScopes: String? = null
-
   @Column(nullable = false)
   lateinit var name: String
 
   @Column(nullable = false)
-  lateinit var baseUrl: String
-
-  /** The manifest's version at the last read, for display; installs snapshot their own. */
-  @Column(nullable = false)
   @ColumnDefault("''")
   var version: String = ""
 
-  /** See [io.tolgee.dtos.apps.AppManifest.icon]; image URLs are stored already resolved. */
-  @Column(name = "icon", length = 500)
+  @Column(nullable = false)
+  lateinit var baseUrl: String
+
+  /** An emoji, a native icon name, or an image URL served by the app's own host. */
+  @Column(length = 500)
   var icon: String? = null
 
+  /** The manifest as last read. */
+  @Type(JsonBinaryType::class)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  lateinit var manifestJson: String
+
   /**
-   * Null for an app backfilled from an install that predates this table: no app-level credential was
-   * ever disclosed for it, so it has none.
+   * The scopes the manifest currently requests, comma-joined. Diffed against each install's
+   * granted scopes to surface pending permission requests.
    */
-  @Column(name = "client_id", length = 64)
-  var clientId: String? = null
+  @Column(columnDefinition = "TEXT", nullable = false)
+  var manifestScopes: String = ""
+
+  @Column(length = 64, nullable = false)
+  lateinit var clientId: String
 
   /**
    * Signs outbound lifecycle deliveries, so it is stored in plaintext — the same trade-off
-   * [io.tolgee.model.webhook.WebhookConfig.webhookSecret] already makes. It authenticates
-   * nothing towards Tolgee. Null on a backfilled app until the first delivery mints one.
+   * [io.tolgee.model.webhook.WebhookConfig.webhookSecret] makes. It authenticates nothing
+   * towards Tolgee.
    */
-  @Column(name = "webhook_secret")
-  var webhookSecret: String? = null
+  @Column(nullable = false)
+  lateinit var webhookSecret: String
 
   @OneToMany(mappedBy = "app", fetch = FetchType.LAZY)
   var secrets: MutableList<AppSecret> = mutableListOf()
 
   /**
-   * Access tokens issued before this moment no longer validate. Set whenever one of the app's
-   * secrets is revoked, which is what makes revocation take effect immediately instead of after the
-   * tokens minted from that secret expire on their own.
-   *
-   * Deliberately app-wide rather than per-secret: revoking is only correct once the app already
-   * holds a replacement, so the only tokens this destroys are ones the app re-mints straight away.
+   * Access tokens issued before this moment no longer validate — set when a secret is revoked, so
+   * revocation takes effect immediately instead of when the minted tokens expire.
    */
-  @Column(name = "tokens_invalid_before")
   var tokensInvalidBefore: Date? = null
 
-  @Column(name = "manifest_last_checked_at")
   var manifestLastCheckedAt: Date? = null
 
-  /** Consecutive failed manifest checks. Reset to zero by the first successful one. */
-  @Column(name = "manifest_failure_count", nullable = false)
+  @Column(nullable = false)
   @ColumnDefault("0")
   var manifestFailureCount: Int = 0
 
-  @Column(name = "manifest_first_failed_at")
   var manifestFirstFailedAt: Date? = null
 
-  @Column(name = "manifest_last_error", length = 500)
+  @Column(length = 500)
   var manifestLastError: String? = null
 
-  /**
-   * Whether the last failure was the host not answering or the manifest it answered with no longer
-   * being valid. Only [AppManifestFailureKind.UNREACHABLE] ever leads to reaping: an invalid
-   * manifest means somebody is still serving it, so the app's author is reachable and can fix it.
-   */
   @Enumerated(EnumType.STRING)
-  @Column(name = "manifest_last_failure_kind", length = 32)
+  @Column(length = 32)
   var manifestLastFailureKind: AppManifestFailureKind? = null
 
-  /** When the app crossed the sustained-failure threshold. Null while it is healthy. */
-  @Column(name = "unhealthy_since")
   var unhealthySince: Date? = null
 
-  @Column(name = "unhealthy_notified_at")
   var unhealthyNotifiedAt: Date? = null
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
@@ -1,0 +1,147 @@
+package io.tolgee.model.apps
+
+import io.tolgee.model.Organization
+import io.tolgee.model.StandardAuditModel
+import io.tolgee.model.UserAccount
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.ColumnDefault
+import java.util.Date
+
+/**
+ * A published app, registered once and installed by any number of organizations. Its credentials
+ * are the app's only long-lived ones: the token endpoint exchanges them plus an install id for the
+ * short-lived tokens that reach an organization's data, so revoking them — which stamps
+ * [tokensInvalidBefore] — cuts the app off everywhere at once.
+ */
+@Entity
+@Table(
+  name = "app",
+  uniqueConstraints = [
+    UniqueConstraint(name = "app_app_id_unique", columnNames = ["app_id"]),
+    UniqueConstraint(name = "app_client_id_unique", columnNames = ["client_id"]),
+  ],
+  indexes = [
+    Index(columnList = "organization_id"),
+    Index(columnList = "author_id"),
+  ],
+)
+class App : StandardAuditModel() {
+  /**
+   * The organization that registered the app and owns it: it holds the app-level credentials,
+   * rotates them, and can take the app off every organization that installed it. Every app has one —
+   * a server admin publishing a first-party app registers it under an organization it controls, the
+   * same way GitHub Apps are owned by a vendor account rather than by nobody.
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var organization: Organization
+
+  /**
+   * Whether every organization on the server may install this app, not only the owner. Set by a
+   * server admin — it is how a first-party or vetted app is offered server-wide. Each organization
+   * that installs it still gets its own install, so tokens and uninstalls stay per-tenant.
+   */
+  @Column(name = "available_to_all_organizations", nullable = false)
+  @ColumnDefault("false")
+  var availableToAllOrganizations: Boolean = false
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var author: UserAccount
+
+  /** The `id` declared in the manifest. Unique across the whole server. */
+  @Column(name = "app_id", nullable = false)
+  lateinit var appId: String
+
+  @Column(nullable = false)
+  lateinit var manifestUrl: String
+
+  /**
+   * The scopes the manifest currently requests, comma-joined — refreshed on registration and by the
+   * periodic manifest check. Diffed against each install's granted scopes to tell an organization
+   * that the app is asking for more than it consented to. Null until the manifest was first read.
+   */
+  @Column(name = "manifest_scopes", columnDefinition = "TEXT")
+  var manifestScopes: String? = null
+
+  @Column(nullable = false)
+  lateinit var name: String
+
+  @Column(nullable = false)
+  lateinit var baseUrl: String
+
+  /** The manifest's version at the last read, for display; installs snapshot their own. */
+  @Column(nullable = false)
+  @ColumnDefault("''")
+  var version: String = ""
+
+  /** See [io.tolgee.dtos.apps.AppManifest.icon]; image URLs are stored already resolved. */
+  @Column(name = "icon", length = 500)
+  var icon: String? = null
+
+  /**
+   * Null for an app backfilled from an install that predates this table: no app-level credential was
+   * ever disclosed for it, so it has none.
+   */
+  @Column(name = "client_id", length = 64)
+  var clientId: String? = null
+
+  /**
+   * Signs outbound lifecycle deliveries, so it is stored in plaintext — the same trade-off
+   * [io.tolgee.model.webhook.WebhookConfig.webhookSecret] already makes. It authenticates
+   * nothing towards Tolgee. Null on a backfilled app until the first delivery mints one.
+   */
+  @Column(name = "webhook_secret")
+  var webhookSecret: String? = null
+
+  @OneToMany(mappedBy = "app", fetch = FetchType.LAZY)
+  var secrets: MutableList<AppSecret> = mutableListOf()
+
+  /**
+   * Access tokens issued before this moment no longer validate. Set whenever one of the app's
+   * secrets is revoked, which is what makes revocation take effect immediately instead of after the
+   * tokens minted from that secret expire on their own.
+   *
+   * Deliberately app-wide rather than per-secret: revoking is only correct once the app already
+   * holds a replacement, so the only tokens this destroys are ones the app re-mints straight away.
+   */
+  @Column(name = "tokens_invalid_before")
+  var tokensInvalidBefore: Date? = null
+
+  @Column(name = "manifest_last_checked_at")
+  var manifestLastCheckedAt: Date? = null
+
+  /** Consecutive failed manifest checks. Reset to zero by the first successful one. */
+  @Column(name = "manifest_failure_count", nullable = false)
+  @ColumnDefault("0")
+  var manifestFailureCount: Int = 0
+
+  @Column(name = "manifest_first_failed_at")
+  var manifestFirstFailedAt: Date? = null
+
+  @Column(name = "manifest_last_error", length = 500)
+  var manifestLastError: String? = null
+
+  /**
+   * Whether the last failure was the host not answering or the manifest it answered with no longer
+   * being valid. Only [AppManifestFailureKind.UNREACHABLE] ever leads to reaping: an invalid
+   * manifest means somebody is still serving it, so the app's author is reachable and can fix it.
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "manifest_last_failure_kind", length = 32)
+  var manifestLastFailureKind: AppManifestFailureKind? = null
+
+  /** When the app crossed the sustained-failure threshold. Null while it is healthy. */
+  @Column(name = "unhealthy_since")
+  var unhealthySince: Date? = null
+
+  @Column(name = "unhealthy_notified_at")
+  var unhealthyNotifiedAt: Date? = null
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppEnabledForProject.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppEnabledForProject.kt
@@ -2,7 +2,6 @@ package io.tolgee.model.apps
 
 import io.tolgee.model.Project
 import io.tolgee.model.StandardAuditModel
-import io.tolgee.model.UserAccount
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.Index
@@ -30,7 +29,4 @@ class AppEnabledForProject : StandardAuditModel() {
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   lateinit var project: Project
-
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  lateinit var author: UserAccount
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppEnabledForProject.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppEnabledForProject.kt
@@ -1,0 +1,36 @@
+package io.tolgee.model.apps
+
+import io.tolgee.model.Project
+import io.tolgee.model.StandardAuditModel
+import io.tolgee.model.UserAccount
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+  name = "app_enabled_for_project",
+  uniqueConstraints = [
+    UniqueConstraint(
+      name = "app_enabled_for_project_unique",
+      columnNames = ["app_install_id", "project_id"],
+    ),
+  ],
+  indexes = [
+    Index(columnList = "app_install_id"),
+    Index(columnList = "project_id"),
+  ],
+)
+class AppEnabledForProject : StandardAuditModel() {
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var appInstall: AppInstall
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var project: Project
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var author: UserAccount
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
@@ -1,103 +1,67 @@
 package io.tolgee.model.apps
 
+import io.hypersistence.utils.hibernate.type.array.EnumArrayType
 import io.tolgee.model.Organization
 import io.tolgee.model.StandardAuditModel
 import io.tolgee.model.UserAccount
 import io.tolgee.model.enums.Scope
-import jakarta.persistence.CollectionTable
 import jakarta.persistence.Column
-import jakarta.persistence.ElementCollection
 import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
-import org.hibernate.annotations.ColumnDefault
+import org.hibernate.annotations.Parameter
+import org.hibernate.annotations.Type
 
+/**
+ * One organization's installation of a registered [App]. All app data (manifest, urls, icon)
+ * lives on the app; the install carries only what is specific to this organization — its consent.
+ */
 @Entity
 @Table(
   name = "app_install",
   uniqueConstraints = [
     UniqueConstraint(
-      name = "app_install_organization_id_app_id_unique",
-      columnNames = ["organization_id", "app_id"],
+      name = "app_install_organization_id_app_unique",
+      columnNames = ["organization_id", "registered_app_id"],
     ),
   ],
   indexes = [
     Index(columnList = "organization_id"),
-    Index(columnList = "author_id"),
-    Index(columnList = "registered_app_id"),
     Index(columnList = "principal_id"),
   ],
 )
 class AppInstall : StandardAuditModel() {
-  /**
-   * The registered [App] this is an installation of. Two organizations installing the same manifest
-   * share one app and hold one install each, with their own credentials.
-   */
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "registered_app_id")
   lateinit var app: App
 
-  /** The organization this app is installed in. Its projects are the ones the app can be enabled for. */
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   lateinit var organization: Organization
 
   /**
-   * Who registered the install. A historical "created by" record only — an organization's app
-   * outlives the employee who created it, so nothing operational may depend on this account still
-   * existing or being enabled. What the install may do comes from [grantedScopes].
-   */
-  @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  lateinit var author: UserAccount
-
-  /**
-   * The install's own account, the identity an install-context request runs as. It is a real
-   * [UserAccount] row so that everything writing a user foreign key — a comment's author, an
-   * import's, a batch job's — works without the person who registered the install still being
-   * around, and so that it is obvious in the data who wrote what.
-   *
-   * It carries no organization role and no project permission, so it grants nothing: the install's
-   * capability is [grantedScopes] alone. It cannot sign in and is excluded from seats and user
-   * listings — see [UserAccount.isAppPrincipal].
+   * The install's own account — the identity an install-context request runs as. It is a real
+   * [UserAccount] row so every user foreign key (a comment's author, an import's, a batch job's)
+   * works without depending on any person's account. It carries no role and no permission; the
+   * install's whole capability is [grantedScopes]. See [UserAccount.isAppPrincipal].
    */
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "principal_id")
   lateinit var principal: UserAccount
 
-  @Column(nullable = false)
-  lateinit var manifestUrl: String
-
-  @Column(nullable = false)
-  lateinit var appId: String
-
-  @Column(nullable = false)
-  lateinit var name: String
-
-  @Column(nullable = false)
-  lateinit var version: String
-
-  @Column(nullable = false)
-  lateinit var baseUrl: String
-
-  /** See [io.tolgee.dtos.apps.AppManifest.icon]; image URLs are stored already resolved. */
-  @Column(name = "icon", length = 500)
-  var icon: String? = null
-
-  /** The whole manifest — far too large for activity data; the scalar fields above cover it. */
-  @Column(columnDefinition = "TEXT", nullable = false)
-  lateinit var manifestJson: String
-
-  @Enumerated(EnumType.STRING)
-  @ElementCollection(targetClass = Scope::class, fetch = FetchType.EAGER)
-  @CollectionTable(
-    name = "app_install_granted_scope",
-    joinColumns = [JoinColumn(name = "app_install_id")],
+  /** What the organization consented to. Requests beyond this show as pending until approved. */
+  @Type(
+    EnumArrayType::class,
+    parameters = [
+      Parameter(
+        name = EnumArrayType.SQL_ARRAY_TYPE,
+        value = "varchar",
+      ),
+    ],
   )
-  @Column(name = "scope", nullable = false)
-  var grantedScopes: MutableSet<Scope> = mutableSetOf()
+  @Column(columnDefinition = "varchar[]", nullable = false)
+  var grantedScopes: Array<Scope> = arrayOf()
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
@@ -1,0 +1,103 @@
+package io.tolgee.model.apps
+
+import io.tolgee.model.Organization
+import io.tolgee.model.StandardAuditModel
+import io.tolgee.model.UserAccount
+import io.tolgee.model.enums.Scope
+import jakarta.persistence.CollectionTable
+import jakarta.persistence.Column
+import jakarta.persistence.ElementCollection
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.ColumnDefault
+
+@Entity
+@Table(
+  name = "app_install",
+  uniqueConstraints = [
+    UniqueConstraint(
+      name = "app_install_organization_id_app_id_unique",
+      columnNames = ["organization_id", "app_id"],
+    ),
+  ],
+  indexes = [
+    Index(columnList = "organization_id"),
+    Index(columnList = "author_id"),
+    Index(columnList = "registered_app_id"),
+    Index(columnList = "principal_id"),
+  ],
+)
+class AppInstall : StandardAuditModel() {
+  /**
+   * The registered [App] this is an installation of. Two organizations installing the same manifest
+   * share one app and hold one install each, with their own credentials.
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "registered_app_id")
+  lateinit var app: App
+
+  /** The organization this app is installed in. Its projects are the ones the app can be enabled for. */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var organization: Organization
+
+  /**
+   * Who registered the install. A historical "created by" record only — an organization's app
+   * outlives the employee who created it, so nothing operational may depend on this account still
+   * existing or being enabled. What the install may do comes from [grantedScopes].
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var author: UserAccount
+
+  /**
+   * The install's own account, the identity an install-context request runs as. It is a real
+   * [UserAccount] row so that everything writing a user foreign key — a comment's author, an
+   * import's, a batch job's — works without the person who registered the install still being
+   * around, and so that it is obvious in the data who wrote what.
+   *
+   * It carries no organization role and no project permission, so it grants nothing: the install's
+   * capability is [grantedScopes] alone. It cannot sign in and is excluded from seats and user
+   * listings — see [UserAccount.isAppPrincipal].
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "principal_id")
+  lateinit var principal: UserAccount
+
+  @Column(nullable = false)
+  lateinit var manifestUrl: String
+
+  @Column(nullable = false)
+  lateinit var appId: String
+
+  @Column(nullable = false)
+  lateinit var name: String
+
+  @Column(nullable = false)
+  lateinit var version: String
+
+  @Column(nullable = false)
+  lateinit var baseUrl: String
+
+  /** See [io.tolgee.dtos.apps.AppManifest.icon]; image URLs are stored already resolved. */
+  @Column(name = "icon", length = 500)
+  var icon: String? = null
+
+  /** The whole manifest — far too large for activity data; the scalar fields above cover it. */
+  @Column(columnDefinition = "TEXT", nullable = false)
+  lateinit var manifestJson: String
+
+  @Enumerated(EnumType.STRING)
+  @ElementCollection(targetClass = Scope::class, fetch = FetchType.EAGER)
+  @CollectionTable(
+    name = "app_install_granted_scope",
+    joinColumns = [JoinColumn(name = "app_install_id")],
+  )
+  @Column(name = "scope", nullable = false)
+  var grantedScopes: MutableSet<Scope> = mutableSetOf()
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppManifestFailureKind.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppManifestFailureKind.kt
@@ -1,0 +1,10 @@
+package io.tolgee.model.apps
+
+/** Why a periodic manifest check of an [App] failed. */
+enum class AppManifestFailureKind {
+  /** Nothing answered at the manifest URL, or what answered was not a successful HTTP response. */
+  UNREACHABLE,
+
+  /** The URL answered, but the document it served is not a manifest Tolgee accepts any more. */
+  INVALID,
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
@@ -11,11 +11,9 @@ import jakarta.persistence.UniqueConstraint
 import java.util.Date
 
 /**
- * One app-level client secret of an [App] — the app's only long-lived credential. The token
- * endpoint exchanges it plus an install id for the short-lived tokens that reach an organization's
- * data, so revoking it cuts the app off everywhere at once.
- *
- * The plaintext is disclosed only in the response to issuing it.
+ * One app-level client secret of an [App] — the app's only long-lived credential, exchanged at the
+ * token endpoint for short-lived install tokens. The plaintext is disclosed only in the response
+ * to issuing it; only the hash is stored.
  */
 @Entity
 @Table(
@@ -34,29 +32,21 @@ class AppSecret : StandardAuditModel() {
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   lateinit var app: App
 
-  /** The hash never belongs in activity data — the prefix and suffix below identify the secret. */
-  @Column(name = "secret_hash", length = 128, nullable = false)
+  @Column(length = 128, nullable = false)
   lateinit var secretHash: String
 
-  @Column(name = "secret_prefix", length = 16, nullable = false)
-  lateinit var secretPrefix: String
+  /** How the secret is identified everywhere it is shown: its start and end, e.g. `tgpubs_ab…yz`. */
+  @Column(length = 32, nullable = false)
+  lateinit var name: String
 
-  /** Last characters of the secret, shown alongside the prefix so two secrets can be told apart. */
-  @Column(name = "secret_suffix", length = 8, nullable = false)
-  var secretSuffix: String = ""
-
-  @Column(name = "last_used_at")
   var lastUsedAt: Date? = null
 
   /**
-   * When this secret stops authenticating, or null while it has no scheduled end. A rotation sets it
-   * on the outgoing secret to keep it working through a grace window (so an app that copies the new
-   * one by hand is not cut off); the secret is treated as dead once the time passes, without needing
-   * a scheduled job to touch the row.
+   * When this secret stops authenticating, or null while it has no scheduled end. A rotation sets
+   * it on the outgoing secret to keep it working through a grace window; past the time the secret
+   * is treated as dead wherever it is read — no job touches the row.
    */
-  @Column(name = "secret_expires_at")
   var expiresAt: Date? = null
 
-  @Column(name = "revoked_at")
   var revokedAt: Date? = null
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
@@ -1,0 +1,62 @@
+package io.tolgee.model.apps
+
+import io.tolgee.model.StandardAuditModel
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.util.Date
+
+/**
+ * One app-level client secret of an [App] — the app's only long-lived credential. The token
+ * endpoint exchanges it plus an install id for the short-lived tokens that reach an organization's
+ * data, so revoking it cuts the app off everywhere at once.
+ *
+ * The plaintext is disclosed only in the response to issuing it.
+ */
+@Entity
+@Table(
+  name = "app_secret",
+  uniqueConstraints = [
+    UniqueConstraint(
+      name = "app_secret_secret_hash_unique",
+      columnNames = ["secret_hash"],
+    ),
+  ],
+  indexes = [
+    Index(columnList = "app_id"),
+  ],
+)
+class AppSecret : StandardAuditModel() {
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  lateinit var app: App
+
+  /** The hash never belongs in activity data — the prefix and suffix below identify the secret. */
+  @Column(name = "secret_hash", length = 128, nullable = false)
+  lateinit var secretHash: String
+
+  @Column(name = "secret_prefix", length = 16, nullable = false)
+  lateinit var secretPrefix: String
+
+  /** Last characters of the secret, shown alongside the prefix so two secrets can be told apart. */
+  @Column(name = "secret_suffix", length = 8, nullable = false)
+  var secretSuffix: String = ""
+
+  @Column(name = "last_used_at")
+  var lastUsedAt: Date? = null
+
+  /**
+   * When this secret stops authenticating, or null while it has no scheduled end. A rotation sets it
+   * on the outgoing secret to keep it working through a grace window (so an app that copies the new
+   * one by hand is not cut off); the secret is treated as dead once the time passes, without needing
+   * a scheduled job to touch the row.
+   */
+  @Column(name = "secret_expires_at")
+  var expiresAt: Date? = null
+
+  @Column(name = "revoked_at")
+  var revokedAt: Date? = null
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
@@ -1,0 +1,61 @@
+package io.tolgee.repository.apps
+
+import io.tolgee.model.Project
+import io.tolgee.model.apps.AppEnabledForProject
+import io.tolgee.model.apps.AppInstall
+import org.springframework.context.annotation.Lazy
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+@Lazy
+interface AppEnabledForProjectRepository : JpaRepository<AppEnabledForProject, Long> {
+  fun findByProjectIdAndAppInstallId(
+    projectId: Long,
+    appInstallId: Long,
+  ): AppEnabledForProject?
+
+  fun findAllByProjectId(projectId: Long): List<AppEnabledForProject>
+
+  @Query(
+    """
+    select e.appInstall from AppEnabledForProject e
+    where e.project.id = :projectId
+    order by e.appInstall.name
+    """,
+  )
+  fun findEnabledInstallsByProjectId(projectId: Long): List<AppInstall>
+
+  @Query(
+    """
+    select p from AppEnabledForProject e
+    join e.project p
+    join fetch p.organizationOwner o
+    where e.appInstall.id = :appInstallId
+      and p.deletedAt is null
+      and o.deletedAt is null
+    order by p.name, p.id
+    """,
+  )
+  fun findEnabledProjectsByAppInstallId(appInstallId: Long): List<Project>
+
+  fun deleteByAppInstallId(appInstallId: Long)
+
+  fun deleteByProjectId(projectId: Long)
+
+  /**
+   * Disables an app in every project whose organization does not own it — used when a server admin
+   * withdraws the app's server-wide availability, so it stops running everywhere it could only be
+   * reached through that offer while staying enabled in the owner's own projects.
+   */
+  @Query(
+    """
+    delete from AppEnabledForProject e
+    where e.appInstall.app.id = :appEntityId
+      and e.project.organizationOwner.id <> e.appInstall.app.organization.id
+    """,
+  )
+  @org.springframework.data.jpa.repository.Modifying
+  fun deleteByAppIdAndProjectOrganizationNotOwner(appEntityId: Long)
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
@@ -5,7 +5,9 @@ import io.tolgee.model.apps.AppEnabledForProject
 import io.tolgee.model.apps.AppInstall
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -22,10 +24,12 @@ interface AppEnabledForProjectRepository : JpaRepository<AppEnabledForProject, L
     """
     select e.appInstall from AppEnabledForProject e
     where e.project.id = :projectId
-    order by e.appInstall.name
+    order by e.appInstall.app.name
     """,
   )
-  fun findEnabledInstallsByProjectId(projectId: Long): List<AppInstall>
+  fun findEnabledInstallsByProjectId(
+    @Param("projectId") projectId: Long,
+  ): List<AppInstall>
 
   @Query(
     """
@@ -38,7 +42,9 @@ interface AppEnabledForProjectRepository : JpaRepository<AppEnabledForProject, L
     order by p.name, p.id
     """,
   )
-  fun findEnabledProjectsByAppInstallId(appInstallId: Long): List<Project>
+  fun findEnabledProjectsByAppInstallId(
+    @Param("appInstallId") appInstallId: Long,
+  ): List<Project>
 
   fun deleteByAppInstallId(appInstallId: Long)
 
@@ -56,6 +62,8 @@ interface AppEnabledForProjectRepository : JpaRepository<AppEnabledForProject, L
       and e.project.organizationOwner.id <> e.appInstall.app.organization.id
     """,
   )
-  @org.springframework.data.jpa.repository.Modifying
-  fun deleteByAppIdAndProjectOrganizationNotOwner(appEntityId: Long)
+  @Modifying(clearAutomatically = true)
+  fun deleteByAppIdAndProjectOrganizationNotOwner(
+    @Param("appEntityId") appEntityId: Long,
+  )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
@@ -3,9 +3,9 @@ package io.tolgee.repository.apps
 import io.tolgee.model.Organization
 import io.tolgee.model.apps.AppInstall
 import org.springframework.context.annotation.Lazy
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
@@ -1,0 +1,76 @@
+package io.tolgee.repository.apps
+
+import io.tolgee.model.Organization
+import io.tolgee.model.apps.AppInstall
+import org.springframework.context.annotation.Lazy
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+@Lazy
+interface AppInstallRepository : JpaRepository<AppInstall, Long> {
+  fun findAllByOrganizationId(organizationId: Long): List<AppInstall>
+
+  fun findByOrganizationIdAndId(
+    organizationId: Long,
+    id: Long,
+  ): AppInstall?
+
+  fun findByOrganizationIdAndAppId(
+    organizationId: Long,
+    appId: String,
+  ): AppInstall?
+
+  /**
+   * Installs of server-wide apps that some *other* organization owns — the ones [organizationId]'s
+   * projects may enable on top of its own installs.
+   */
+  @Query(
+    """
+    select i from AppInstall i
+    where i.app.availableToAllOrganizations = true and i.organization.id <> :organizationId
+    order by i.name
+    """,
+  )
+  fun findAvailableToOtherOrganizations(organizationId: Long): List<AppInstall>
+
+  /**
+   * The app is fetched eagerly because app-token authentication reads its token cutoff from the
+   * servlet filter, outside any session — a lazy proxy there fails the request instead of
+   * authenticating it.
+   */
+  @Query("select i from AppInstall i join fetch i.app where i.id = :id")
+  fun findWithAppById(id: Long): AppInstall?
+
+  @Query("select count(i) from AppInstall i where i.app.id = :appId")
+  fun countByRegisteredAppId(appId: Long): Long
+
+  @Query("select i from AppInstall i where i.app.id = :appId")
+  fun findAllByRegisteredAppId(appId: Long): List<AppInstall>
+
+  fun countByOrganizationId(organizationId: Long): Long
+
+  /** The organizations that currently have the app installed, for the owner's installations view. */
+  @Query(
+    """
+    select distinct i.organization from AppInstall i where i.app.id = :appEntityId
+      and (:search is null
+        or lower(i.organization.name) like lower(concat('%', cast(:search as text), '%'))
+        or lower(i.organization.slug) like lower(concat('%', cast(:search as text), '%')))
+    """,
+    countQuery = """
+    select count(distinct i.organization) from AppInstall i where i.app.id = :appEntityId
+      and (:search is null
+        or lower(i.organization.name) like lower(concat('%', cast(:search as text), '%'))
+        or lower(i.organization.slug) like lower(concat('%', cast(:search as text), '%')))
+    """,
+  )
+  fun findInstallingOrganizations(
+    appEntityId: Long,
+    search: String?,
+    pageable: Pageable,
+  ): Page<Organization>
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -19,23 +20,16 @@ interface AppInstallRepository : JpaRepository<AppInstall, Long> {
     id: Long,
   ): AppInstall?
 
-  fun findByOrganizationIdAndAppId(
-    organizationId: Long,
-    appId: String,
-  ): AppInstall?
-
-  /**
-   * Installs of server-wide apps that some *other* organization owns — the ones [organizationId]'s
-   * projects may enable on top of its own installs.
-   */
   @Query(
     """
     select i from AppInstall i
-    where i.app.availableToAllOrganizations = true and i.organization.id <> :organizationId
-    order by i.name
+    where i.organization.id = :organizationId and i.app.appId = :appId
     """,
   )
-  fun findAvailableToOtherOrganizations(organizationId: Long): List<AppInstall>
+  fun findByOrganizationIdAndManifestAppId(
+    @Param("organizationId") organizationId: Long,
+    @Param("appId") appId: String,
+  ): AppInstall?
 
   /**
    * The app is fetched eagerly because app-token authentication reads its token cutoff from the
@@ -43,23 +37,34 @@ interface AppInstallRepository : JpaRepository<AppInstall, Long> {
    * authenticating it.
    */
   @Query("select i from AppInstall i join fetch i.app where i.id = :id")
-  fun findWithAppById(id: Long): AppInstall?
+  fun findWithAppById(
+    @Param("id") id: Long,
+  ): AppInstall?
 
-  @Query("select count(i) from AppInstall i where i.app.id = :appId")
-  fun countByRegisteredAppId(appId: Long): Long
+  @Query("select count(i) from AppInstall i where i.app.id = :appEntityId")
+  fun countByRegisteredAppId(
+    @Param("appEntityId") appEntityId: Long,
+  ): Long
 
-  @Query("select i from AppInstall i where i.app.id = :appId")
-  fun findAllByRegisteredAppId(appId: Long): List<AppInstall>
+  @Query("select i from AppInstall i where i.app.id = :appEntityId")
+  fun findAllByRegisteredAppId(
+    @Param("appEntityId") appEntityId: Long,
+  ): List<AppInstall>
 
   fun countByOrganizationId(organizationId: Long): Long
 
-  /** The organizations that currently have the app installed, for the owner's installations view. */
+  /**
+   * The organizations that currently have the app installed, for the owner's installations view.
+   * Ordered here (name, then id for ties) because a paged select without a total order can repeat
+   * or drop rows across pages.
+   */
   @Query(
     """
     select distinct i.organization from AppInstall i where i.app.id = :appEntityId
       and (:search is null
         or lower(i.organization.name) like lower(concat('%', cast(:search as text), '%'))
         or lower(i.organization.slug) like lower(concat('%', cast(:search as text), '%')))
+    order by i.organization.name, i.organization.id
     """,
     countQuery = """
     select count(distinct i.organization) from AppInstall i where i.app.id = :appEntityId
@@ -69,8 +74,8 @@ interface AppInstallRepository : JpaRepository<AppInstall, Long> {
     """,
   )
   fun findInstallingOrganizations(
-    appEntityId: Long,
-    search: String?,
+    @Param("appEntityId") appEntityId: Long,
+    @Param("search") search: String?,
     pageable: Pageable,
   ): Page<Organization>
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppRepository.kt
@@ -2,9 +2,10 @@ package io.tolgee.repository.apps
 
 import io.tolgee.model.apps.App
 import org.springframework.context.annotation.Lazy
-import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Limit
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -36,7 +37,9 @@ interface AppRepository : JpaRepository<App, Long> {
     order by a.name asc
     """,
   )
-  fun findAvailableToInstall(organizationId: Long): List<App>
+  fun findAvailableToInstall(
+    @Param("organizationId") organizationId: Long,
+  ): List<App>
 
   /**
    * Ids only, ascending, so the manifest reaper can walk every app in bounded batches without
@@ -44,7 +47,7 @@ interface AppRepository : JpaRepository<App, Long> {
    */
   @Query("select a.id from App a where a.id > :afterId order by a.id")
   fun findIdsAfter(
-    afterId: Long,
-    pageable: Pageable,
+    @Param("afterId") afterId: Long,
+    limit: Limit,
   ): List<Long>
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppRepository.kt
@@ -1,0 +1,50 @@
+package io.tolgee.repository.apps
+
+import io.tolgee.model.apps.App
+import org.springframework.context.annotation.Lazy
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+@Lazy
+interface AppRepository : JpaRepository<App, Long> {
+  fun findByAppId(appId: String): App?
+
+  fun findByClientId(clientId: String): App?
+
+  fun findAllByOrganizationIdOrderByNameAsc(organizationId: Long): List<App>
+
+  fun findByIdAndOrganizationId(
+    id: Long,
+    organizationId: Long,
+  ): App?
+
+  /**
+   * Apps a server admin has offered to every organization that [organizationId] neither owns nor has
+   * already installed — the ones it can still add from the "Available on this server" list.
+   */
+  @Query(
+    """
+    select a from App a
+    where a.availableToAllOrganizations = true
+      and a.organization.id <> :organizationId
+      and not exists (
+        select 1 from AppInstall i where i.app = a and i.organization.id = :organizationId
+      )
+    order by a.name asc
+    """,
+  )
+  fun findAvailableToInstall(organizationId: Long): List<App>
+
+  /**
+   * Ids only, ascending, so the manifest reaper can walk every app in bounded batches without
+   * holding a transaction open across the HTTP fetches it does between them.
+   */
+  @Query("select a.id from App a where a.id > :afterId order by a.id")
+  fun findIdsAfter(
+    afterId: Long,
+    pageable: Pageable,
+  ): List<Long>
+}

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppSecretRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppSecretRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Lazy
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.util.Date
 
@@ -13,19 +14,40 @@ import java.util.Date
 interface AppSecretRepository : JpaRepository<AppSecret, Long> {
   fun findAllByAppIdOrderByCreatedAtDesc(appId: Long): List<AppSecret>
 
-  fun findAllByAppIdAndRevokedAtIsNull(appId: Long): List<AppSecret>
-
   fun findByIdAndAppId(
     id: Long,
     appId: Long,
   ): AppSecret?
 
-  fun countByAppIdAndRevokedAtIsNull(appId: Long): Long
+  /** Secrets that still authenticate: not revoked and not past their expiry. */
+  @Query(
+    """
+    select s from AppSecret s
+    where s.app.id = :appId and s.revokedAt is null
+      and (s.expiresAt is null or s.expiresAt > :now)
+    """,
+  )
+  fun findActiveByAppId(
+    @Param("appId") appId: Long,
+    @Param("now") now: Date,
+  ): List<AppSecret>
+
+  @Query(
+    """
+    select count(s) from AppSecret s
+    where s.app.id = :appId and s.revokedAt is null
+      and (s.expiresAt is null or s.expiresAt > :now)
+    """,
+  )
+  fun countActiveByAppId(
+    @Param("appId") appId: Long,
+    @Param("now") now: Date,
+  ): Long
 
   @Modifying
   @Query("update AppSecret s set s.lastUsedAt = :lastUsedAt where s.id = :id")
   fun updateLastUsedById(
-    id: Long,
-    lastUsedAt: Date,
+    @Param("id") id: Long,
+    @Param("lastUsedAt") lastUsedAt: Date,
   )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppSecretRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppSecretRepository.kt
@@ -1,0 +1,31 @@
+package io.tolgee.repository.apps
+
+import io.tolgee.model.apps.AppSecret
+import org.springframework.context.annotation.Lazy
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.Date
+
+@Repository
+@Lazy
+interface AppSecretRepository : JpaRepository<AppSecret, Long> {
+  fun findAllByAppIdOrderByCreatedAtDesc(appId: Long): List<AppSecret>
+
+  fun findAllByAppIdAndRevokedAtIsNull(appId: Long): List<AppSecret>
+
+  fun findByIdAndAppId(
+    id: Long,
+    appId: Long,
+  ): AppSecret?
+
+  fun countByAppIdAndRevokedAtIsNull(appId: Long): Long
+
+  @Modifying
+  @Query("update AppSecret s set s.lastUsedAt = :lastUsedAt where s.id = :id")
+  fun updateLastUsedById(
+    id: Long,
+    lastUsedAt: Date,
+  )
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistry.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/projectExportImport/ProjectExportImportPolicyRegistry.kt
@@ -29,6 +29,10 @@ import io.tolgee.model.UserPreferences
 import io.tolgee.model.activity.ActivityDescribingEntity
 import io.tolgee.model.activity.ActivityModifiedEntity
 import io.tolgee.model.activity.ActivityRevision
+import io.tolgee.model.apps.App
+import io.tolgee.model.apps.AppEnabledForProject
+import io.tolgee.model.apps.AppInstall
+import io.tolgee.model.apps.AppSecret
 import io.tolgee.model.automations.Automation
 import io.tolgee.model.automations.AutomationAction
 import io.tolgee.model.automations.AutomationTrigger
@@ -188,6 +192,10 @@ object ProjectExportImportPolicyRegistry {
         NotificationSetting::class,
         UploadedImage::class,
         TranslationAgency::class,
+        App::class,
+        AppSecret::class,
+        AppInstall::class,
+        AppEnabledForProject::class,
         InstanceId::class,
         ForcedServerDateTime::class,
       )

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -6144,7 +6144,7 @@
             <column name="secret_prefix" type="VARCHAR(16)">
                 <constraints nullable="false"/>
             </column>
-            <column name="secret_suffix" type="VARCHAR(8)" defaultValue="">
+            <column name="secret_suffix" type="VARCHAR(8)">
                 <constraints nullable="false"/>
             </column>
             <column name="last_used_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5890,28 +5890,34 @@
             <column name="organization_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="author_id" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
             <column name="app_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="manifest_url" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="manifest_scopes" type="TEXT"/>
             <column name="name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="base_url" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="version" type="VARCHAR(255)" defaultValue="">
                 <constraints nullable="false"/>
             </column>
+            <column name="base_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="icon" type="VARCHAR(500)"/>
-            <column name="client_id" type="VARCHAR(64)"/>
-            <column name="webhook_secret" type="VARCHAR(255)"/>
+            <column name="manifest_json" type="JSONB">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manifest_scopes" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="client_id" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="webhook_secret" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="available_to_all_organizations" type="BOOLEAN" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
@@ -5931,9 +5937,6 @@
         <createIndex indexName="IDX_app_organization_id" tableName="app">
             <column name="organization_id"/>
         </createIndex>
-        <createIndex indexName="IDX_app_author_id" tableName="app">
-            <column name="author_id"/>
-        </createIndex>
         <addForeignKeyConstraint baseColumnNames="organization_id"
                                  baseTableName="app"
                                  constraintName="FK_app_organization"
@@ -5942,14 +5945,6 @@
                                  referencedColumnNames="id"
                                  referencedTableName="organization"
                                  onDelete="CASCADE"
-                                 validate="true"/>
-        <addForeignKeyConstraint baseColumnNames="author_id"
-                                 baseTableName="app"
-                                 constraintName="FK_app_author"
-                                 deferrable="false"
-                                 initiallyDeferred="false"
-                                 referencedColumnNames="id"
-                                 referencedTableName="user_account"
                                  validate="true"/>
     </changeSet>
     <changeSet author="jcizmar" id="1787000000000-2">
@@ -5969,43 +5964,18 @@
             <column name="organization_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="author_id" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
             <column name="principal_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
-            <column name="manifest_url" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="app_id" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="base_url" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="icon" type="VARCHAR(500)"/>
-            <column name="manifest_json" type="TEXT">
+            <column name="granted_scopes" type="VARCHAR[]">
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addUniqueConstraint columnNames="organization_id, app_id"
-                             constraintName="app_install_organization_id_app_id_unique"
+        <addUniqueConstraint columnNames="organization_id, registered_app_id"
+                             constraintName="app_install_organization_id_app_unique"
                              tableName="app_install"/>
-        <createIndex indexName="IDX_app_install_registered_app_id" tableName="app_install">
-            <column name="registered_app_id"/>
-        </createIndex>
         <createIndex indexName="IDX_app_install_organization_id" tableName="app_install">
             <column name="organization_id"/>
-        </createIndex>
-        <createIndex indexName="IDX_app_install_author_id" tableName="app_install">
-            <column name="author_id"/>
         </createIndex>
         <createIndex indexName="IDX_app_install_principal_id" tableName="app_install">
             <column name="principal_id"/>
@@ -6027,14 +5997,6 @@
                                  referencedColumnNames="id"
                                  referencedTableName="organization"
                                  onDelete="CASCADE"
-                                 validate="true"/>
-        <addForeignKeyConstraint baseColumnNames="author_id"
-                                 baseTableName="app_install"
-                                 constraintName="FK_app_install_author"
-                                 deferrable="false"
-                                 initiallyDeferred="false"
-                                 referencedColumnNames="id"
-                                 referencedTableName="user_account"
                                  validate="true"/>
         <addForeignKeyConstraint baseColumnNames="principal_id"
                                  baseTableName="app_install"
@@ -6060,9 +6022,6 @@
                 <constraints nullable="false"/>
             </column>
             <column name="project_id" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="author_id" type="BIGINT">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -6093,38 +6052,8 @@
                                  referencedTableName="project"
                                  onDelete="CASCADE"
                                  validate="true"/>
-        <addForeignKeyConstraint baseColumnNames="author_id"
-                                 baseTableName="app_enabled_for_project"
-                                 constraintName="FK_app_enabled_for_project_author"
-                                 deferrable="false"
-                                 initiallyDeferred="false"
-                                 referencedColumnNames="id"
-                                 referencedTableName="user_account"
-                                 validate="true"/>
     </changeSet>
     <changeSet author="jcizmar" id="1787000000000-4">
-        <createTable tableName="app_install_granted_scope">
-            <column name="app_install_id" type="BIGINT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="scope" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-        <addPrimaryKey columnNames="app_install_id, scope"
-                       constraintName="app_install_granted_scopePK"
-                       tableName="app_install_granted_scope"/>
-        <addForeignKeyConstraint baseColumnNames="app_install_id"
-                                 baseTableName="app_install_granted_scope"
-                                 constraintName="FK_app_install_granted_scope_app_install"
-                                 deferrable="false"
-                                 initiallyDeferred="false"
-                                 referencedColumnNames="id"
-                                 referencedTableName="app_install"
-                                 onDelete="CASCADE"
-                                 validate="true"/>
-    </changeSet>
-    <changeSet author="jcizmar" id="1787000000000-5">
         <createTable tableName="app_secret">
             <column name="id" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="app_secretPK"/>
@@ -6141,14 +6070,11 @@
             <column name="secret_hash" type="VARCHAR(128)">
                 <constraints nullable="false"/>
             </column>
-            <column name="secret_prefix" type="VARCHAR(16)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="secret_suffix" type="VARCHAR(8)">
+            <column name="name" type="VARCHAR(32)">
                 <constraints nullable="false"/>
             </column>
             <column name="last_used_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
-            <column name="secret_expires_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="expires_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
             <column name="revoked_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
         </createTable>
         <addUniqueConstraint columnNames="secret_hash"
@@ -6167,7 +6093,7 @@
                                  onDelete="CASCADE"
                                  validate="true"/>
     </changeSet>
-    <changeSet author="jcizmar" id="1787000000000-6">
+    <changeSet author="jcizmar" id="1787000000000-5">
         <comment>Marks an install's own account so it is kept out of seats, user listings and sign-in
             while still resolving as a real principal for the writes an install makes.</comment>
         <addColumn tableName="user_account">

--- a/backend/data/src/main/resources/db/changelog/schema.xml
+++ b/backend/data/src/main/resources/db/changelog/schema.xml
@@ -5876,4 +5876,304 @@
             END $$;
         </sql>
     </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-1">
+        <createTable tableName="app">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="appPK"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="app_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manifest_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manifest_scopes" type="TEXT"/>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="base_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(255)" defaultValue="">
+                <constraints nullable="false"/>
+            </column>
+            <column name="icon" type="VARCHAR(500)"/>
+            <column name="client_id" type="VARCHAR(64)"/>
+            <column name="webhook_secret" type="VARCHAR(255)"/>
+            <column name="available_to_all_organizations" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tokens_invalid_before" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="manifest_last_checked_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="manifest_failure_count" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manifest_first_failed_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="manifest_last_error" type="VARCHAR(500)"/>
+            <column name="manifest_last_failure_kind" type="VARCHAR(32)"/>
+            <column name="unhealthy_since" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="unhealthy_notified_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+        </createTable>
+        <addUniqueConstraint columnNames="app_id" constraintName="app_app_id_unique" tableName="app"/>
+        <addUniqueConstraint columnNames="client_id" constraintName="app_client_id_unique" tableName="app"/>
+        <createIndex indexName="IDX_app_organization_id" tableName="app">
+            <column name="organization_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_app_author_id" tableName="app">
+            <column name="author_id"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="organization_id"
+                                 baseTableName="app"
+                                 constraintName="FK_app_organization"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="organization"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="author_id"
+                                 baseTableName="app"
+                                 constraintName="FK_app_author"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_account"
+                                 validate="true"/>
+    </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-2">
+        <createTable tableName="app_install">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="app_installPK"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registered_app_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="principal_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="manifest_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="app_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="base_url" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="icon" type="VARCHAR(500)"/>
+            <column name="manifest_json" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint columnNames="organization_id, app_id"
+                             constraintName="app_install_organization_id_app_id_unique"
+                             tableName="app_install"/>
+        <createIndex indexName="IDX_app_install_registered_app_id" tableName="app_install">
+            <column name="registered_app_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_app_install_organization_id" tableName="app_install">
+            <column name="organization_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_app_install_author_id" tableName="app_install">
+            <column name="author_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_app_install_principal_id" tableName="app_install">
+            <column name="principal_id"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="registered_app_id"
+                                 baseTableName="app_install"
+                                 constraintName="FK_app_install_app"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="app"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="organization_id"
+                                 baseTableName="app_install"
+                                 constraintName="FK_app_install_organization"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="organization"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="author_id"
+                                 baseTableName="app_install"
+                                 constraintName="FK_app_install_author"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_account"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="principal_id"
+                                 baseTableName="app_install"
+                                 constraintName="FK_app_install_principal"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_account"
+                                 validate="true"/>
+    </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-3">
+        <createTable tableName="app_enabled_for_project">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="app_enabled_for_projectPK"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="app_install_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="project_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="author_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint columnNames="app_install_id, project_id"
+                             constraintName="app_enabled_for_project_unique"
+                             tableName="app_enabled_for_project"/>
+        <createIndex indexName="IDX_app_enabled_for_project_app_install_id" tableName="app_enabled_for_project">
+            <column name="app_install_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_app_enabled_for_project_project_id" tableName="app_enabled_for_project">
+            <column name="project_id"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="app_install_id"
+                                 baseTableName="app_enabled_for_project"
+                                 constraintName="FK_app_enabled_for_project_app_install"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="app_install"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="project_id"
+                                 baseTableName="app_enabled_for_project"
+                                 constraintName="FK_app_enabled_for_project_project"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="project"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="author_id"
+                                 baseTableName="app_enabled_for_project"
+                                 constraintName="FK_app_enabled_for_project_author"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="user_account"
+                                 validate="true"/>
+    </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-4">
+        <createTable tableName="app_install_granted_scope">
+            <column name="app_install_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="scope" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="app_install_id, scope"
+                       constraintName="app_install_granted_scopePK"
+                       tableName="app_install_granted_scope"/>
+        <addForeignKeyConstraint baseColumnNames="app_install_id"
+                                 baseTableName="app_install_granted_scope"
+                                 constraintName="FK_app_install_granted_scope_app_install"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="app_install"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+    </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-5">
+        <createTable tableName="app_secret">
+            <column name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="app_secretPK"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="app_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="secret_hash" type="VARCHAR(128)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="secret_prefix" type="VARCHAR(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="secret_suffix" type="VARCHAR(8)" defaultValue="">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_used_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="secret_expires_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="revoked_at" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+        </createTable>
+        <addUniqueConstraint columnNames="secret_hash"
+                             constraintName="app_secret_secret_hash_unique"
+                             tableName="app_secret"/>
+        <createIndex indexName="IDX_app_secret_app_id" tableName="app_secret">
+            <column name="app_id"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="app_id"
+                                 baseTableName="app_secret"
+                                 constraintName="FK_app_secret_app"
+                                 deferrable="false"
+                                 initiallyDeferred="false"
+                                 referencedColumnNames="id"
+                                 referencedTableName="app"
+                                 onDelete="CASCADE"
+                                 validate="true"/>
+    </changeSet>
+    <changeSet author="jcizmar" id="1787000000000-6">
+        <comment>Marks an install's own account so it is kept out of seats, user listings and sign-in
+            while still resolving as a real principal for the writes an install makes.</comment>
+        <addColumn tableName="user_account">
+            <column name="is_app_principal" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
First slice of the Tolgee Apps alpha, re-staged for review. This series lands on the `feat-apps-alpha` integration branch; each PR compiles and passes tests on its own.

## What's here

- **Entities**: `App` (registered once per server, owned by an organization, holds the app-level credentials and manifest snapshot incl. `icon`/`version`), `AppInstall` (one per installing organization, with its own principal account and `grantedScopes` as the consent record), `AppSecret` (hashed, `prefix…suffix` display, lazy expiry for roll-with-grace rotation), `AppEnabledForProject`, and `AppManifestFailureKind`.
- **`UserAccount.isAppPrincipal`** — marks an install's own account; the people-facing query filters (sign-in, seats, listings, the org-migration job) land together with the principal service in a later slice.
- **Repositories** for all of the above, including the paged/searched installing-organizations query used by the owner's installations view.
- **One consolidated Liquibase changeset** (`1787000000000-1..6`) instead of the nine incremental ones from development.

## Not here yet (later slices)

Manifest fetching/validation (2), registration & installs incl. limits (3), credentials & token flow (4), lifecycle channel & self-registration (5), manifest health & re-consent (6), activity/analytics incl. the `activity_revision.app_install_id` column and entity annotations (7).

## Notes for review

- Activity annotations are deliberately absent from the entities here so this slice is pure data model; they join in slice 7 with the ActivityTypes that reference these classes.
- The preview environment DB needs `recreateDb` on its next deploy (it carries checksums of the squashed dev changesets); production has never seen any of these changesets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational support for registering and installing applications.
  * Added app availability across organizations and project-level enablement.
  * Added management of app permissions, credentials, secrets, and installation metadata.
  * Added tracking for app manifest health and failure status.
  * Added support for installation-specific principal accounts.
* **Data & Security**
  * Added secure storage and lifecycle tracking for app secrets.
  * Added database support for applications, installations, granted permissions, and project associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->