### PR TITLE
docs: rewrite the Docker Hub overview and keep its source in the repo

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,23 @@
+name: Docker Hub description
+
+# Run manually from the Actions tab after changing docker/DOCKERHUB.md.
+# Updating a description requires the Docker Hub credential to have Admin on
+# the repository — push access, which is all the release workflows need, is not
+# enough.
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push description to Docker Hub
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: tolgee/tolgee
+          readme-filepath: ./docker/DOCKERHUB.md
+          short-description: "Open-source localization platform — self-host the whole Tolgee server in one container."

--- a/docker/DOCKERHUB.md
+++ b/docker/DOCKERHUB.md
@@ -1,0 +1,157 @@
+[![Docker Image Version](https://img.shields.io/docker/v/tolgee/tolgee/latest?label=docker&logo=docker&logoColor=fff&color=2496ED)](https://hub.docker.com/r/tolgee/tolgee/tags)
+[![GitHub Release](https://img.shields.io/github/v/release/tolgee/tolgee-platform?label=release)](https://github.com/tolgee/tolgee-platform/releases/latest)
+[![License](https://img.shields.io/badge/license-Apache%202%20%2F%20Tolgee%20EL-blue)](https://github.com/tolgee/tolgee-platform/blob/main/LICENSE)
+[![Docs](https://img.shields.io/badge/docs-tolgee.io-EC407A)](https://docs.tolgee.io/platform/self_hosting/running_with_docker)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=fff)](https://join.slack.com/t/tolgeecommunity/shared_invite/zt-2zp55d175-_agXTfKKVbf1BYXlKlmwbA)
+
+# Tolgee — open-source localization platform
+
+[<img src="https://raw.githubusercontent.com/tolgee/documentation/main/tolgee_logo_text.svg" alt="Tolgee" width="180" />](https://tolgee.io)
+
+An open-source alternative to Crowdin, Phrase and Lokalise. This image runs the entire
+Tolgee server — web app, REST API, background workers and an optional bundled
+PostgreSQL — in a single container.
+
+`linux/amd64` · `linux/arm64` · JRE 25 on Alpine
+
+---
+
+## Quick start
+
+```bash
+docker run -v tolgee_data:/data -p 8085:8080 tolgee/tolgee
+```
+
+Open <http://localhost:8085>. Sign in as `admin` — the initial password is generated on
+first boot and written into the volume:
+
+```bash
+docker exec <container> cat /data/initial.pwd
+```
+
+> **The bundled PostgreSQL is for evaluation only.** For anything you care about, run an
+> external database — see **Production setup** below.
+
+## Production setup (docker compose)
+
+`docker-compose.yaml`:
+
+```yaml
+services:
+  app:
+    image: tolgee/tolgee:latest
+    volumes:
+      - ./data:/data
+      - ./config.yaml:/config.yaml
+    ports:
+      - '8080:8080'
+    environment:
+      spring.config.additional-location: file:///config.yaml
+    depends_on:
+      - db
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: change_me
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
+```
+
+`config.yaml`:
+
+```yaml
+tolgee:
+  postgres-autostart:
+    enabled: false          # turn off the bundled database
+  authentication:
+    enabled: true
+    jwt-secret: change_me   # keeps sessions valid across restarts
+spring:
+  datasource:
+    url: jdbc:postgresql://db:5432/postgres
+    username: postgres
+    password: change_me
+```
+
+```bash
+docker compose up -d
+```
+
+Full walkthrough: [Running with Docker](https://docs.tolgee.io/platform/self_hosting/running_with_docker).
+
+## Tags
+
+| Tag | Use it for |
+| --- | --- |
+| `latest` | Tracks the newest release. Fine for trying Tolgee out. |
+| `v3.218.6` — every release | Immutable. **Pin one of these in production.** |
+
+Every tag is a multi-arch manifest for `linux/amd64` and `linux/arm64`.
+Releases go out several times a week — see the
+[changelog](https://github.com/tolgee/tolgee-platform/releases).
+
+## Image reference
+
+| | |
+| --- | --- |
+| **Port 8080** | Web app + REST API |
+| **Port 25432** | Bundled PostgreSQL, when `postgres-autostart` is on |
+| **Volume `/data`** | Database files, uploaded screenshots, `initial.pwd` |
+| **Healthcheck** | `GET /actuator/health` (already declared in the image) |
+| **Base** | `postgres:13-alpine` + Eclipse Temurin JRE 25 |
+| **Config** | `TOLGEE_*` env vars, or mount a YAML file and point `spring.config.additional-location` at it |
+
+## Common configuration
+
+| Variable | What it does |
+| --- | --- |
+| `TOLGEE_AUTHENTICATION_ENABLED` | Turn authentication on (do this). |
+| `TOLGEE_AUTHENTICATION_INITIAL_USERNAME` | First admin account. Defaults to `admin`. |
+| `TOLGEE_AUTHENTICATION_INITIAL_PASSWORD` | Set it yourself, or read the generated one from `/data/initial.pwd`. |
+| `TOLGEE_AUTHENTICATION_JWT_SECRET` | Signs sessions. Set it, or everyone is logged out on restart. |
+| `TOLGEE_POSTGRES_AUTOSTART_ENABLED` | `false` to use your own PostgreSQL. |
+| `SPRING_DATASOURCE_URL` | Your database, e.g. `jdbc:postgresql://db:5432/postgres`. |
+| `TOLGEE_SMTP_HOST` and friends | Outgoing mail — invitations, password resets. |
+| `TOLGEE_FILE_STORAGE_*` | Store screenshots in S3 instead of the volume. |
+| `OTEL_JAVAAGENT_ENABLED` | `true` starts the bundled OpenTelemetry agent for traces. |
+
+Every property, in env / YAML / properties form:
+[configuration reference](https://docs.tolgee.io/platform/self_hosting/configuration).
+
+## What you get
+
+**Translating**
+Web editor with comments, translation history and an activity log · translation memory
+with similarity scoring · glossaries · machine translation via DeepL, Google Translate,
+AWS Translate and LLM providers · auto-translation of new keys · review and task
+workflows.
+
+**In your app**
+In-context editing — ALT-click a string in your running app and edit it, production
+included · one-click screenshots with the phrases highlighted · SDKs for React, Vue,
+Svelte, Angular, Next.js, Nuxt, i18next and more · content delivery to a CDN ·
+webhooks · a CLI · a Figma plugin, a VS Code extension and a Chrome extension.
+
+**For teams**
+Organizations, granular permissions and SSO/SAML · branching, so translations follow
+your feature branches · batch operations across thousands of keys · an
+[MCP server](https://github.com/tolgee/tolgee-platform/blob/main/DEVELOPMENT.md#mcp-server)
+so AI coding assistants can manage translations directly.
+
+## Licensing
+
+The platform is Apache 2.0. The `ee/` directory is covered by the
+[Tolgee Enterprise License](https://github.com/tolgee/tolgee-platform/blob/main/ee/LICENSE)
+and its features need a license key — everything else in this image is free to
+self-host, with no seat or key limit. Details:
+[self-hosted licensing](https://docs.tolgee.io/platform/self_hosting/licensing).
+
+## Links
+
+[Documentation](https://docs.tolgee.io/) ·
+[GitHub](https://github.com/tolgee/tolgee-platform) ·
+[Report a bug](https://github.com/tolgee/tolgee-platform/issues) ·
+[Slack community](https://join.slack.com/t/tolgeecommunity/shared_invite/zt-2zp55d175-_agXTfKKVbf1BYXlKlmwbA) ·
+[Tolgee Cloud](https://app.tolgee.io/sign_up)


### PR DESCRIPTION
The [tolgee/tolgee Docker Hub page](https://hub.docker.com/r/tolgee/tolgee) has not had a content update since **October 2021**. It has taken 1.66M pulls since. This moves its source into the repo and rewrites it.

## What is wrong with the current page

| | |
| --- | --- |
| **Both doc links 404** | They point at the old `server_and_web_app` docs tree. These are the page's only two routes into the docs. |
| **You cannot log in by following it** | It never mentions that the admin password is generated on first boot into `/data/initial.pwd`. |
| **Silent about the bundled PostgreSQL** | The image is built on `postgres:13-alpine` and autostarts a database. Nothing tells a reader to disable it and attach a real one before production. |
| **No reference material** | No tags, platforms, ports, volume, healthcheck or environment variables — the things a Docker Hub reader actually comes for. |
| **Feature list stops at 2021** | No translation memory, glossaries, LLM machine translation, branching, SSO, batch operations, content delivery, webhooks, CLI, SDK range or MCP server. |
| **Screenshot and GIF are from 2021** | 2021 `user-images.githubusercontent.com` uploads of a UI that no longer exists. |
| **Short description is empty** | The repository renders blank in Docker Hub search. |

The root cause is that the description is hand-maintained in the Docker Hub UI, with no copy in the repo — so nobody reviewing a change to `docker/` ever saw it drift.

## What this PR does

- **`docker/DOCKERHUB.md`** — the new page, and from here on the source of truth for it. Quick start (including reading `initial.pwd`), production compose with an external database, tag and image reference, the common `TOLGEE_*` variables, the current feature set, licensing.
- **`.github/workflows/dockerhub-description.yml`** — pushes that file and the short description to Docker Hub. **Manual dispatch only**, no push trigger.

Every claim in the file is taken from `docker/app/Dockerfile`, `gradle/docker.gradle`, the Docker Hub tags API or the current self-hosting docs. All 21 links in it were checked and resolve.

### Why dispatch-only

Updating a Docker Hub description requires the credential to have **Admin** on the repository — push access, which is all the release workflows need, is not enough, and we do not know yet whether `DOCKERHUB_PASSWORD` clears that bar. Dispatch-only keeps that uncertainty off `main`: nothing runs on merge, and the first run is a deliberate click by someone who can read the result. The page changes maybe once a year, so a push trigger buys little anyway.

If the run fails on permissions, the fix is to reissue `DOCKERHUB_PASSWORD` as a PAT with `read/write/delete` scope on an account with Admin on `tolgee/tolgee`. Failing that, the file can simply be pasted into the Docker Hub UI by hand.

## Still needs someone with Docker Hub access

**Categories are unset**, and the action cannot set them — so the repository currently appears in no browse listing. That is a manual change in the Docker Hub UI.

## Follow-up, not included here

The page needs one current screenshot of the translation editor and one in-context GIF, committed to the repo rather than relying on the 2021 uploads. I left the old ones out entirely rather than ship a fresh page with a four-year-old UI in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive Docker Hub documentation covering supported architectures, runtime requirements, quick-start instructions, configuration options, image tags, licensing, and deployment guidance.
  - Documented evaluation and production deployment options, including PostgreSQL requirements and administrator password retrieval.

- **Chores**
  - Added a manually triggered process to synchronize the Docker Hub description with the latest project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->