### PR TITLE
fix: improve key description UX 

### DIFF
--- a/webapp/src/component/LimitedHeightText.tsx
+++ b/webapp/src/component/LimitedHeightText.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, RefObject } from 'react';
-import { Popper, keyframes, styled } from '@mui/material';
+import { Button, Popper, keyframes, styled } from '@mui/material';
 import { useTimer } from '../fixtures/useTimer';
 import { getEffectiveBackgroundColor } from 'tg.fixtures/getEffectiveElementBackground';
 
@@ -35,6 +35,13 @@ const StyledOverlay = styled('div')`
   box-shadow: '0px 0px 5px 2px rgba(0,0,0,0.1)';
 `;
 
+const StyledExpandButton = styled(Button)`
+  min-width: 0;
+  padding: 2px 0;
+  font-size: inherit;
+  text-transform: none;
+`;
+
 type Props = {
   maxLines?: number | undefined;
   lang?: string;
@@ -43,6 +50,10 @@ type Props = {
   overlayPadding?: number;
   lineHeight?: string;
   overlay?: boolean;
+  expandControls?: {
+    showMore: React.ReactNode;
+    showLess: React.ReactNode;
+  };
 };
 
 export const LimitedHeightText: React.FC<React.PropsWithChildren<Props>> = ({
@@ -54,14 +65,16 @@ export const LimitedHeightText: React.FC<React.PropsWithChildren<Props>> = ({
   overlayPadding = 8,
   lineHeight = '1.2em',
   overlay = true,
+  expandControls,
 }) => {
   const textRef = useRef<HTMLDivElement>();
   const [expandable, setExpandable] = useState<boolean>(false);
   const [overlayOpen, setOverlayOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
 
   const detectExpandability = () => {
     const textElement = textRef.current;
-    if (textElement != null) {
+    if (textElement != null && !expanded) {
       // Use a 2px threshold to account for browser rounding differences
       const heightDifference =
         textElement.scrollHeight - textElement.clientHeight;
@@ -69,11 +82,11 @@ export const LimitedHeightText: React.FC<React.PropsWithChildren<Props>> = ({
     }
   };
 
-  const overlayEnabled = expandable && overlay;
+  const overlayEnabled = expandable && overlay && !expandControls;
 
   const { clearTimer, reStartTimer } = useTimer({
     callback: () => setOverlayOpen(true),
-    delay: 1000,
+    delay: 10,
     enabled: overlayEnabled && !overlayOpen,
   });
 
@@ -86,81 +99,99 @@ export const LimitedHeightText: React.FC<React.PropsWithChildren<Props>> = ({
     detectExpandability();
   });
 
-  const gradient = expandable
-    ? `linear-gradient(to top, rgba(0,0,0,0) 0%, rgba(0,0,0,0.87) ${lineHeight}, rgba(0,0,0,0.87) ${
-        100 / (maxLines || 100)
-      }%, black 100%)`
-    : undefined;
+  const gradient =
+    expandable && !expanded
+      ? `linear-gradient(to top, rgba(0,0,0,0) 0%, rgba(0,0,0,0.87) ${lineHeight}, rgba(0,0,0,0.87) ${
+          100 / (maxLines || 100)
+        }%, black 100%)`
+      : undefined;
 
   return (
-    <StyledContainer
-      className="text"
-      ref={textRef as RefObject<HTMLDivElement>}
-      // when moving mouse, reinitialize timer
-      // so it only fires when you stop the mouse
-      onMouseMove={reStartTimer}
-      onMouseLeave={handleLeave}
-      style={{
-        maxHeight: maxLines ? `calc(${lineHeight} * ${maxLines})` : undefined,
-        WebkitMaskImage: gradient,
-        maskImage: gradient,
-        wordBreak: wrap,
-        lineHeight: lineHeight,
-      }}
-      lang={lang}
-    >
-      {children}
-      {overlayEnabled && overlayOpen && textRef.current ? (
-        <Popper
-          open={true}
-          anchorEl={textRef.current}
-          placement="bottom-start"
-          style={{
-            pointerEvents: 'none',
-          }}
-          modifiers={[
-            {
-              name: 'offset',
-              options: {
-                offset: ({ reference }) => {
-                  return [0, -reference.height];
+    <>
+      <StyledContainer
+        className="text"
+        ref={textRef as RefObject<HTMLDivElement>}
+        // when moving mouse, reinitialize timer
+        // so it only fires when you stop the mouse
+        onMouseMove={expandControls ? undefined : reStartTimer}
+        onMouseLeave={expandControls ? undefined : handleLeave}
+        style={{
+          maxHeight:
+            maxLines && !expanded
+              ? `calc(${lineHeight} * ${maxLines})`
+              : undefined,
+          WebkitMaskImage: gradient,
+          maskImage: gradient,
+          wordBreak: wrap,
+          lineHeight: lineHeight,
+        }}
+        lang={lang}
+      >
+        {children}
+        {overlayEnabled && overlayOpen && textRef.current ? (
+          <Popper
+            open={true}
+            anchorEl={textRef.current}
+            placement="bottom-start"
+            style={{
+              pointerEvents: 'none',
+            }}
+            modifiers={[
+              {
+                name: 'offset',
+                options: {
+                  offset: ({ reference }) => {
+                    return [0, -reference.height];
+                  },
                 },
               },
-            },
-            {
-              name: 'computeStyles',
-              options: {
-                gpuAcceleration: false,
+              {
+                name: 'computeStyles',
+                options: {
+                  gpuAcceleration: false,
+                },
               },
-            },
-            {
-              name: 'preventOverflow',
-              enabled: true,
-              options: {
-                padding: 0,
+              {
+                name: 'preventOverflow',
+                enabled: true,
+                options: {
+                  padding: 0,
+                },
               },
-            },
-          ]}
-        >
-          <StyledOverlay
-            lang={lang}
-            className="text"
-            style={{
-              width: textRef.current?.clientWidth + 'px',
-              background: getEffectiveBackgroundColor(textRef.current),
-              color: window.getComputedStyle(textRef.current).color,
-              wordBreak: wrap,
-              top: -overlayPadding,
-              left: -overlayPadding,
-              padding: overlayPadding,
-              lineHeight: lineHeight,
-              fontSize: window.getComputedStyle(textRef.current).fontSize,
-            }}
+            ]}
           >
-            {children}
-          </StyledOverlay>
-        </Popper>
-      ) : null}
-    </StyledContainer>
+            <StyledOverlay
+              lang={lang}
+              className="text"
+              style={{
+                width: textRef.current?.clientWidth + 'px',
+                background: getEffectiveBackgroundColor(textRef.current),
+                color: window.getComputedStyle(textRef.current).color,
+                wordBreak: wrap,
+                top: -overlayPadding,
+                left: -overlayPadding,
+                padding: overlayPadding,
+                lineHeight: lineHeight,
+                fontSize: window.getComputedStyle(textRef.current).fontSize,
+              }}
+            >
+              {children}
+            </StyledOverlay>
+          </Popper>
+        ) : null}
+      </StyledContainer>
+      {expandControls && expandable && (
+        <StyledExpandButton
+          size="small"
+          onClick={(event) => {
+            event.stopPropagation();
+            setExpanded((value) => !value);
+          }}
+          aria-expanded={expanded}
+        >
+          {expanded ? expandControls.showLess : expandControls.showMore}
+        </StyledExpandButton>
+      )}
+    </>
   );
 };

--- a/webapp/src/views/projects/translations/KeyCellContent.tsx
+++ b/webapp/src/views/projects/translations/KeyCellContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { styled } from '@mui/material';
 import ReactMarkdown from 'react-markdown';
+import { useTranslate } from '@tolgee/react';
 
 import { LimitedHeightText } from 'tg.component/LimitedHeightText';
 import { MarkdownLink } from 'tg.component/common/MarkdownLink';
@@ -23,6 +24,8 @@ export const StyledDescription = styled('div')`
       : theme.palette.emphasis[500]};
 `;
 
+const Markdown = styled('div')``;
+
 type Props = {
   keyName: string;
   description?: string | null;
@@ -34,6 +37,8 @@ export const KeyCellContent: React.FC<React.PropsWithChildren<Props>> = ({
   description,
   width,
 }) => {
+  const { t } = useTranslate();
+
   return (
     <>
       <StyledKey data-cy="translations-key-name">
@@ -43,14 +48,28 @@ export const KeyCellContent: React.FC<React.PropsWithChildren<Props>> = ({
       </StyledKey>
       {description && (
         <StyledDescription data-cy="translations-key-cell-description">
-          <LimitedHeightText maxLines={5}>
-            <ReactMarkdown
-              components={{
-                a: MarkdownLink,
-              }}
-            >
-              {description}
-            </ReactMarkdown>
+          <LimitedHeightText
+            maxLines={5}
+            expandControls={{
+              showMore: t(
+                'translations_key_description_show_more',
+                'Show more'
+              ),
+              showLess: t(
+                'translations_key_description_show_less',
+                'Show less'
+              ),
+            }}
+          >
+            <Markdown>
+              <ReactMarkdown
+                components={{
+                  a: MarkdownLink,
+                }}
+              >
+                {description}
+              </ReactMarkdown>
+            </Markdown>
           </LimitedHeightText>
         </StyledDescription>
       )}


### PR DESCRIPTION
## Summary

- Fix Markdown horizontal rules rendering as dots in collapsed key descriptions. #3679
- Add explicit “Show more” and “Show less” controls for overflowing descriptions.
- Disable hidden hover expansion when explicit controls are available.
- issue - 

<img width="490" height="344" alt="image" src="https://github.com/user-attachments/assets/7d1b5061-38c9-4a27-a22c-04770741e02d" />


Closes #3679







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added “Show more” and “Show less” controls for expanding and collapsing long translation descriptions.
  - Expand/collapse labels are now localized.

- **Bug Fixes**
  - Improved long-text display behavior and reduced overlay delay.
  - Prevented the translation editor from overflowing its available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->