### PR TITLE
chore: refresh Snyk container snapshot on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,15 @@ jobs:
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
 
+      - name: Refresh Snyk container snapshot
+        if: ${{ steps.version.outputs.VERSION != '' }}
+        continue-on-error: true
+        run: |
+          npm i -g snyk
+          snyk container monitor tolgee/tolgee:latest --org=jancizmar
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
       - name: Pack with webapp
         if: ${{ steps.version.outputs.VERSION != '' }}
         run: ./gradlew packResources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,15 @@ jobs:
           TOLGEE_API_KEY: ${{secrets.TOLGEE_API_KEY}}
           TOLGEE_API_URL: ${{secrets.TOLGEE_API_URL}}
 
+      - name: Install Snyk CLI
+        if: ${{ steps.version.outputs.VERSION != '' }}
+        continue-on-error: true
+        run: npm i -g snyk@1.1307.0
+
       - name: Refresh Snyk container snapshot
         if: ${{ steps.version.outputs.VERSION != '' }}
         continue-on-error: true
-        run: |
-          npm i -g snyk
-          snyk container monitor tolgee/tolgee:latest --org=jancizmar
+        run: snyk container monitor tolgee/tolgee:latest --org=jancizmar
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
## What
Adds a `snyk container monitor tolgee/tolgee:latest` step to the release workflow, right after `dockerPublish`, guarded by `continue-on-error` so Snyk problems can never block a release.

## Why
The `tolgee/tolgee` target in Snyk is a CLI-imported snapshot — Snyk re-tests the stored package inventory against new CVE data daily, but never re-pulls the image. The snapshot had rotted for months, producing phantom criticals in #vulnerabilities for netty/spring/thymeleaf versions we no longer ship. Refreshing on every release keeps Snyk describing the image users actually run.

## Setup required
Needs a `SNYK_TOKEN` repository secret (Snyk API token of a user in the jancizmar org). Until it's added, the step fails softly without affecting the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated security monitoring for the latest container image during releases.
  * Release workflows continue even if monitoring encounters an error, helping maintain reliable release automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->