### PR TITLE
feat: add language-scoped filter for translations never included in a task

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
@@ -272,9 +272,12 @@ class TaskTestData : BaseTestData("tasksTestUser", "Project with tasks") {
     state: TaskState,
     type: TaskType,
     number: Long,
-  ) {
+    taskLanguage: Language = englishLanguage,
+    taskKeys: Collection<KeyBuilder> = keysInTask,
+  ): TaskBuilder {
+    lateinit var createdTask: TaskBuilder
     projectBuilder.apply {
-      blockedTask =
+      createdTask =
         addTask {
           this.number = number
           this.name = name
@@ -285,20 +288,54 @@ class TaskTestData : BaseTestData("tasksTestUser", "Project with tasks") {
               user,
             )
           project = projectBuilder.self
-          language = englishLanguage
+          language = taskLanguage
           author = projectUser.self
           this.state = state
         }
 
-      keysInTask.forEach {
+      taskKeys.forEach {
         addTaskKey {
-          task = blockedTask.self
+          task = createdTask.self
           key = it.self
           done = true
           author = user
         }
       }
     }
+    blockedTask = createdTask
+    return createdTask
+  }
+
+  fun addKeyWithOwnTask(
+    keyName: String,
+    number: Long,
+    taskLanguage: Language = englishLanguage,
+    type: TaskType = TaskType.TRANSLATE,
+    state: TaskState = TaskState.NEW,
+  ): KeyBuilder {
+    lateinit var createdKey: KeyBuilder
+    projectBuilder.apply {
+      createdKey =
+        addKey(null, keyName) {
+          addTranslation("en", "Translation of $keyName")
+          addTranslation("cs", "Překlad $keyName")
+        }
+      val ownTask =
+        addTask {
+          this.number = number
+          this.name = "Task of $keyName"
+          this.type = type
+          this.state = state
+          project = projectBuilder.self
+          language = taskLanguage
+          author = projectUser.self
+        }
+      addTaskKey {
+        task = ownTask.self
+        key = createdKey.self
+      }
+    }
+    return createdKey
   }
 
   fun createManyOutOfTaskKeys(): List<KeyBuilder> {

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TaskTestData.kt
@@ -272,12 +272,9 @@ class TaskTestData : BaseTestData("tasksTestUser", "Project with tasks") {
     state: TaskState,
     type: TaskType,
     number: Long,
-    taskLanguage: Language = englishLanguage,
-    taskKeys: Collection<KeyBuilder> = keysInTask,
-  ): TaskBuilder {
-    lateinit var createdTask: TaskBuilder
+  ) {
     projectBuilder.apply {
-      createdTask =
+      blockedTask =
         addTask {
           this.number = number
           this.name = name
@@ -288,22 +285,20 @@ class TaskTestData : BaseTestData("tasksTestUser", "Project with tasks") {
               user,
             )
           project = projectBuilder.self
-          language = taskLanguage
+          language = englishLanguage
           author = projectUser.self
           this.state = state
         }
 
-      taskKeys.forEach {
+      keysInTask.forEach {
         addTaskKey {
-          task = createdTask.self
+          task = blockedTask.self
           key = it.self
           done = true
           author = user
         }
       }
     }
-    blockedTask = createdTask
-    return createdTask
   }
 
   fun addKeyWithOwnTask(

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
@@ -209,6 +209,24 @@ $PATTERN_GRAMMAR_DOC""",
   var filterTaskKeysDone: Boolean? = null
 
   @field:Parameter(
+    description =
+      "Select only keys currently linked to a task in any of the provided languages. Tasks in all " +
+        "states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The " +
+        "link is dropped when a key is removed from a task or when the branch holding it is deleted, " +
+        "so this reflects current task membership rather than an immutable audit log.",
+  )
+  var filterHasTaskInLang: List<String>? = null
+
+  @field:Parameter(
+    description =
+      "Select only keys not currently linked to a task in at least one of the provided languages. " +
+        "Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) " +
+        "count. The link is dropped when a key is removed from a task or when the branch holding it " +
+        "is deleted, so a key can reappear here after having been in a task.",
+  )
+  var filterHasNoTaskInLang: List<String>? = null
+
+  @field:Parameter(
     description = "Filter keys with unresolved comments in lang",
   )
   var filterHasUnresolvedCommentsInLang: List<String>? = null

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/request/translation/TranslationFilters.kt
@@ -219,10 +219,11 @@ $PATTERN_GRAMMAR_DOC""",
 
   @field:Parameter(
     description =
-      "Select only keys not currently linked to a task in at least one of the provided languages. " +
-        "Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) " +
-        "count. The link is dropped when a key is removed from a task or when the branch holding it " +
-        "is deleted, so a key can reappear here after having been in a task.",
+      "Select only keys not currently linked to a task in any of the provided languages, the exact " +
+        "complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) " +
+        "and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed " +
+        "from a task or when the branch holding it is deleted, so a key can reappear here after " +
+        "having been in a task.",
   )
   var filterHasNoTaskInLang: List<String>? = null
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryBase.kt
@@ -62,6 +62,7 @@ class QueryBase<T>(
   private val entityManager: EntityManager,
   private val qaEnabled: Boolean,
   val qaDisabledLanguageIds: Set<Long>,
+  private val tasksEnabled: Boolean,
   val isCountQuery: Boolean = false,
 ) {
   val whereConditions: MutableSet<Predicate> = HashSet()
@@ -108,6 +109,9 @@ class QueryBase<T>(
     addLeftJoinedColumns()
     applyTranslationFilters()
     queryGlobalFiltering.apply()
+    if (tasksEnabled) {
+      queryGlobalFiltering.applyTaskHistoryFilters()
+    }
   }
 
   private fun addLeftJoinedColumns() {

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
@@ -30,7 +30,9 @@ import jakarta.persistence.Tuple
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.Path
 import jakarta.persistence.criteria.Predicate
+import jakarta.persistence.criteria.Root
 import jakarta.persistence.criteria.Subquery
 import org.hibernate.query.criteria.JpaCteContainer
 import org.hibernate.query.criteria.JpaCteCriteria
@@ -453,27 +455,77 @@ class QueryGlobalFiltering(
 
   private fun filterTask() {
     val taskNumbers = params.filterTaskNumber ?: return
+    queryBase.whereConditions.add(
+      taskKeyPredicate { tkRoot ->
+        val conditions = mutableListOf<Predicate>()
+        conditions.add(tkRoot.get(TaskKey_.task).get(Task_.number).`in`(taskNumbers))
+        if (params.filterTaskKeysNotDone == true) {
+          conditions.add(cb.equal(tkRoot.get(TaskKey_.done), false))
+        }
+        if (params.filterTaskKeysDone == true) {
+          conditions.add(cb.equal(tkRoot.get(TaskKey_.done), true))
+        }
+        conditions
+      },
+    )
+  }
 
+  fun applyTaskHistoryFilters() {
+    filterHasTaskInLang()
+    filterHasNoTaskInLang()
+  }
+
+  private fun filterHasTaskInLang() {
+    val languageIds =
+      queryBase.queryTranslationFiltering.languageIdsForTags(params.filterHasTaskInLang) ?: return
+    queryBase.whereConditions.add(taskInLanguagePredicate(languageIds))
+  }
+
+  private fun filterHasNoTaskInLang() {
+    val languageIds =
+      queryBase.queryTranslationFiltering.languageIdsForTags(params.filterHasNoTaskInLang) ?: return
+    val perLanguage = languageIds.map { cb.not(taskInLanguagePredicate(listOf(it), forceCorrelated = true)) }
+    queryBase.whereConditions.add(cb.or(*perLanguage.toTypedArray()))
+  }
+
+  private fun taskInLanguagePredicate(
+    languageIds: List<Long>,
+    forceCorrelated: Boolean = false,
+  ): Predicate =
+    taskKeyPredicate(forceCorrelated) { tkRoot ->
+      listOf(
+        taskLanguagePredicate(
+          tkRoot.get(TaskKey_.task).get(Task_.language).get(Language_.id),
+          languageIds,
+        ),
+      )
+    }
+
+  private fun taskLanguagePredicate(
+    languageIdPath: Path<Long>,
+    languageIds: List<Long>,
+  ): Predicate {
+    if (languageIds.size == 1) return cb.equal(languageIdPath, cb.literal(languageIds.first()))
+    return languageIdPath.`in`(languageIds)
+  }
+
+  private fun taskKeyPredicate(
+    forceCorrelated: Boolean = false,
+    extraConditions: (Root<TaskKey>) -> List<Predicate>,
+  ): Predicate {
+    val useInClause = isCountQuery && !forceCorrelated
     val subquery = queryBase.query.subquery(Long::class.java)
     val tkRoot = subquery.from(TaskKey::class.java)
+    val keyIdPath = tkRoot.get(TaskKey_.key).get(Key_.id)
     val conditions = mutableListOf<Predicate>()
-    if (isCountQuery) {
-      subquery.select(tkRoot.get(TaskKey_.key).get(Key_.id))
-    } else {
-      subquery.select(cb.literal(1L))
-      conditions.add(cb.equal(tkRoot.get(TaskKey_.key).get(Key_.id), queryBase.root.get(Key_.id)))
+    conditions.addAll(extraConditions(tkRoot))
+    if (!useInClause) {
+      conditions.add(cb.equal(keyIdPath, queryBase.root.get(Key_.id)))
     }
-    conditions.add(tkRoot.get(TaskKey_.task).get(Task_.number).`in`(taskNumbers))
-    if (params.filterTaskKeysNotDone == true) {
-      conditions.add(cb.equal(tkRoot.get(TaskKey_.done), false))
-    }
-    if (params.filterTaskKeysDone == true) {
-      conditions.add(cb.equal(tkRoot.get(TaskKey_.done), true))
-    }
+    subquery.select(if (useInClause) keyIdPath else cb.literal(1L))
     subquery.where(cb.and(*conditions.toTypedArray()))
-    queryBase.whereConditions.add(
-      if (isCountQuery) queryBase.root.get(Key_.id).`in`(subquery) else cb.exists(subquery),
-    )
+    if (useInClause) return queryBase.root.get(Key_.id).`in`(subquery)
+    return cb.exists(subquery)
   }
 
   private fun filterRevisionId() {

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryGlobalFiltering.kt
@@ -484,8 +484,7 @@ class QueryGlobalFiltering(
   private fun filterHasNoTaskInLang() {
     val languageIds =
       queryBase.queryTranslationFiltering.languageIdsForTags(params.filterHasNoTaskInLang) ?: return
-    val perLanguage = languageIds.map { cb.not(taskInLanguagePredicate(listOf(it), forceCorrelated = true)) }
-    queryBase.whereConditions.add(cb.or(*perLanguage.toTypedArray()))
+    queryBase.whereConditions.add(cb.not(taskInLanguagePredicate(languageIds, forceCorrelated = true)))
   }
 
   private fun taskInLanguagePredicate(

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/QueryTranslationFiltering.kt
@@ -366,7 +366,7 @@ class QueryTranslationFiltering(
 
   private fun languageByTag(tag: String): LanguageDto? = queryBase.languages.find { it.tag == tag }
 
-  private fun languageIdsForTags(tags: List<String>?): List<Long>? {
+  fun languageIdsForTags(tags: List<String>?): List<Long>? {
     if (tags.isNullOrEmpty()) return null
     val ids = tags.mapNotNull { tag -> languageByTag(tag)?.id }
     return ids.takeIf { it.isNotEmpty() }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationViewDataProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationViewDataProvider.kt
@@ -49,15 +49,36 @@ class TranslationViewDataProvider(
     val project = projectService.get(projectId)
     val qaEnabled = projectFeatureGuard.isFeatureEnabled(Feature.QA_CHECKS, project)
     val qaDisabledLanguageIds = resolveQaDisabledLanguageIds(projectId, qaEnabled)
+    val tasksEnabled =
+      projectFeatureGuard.isFeatureEnabled(Feature.TASKS, project) ||
+        projectFeatureGuard.isFeatureEnabled(Feature.ORDER_TRANSLATION, project)
 
     createFailedKeysInJobTempTable(params.filterFailedKeysOfJob)
 
     val countBuilder =
-      getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled, qaDisabledLanguageIds)
+      getTranslationsViewQueryBuilder(
+        projectId,
+        languages,
+        params,
+        pageable,
+        cursor,
+        qaEnabled,
+        qaDisabledLanguageIds,
+        tasksEnabled,
+      )
     val count = em.createQuery(countBuilder.countQuery).singleResult
 
     val translationsViewQueryBuilder =
-      getTranslationsViewQueryBuilder(projectId, languages, params, pageable, cursor, qaEnabled, qaDisabledLanguageIds)
+      getTranslationsViewQueryBuilder(
+        projectId,
+        languages,
+        params,
+        pageable,
+        cursor,
+        qaEnabled,
+        qaDisabledLanguageIds,
+        tasksEnabled,
+      )
     val query = em.createQuery(translationsViewQueryBuilder.dataQuery).setMaxResults(pageable.pageSize)
     if (cursor == null) {
       query.firstResult = pageable.offset.toInt()
@@ -300,6 +321,9 @@ class TranslationViewDataProvider(
     val project = projectService.get(projectId)
     val qaEnabled = projectFeatureGuard.isFeatureEnabled(Feature.QA_CHECKS, project)
     val qaDisabledLanguageIds = resolveQaDisabledLanguageIds(projectId, qaEnabled)
+    val tasksEnabled =
+      projectFeatureGuard.isFeatureEnabled(Feature.TASKS, project) ||
+        projectFeatureGuard.isFeatureEnabled(Feature.ORDER_TRANSLATION, project)
     createFailedKeysInJobTempTable(params.filterFailedKeysOfJob)
     val translationsViewQueryBuilder =
       TranslationsViewQueryBuilder(
@@ -311,6 +335,7 @@ class TranslationViewDataProvider(
         entityManager = em,
         qaEnabled = qaEnabled,
         qaDisabledLanguageIds = qaDisabledLanguageIds,
+        tasksEnabled = tasksEnabled,
       )
     val result = em.createQuery(translationsViewQueryBuilder.keyIdsQuery).resultList
     deleteFailedKeysInJobTempTable()
@@ -325,6 +350,7 @@ class TranslationViewDataProvider(
     cursor: String?,
     qaEnabled: Boolean,
     qaDisabledLanguageIds: Set<Long>,
+    tasksEnabled: Boolean,
   ) = TranslationsViewQueryBuilder(
     cb = em.criteriaBuilder,
     projectId = projectId,
@@ -335,5 +361,6 @@ class TranslationViewDataProvider(
     entityManager = em,
     qaEnabled = qaEnabled,
     qaDisabledLanguageIds = qaDisabledLanguageIds,
+    tasksEnabled = tasksEnabled,
   )
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/queryBuilders/translationViewBuilder/TranslationsViewQueryBuilder.kt
@@ -25,6 +25,7 @@ class TranslationsViewQueryBuilder(
   private val entityManager: EntityManager,
   private val qaEnabled: Boolean,
   private val qaDisabledLanguageIds: Set<Long>,
+  private val tasksEnabled: Boolean,
 ) {
   private fun <T> getBaseQuery(
     query: CriteriaQuery<T>,
@@ -39,6 +40,7 @@ class TranslationsViewQueryBuilder(
       entityManager,
       qaEnabled = qaEnabled,
       qaDisabledLanguageIds = qaDisabledLanguageIds,
+      tasksEnabled = tasksEnabled,
       isCountQuery = isCountQuery,
     )
   }

--- a/e2e/cypress/e2e/translations/translationFilters.general.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.general.cy.ts
@@ -1,5 +1,9 @@
 import { ProjectDTO } from '../../../../webapp/src/service/response.types';
-import { toggleLang, visitTranslations } from '../../common/translations';
+import {
+  selectAllLanguages,
+  toggleLang,
+  visitTranslations,
+} from '../../common/translations';
 import { assertMessage, assertMultiselect } from '../../common/shared';
 import { waitForGlobalLoading } from '../../common/loading';
 import { translationsTestData } from '../../common/apiCalls/testData/testData';
@@ -55,6 +59,35 @@ describe('Translations Base', () => {
       'German',
       'English',
     ]);
+  });
+
+  it('drops a language scoped filter when its language is deselected', () => {
+    selectAllLanguages();
+
+    cy.gcy('translations-filter-select').click();
+    cy.waitForDom();
+    cy.gcy('submenu-item').contains('Translations').click();
+    cy.waitForDom();
+    cy.gcy('filter-item').contains('Translated').click();
+    cy.gcy('translations-filter-apply-for-expand').click();
+    cy.gcy('translations-filter-apply-for-language').contains('German').click();
+    cy.focused().type('{Esc}');
+    cy.focused().type('{Esc}');
+    waitForGlobalLoading();
+
+    cy.location('search').should((search) => {
+      expect(decodeURIComponent(search)).to.contain(
+        '"filterTranslationLanguage":"de"'
+      );
+    });
+
+    toggleLang('German');
+
+    cy.location('search').should((search) => {
+      const filters = decodeURIComponent(search);
+      expect(filters).not.to.contain('filterTranslationLanguage');
+      expect(filters).to.contain('filterTranslationState');
+    });
   });
 
   it('filters unresolved comments', () => {

--- a/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
@@ -27,7 +27,7 @@ describe('Translation filters tasks', () => {
   it('filters keys never in a task', () => {
     assertFilter({
       submenu: 'Tasks',
-      filterOption: ['Never in a task'],
+      and: () => cy.gcy('translations-filter-never-in-task').click(),
       toSeeAfter: ['key 2', 'key 3'],
       checkAfter() {
         cy.gcy('translations-filter-select').contains('Never in a task');
@@ -38,7 +38,7 @@ describe('Translation filters tasks', () => {
   it('filters keys which have been in a task', () => {
     assertFilter({
       submenu: 'Tasks',
-      filterOption: ['Has been in a task'],
+      and: () => cy.gcy('translations-filter-has-been-in-task').click(),
       toSeeAfter: ['key 0', 'key 1'],
     });
   });

--- a/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
@@ -1,0 +1,41 @@
+import { visitTranslations } from '../../common/translations';
+import { waitForGlobalLoading } from '../../common/loading';
+import { tasks } from '../../common/apiCalls/testData/testData';
+import { login } from '../../common/apiCalls/common';
+import { assertFilter } from '../../common/filters';
+
+describe('Translation filters tasks', () => {
+  beforeEach(() => {
+    tasks.clean({ failOnStatusCode: false });
+    tasks
+      .generateStandard()
+      .then((r) => r.body)
+      .then(({ users, projects }) => {
+        login(users.find((u) => u.name === 'Tasks test user')?.username);
+        const testProject = projects.find(
+          ({ name }) => name === 'Project with tasks'
+        );
+        visitTranslations(testProject.id);
+      });
+    waitForGlobalLoading();
+  });
+
+  it('filters keys never in a task', () => {
+    assertFilter({
+      submenu: 'Tasks',
+      filterOption: ['Never in a task'],
+      toSeeAfter: ['key 2', 'key 3'],
+      checkAfter() {
+        cy.gcy('translations-filter-select').contains('Never in a task');
+      },
+    });
+  });
+
+  it('filters keys which have been in a task', () => {
+    assertFilter({
+      submenu: 'Tasks',
+      filterOption: ['Has been in a task'],
+      toSeeAfter: ['key 0', 'key 1'],
+    });
+  });
+});

--- a/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
+++ b/e2e/cypress/e2e/translations/translationFilters.tasks.cy.ts
@@ -20,6 +20,10 @@ describe('Translation filters tasks', () => {
     waitForGlobalLoading();
   });
 
+  after(() => {
+    tasks.clean({ failOnStatusCode: false });
+  });
+
   it('filters keys never in a task', () => {
     assertFilter({
       submenu: 'Tasks',

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -944,6 +944,8 @@ declare namespace DataCy {
         "translations-filter-apply-for-expand": true;
         "translations-filter-apply-for-language": true;
         "translations-filter-apply-no-base": true;
+        "translations-filter-has-been-in-task": true;
+        "translations-filter-never-in-task": true;
         "translations-filter-select": true;
         "translations-filter-select-clear": true;
         "translations-history-load-more-button": true;

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/task/TranslationScopeFilters.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/data/task/TranslationScopeFilters.kt
@@ -12,6 +12,19 @@ data class TranslationScopeFilters(
     description = "Include keys where translation is outdated",
   )
   var filterOutdated: Boolean? = false,
+  @Schema(
+    description =
+      "Include only keys whose translation into the task language was never part of any task. " +
+        "Evaluated per task language, so a key already tasked for one language is still included " +
+        "for the others.",
+  )
+  var filterNeverInTask: Boolean? = false,
+  @Schema(
+    description =
+      "Include only keys whose translation into the task language is or was part of some task. " +
+        "Evaluated per task language.",
+  )
+  var filterHasBeenInTask: Boolean? = false,
 ) {
   val filterStateOrdinal: List<Int>? get() {
     return filterState?.map { it.ordinal }

--- a/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TaskRepository.kt
+++ b/ee/backend/app/src/main/kotlin/io/tolgee/ee/repository/TaskRepository.kt
@@ -245,6 +245,22 @@ interface TaskRepository : JpaRepository<Task, Long> {
               and :#{#filters.filterState} is null
             )
           )
+          and (
+            COALESCE(:#{#filters.filterNeverInTask}, false) = false
+            or not exists (
+              select 1 from task_key hist_tk
+                  join task hist_t on (hist_tk.task_id = hist_t.id)
+              where hist_tk.key_id = key.id and hist_t.language_id = :languageId
+            )
+          )
+          and (
+            COALESCE(:#{#filters.filterHasBeenInTask}, false) = false
+            or exists (
+              select 1 from task_key hist_tk
+                  join task hist_t on (hist_tk.task_id = hist_t.id)
+              where hist_tk.key_id = key.id and hist_t.language_id = :languageId
+            )
+          )
     """,
   )
   fun getKeysIncludingConflicts(
@@ -288,6 +304,22 @@ interface TaskRepository : JpaRepository<Task, Long> {
               -- no filter is applied
               COALESCE(:#{#filters.filterOutdated}, false) = false
               and :#{#filters.filterState} is null
+            )
+          )
+          and (
+            COALESCE(:#{#filters.filterNeverInTask}, false) = false
+            or not exists (
+              select 1 from task_key hist_tk
+                  join task hist_t on (hist_tk.task_id = hist_t.id)
+              where hist_tk.key_id = key.id and hist_t.language_id = :languageId
+            )
+          )
+          and (
+            COALESCE(:#{#filters.filterHasBeenInTask}, false) = false
+            or exists (
+              select 1 from task_key hist_tk
+                  join task hist_t on (hist_tk.task_id = hist_t.id)
+              where hist_tk.key_id = key.id and hist_t.language_id = :languageId
             )
           )
     """,

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/TranslationsControllerTaskHistoryFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/TranslationsControllerTaskHistoryFilterTest.kt
@@ -138,7 +138,7 @@ class TranslationsControllerTaskHistoryFilterTest : ProjectAuthControllerTest("/
 
   @ProjectJWTAuthTestMethod
   @Test
-  fun `matches keys untouched in at least one of several languages`() {
+  fun `matches only keys untouched in every one of several languages`() {
     initTestData()
     testData.addKeyWithOwnTask("czech only", number = 10, taskLanguage = testData.czechLanguage)
     saveTestData()
@@ -147,10 +147,26 @@ class TranslationsControllerTaskHistoryFilterTest : ProjectAuthControllerTest("/
       "/translations?filterHasNoTaskInLang=en&filterHasNoTaskInLang=cs",
     ).andIsOk.andAssertThatJson {
       node("_embedded.keys") {
-        isArray.hasSize(3)
-        node("[2].keyName").isEqualTo("czech only")
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
       }
-      node("page.totalElements").isEqualTo(3)
+      node("page.totalElements").isEqualTo(2)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `keeps the two directions disjoint across several languages`() {
+    initTestData()
+    testData.addKeyWithOwnTask("czech only", number = 10, taskLanguage = testData.czechLanguage)
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasTaskInLang=en&filterHasTaskInLang=cs" +
+        "&filterHasNoTaskInLang=en&filterHasNoTaskInLang=cs",
+    ).andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
     }
   }
 

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/TranslationsControllerTaskHistoryFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/TranslationsControllerTaskHistoryFilterTest.kt
@@ -1,0 +1,245 @@
+package io.tolgee.ee.api.v2.controllers
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.constants.Feature
+import io.tolgee.development.testDataBuilder.data.TaskTestData
+import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
+import io.tolgee.model.enums.TaskState
+import io.tolgee.model.enums.TaskType
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class TranslationsControllerTaskHistoryFilterTest : ProjectAuthControllerTest("/v2/projects/") {
+  lateinit var testData: TaskTestData
+
+  @Autowired
+  lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  private fun saveTestData(tasksEnabled: Boolean = true) {
+    enabledFeaturesProvider.forceEnabled = if (tasksEnabled) setOf(Feature.TASKS) else emptySet()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    projectSupplier = { testData.projectBuilder.self }
+  }
+
+  private fun initTestData() {
+    testData = TaskTestData()
+    projectSupplier = { testData.projectBuilder.self }
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+    userAccount = null
+    enabledFeaturesProvider.forceEnabled = null
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `returns keys never in a task in the language`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
+      }
+      node("page.totalElements").isEqualTo(2)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `returns keys that were in a task in the language`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet("/translations?filterHasTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 0")
+        node("[1].keyName").isEqualTo("key 1")
+      }
+      node("page.totalElements").isEqualTo(2)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `scopes task history to the selected language`() {
+    initTestData()
+    testData.addKeyWithOwnTask("czech only", number = 10, taskLanguage = testData.czechLanguage)
+    saveTestData()
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") { isArray.hasSize(3) }
+      node("page.totalElements").isEqualTo(3)
+    }
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=cs").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
+      }
+    }
+
+    performProjectAuthGet("/translations?filterHasTaskInLang=cs").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(3)
+        node("[2].keyName").isEqualTo("czech only")
+      }
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `counts canceled and finished tasks as history`() {
+    initTestData()
+    testData.addKeyWithOwnTask("canceled only", number = 10, state = TaskState.CANCELED)
+    testData.addKeyWithOwnTask("finished only", number = 11, state = TaskState.FINISHED)
+    saveTestData()
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
+      }
+    }
+
+    performProjectAuthGet("/translations?filterHasTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") { isArray.hasSize(4) }
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `counts review tasks as history`() {
+    initTestData()
+    testData.addKeyWithOwnTask("review only", number = 10, type = TaskType.REVIEW)
+    saveTestData()
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=en").andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
+      }
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `matches keys untouched in at least one of several languages`() {
+    initTestData()
+    testData.addKeyWithOwnTask("czech only", number = 10, taskLanguage = testData.czechLanguage)
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasNoTaskInLang=en&filterHasNoTaskInLang=cs",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(3)
+        node("[2].keyName").isEqualTo("czech only")
+      }
+      node("page.totalElements").isEqualTo(3)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `matches keys tasked in any of several languages`() {
+    initTestData()
+    testData.addKeyWithOwnTask("czech only", number = 10, taskLanguage = testData.czechLanguage)
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasTaskInLang=en&filterHasTaskInLang=cs",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(3)
+        node("[2].keyName").isEqualTo("czech only")
+      }
+      node("page.totalElements").isEqualTo(3)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `intersects with other filters rather than unioning`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasNoTaskInLang=en&filterState=en,TRANSLATED",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+        node("[1].keyName").isEqualTo("key 3")
+      }
+      node("page.totalElements").isEqualTo(2)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `returns nothing when both directions are combined`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasTaskInLang=en&filterHasNoTaskInLang=en",
+    ).andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(0)
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `select-all returns the same keys as the list`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations/select-all?languages=en&languages=cs&filterHasNoTaskInLang=en",
+    ).andIsOk.andAssertThatJson {
+      node("ids") { isArray.hasSize(2) }
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `drops unresolvable language tags`() {
+    initTestData()
+    saveTestData()
+
+    performProjectAuthGet(
+      "/translations?filterHasNoTaskInLang=en&filterHasNoTaskInLang=xx",
+    ).andIsOk.andAssertThatJson {
+      node("_embedded.keys") {
+        isArray.hasSize(2)
+        node("[0].keyName").isEqualTo("key 2")
+      }
+    }
+  }
+
+  @ProjectJWTAuthTestMethod
+  @Test
+  fun `ignores the filter when the tasks feature is disabled`() {
+    initTestData()
+    saveTestData(tasksEnabled = false)
+
+    performProjectAuthGet("/translations?filterHasNoTaskInLang=en").andIsOk.andAssertThatJson {
+      node("page.totalElements").isEqualTo(4)
+    }
+  }
+}

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskScopeTaskHistoryFilterTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/task/TaskScopeTaskHistoryFilterTest.kt
@@ -1,0 +1,142 @@
+package io.tolgee.ee.api.v2.controllers.task
+
+import io.tolgee.ProjectAuthControllerTest
+import io.tolgee.constants.Feature
+import io.tolgee.development.testDataBuilder.builders.KeyBuilder
+import io.tolgee.development.testDataBuilder.data.TaskTestData
+import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.ee.data.task.CalculateScopeRequest
+import io.tolgee.ee.data.task.CreateMultipleTasksRequest
+import io.tolgee.ee.data.task.CreateTaskRequest
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.model.enums.TaskState
+import io.tolgee.model.enums.TaskType
+import io.tolgee.testing.annotations.ProjectJWTAuthTestMethod
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+
+class TaskScopeTaskHistoryFilterTest : ProjectAuthControllerTest("/v2/projects/") {
+  lateinit var testData: TaskTestData
+
+  @Autowired
+  private lateinit var enabledFeaturesProvider: PublicEnabledFeaturesProvider
+
+  private lateinit var czechOnlyKey: KeyBuilder
+
+  private val czechOnlyKeyId get() = czechOnlyKey.self.id
+
+  @BeforeEach
+  fun setup() {
+    testData = TaskTestData()
+    czechOnlyKey =
+      testData.addKeyWithOwnTask(
+        "czech only",
+        number = 10,
+        taskLanguage = testData.czechLanguage,
+        state = TaskState.FINISHED,
+      )
+    projectSupplier = { testData.projectBuilder.self }
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    enabledFeaturesProvider.forceEnabled = setOf(Feature.TASKS)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+    userAccount = null
+    enabledFeaturesProvider.forceEnabled = null
+  }
+
+  private fun scopeRequest(languageId: Long) =
+    CalculateScopeRequest(
+      languageId = languageId,
+      type = TaskType.TRANSLATE,
+      keys = mutableSetOf(czechOnlyKeyId),
+    )
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `without the filter the key is in scope for both languages`() {
+    performProjectAuthPost(
+      "tasks/calculate-scope",
+      scopeRequest(testData.czechLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(1) }
+
+    performProjectAuthPost(
+      "tasks/calculate-scope",
+      scopeRequest(testData.englishLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(1) }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `filterNeverInTask excludes the key only for the language it was tasked in`() {
+    performProjectAuthPost(
+      "tasks/calculate-scope?filterNeverInTask=true",
+      scopeRequest(testData.czechLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(0) }
+
+    performProjectAuthPost(
+      "tasks/calculate-scope?filterNeverInTask=true",
+      scopeRequest(testData.englishLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(1) }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `filterHasBeenInTask keeps the key only for the language it was tasked in`() {
+    performProjectAuthPost(
+      "tasks/calculate-scope?filterHasBeenInTask=true",
+      scopeRequest(testData.czechLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(1) }
+
+    performProjectAuthPost(
+      "tasks/calculate-scope?filterHasBeenInTask=true",
+      scopeRequest(testData.englishLanguage.id),
+    ).andIsOk.andAssertThatJson { node("keyCount").isEqualTo(0) }
+  }
+
+  @Test
+  @ProjectJWTAuthTestMethod
+  fun `creating tasks for several languages does not re-task the key in the language that already had it`() {
+    val untouchedKeyId =
+      testData.keysOutOfTask
+        .first()
+        .self.id
+    val batchKeys = mutableSetOf(czechOnlyKeyId, untouchedKeyId)
+
+    performProjectAuthPost(
+      "tasks/create-multiple-tasks?filterNeverInTask=true",
+      CreateMultipleTasksRequest(
+        mutableSetOf(
+          CreateTaskRequest(
+            name = "EnglishBatch",
+            type = TaskType.TRANSLATE,
+            languageId = testData.englishLanguage.id,
+            assignees = mutableSetOf(),
+            keys = batchKeys,
+          ),
+          CreateTaskRequest(
+            name = "CzechBatch",
+            type = TaskType.TRANSLATE,
+            languageId = testData.czechLanguage.id,
+            assignees = mutableSetOf(),
+            keys = batchKeys,
+          ),
+        ),
+      ),
+    ).andIsOk
+
+    performProjectAuthGet("tasks?search=EnglishBatch").andIsOk.andAssertThatJson {
+      node("_embedded.tasks[0].totalItems").isEqualTo(2)
+    }
+
+    performProjectAuthGet("tasks?search=CzechBatch").andIsOk.andAssertThatJson {
+      node("_embedded.tasks[0].totalItems").isEqualTo(1)
+    }
+  }
+}

--- a/webapp/src/ee/orderTranslations/OrderTranslationsDialog.tsx
+++ b/webapp/src/ee/orderTranslations/OrderTranslationsDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 import { Formik } from 'formik';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CheckCircle } from '@untitled-ui/icons-react';
 import clsx from 'clsx';
 
@@ -145,6 +145,12 @@ export const OrderTranslationsDialog: React.FC<
     setFilters,
     selectedLanguages: selectedLanguageTags,
   });
+
+  const { updateSelectedLanguages } = actions;
+  useEffect(() => {
+    updateSelectedLanguages(selectedLanguageTags);
+  }, [selectedLanguageTags]);
+
   const [successMessage, setSuccessMessage] = useState(false);
 
   const [_step, setStep] = useState<number | undefined>(undefined);

--- a/webapp/src/ee/orderTranslations/OrderTranslationsDialog.tsx
+++ b/webapp/src/ee/orderTranslations/OrderTranslationsDialog.tsx
@@ -18,7 +18,7 @@ import {
 } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 import { Formik } from 'formik';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CheckCircle } from '@untitled-ui/icons-react';
 import clsx from 'clsx';
 
@@ -131,12 +131,20 @@ export const OrderTranslationsDialog: React.FC<
   });
 
   const [filters, setFilters] = useState<FiltersInternal>({});
+  const [_stateFilters, setStateFilters] = useState<TranslationStateType[]>();
+  const [languages, setLanguages] = useState(initialValues?.languages ?? []);
+  const selectedLanguageTags = useMemo(
+    () =>
+      languages
+        .map((id) => allLanguages.find((l) => l.id === id)?.tag)
+        .filter((tag): tag is string => Boolean(tag)),
+    [languages, allLanguages]
+  );
   const { filtersQuery, ...actions } = useTranslationFilters({
     filters,
     setFilters,
+    selectedLanguages: selectedLanguageTags,
   });
-  const [_stateFilters, setStateFilters] = useState<TranslationStateType[]>();
-  const [languages, setLanguages] = useState(initialValues?.languages ?? []);
   const [successMessage, setSuccessMessage] = useState(false);
 
   const [_step, setStep] = useState<number | undefined>(undefined);
@@ -301,6 +309,8 @@ export const OrderTranslationsDialog: React.FC<
                     (i) => i !== 'OUTDATED' && i !== 'AUTO_TRANSLATED'
                   ),
                   filterOutdated: stateFilters.includes('OUTDATED'),
+                  filterNeverInTask: Boolean(filters.filterHasNoTask),
+                  filterHasBeenInTask: Boolean(filters.filterHasTask),
                 },
                 content: {
                   'application/json': {

--- a/webapp/src/ee/task/components/SubfilterTasks.tsx
+++ b/webapp/src/ee/task/components/SubfilterTasks.tsx
@@ -5,7 +5,6 @@ import { ChevronDown, ChevronUp } from '@untitled-ui/icons-react';
 
 import { SubmenuItem } from 'tg.component/SubmenuItem';
 import { CompactListSubheader } from 'tg.component/ListComponents';
-import { useEnabledFeatures } from 'tg.globalContext/helpers';
 
 import { FilterItem } from 'tg.views/projects/translations/TranslationFilters/FilterItem';
 import { SubfilterTasksProps } from 'eeSetup/EeModuleType';
@@ -23,12 +22,6 @@ export const SubfilterTasks = ({
   const [expanded, setExpanded] = useState(
     value.filterTaskLanguage !== undefined
   );
-  const { isEnabled } = useEnabledFeatures();
-
-  if (!isEnabled('TASKS') && !isEnabled('ORDER_TRANSLATION')) {
-    return null;
-  }
-
   const disabled = hideLanguageScope && selectedLanguages.length === 0;
 
   function toggleFilterLanguage(

--- a/webapp/src/ee/task/components/SubfilterTasks.tsx
+++ b/webapp/src/ee/task/components/SubfilterTasks.tsx
@@ -1,0 +1,189 @@
+import { useRef, useState } from 'react';
+import { T, useTranslate } from '@tolgee/react';
+import { Box, Menu, MenuItem } from '@mui/material';
+import { ChevronDown, ChevronUp } from '@untitled-ui/icons-react';
+
+import { SubmenuItem } from 'tg.component/SubmenuItem';
+import { CompactListSubheader } from 'tg.component/ListComponents';
+import { useEnabledFeatures } from 'tg.globalContext/helpers';
+
+import { FilterItem } from 'tg.views/projects/translations/TranslationFilters/FilterItem';
+import { SubfilterTasksProps } from 'eeSetup/EeModuleType';
+import { FiltersInternal } from 'tg.views/projects/translations/TranslationFilters/tools';
+
+export const SubfilterTasks = ({
+  value,
+  actions,
+  selectedLanguages,
+  hideLanguageScope,
+}: SubfilterTasksProps) => {
+  const { t } = useTranslate();
+  const [open, setOpen] = useState(false);
+  const anchorEl = useRef<HTMLElement>(null);
+  const [expanded, setExpanded] = useState(
+    value.filterTaskLanguage !== undefined
+  );
+  const { isEnabled } = useEnabledFeatures();
+
+  if (!isEnabled('TASKS') && !isEnabled('ORDER_TRANSLATION')) {
+    return null;
+  }
+
+  const disabled = hideLanguageScope && selectedLanguages.length === 0;
+
+  function toggleFilterLanguage(
+    newValue: FiltersInternal['filterTaskLanguage']
+  ) {
+    actions.setFilters({
+      ...value,
+      filterTaskLanguage:
+        newValue === value.filterTaskLanguage ? undefined : newValue,
+    });
+  }
+
+  function handleToggleHasTask(newValue: boolean) {
+    if (newValue) {
+      actions.addFilter('filterHasTask');
+    } else {
+      actions.removeFilter('filterHasTask');
+    }
+  }
+
+  function handleToggleHasNoTask(newValue: boolean) {
+    if (newValue) {
+      actions.addFilter('filterHasNoTask');
+    } else {
+      actions.removeFilter('filterHasNoTask');
+    }
+  }
+
+  return (
+    <>
+      <SubmenuItem
+        ref={anchorEl as any}
+        label={t('translations_filters_heading_tasks', 'Tasks')}
+        onClick={() => setOpen(true)}
+        selected={Boolean(getTaskFiltersLength(value))}
+        open={open}
+      />
+      {open && (
+        <Menu
+          open={open}
+          anchorEl={anchorEl.current!}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          onClose={() => {
+            setOpen(false);
+          }}
+          slotProps={{ paper: { style: { minWidth: 250 } } }}
+        >
+          <Box display="grid">
+            {disabled && (
+              <CompactListSubheader>
+                {t(
+                  'translation_filters_task_select_language_first',
+                  'Select target languages first'
+                )}
+              </CompactListSubheader>
+            )}
+            <FilterItem
+              label={t('translation_filters_has_task', 'Has been in a task')}
+              selected={Boolean(value.filterHasTask)}
+              disabled={disabled}
+              onClick={() => handleToggleHasTask(!value.filterHasTask)}
+            />
+            <FilterItem
+              label={t('translation_filters_has_no_task', 'Never in a task')}
+              selected={Boolean(value.filterHasNoTask)}
+              disabled={disabled}
+              onClick={() => handleToggleHasNoTask(!value.filterHasNoTask)}
+            />
+            {!hideLanguageScope && (
+              <>
+                <CompactListSubheader>
+                  <Box display="flex" justifyContent="space-between">
+                    <Box>{t('translations_filter_languages_select_title')}</Box>
+                  </Box>
+                </CompactListSubheader>
+                <FilterItem
+                  data-cy="translations-filter-apply-no-base"
+                  label={t('translations_filter_languages_no_base')}
+                  selected={value.filterTaskLanguage === undefined}
+                  onClick={() => toggleFilterLanguage(undefined)}
+                  exclusive
+                />
+                {expanded && (
+                  <>
+                    <FilterItem
+                      data-cy="translations-filter-apply-for-all"
+                      label={t('translations_filter_languages_all')}
+                      selected={value.filterTaskLanguage === true}
+                      onClick={() => toggleFilterLanguage(true)}
+                      exclusive
+                    />
+                    {selectedLanguages?.map((lang) => {
+                      return (
+                        <FilterItem
+                          data-cy="translations-filter-apply-for-language"
+                          key={lang.id}
+                          label={lang.name}
+                          selected={value.filterTaskLanguage === lang.tag}
+                          onClick={() => toggleFilterLanguage(lang.tag)}
+                          exclusive
+                        />
+                      );
+                    })}
+                  </>
+                )}
+                <MenuItem
+                  data-cy="translations-filter-apply-for-expand"
+                  role="button"
+                  onClick={() => setExpanded((value) => !value)}
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  {expanded ? <ChevronUp /> : <ChevronDown />}
+                </MenuItem>
+              </>
+            )}
+          </Box>
+        </Menu>
+      )}
+    </>
+  );
+};
+
+export function getTaskFiltersLength(value: FiltersInternal) {
+  return (
+    Number(value.filterHasTask !== undefined) +
+    Number(value.filterHasNoTask !== undefined)
+  );
+}
+
+export function getTaskFiltersName(value: FiltersInternal) {
+  if (value.filterHasTask) {
+    return (
+      <T
+        keyName="translation_filters_has_task"
+        defaultValue="Has been in a task"
+      />
+    );
+  }
+
+  if (value.filterHasNoTask) {
+    return (
+      <T
+        keyName="translation_filters_has_no_task"
+        defaultValue="Never in a task"
+      />
+    );
+  }
+}

--- a/webapp/src/ee/task/components/SubfilterTasks.tsx
+++ b/webapp/src/ee/task/components/SubfilterTasks.tsx
@@ -86,12 +86,14 @@ export const SubfilterTasks = ({
               </CompactListSubheader>
             )}
             <FilterItem
+              data-cy="translations-filter-has-been-in-task"
               label={t('translation_filters_has_task', 'Has been in a task')}
               selected={Boolean(value.filterHasTask)}
               disabled={disabled}
               onClick={() => handleToggleHasTask(!value.filterHasTask)}
             />
             <FilterItem
+              data-cy="translations-filter-never-in-task"
               label={t('translation_filters_has_no_task', 'Never in a task')}
               selected={Boolean(value.filterHasNoTask)}
               disabled={disabled}

--- a/webapp/src/ee/task/components/taskCreate/TaskCreateDialog.tsx
+++ b/webapp/src/ee/task/components/taskCreate/TaskCreateDialog.tsx
@@ -1,7 +1,7 @@
 import { Button, Dialog, DialogTitle, styled } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 import { Formik } from 'formik';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Validation } from 'tg.constants/GlobalValidationSchema';
 import { components } from 'tg.service/apiSchema.generated';
@@ -111,6 +111,11 @@ export const TaskCreateDialog = ({
     setFilters,
     selectedLanguages: selectedLanguageTags,
   });
+
+  const { updateSelectedLanguages } = actions;
+  useEffect(() => {
+    updateSelectedLanguages(selectedLanguageTags);
+  }, [selectedLanguageTags]);
 
   const selectedLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/translations/select-all',

--- a/webapp/src/ee/task/components/taskCreate/TaskCreateDialog.tsx
+++ b/webapp/src/ee/task/components/taskCreate/TaskCreateDialog.tsx
@@ -1,14 +1,17 @@
 import { Button, Dialog, DialogTitle, styled } from '@mui/material';
 import { T, useTranslate } from '@tolgee/react';
 import { Formik } from 'formik';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Validation } from 'tg.constants/GlobalValidationSchema';
 import { components } from 'tg.service/apiSchema.generated';
 import { useApiMutation, useApiQuery } from 'tg.service/http/useQueryApi';
 import { messageService } from 'tg.service/MessageService';
 import LoadingButton from 'tg.component/common/form/LoadingButton';
-import { FiltersType } from 'tg.views/projects/translations/TranslationFilters/tools';
+import {
+  FiltersInternal,
+  FiltersType,
+} from 'tg.views/projects/translations/TranslationFilters/tools';
 import { User } from 'tg.component/UserAccount';
 import { TranslationStateType } from 'tg.translationTools/useStateTranslation';
 import { StateType } from 'tg.constants/translationStates';
@@ -93,13 +96,21 @@ export const TaskCreateDialog = ({
     invalidatePrefix: ['/v2/projects/{projectId}/tasks', '/v2/user-tasks'],
   });
 
-  const [filters, setFilters] = useState<FiltersType>({});
+  const [filters, setFilters] = useState<FiltersInternal>({});
+  const [_stateFilters, setStateFilters] = useState<TranslationStateType[]>();
+  const [languages, setLanguages] = useState(initialValues?.languages ?? []);
+  const selectedLanguageTags = useMemo(
+    () =>
+      languages
+        .map((id) => allLanguages.find((l) => l.id === id)?.tag)
+        .filter((tag): tag is string => Boolean(tag)),
+    [languages, allLanguages]
+  );
   const { filtersQuery, ...actions } = useTranslationFilters({
     filters,
     setFilters,
+    selectedLanguages: selectedLanguageTags,
   });
-  const [_stateFilters, setStateFilters] = useState<TranslationStateType[]>();
-  const [languages, setLanguages] = useState(initialValues?.languages ?? []);
 
   const selectedLoadable = useApiQuery({
     url: '/v2/projects/{projectId}/translations/select-all',
@@ -187,6 +198,8 @@ export const TaskCreateDialog = ({
                   (i) => i !== 'OUTDATED'
                 ) as StateType[],
                 filterOutdated: stateFilters.includes('OUTDATED'),
+                filterNeverInTask: Boolean(filters.filterHasNoTask),
+                filterHasBeenInTask: Boolean(filters.filterHasTask),
               },
               content: {
                 'application/json': { tasks: data },

--- a/webapp/src/ee/task/components/taskCreate/TaskCreateForm.tsx
+++ b/webapp/src/ee/task/components/taskCreate/TaskCreateForm.tsx
@@ -18,7 +18,7 @@ import { TaskPreview } from './TaskPreview';
 import { Field, useFormikContext } from 'formik';
 import {
   FilterActions,
-  FiltersType,
+  FiltersInternal,
 } from 'tg.views/projects/translations/TranslationFilters/tools';
 import { Select } from 'tg.component/common/Select';
 import { useEffect } from 'react';
@@ -63,7 +63,7 @@ type Props = {
   languages: number[];
   setLanguages: (languages: number[]) => void;
   allLanguages: LanguageModel[];
-  filters: FiltersType;
+  filters: FiltersInternal;
   filterActions?: FilterActions;
   stateFilters: TranslationStateType[];
   setStateFilters: (filters: TranslationStateType[]) => void;
@@ -115,6 +115,8 @@ export const TaskCreateForm = ({
             (i) => i !== 'OUTDATED' && i !== 'AUTO_TRANSLATED'
           ),
           filterOutdated: stateFilters.includes('OUTDATED'),
+          filterNeverInTask: Boolean(filters.filterHasNoTask),
+          filterHasBeenInTask: Boolean(filters.filterHasTask),
         },
       };
     })
@@ -241,10 +243,12 @@ export const TaskCreateForm = ({
               <TranslationFilters
                 value={filters}
                 actions={filterActions}
-                selectedLanguages={[]}
+                selectedLanguages={allLanguages.filter((l) =>
+                  languages.includes(l.id)
+                )}
                 projectId={projectId}
                 placeholder={t('create_task_filter_keys_placeholder')}
-                filterOptions={{ keyRelatedOnly: true }}
+                filterOptions={{ keyRelatedOnly: true, showTaskFilter: true }}
                 sx={{ width: '100%', maxWidth: '270px' }}
               />
             )}

--- a/webapp/src/eeSetup/EeModuleType.ts
+++ b/webapp/src/eeSetup/EeModuleType.ts
@@ -91,3 +91,10 @@ export type SubfilterQaChecksProps = {
   actions: FilterActions;
   selectedLanguages: LanguageModel[];
 };
+
+export type SubfilterTasksProps = {
+  value: FiltersInternal;
+  actions: FilterActions;
+  selectedLanguages: LanguageModel[];
+  hideLanguageScope?: boolean;
+};

--- a/webapp/src/eeSetup/eeModule.ee.tsx
+++ b/webapp/src/eeSetup/eeModule.ee.tsx
@@ -66,6 +66,11 @@ export {
   getQaChecksFiltersLength,
   getQaChecksFiltersName,
 } from '../ee/qa/components/SubfilterQaChecks';
+export {
+  SubfilterTasks,
+  getTaskFiltersLength,
+  getTaskFiltersName,
+} from '../ee/task/components/SubfilterTasks';
 import { GlossaryRouter } from '../ee/glossary/views/GlossaryRouter';
 import { createAdder } from '../fixtures/pluginAdder';
 import { ProjectSettingsTab } from '../views/projects/project/ProjectSettingsView';

--- a/webapp/src/eeSetup/eeModule.oss.tsx
+++ b/webapp/src/eeSetup/eeModule.oss.tsx
@@ -8,6 +8,7 @@ import {
   QaBadgeProps,
   QaIssueHighlightProps,
   SubfilterQaChecksProps,
+  SubfilterTasksProps,
 } from './EeModuleType';
 import type { FiltersInternal } from 'tg.views/projects/translations/TranslationFilters/tools';
 
@@ -51,6 +52,12 @@ export const SubfilterQaChecks = (_props: SubfilterQaChecksProps) =>
   Empty() as JSX.Element;
 export const getQaChecksFiltersLength = (_value: FiltersInternal) => 0;
 export const getQaChecksFiltersName = (
+  _value: FiltersInternal
+): JSX.Element | undefined => undefined;
+export const SubfilterTasks = (_props: SubfilterTasksProps) =>
+  Empty() as JSX.Element;
+export const getTaskFiltersLength = (_value: FiltersInternal) => 0;
+export const getTaskFiltersName = (
   _value: FiltersInternal
 ): JSX.Element | undefined => undefined;
 

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -19747,7 +19747,7 @@ export interface operations {
         filterTaskKeysDone?: boolean;
         /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
         filterHasTaskInLang?: string[];
-        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        /** Select only keys not currently linked to a task in any of the provided languages, the exact complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
         filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
@@ -20006,7 +20006,7 @@ export interface operations {
         filterTaskKeysDone?: boolean;
         /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
         filterHasTaskInLang?: string[];
-        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        /** Select only keys not currently linked to a task in any of the provided languages, the exact complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
         filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
@@ -20309,7 +20309,7 @@ export interface operations {
         filterTaskKeysDone?: boolean;
         /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
         filterHasTaskInLang?: string[];
-        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        /** Select only keys not currently linked to a task in any of the provided languages, the exact complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
         filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
@@ -26371,7 +26371,7 @@ export interface operations {
         filterTaskKeysDone?: boolean;
         /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
         filterHasTaskInLang?: string[];
-        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        /** Select only keys not currently linked to a task in any of the provided languages, the exact complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
         filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
@@ -26842,7 +26842,7 @@ export interface operations {
         filterTaskKeysDone?: boolean;
         /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
         filterHasTaskInLang?: string[];
-        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        /** Select only keys not currently linked to a task in any of the provided languages, the exact complement of filterHasTaskInLang. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
         filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -19745,6 +19745,10 @@ export interface operations {
         filterTaskKeysNotDone?: boolean;
         /** Filter task keys which are `done` */
         filterTaskKeysDone?: boolean;
+        /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
+        filterHasTaskInLang?: string[];
+        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
         /** Filter keys with any comments in lang */
@@ -20000,6 +20004,10 @@ export interface operations {
         filterTaskKeysNotDone?: boolean;
         /** Filter task keys which are `done` */
         filterTaskKeysDone?: boolean;
+        /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
+        filterHasTaskInLang?: string[];
+        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
         /** Filter keys with any comments in lang */
@@ -20299,6 +20307,10 @@ export interface operations {
         filterTaskKeysNotDone?: boolean;
         /** Filter task keys which are `done` */
         filterTaskKeysDone?: boolean;
+        /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
+        filterHasTaskInLang?: string[];
+        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
         /** Filter keys with any comments in lang */
@@ -24988,6 +25000,10 @@ export interface operations {
         )[];
         /** Include keys where translation is outdated */
         filterOutdated?: boolean;
+        /** Include only keys whose translation into the task language was never part of any task. Evaluated per task language, so a key already tasked for one language is still included for the others. */
+        filterNeverInTask?: boolean;
+        /** Include only keys whose translation into the task language is or was part of some task. Evaluated per task language. */
+        filterHasBeenInTask?: boolean;
       };
       path: {
         projectId: number;
@@ -25051,6 +25067,10 @@ export interface operations {
         )[];
         /** Include keys where translation is outdated */
         filterOutdated?: boolean;
+        /** Include only keys whose translation into the task language was never part of any task. Evaluated per task language, so a key already tasked for one language is still included for the others. */
+        filterNeverInTask?: boolean;
+        /** Include only keys whose translation into the task language is or was part of some task. Evaluated per task language. */
+        filterHasBeenInTask?: boolean;
       };
       path: {
         projectId: number;
@@ -25114,6 +25134,10 @@ export interface operations {
         )[];
         /** Include keys where translation is outdated */
         filterOutdated?: boolean;
+        /** Include only keys whose translation into the task language was never part of any task. Evaluated per task language, so a key already tasked for one language is still included for the others. */
+        filterNeverInTask?: boolean;
+        /** Include only keys whose translation into the task language is or was part of some task. Evaluated per task language. */
+        filterHasBeenInTask?: boolean;
       };
       path: {
         projectId: number;
@@ -26345,6 +26369,10 @@ export interface operations {
         filterTaskKeysNotDone?: boolean;
         /** Filter task keys which are `done` */
         filterTaskKeysDone?: boolean;
+        /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
+        filterHasTaskInLang?: string[];
+        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
         /** Filter keys with any comments in lang */
@@ -26812,6 +26840,10 @@ export interface operations {
         filterTaskKeysNotDone?: boolean;
         /** Filter task keys which are `done` */
         filterTaskKeysDone?: boolean;
+        /** Select only keys currently linked to a task in any of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so this reflects current task membership rather than an immutable audit log. */
+        filterHasTaskInLang?: string[];
+        /** Select only keys not currently linked to a task in at least one of the provided languages. Tasks in all states (including CANCELED and FINISHED) and of both types (TRANSLATE, REVIEW) count. The link is dropped when a key is removed from a task or when the branch holding it is deleted, so a key can reappear here after having been in a task. */
+        filterHasNoTaskInLang?: string[];
         /** Filter keys with unresolved comments in lang */
         filterHasUnresolvedCommentsInLang?: string[];
         /** Filter keys with any comments in lang */

--- a/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
@@ -17,7 +17,11 @@ import { SubfilterComments } from './SubfilterComments';
 import { SubfilterLabels } from 'tg.views/projects/translations/TranslationFilters/SubfilterLabels';
 import { SubfilterSuggestions } from './SubfilterSuggestions';
 import { SubfilterDeletedBy } from './SubfilterDeletedBy';
-import { getQaChecksFiltersLength, SubfilterQaChecks } from 'tg.ee';
+import {
+  getQaChecksFiltersLength,
+  SubfilterQaChecks,
+  SubfilterTasks,
+} from 'tg.ee';
 
 type Props = {
   value: FiltersType;
@@ -101,6 +105,14 @@ export const TranslationFiltersPopup = ({
               />
             )}
           </>
+        )}
+        {(!filterOptions?.keyRelatedOnly || filterOptions?.showTaskFilter) && (
+          <SubfilterTasks
+            value={value}
+            actions={actions}
+            selectedLanguages={selectedLanguages}
+            hideLanguageScope={filterOptions?.keyRelatedOnly}
+          />
         )}
         {project.suggestionsMode !== 'DISABLED' && (
           <SubfilterSuggestions

--- a/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/TranslationFiltersPopup.tsx
@@ -1,6 +1,7 @@
 import { Box, Menu, MenuItem } from '@mui/material';
 import { useTranslate } from '@tolgee/react';
 import { useProject } from 'tg.hooks/useProject';
+import { useEnabledFeatures } from 'tg.globalContext/helpers';
 
 import { FilterActions, FilterOptions } from './tools';
 import { FiltersType, LanguageModel } from './tools';
@@ -46,6 +47,8 @@ export const TranslationFiltersPopup = ({
 }: Props) => {
   const { t } = useTranslate();
   const project = useProject();
+  const { isEnabled } = useEnabledFeatures();
+  const tasksEnabled = isEnabled('TASKS') || isEnabled('ORDER_TRANSLATION');
   return (
     <Menu
       open={true}
@@ -106,14 +109,15 @@ export const TranslationFiltersPopup = ({
             )}
           </>
         )}
-        {(!filterOptions?.keyRelatedOnly || filterOptions?.showTaskFilter) && (
-          <SubfilterTasks
-            value={value}
-            actions={actions}
-            selectedLanguages={selectedLanguages}
-            hideLanguageScope={filterOptions?.keyRelatedOnly}
-          />
-        )}
+        {tasksEnabled &&
+          (!filterOptions?.keyRelatedOnly || filterOptions?.showTaskFilter) && (
+            <SubfilterTasks
+              value={value}
+              actions={actions}
+              selectedLanguages={selectedLanguages}
+              hideLanguageScope={filterOptions?.keyRelatedOnly}
+            />
+          )}
         {project.suggestionsMode !== 'DISABLED' && (
           <SubfilterSuggestions
             value={value}

--- a/webapp/src/views/projects/translations/TranslationFilters/summary.ts
+++ b/webapp/src/views/projects/translations/TranslationFilters/summary.ts
@@ -32,7 +32,12 @@ import {
   getDeletedByFiltersLength,
   getDeletedByFiltersName,
 } from './SubfilterDeletedBy';
-import { getQaChecksFiltersLength, getQaChecksFiltersName } from 'tg.ee';
+import {
+  getQaChecksFiltersLength,
+  getQaChecksFiltersName,
+  getTaskFiltersLength,
+  getTaskFiltersName,
+} from 'tg.ee';
 import { components } from 'tg.service/apiSchema.generated';
 
 type LabelModel = components['schemas']['LabelModel'];
@@ -48,6 +53,7 @@ export function countFilters(value: FiltersInternal) {
     getLabelFiltersLength(value) +
     getSuggestionsFiltersLength(value) +
     getDeletedByFiltersLength(value) +
+    getTaskFiltersLength(value) +
     getQaChecksFiltersLength(value)
   );
 }
@@ -63,6 +69,7 @@ export function getFilterName(value: FiltersInternal, labels?: LabelModel[]) {
     getLabelFiltersName(value, labels) ||
     getSuggestionsFiltersName(value) ||
     getDeletedByFiltersName(value) ||
+    getTaskFiltersName(value) ||
     getQaChecksFiltersName(value)
   );
 }

--- a/webapp/src/views/projects/translations/TranslationFilters/tools.ts
+++ b/webapp/src/views/projects/translations/TranslationFilters/tools.ts
@@ -26,6 +26,8 @@ export type FiltersInternal = {
   filterLabel?: string[];
   filterHasSuggestions?: boolean;
   filterHasNoSuggestions?: boolean;
+  filterHasTask?: boolean;
+  filterHasNoTask?: boolean;
   filterDeletedByUserId?: number[];
 
   /*
@@ -37,6 +39,7 @@ export type FiltersInternal = {
   filterTranslationLanguage?: true | string;
   // same for suggestions
   filterSuggestionLanguage?: true | string;
+  filterTaskLanguage?: true | string;
 
   /*
    * this one differs from the two above
@@ -66,6 +69,8 @@ export type AddParams =
   | ['filterLabel', string]
   | ['filterHasSuggestions']
   | ['filterHasNoSuggestions']
+  | ['filterHasTask']
+  | ['filterHasNoTask']
   | ['filterDeletedByUserId', number];
 
 export type FilterActions = {
@@ -77,4 +82,5 @@ export type FilterActions = {
 export type FilterOptions = {
   keyRelatedOnly?: boolean;
   showDeletedBy?: boolean;
+  showTaskFilter?: boolean;
 };

--- a/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
@@ -10,6 +10,12 @@ function add<T extends string | number>(list: T[] | undefined, value: T) {
   return [...(remove(list, value) || []), value];
 }
 
+const LANGUAGE_SCOPES = [
+  'filterTranslationLanguage',
+  'filterSuggestionLanguage',
+  'filterTaskLanguage',
+] as const satisfies readonly (keyof FiltersInternal)[];
+
 type Props = {
   filters: FiltersInternal;
   setFilters: (value: FiltersInternal) => void;
@@ -26,21 +32,21 @@ export const useTranslationFilters = ({
   // adjusts filters to newly incoming languages
   // so in next render it's already correct
   function updateSelectedLanguages(newLanguages: string[] | undefined) {
-    if (
-      typeof filters.filterTranslationLanguage === 'string' &&
-      newLanguages &&
-      newLanguages.includes(filters.filterTranslationLanguage)
-    ) {
-      setFilters({ filterTranslationLanguage: undefined });
+    if (!newLanguages) {
       return;
     }
-    if (
-      typeof filters.filterTaskLanguage === 'string' &&
-      newLanguages &&
-      !newLanguages.includes(filters.filterTaskLanguage)
-    ) {
-      setFilters({ ...filters, filterTaskLanguage: undefined });
+    const dangling = LANGUAGE_SCOPES.filter((scope) => {
+      const value = filters[scope];
+      return typeof value === 'string' && !newLanguages.includes(value);
+    });
+    if (!dangling.length) {
+      return;
     }
+    const updated = { ...filters };
+    dangling.forEach((scope) => {
+      updated[scope] = undefined;
+    });
+    setFilters(updated);
   }
 
   function addFilter(...params: AddParams) {

--- a/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
+++ b/webapp/src/views/projects/translations/TranslationFilters/useTranslationFilters.tsx
@@ -32,6 +32,14 @@ export const useTranslationFilters = ({
       newLanguages.includes(filters.filterTranslationLanguage)
     ) {
       setFilters({ filterTranslationLanguage: undefined });
+      return;
+    }
+    if (
+      typeof filters.filterTaskLanguage === 'string' &&
+      newLanguages &&
+      !newLanguages.includes(filters.filterTaskLanguage)
+    ) {
+      setFilters({ ...filters, filterTaskLanguage: undefined });
     }
   }
 
@@ -130,6 +138,18 @@ export const useTranslationFilters = ({
           filterHasNoSuggestions: true,
           filterHasSuggestions: undefined,
         });
+      case 'filterHasTask':
+        return setFilters({
+          ...filters,
+          filterHasTask: true,
+          filterHasNoTask: undefined,
+        });
+      case 'filterHasNoTask':
+        return setFilters({
+          ...filters,
+          filterHasNoTask: true,
+          filterHasTask: undefined,
+        });
       case 'filterDeletedByUserId':
         return setFilters({
           ...filters,
@@ -222,6 +242,16 @@ export const useTranslationFilters = ({
         return setFilters({
           ...filters,
           filterHasNoSuggestions: undefined,
+        });
+      case 'filterHasTask':
+        return setFilters({
+          ...filters,
+          filterHasTask: undefined,
+        });
+      case 'filterHasNoTask':
+        return setFilters({
+          ...filters,
+          filterHasNoTask: undefined,
         });
       case 'filterDeletedByUserId':
         return setFilters({
@@ -346,6 +376,32 @@ export const useTranslationFilters = ({
         if (filters.filterHasNoSuggestions) {
           filtersQuery.filterHasNoSuggestionsInLang = add(
             filtersQuery.filterHasNoSuggestionsInLang,
+            tag
+          );
+        }
+      });
+
+    selectedLanguages
+      .filter((tag) => {
+        switch (filters.filterTaskLanguage) {
+          case undefined:
+            return tag !== baseLang;
+          case true:
+            return true;
+          default:
+            return tag === filters.filterTaskLanguage;
+        }
+      })
+      .forEach((tag) => {
+        if (filters.filterHasTask) {
+          filtersQuery.filterHasTaskInLang = add(
+            filtersQuery.filterHasTaskInLang,
+            tag
+          );
+        }
+        if (filters.filterHasNoTask) {
+          filtersQuery.filterHasNoTaskInLang = add(
+            filtersQuery.filterHasNoTaskInLang,
             tag
           );
         }


### PR DESCRIPTION
Closes #3848

Adds a language-scoped filter answering "has this translation been in a task before?", so teams sending recurring batches to an external agency can avoid sending the same work twice without relying on manually maintained date tags.

## What's in it

**Translations view** — a new **Tasks** subfilter with `Has been in a task` / `Never in a task`, plus the usual language-scope submenu (all languages / all but base / one specific language). Backed by two new query params, `filterHasTaskInLang` and `filterHasNoTaskInLang`.

**Task creation & Order translations dialogs** — the same two options, scoped per target language server-side via `filterNeverInTask` / `filterHasBeenInTask` on `TranslationScopeFilters`. `select-all` narrows the key set with OR-across-languages semantics, then `calculate-scope` and `create-multiple-tasks` apply the per-language filter, so a key tasked in `de` but not `fr` lands only in the `fr` task.

## Notes for the reviewer

- **Task membership, not an immutable audit log.** The filter reads `task_key`. Rows survive CANCELED/FINISHED tasks and both task types, but are hard-deleted when a key is removed from a task (`TaskService.updateTaskKeys`) or a task is deleted (`TaskService.deleteAll`). So deleting a finished agency task makes its keys eligible again. The parameter docs say this explicitly; flagging it here because the labels ("Never in a task") promise slightly more than the data model delivers. Happy to rename the labels or back this with the activity log if that's the call.
- **AND, not OR.** These filters are AND-ed with the rest of the query rather than joining the OR-ed `translationConditions` bucket, so combining with a state filter narrows rather than re-admits already-tasked keys. Consistent with the existing `filterTaskNumber`.
- **Gated on TASKS / ORDER_TRANSLATION**, mirroring how QA check filters are gated — silently ignored without the feature.
- **Second commit fixes a pre-existing bug** beyond the ticket: `updateSelectedLanguages` cleared `filterTranslationLanguage` when the scoped language was *still* selected rather than when it was gone, and replaced the whole filter object instead of merging — so adding any language to the view wiped every active filter. `filterSuggestionLanguage` had no cleanup at all.
- **Side effect worth knowing:** `TaskCreateForm` previously passed `selectedLanguages={[]}`, which made the suggestion filters in the task/order dialogs settable but inert. They now work.
- Needs tolgee/billing#299 (schema regen for the order-translation endpoint; same branch name).

## Testing

- `TranslationsControllerTaskHistoryFilterTest` — 12 tests covering per-language scoping, canceled/finished/review tasks, multi-language OR, AND with other filters, `select-all` parity, unresolvable tags, and the feature-disabled path.
- `TaskScopeTaskHistoryFilterTest` — per-language scope calculation and a multi-language batch that must not re-task a key in the language that already had it.
- Cypress: `translationFilters.tasks.cy.ts` (both directions) and a regression spec for the language-scope clearing fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation filters for keys that have, or have never had, tasks.
  * Added task-language filtering to refine results by target language.
  * Added task-history filters to task creation and ordering workflows.
  * Prevented keys from being re-added for languages where they were already assigned.
* **Bug Fixes**
  * Cleared language-specific filters when languages are deselected.
* **Tests**
  * Added coverage across languages, task states, task types, and task creation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->