### PR TITLE
chore: drop httpclient5 5.4.4 pin, use Spring Boot managed version

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     implementation libs.icu4j
     implementation libs.jacksonModuleKotlin
     implementation libs.jacksonDataFormatXml
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.4'
+    implementation 'org.apache.httpcomponents.client5:httpclient5'
 
     implementation "org.springframework.boot:spring-boot-properties-migrator"
 


### PR DESCRIPTION
## What
Removes the explicit `httpclient5:5.4.4` version in `backend/app/build.gradle` so the Spring Boot BOM's managed version (currently 5.6.1) resolves instead.

## Why
The pin downgraded httpclient5 from the BOM-requested 5.6.1 down to 5.4.4, which Snyk flags (Missing Release of Resource after Effective Lifetime, fixable). This was the last Snyk finding actually present on `main` — the netty/spring-web/thymeleaf criticals in the Slack #vulnerabilities feed only affect the stale `tolgee/tolgee:v3.137.0` / `v3.180.1` image tags still monitored in Snyk, not current releases.

## Verification
- `dependencyInsight`: httpclient5 now resolves to 5.6.1
- Only direct usage is `HttpClientBuilder` basics in `RestTemplateConfiguration.kt` — API stable across 5.4→5.6
- `:server-app:compileKotlin` + `compileTestKotlin` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache HttpClient 5 version resolution to use the managed dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->