### PR TITLE
feat: add project switcher dropdown to the project breadcrumb

### DIFF
--- a/e2e/cypress/e2e/administration/base.cy.ts
+++ b/e2e/cypress/e2e/administration/base.cy.ts
@@ -122,12 +122,17 @@ function changeUserRole(user: string, role: 'Admin' | 'Supporter' | 'User') {
   assertMessage('Role changed');
 }
 
+function openUserMenuOrganizationSwitch() {
+  gcy('global-user-menu-button').click();
+  gcy('user-menu-organization-switch').click();
+}
+
 function assertOrganizationAddButtonVisible() {
-  gcy('organization-switch').click();
+  openUserMenuOrganizationSwitch();
   gcy('switch-popover-new').should('be.visible');
 }
 
 function assertOrganizationAddButtonNotVisible() {
-  gcy('organization-switch').click();
+  openUserMenuOrganizationSwitch();
   gcy('switch-popover-new').should('not.exist');
 }

--- a/e2e/cypress/e2e/organizations/organizationsList.cy.ts
+++ b/e2e/cypress/e2e/organizations/organizationsList.cy.ts
@@ -138,7 +138,8 @@ describe('Organization List', () => {
   });
 
   const goToNewOrganizationForm = () => {
-    gcy('organization-switch').click();
+    gcy('global-user-menu-button').click();
+    gcy('user-menu-organization-switch').click();
     gcy('switch-popover-new').click();
   };
 

--- a/e2e/cypress/e2e/organizations/organizationsSwitching.cy.ts
+++ b/e2e/cypress/e2e/organizations/organizationsSwitching.cy.ts
@@ -67,6 +67,12 @@ describe('Organization switching', () => {
     assertOrganizationIsPreferred('Microsoft');
   });
 
+  it('does not offer creating an organization from the breadcrumb switcher', () => {
+    gcy('organization-switch').click();
+    gcy('switch-popover-item').first().should('be.visible');
+    gcy('switch-popover-new').should('not.exist');
+  });
+
   const visit = () => {
     cy.visit(`${HOST}/projects`);
   };

--- a/e2e/cypress/e2e/projects/projectSwitching.cy.ts
+++ b/e2e/cypress/e2e/projects/projectSwitching.cy.ts
@@ -1,0 +1,36 @@
+import { login, setBypassSeatCountCheck } from '../../common/apiCalls/common';
+import { projectListData } from '../../common/apiCalls/testData/testData';
+import { waitForGlobalLoading } from '../../common/loading';
+import { enterProject } from '../../common/projects';
+import { gcy } from '../../common/shared';
+
+describe('Project switching', () => {
+  beforeEach(() => {
+    setBypassSeatCountCheck(true);
+    projectListData.clean();
+    projectListData.generate();
+    login('projectListDashboardUser', 'admin');
+    enterProject('test_project');
+  });
+
+  afterEach(() => {
+    projectListData.clean();
+    setBypassSeatCountCheck(false);
+  });
+
+  it('switches to another project of the organization', () => {
+    gcy('project-switch').click();
+    gcy('switch-popover-item').contains('Project 2').click();
+    waitForGlobalLoading();
+
+    gcy('navigation-item').contains('Project 2').should('be.visible');
+    cy.url().should('not.contain', '/translations');
+  });
+
+  it('keeps the project name linking to the dashboard', () => {
+    gcy('navigation-item').contains('test_project').click();
+    waitForGlobalLoading();
+
+    gcy('project-dashboard-language-count').should('be.visible');
+  });
+});

--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -683,6 +683,7 @@ declare namespace DataCy {
         "project-states-bar-legend": true;
         "project-states-bar-root": true;
         "project-states-bar-state-progress": true;
+        "project-switch": true;
         "project-transfer-autocomplete-field": true;
         "project-transfer-autocomplete-suggested-option": true;
         "project-transfer-confirmation-field": true;

--- a/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationPopover.tsx
@@ -16,7 +16,7 @@ type Props = {
   onSelect: (value: OrganizationModel) => void;
   anchorEl: HTMLElement;
   selected: OrganizationModel | undefined;
-  onAddNew: () => void;
+  onAddNew?: () => void;
   ownedOnly?: boolean;
   onCommunityNavigate?: () => void;
   communitySelected?: boolean;

--- a/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
+++ b/webapp/src/component/organizationSwitch/OrganizationSwitch.tsx
@@ -62,11 +62,6 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
     onSelect?.(organization);
   };
 
-  const handleCreateNewOrg = () => {
-    handleClose();
-    history.push(LINKS.ORGANIZATIONS_ADD.build());
-  };
-
   const isCommunitySurface = selectedSurface === 'community';
 
   const switchLabel = isCommunitySurface ? (
@@ -89,7 +84,6 @@ export const OrganizationSwitch: React.FC<React.PropsWithChildren<Props>> = ({
         selected={preferredOrganization}
         onSelect={handleSelectOrganization}
         anchorEl={anchorEl.current!}
-        onAddNew={handleCreateNewOrg}
         communitySelected={isCommunitySurface}
         onCommunityNavigate={
           hasCommunityContributions

--- a/webapp/src/component/projectSwitch/ProjectSwitch.tsx
+++ b/webapp/src/component/projectSwitch/ProjectSwitch.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useRef, useState } from 'react';
+import { IconButton } from '@mui/material';
+import { useTranslate } from '@tolgee/react';
+import { useHistory } from 'react-router-dom';
+
+import { ArrowDropDown } from 'tg.component/CustomIcons';
+import { ProjectSearchSelectItem } from 'tg.component/projectSearchSelect/ProjectSearchSelectItem';
+import { SwitchPopover } from 'tg.component/SwitchPopover/SwitchPopover';
+import { LINKS, PARAMS } from 'tg.constants/links';
+import { components } from 'tg.service/apiSchema.generated';
+import { useApiInfiniteQuery } from 'tg.service/http/useQueryApi';
+
+type ProjectModel = components['schemas']['ProjectModel'];
+
+type Props = {
+  project: ProjectModel;
+};
+
+export const ProjectSwitch: React.FC<Props> = ({ project }) => {
+  const anchorEl = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const { t } = useTranslate();
+  const history = useHistory();
+
+  const slug = project.organizationOwner?.slug || '';
+
+  const query = {
+    search: search || undefined,
+    size: 20,
+    sort: ['name'],
+  };
+
+  const projectsLoadable = useApiInfiniteQuery({
+    url: '/v2/organizations/{slug}/projects',
+    method: 'get',
+    path: { slug },
+    query,
+    options: {
+      keepPreviousData: true,
+      enabled: isOpen && Boolean(slug),
+      getNextPageParam: (lastPage) => {
+        if (
+          lastPage.page &&
+          lastPage.page.number! < lastPage.page.totalPages! - 1
+        ) {
+          return {
+            path: { slug },
+            query: {
+              ...query,
+              page: lastPage.page!.number! + 1,
+            },
+          };
+        } else {
+          return null;
+        }
+      },
+    },
+  });
+
+  const items = (projectsLoadable.data?.pages
+    .flatMap((page) => page._embedded?.projects)
+    .filter(Boolean) ?? []) as ProjectModel[];
+
+  const totalElements =
+    projectsLoadable.data?.pages[0]?.page?.totalElements ?? 0;
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+  }, []);
+
+  const handleSelect = (selected: ProjectModel) => {
+    setIsOpen(false);
+    history.push(
+      LINKS.PROJECT_DASHBOARD.build({ [PARAMS.PROJECT_ID]: selected.id })
+    );
+  };
+
+  return (
+    <>
+      {/* Anchored on the preceding breadcrumb link (avatar + project name) rather
+          than on this button, so the popover lines up with the project the same way
+          the organization one lines up with its label. Rendering this switch anywhere
+          other than directly after that link silently misplaces the popover. */}
+      <IconButton
+        ref={anchorEl}
+        sx={{ p: 0, color: 'inherit' }}
+        onClick={() => setIsOpen(true)}
+        data-cy="project-switch"
+        aria-label={t('projects_switch_label', 'Switch project')}
+        size="small"
+      >
+        <ArrowDropDown width={20} height={20} />
+      </IconButton>
+
+      <SwitchPopover
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        onSelect={handleSelect}
+        anchorEl={
+          (anchorEl.current?.previousElementSibling as HTMLElement) ??
+          anchorEl.current!
+        }
+        selectedId={project.id}
+        items={items}
+        isLoading={projectsLoadable.isFetching}
+        hasNextPage={projectsLoadable.hasNextPage ?? false}
+        fetchNextPage={() => projectsLoadable.fetchNextPage()}
+        totalElements={totalElements}
+        renderItem={(item) => <ProjectSearchSelectItem data={item} />}
+        searchPlaceholder={t('projects_search_placeholder', 'Search projects')}
+        headingText={t('projects_title', 'Projects')}
+        onSearchChange={handleSearchChange}
+      />
+    </>
+  );
+};

--- a/webapp/src/views/projects/BaseProjectView.tsx
+++ b/webapp/src/views/projects/BaseProjectView.tsx
@@ -6,6 +6,7 @@ import { BaseView, BaseViewProps } from 'tg.component/layout/BaseView';
 import { NavigationItem } from 'tg.component/navigation/Navigation';
 import { SmallProjectAvatar } from 'tg.component/navigation/SmallProjectAvatar';
 import { OrganizationSwitch } from 'tg.component/organizationSwitch/OrganizationSwitch';
+import { ProjectSwitch } from 'tg.component/projectSwitch/ProjectSwitch';
 import { LINKS, PARAMS } from 'tg.constants/links';
 import { useProject } from 'tg.hooks/useProject';
 import { BatchOperationsSummary } from './translations/BatchOperations/OperationsSummary/OperationsSummary';
@@ -44,7 +45,10 @@ export const BaseProjectView: React.FC<React.PropsWithChildren<Props>> = ({
         [PARAMS.PROJECT_ID]: project.id,
       }),
       <SmallProjectAvatar key="avatar" project={project} />,
-      branching ? <GlobalBranchSelector key="branch" /> : undefined,
+      <React.Fragment key="suffix">
+        <ProjectSwitch project={project} />
+        {branching && <GlobalBranchSelector />}
+      </React.Fragment>,
     ]);
   }
 


### PR DESCRIPTION
Closes #2150

## What

- Adds a project switcher next to the project name in the breadcrumb, so users can jump between projects of the current organization without going back to the list.
- Removes the "+" (create organization) button from the breadcrumb organization dropdown, per @ZuzanaOdstrcilova's note that creating an organization belongs in settings rather than in the quick switcher.

## How

The switcher reuses the existing generic `SwitchPopover` (search, paging, keyboard nav) that already backs the organization dropdown, and the existing `ProjectSearchSelectItem` for rows. No backend change — `/v2/organizations/{slug}/projects` already supports `search` and paging.

The project name stays a link to the project dashboard; the dropdown is a separate arrow button beside it. Projects are scoped to the *viewed project's* organization (`project.organizationOwner`), not the globally preferred organization, so opening a shared link to a project in another org lists the right projects even before the preferred-organization state catches up.

Creating an organization is still available from the user avatar menu → Switch organization → "+", which is now the single entry point.

## Deliberately out of scope

- The Figma visual polish listed in the 2024 comment (new colors, 8px corners, elevation) — this PR only adds the control.
- No "+ new project" in the project dropdown, per the same comment.
- #2737 ("remove organization dropdown") is a separate decision and is untouched here.

## Testing

- New `e2e/cypress/e2e/projects/projectSwitching.cy.ts`: switching to another project of the organization, and the project name still linking to the dashboard.
- `organizationsSwitching.cy.ts`: asserts the breadcrumb dropdown no longer offers "+".
- `organizationsList.cy.ts` and `administration/base.cy.ts` repointed at the user-menu switcher for their organization-creation assertions.

All four specs pass locally (21/21), plus webapp/e2e eslint + tsc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a project switcher to project navigation with search, pagination, and direct navigation to selected projects.
  - Project names now open the project dashboard.
  - Organization switching is available through the global user menu.

- **Bug Fixes**
  - Organization creation is no longer offered from the organization breadcrumb switcher.

- **Tests**
  - Added end-to-end coverage for project switching and organization switcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->