### PR TITLE
chore: skip CI on emergency releases via pull request labels

### DIFF
--- a/.github/actions/resolve-test-policy/action.yaml
+++ b/.github/actions/resolve-test-policy/action.yaml
@@ -1,0 +1,68 @@
+name: Resolve test policy
+description: Reads the emergency test labels off the pull request behind a commit
+
+inputs:
+  sha:
+    description: >-
+      Commit to look up. Empty falls back to the event: payload labels on
+      pull_request, github.sha on push, none otherwise.
+    required: false
+    default: ""
+  github-token:
+    description: Token used for the pull request lookup
+    required: true
+
+outputs:
+  emergency:
+    description: true when either emergency label waived this commit's tests
+    value: ${{ steps.resolve.outputs.emergency }}
+  skip-billing-tests:
+    description: true only for skip-all-tests
+    value: ${{ steps.resolve.outputs.skip-billing-tests }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ inputs.sha }}
+      run: |
+        set -uo pipefail
+        # A lookup error must read as "no labels", never as a waiver.
+        lookup() {
+          gh api "repos/$REPO/commits/$1/pulls" \
+            --jq '[.[].labels[].name] | join(",")' 2>/dev/null || echo ""
+        }
+
+        if [ -n "$SHA" ]; then
+          labels=$(lookup "$SHA")
+        elif [ "$EVENT_NAME" = "pull_request" ]; then
+          labels="$PR_LABELS"
+        elif [ "$EVENT_NAME" = "push" ]; then
+          labels=$(lookup "$GITHUB_SHA")
+        else
+          # A manual run means "run the tests" — never inherit a waiver from
+          # whatever pull request last touched HEAD.
+          labels=""
+        fi
+        echo "Labels: ${labels:-<none>}"
+
+        emergency=false
+        skip_billing=false
+        if [[ ",$labels," == *",skip-all-tests,"* ]]; then
+          emergency=true
+          skip_billing=true
+          echo "skip-all-tests: nothing gates this release."
+        # test-cloud-only keeps billing's run: it is the only one that builds
+        # platform + ee + billing, so the only one that tests what reaches cloud.
+        elif [[ ",$labels," == *",test-cloud-only,"* ]]; then
+          emergency=true
+          echo "test-cloud-only: billing's composed run is the gate."
+        fi
+        echo "emergency=$emergency" >> "$GITHUB_OUTPUT"
+        echo "skip-billing-tests=$skip_billing" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,16 @@ jobs:
             -H "Authorization: token ${{ secrets.TOLGEE_MACHINE_PAT }}" \
             https://api.github.com/repos/tolgee/billing/actions/workflows/test.yml/dispatches \
             -d "{\"ref\":\"main\",\"inputs\":{\"release-version\":\"${{ steps.version.outputs.VERSION }}\",\"skip-tests\":\"$SKIP_TESTS\"}}"
+
+      # Omitting release-version is what makes this signal only: billing runs the
+      # composed suite and its trigger-release job skips itself. Nothing else
+      # covers the cloud composition when skip-all-tests waived billing's run.
+      - name: Trigger Billing tests for signal only
+        if: ${{ steps.version.outputs.VERSION != '' && steps.policy.outputs.skip-billing-tests == 'true' }}
+        run: |
+          curl --fail-with-body \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.TOLGEE_MACHINE_PAT }}" \
+            https://api.github.com/repos/tolgee/billing/actions/workflows/test.yml/dispatches \
+            -d '{"ref":"main","inputs":{}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,21 +106,11 @@ jobs:
       - name: Resolve test policy
         id: policy
         if: ${{ steps.version.outputs.VERSION != '' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
+        uses: ./.github/actions/resolve-test-policy
+        with:
+          github-token: ${{ github.token }}
           # Not github.sha, which here is the default branch head.
-          SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          set -uo pipefail
-          labels=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-            --jq '[.[].labels[].name] | join(",")' 2>/dev/null) || labels=""
-          echo "Labels: ${labels:-<none>}"
-          skip=false
-          if [[ ",$labels," == *",skip-all-tests,"* ]]; then
-            skip=true
-          fi
-          echo "skip-tests=$skip" >> "$GITHUB_OUTPUT"
+          sha: ${{ github.event.workflow_run.head_sha }}
 
       # --fail-with-body: an input billing does not declare is rejected with 422,
       # which curl otherwise prints while exiting 0 — a release that never
@@ -128,7 +118,7 @@ jobs:
       - name: Trigger Billing repo tests & testing deploy
         if: ${{ steps.version.outputs.VERSION != '' }}
         env:
-          SKIP_TESTS: ${{ steps.policy.outputs.skip-tests }}
+          SKIP_TESTS: ${{ steps.policy.outputs.skip-billing-tests }}
         run: |
           curl --fail-with-body \
             -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,12 +103,36 @@ jobs:
             ./e2e/cypress/screenshots/**/*
             ./build/reports/**/*
 
+      - name: Resolve test policy
+        id: policy
+        if: ${{ steps.version.outputs.VERSION != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # Not github.sha, which here is the default branch head.
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -uo pipefail
+          labels=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+            --jq '[.[].labels[].name] | join(",")' 2>/dev/null) || labels=""
+          echo "Labels: ${labels:-<none>}"
+          skip=false
+          if [[ ",$labels," == *",skip-all-tests,"* ]]; then
+            skip=true
+          fi
+          echo "skip-tests=$skip" >> "$GITHUB_OUTPUT"
+
+      # --fail-with-body: an input billing does not declare is rejected with 422,
+      # which curl otherwise prints while exiting 0 — a release that never
+      # reaches billing would look green.
       - name: Trigger Billing repo tests & testing deploy
         if: ${{ steps.version.outputs.VERSION != '' }}
+        env:
+          SKIP_TESTS: ${{ steps.policy.outputs.skip-tests }}
         run: |
-          curl \
+          curl --fail-with-body \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token ${{ secrets.TOLGEE_MACHINE_PAT }}" \
             https://api.github.com/repos/tolgee/billing/actions/workflows/test.yml/dispatches \
-            -d '{"ref":"main","inputs":{"release-version":"${{ steps.version.outputs.VERSION }}"}}'
+            -d "{\"ref\":\"main\",\"inputs\":{\"release-version\":\"${{ steps.version.outputs.VERSION }}\",\"skip-tests\":\"$SKIP_TESTS\"}}"

--- a/.github/workflows/test-async.yml
+++ b/.github/workflows/test-async.yml
@@ -1,0 +1,37 @@
+# Runs the suite an emergency label waived, off the release path.
+#
+# The name is load-bearing: Release subscribes to `workflow_run` of the workflow
+# named "Test", so naming this one "Test" would fire a second release.
+name: Test (async)
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: test-async-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    name: Test policy 🚦
+    runs-on: ubuntu-24.04
+    outputs:
+      emergency: ${{ steps.labels.outputs.emergency }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve emergency labels
+        id: labels
+        uses: ./.github/actions/resolve-test-policy
+        with:
+          github-token: ${{ github.token }}
+
+  tests:
+    name: Waived tests
+    needs: [policy]
+    if: needs.policy.outputs.emergency == 'true'
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
+    with:
+      force-run-tests: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,41 +14,23 @@ jobs:
     name: Test policy 🚦
     runs-on: ubuntu-24.04
     outputs:
-      run-tests: ${{ steps.resolve.outputs.run-tests }}
+      run-tests: ${{ steps.decide.outputs.run-tests }}
     steps:
-      - name: Resolve emergency labels
-        id: resolve
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          # On pull_request the labels ride along on the event. On push they do
-          # not, so ask which PR produced the commit — for a squash merge that
-          # is the PR whose label we want.
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-        run: |
-          set -uo pipefail
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            labels="$PR_LABELS"
-          elif [ "$EVENT_NAME" = "push" ]; then
-            # A failed lookup must read as "no labels" so the tests still run:
-            # never let a transient API error skip them.
-            labels=$(gh api "repos/$REPO/commits/$SHA/pulls" \
-              --jq '[.[].labels[].name] | join(",")' 2>/dev/null) || labels=""
-          else
-            labels=""
-          fi
-          echo "Labels: ${labels:-<none>}"
+      - uses: actions/checkout@v4
 
-          run=true
-          if [[ ",$labels," == *",skip-all-tests,"* ]]; then
-            run=false
-            echo "skip-all-tests: running nothing, here or in billing."
-          elif [[ ",$labels," == *",test-cloud-only,"* ]]; then
-            run=false
-            echo "test-cloud-only: billing's composed run is the gate instead."
-          fi
+      - name: Resolve emergency labels
+        id: labels
+        uses: ./.github/actions/resolve-test-policy
+        with:
+          github-token: ${{ github.token }}
+
+      - name: Decide
+        id: decide
+        env:
+          EMERGENCY: ${{ steps.labels.outputs.emergency }}
+        run: |
+          if [ "$EMERGENCY" = "true" ]; then run=false; else run=true; fi
+          echo "Emergency: $EMERGENCY -> run-tests=$run"
           echo "run-tests=$run" >> "$GITHUB_OUTPUT"
 
   backend-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches: [main, release]
   pull_request:
+  # Called only by "Test (async)", to run what an emergency label waived.
+  workflow_call:
+    inputs:
+      force-run-tests:
+        description: Run the jobs even when an emergency label waived them
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   # Every job below can be skipped, but the run itself must still complete
@@ -28,9 +36,14 @@ jobs:
         id: decide
         env:
           EMERGENCY: ${{ steps.labels.outputs.emergency }}
+          FORCED: ${{ inputs.force-run-tests }}
         run: |
-          if [ "$EMERGENCY" = "true" ]; then run=false; else run=true; fi
-          echo "Emergency: $EMERGENCY -> run-tests=$run"
+          if [ "$FORCED" = "true" ] || [ "$EMERGENCY" != "true" ]; then
+            run=true
+          else
+            run=false
+          fi
+          echo "Forced: $FORCED, emergency: $EMERGENCY -> run-tests=$run"
           echo "run-tests=$run" >> "$GITHUB_OUTPUT"
 
   backend-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,55 @@ on:
   pull_request:
 
 jobs:
+  # Every job below can be skipped, but the run itself must still complete
+  # successfully: Release triggers on `workflow_run` of this workflow, so
+  # suppressing the run outright (a [skip ci] commit, say) means no release.
+  policy:
+    name: Test policy 🚦
+    runs-on: ubuntu-24.04
+    outputs:
+      run-tests: ${{ steps.resolve.outputs.run-tests }}
+    steps:
+      - name: Resolve emergency labels
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          # On pull_request the labels ride along on the event. On push they do
+          # not, so ask which PR produced the commit — for a squash merge that
+          # is the PR whose label we want.
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            labels="$PR_LABELS"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            # A failed lookup must read as "no labels" so the tests still run:
+            # never let a transient API error skip them.
+            labels=$(gh api "repos/$REPO/commits/$SHA/pulls" \
+              --jq '[.[].labels[].name] | join(",")' 2>/dev/null) || labels=""
+          else
+            labels=""
+          fi
+          echo "Labels: ${labels:-<none>}"
+
+          run=true
+          if [[ ",$labels," == *",skip-all-tests,"* ]]; then
+            run=false
+            echo "skip-all-tests: running nothing, here or in billing."
+          elif [[ ",$labels," == *",test-cloud-only,"* ]]; then
+            run=false
+            echo "test-cloud-only: billing's composed run is the gate instead."
+          fi
+          echo "run-tests=$run" >> "$GITHUB_OUTPUT"
+
   backend-build:
     name: Build backend 🏗️
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +78,8 @@ jobs:
   backend-build-without-ee:
     name: Build backend without ee 🏗️
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     permissions:
       contents: read
     steps:
@@ -240,6 +288,8 @@ jobs:
   frontend-build:
     name: Build frontend 🏗️
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -261,6 +311,8 @@ jobs:
   frontend-code-check:
     name: Frontend static check 🪲
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -323,6 +375,8 @@ jobs:
   frontend-test:
     name: Frontend unit tests 🧪
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -346,6 +400,8 @@ jobs:
   frontend-test-without-ee:
     name: Frontend unit tests without ee 🧪
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     permissions:
       contents: read
     steps:
@@ -459,6 +515,8 @@ jobs:
   data-cy-check:
     name: DataCy Check 🏷️
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -489,6 +547,8 @@ jobs:
   e2e-code-checks:
     name: E2E Static Check 🪲
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -512,6 +572,8 @@ jobs:
   e2e-install-deps:
     name: Install E2E dependencies ⬇️
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -543,6 +605,8 @@ jobs:
   backend-code-checks:
     name: Ktlint 🪲
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -557,6 +621,8 @@ jobs:
   email-code-checks:
     name: Email templates static check 🪲
     runs-on: ubuntu-24.04
+    needs: [policy]
+    if: needs.policy.outputs.run-tests == 'true'
     steps:
       - uses: actions/checkout@v4
 
@@ -661,73 +727,35 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     steps:
-      - run: |
-          # Check the results of all jobs
+      # skipped is a pass — the labels skip these on purpose. A job skipped by a
+      # failed dependency is still caught: the dependency itself reports it.
+      - env:
+          RESULTS: |
+            backend-build=${{ needs.backend-build.result }}
+            backend-build-without-ee=${{ needs.backend-build-without-ee.result }}
+            backend-test=${{ needs.backend-test.result }}
+            backend-code-checks=${{ needs.backend-code-checks.result }}
+            email-code-checks=${{ needs.email-code-checks.result }}
+            frontend-build=${{ needs.frontend-build.result }}
+            frontend-code-check=${{ needs.frontend-code-check.result }}
+            frontend-test=${{ needs.frontend-test.result }}
+            frontend-test-without-ee=${{ needs.frontend-test-without-ee.result }}
+            schema-check=${{ needs.schema-check.result }}
+            migration-check=${{ needs.migration-check.result }}
+            data-cy-check=${{ needs.data-cy-check.result }}
+            docker-slim-smoke=${{ needs.docker-slim-smoke.result }}
+            e2e=${{ needs.e2e.result }}
+            e2e-code-checks=${{ needs.e2e-code-checks.result }}
+            e2e-install-deps=${{ needs.e2e-install-deps.result }}
+        run: |
           failed_jobs=()
-
-          if [[ "${{ needs.backend-build.result }}" != "success" ]]; then
-            failed_jobs+=("backend-build")
-          fi
-
-          if [[ "${{ needs.backend-build-without-ee.result }}" != "success" ]]; then
-            failed_jobs+=("backend-build-without-ee")
-          fi
-
-          if [[ "${{ needs.backend-test.result }}" != "success" ]]; then
-            failed_jobs+=("backend-test")
-          fi
-
-          if [[ "${{ needs.backend-code-checks.result }}" != "success" ]]; then
-            failed_jobs+=("backend-code-checks")
-          fi
-
-          if [[ "${{ needs.frontend-build.result }}" != "success" ]]; then
-            failed_jobs+=("frontend-build")
-          fi
-
-          if [[ "${{ needs.frontend-code-check.result }}" != "success" ]]; then
-            failed_jobs+=("frontend-code-check")
-          fi
-
-          if [[ "${{ needs.frontend-test.result }}" != "success" ]]; then
-            failed_jobs+=("frontend-test")
-          fi
-
-          if [[ "${{ needs.frontend-test-without-ee.result }}" != "success" ]]; then
-            failed_jobs+=("frontend-test-without-ee")
-          fi
-
-          if [[ "${{ needs.schema-check.result }}" != "success" ]]; then
-            failed_jobs+=("schema-check")
-          fi
-
-          if [[ "${{ needs.migration-check.result }}" != "success" ]]; then
-            failed_jobs+=("migration-check")
-          fi
-
-          if [[ "${{ needs.data-cy-check.result }}" != "success" ]]; then
-            failed_jobs+=("data-cy-check")
-          fi
-
-          if [[ "${{ needs.docker-slim-smoke.result }}" != "success" ]]; then
-            failed_jobs+=("docker-slim-smoke")
-          fi
-
-          if [[ "${{ needs.e2e.result }}" != "success" ]]; then
-            failed_jobs+=("e2e")
-          fi
-
-          if [[ "${{ needs.e2e-code-checks.result }}" != "success" ]]; then
-            failed_jobs+=("e2e-code-checks")
-          fi
-
-          if [[ "${{ needs.e2e-install-deps.result }}" != "success" ]]; then
-            failed_jobs+=("e2e-install-deps")
-          fi
-
-          if [[ "${{ needs.email-code-checks.result }}" != "success" ]]; then
-            failed_jobs+=("email-code-checks")
-          fi
+          while IFS='=' read -r name result; do
+            [ -z "$name" ] && continue
+            case "$result" in
+              success | skipped) ;;
+              *) failed_jobs+=("$name ($result)") ;;
+            esac
+          done <<< "$RESULTS"
 
           if [[ "${#failed_jobs[@]}" -gt 0 ]]; then
             echo "The following jobs failed: ${failed_jobs[*]}"


### PR DESCRIPTION
Part 2 of 2. **Merge tolgee/billing#297 first** — once this starts sending `skip-tests`, a billing that doesn't declare the input rejects the dispatch with HTTP 422.

## Problem

An emergency fix waits for the platform suite three times: on the PR, again on the push to main (a squash merge of an unmoved main reproduces the same tree), and a third time in billing. Roughly **85–120 minutes** from merge to production.

## Two labels

| Label | ① PR | ② push:main | ③ billing composed run |
|---|---|---|---|
| *(none)* | runs | runs | runs |
| `test-cloud-only` | skipped | skipped | **runs** |
| `skip-all-tests` | skipped | skipped | skipped |

`test-cloud-only` keeps the run that matters. Nothing in *this* repo tests the cloud composition — `settings.gradle` includes `:billing-app` only when `../billing/app` exists, which never holds in platform CI, so ① and ② build `server-app` without billing. Billing's run is the only one that builds platform + ee + billing, i.e. the image that actually reaches cloud. Time to production drops to **~55 min with no pre-merge wait**.

`skip-all-tests` is the 2am option and blocks nothing.

## Why labels, not a commit marker

A squash merge puts the PR title into the commit subject, and semantic-release feeds that subject straight into the changelog and the GitHub release notes — a `[skip-tests]` marker would be *published*. A label is also revocable when the emergency turns out not to be one.

## The constraint that shapes the implementation

**The run must still complete successfully with every job skipped.** Release triggers on `workflow_run` of this workflow, so suppressing the run outright (a `[skip ci]` commit) means **no release at all**. Two consequences:

- `everything-passed` had to stop counting `skipped` as failure — otherwise the run goes red and the whole chain stops. A job skipped because its dependency failed is still caught, since the dependency reports it.
- Only the eleven jobs without a `needs:` clause carry the condition; the other five skip transitively.

## Async follow-up

`Test (async)` runs the waived suite off the release path, so `skip-all-tests` no longer means "never tested" — it means "nothing *blocks* the release". It can't stop a bad release, it shortens how long one goes unnoticed to ~20 min.

There's no flag for this: what makes it asynchronous is that it's a separate run nothing subscribes to. Release matches `workflows: ["Test"]` by **exact name**, so `Test (async)` is invisible to it, and both fire on the same push. Doing it inside `Test` with `continue-on-error` wouldn't work — `workflow_run` fires when the *run* completes, not per job.

⚠️ **That name is load-bearing.** Calling this workflow `Test` would fire a second release.

`skip-all-tests` also gets a second billing dispatch with no `release-version`: billing runs the composed suite and its `trigger-release` job skips itself. Signal only, no second release.

## Commits

1. `chore: skip CI on emergency releases via pull request labels`
2. `chore: extract the emergency label lookup into a composite action` — pure refactor, no behaviour change
3. `chore: run the tests an emergency release waived, off the release path`

The extraction is split out because writing it as "no behaviour change" caught a real bug: collapsing the event switch made a manual `workflow_dispatch` of Test inherit a waiver from whatever PR last touched `HEAD` — a manual run means *run the tests*.

## Before merging

Labels need creating:

```bash
gh label create test-cloud-only --repo tolgee/tolgee-platform --color FBCA04 \
  --description "Emergency: skip platform CI; billing's composed run gates cloud"
gh label create skip-all-tests --repo tolgee/tolgee-platform --color D93F0B \
  --description "Emergency: run no tests anywhere, including the cloud image"
```

## Known sharp edges

- **Self-hosted artifacts ship untested under either label.** `release.yml` publishes `tolgee/tolgee:VERSION`, `:latest`, the tag and the GitHub release *before* it dispatches billing — so ③ can't gate them, and the without-EE configuration is covered only by ①/②. Cloud is protected; self-hosted is not. The structural fix is reordering the chain, which is separate work.
- **Label before you merge.** ②, async and billing all read labels live via the API, so labelling any time before the merge works. Labelling *after* races the push event. The PR's own run reads the frozen event payload, so it won't retroactively skip — that only wastes compute, since nothing blocks the merge.
- **A red `Test (async)` reaches nobody's review queue.** It has no PR attached; GitHub emails the actor and that's it. Worth wiring a Slack notification, or this is an audit trail rather than a safety net.
- **Worth confirming on first use** that a reusable workflow doesn't emit its own `workflow_run` event (the design assumes it doesn't). If it did, an async run would fire a redundant Release — a no-op, but `concurrency: {group: release}` on `release.yml` would be cheap insurance.

## Testing

The label matcher was exercised across 13 cases including substring traps (`no-skip-all-tests-please`, `skip-all-tests-later`, `xskip-duplicate-tests` correctly don't match), the `force-run-tests` truth table across all six input combinations, and the `everything-passed` gate across 7 result mixtures. All four YAML files parse.