### PR TITLE
fix: Text overflow in keys Search field/#3852

### DIFF
--- a/webapp/src/views/projects/translations/TranslationHeader/search/searchFieldStyles.ts
+++ b/webapp/src/views/projects/translations/TranslationHeader/search/searchFieldStyles.ts
@@ -26,6 +26,7 @@ export const StyledRoot = styled('div')`
   & .cm-editor {
     outline: none;
     width: 100%;
+    min-width: 0;
   }
 
   & .cm-scroller {


### PR DESCRIPTION
Addressed the review feedback:

Separate PR for #3852 

1. Removed the redundant `min-width` and `max-width` properties from `.cm-scroller`.
2. Kept only `min-width: 0` on `.cm-editor`, which is sufficient to prevent long search text from overflowing in Firefox.
3. Updated the commit message to start with `fix:`.
4. Kept the search-field fix isolated in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the translation search field layout so the editor can shrink properly within its container.
  * Prevented potential overflow or misalignment in narrow or flexible layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->