### PR TITLE
fix: bump Spring Boot to 4.1.1 to patch Snyk-reported vulnerabilities

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ kapt.include.compile.classpath=false
 # Versions
 kotlinVersion=2.3.21
 javaVersion=25
-springBootVersion=4.1.0
+springBootVersion=4.1.1
 springDocVersion=3.0.3
 jjwtVersion=0.11.2
 hibernateVersion=7.4.1.Final
@@ -17,7 +17,7 @@ amazonAwsSdkVersion=2.46.15
 springDependencyManagementVersion=1.1.7
 # Keep aligned with the Spring Boot BOM's jackson-bom.version (used by the version
 # catalog so the standalone `misc` module, which has no Spring BOM, can resolve Jackson).
-jacksonVersion=3.1.4
+jacksonVersion=3.1.5
 slackSdkVersion=1.37.0
 nettyVersion=4.2.17.Final
 commonsLang3Version=3.20.0


### PR DESCRIPTION
## What

`springBootVersion` 4.1.0 → 4.1.1, and `jacksonVersion` 3.1.4 → 3.1.5 to keep the documented alignment with the BOM's `jackson-bom.version`.

## Why

A fresh Snyk scan of the billing image flags eight advisories, all of them jars managed by the Spring Boot BOM:

| Package | CVE | Severity | Issue | In | Fixed in |
|---|---|---|---|---|---|
| `spring-webmvc` | CVE-2026-47884 | **critical** (9.1) | arbitrary code injection | 7.0.8 | 7.0.9 |
| `spring-expression` | CVE-2026-59283 | high (8.3) | resource exhaustion | 7.0.8 | 7.0.9 |
| `spring-web` | CVE-2026-47889 | high (8.3) | sensitive cookie without `Secure` | 7.0.8 | 7.0.9 |
| `spring-beans` | CVE-2026-59282 | high (8.2) | resource exhaustion | 7.0.8 | 7.0.9 |
| `spring-context-support` | CVE-2026-59280 | high (8.2) | directory traversal | 7.0.8 | 7.0.9 |
| `micrometer-core` | CVE-2026-59296 | high (8.2) | CRLF injection | 1.17.0 | 1.17.1 |
| `reactor-netty-http` | CVE-2026-47874 | high (8.7) | resource exhaustion | 1.3.6 | 1.3.7 |
| `reactor-core` | CVE-2026-47857 | high (8.2) | resource exhaustion | 3.8.6 | 3.8.7 |
| `reactor-core` | CVE-2026-47863 | high (8.2) | race condition | 3.8.6 | 3.8.7 |

Boot 4.1.1 clears every one of them in a single bump:

| BOM property | 4.1.0 | 4.1.1 |
|---|---|---|
| `spring-framework.version` | 7.0.8 | **7.0.9** |
| `micrometer.version` | 1.17.0 | **1.17.1** |
| `reactor-bom.version` | 2025.0.6 | **2025.0.7** |
| `netty.version` | 4.2.15 | 4.2.17 |

### Why this lands in the platform repo

Billing declares no dependency versions of its own — `billing/app/build.gradle` imports `SpringBootPlugin.BOM_COORDINATES` and builds as `:billing-app` inside this project (`settings.gradle:139-141`). The BOM version lives here, so the fix does too, and it clears the platform image at the same time.

### Why the Spring Boot 4 migration didn't already cover this

It couldn't have. #3804 merged 2026-08-04 on Boot 4.1.0, which was released 2026-06-10 and was the latest available at the time. Spring Framework 7.0.9 and Boot 4.1.1 were both published 2026-08-20, 16 days later. Normal patch lag, not a gap in the migration.

### Notes on the neighbouring properties

- `jacksonVersion` → 3.1.5: the comment above it asks that it track the BOM's `jackson-bom.version`, which 4.1.1 moves to 3.1.5. Leaving it at 3.1.4 would ship mixed Jackson versions.
- `nettyVersion` unchanged: 4.1.1 manages exactly the 4.2.17 that #3866 pinned by hand, and the version catalog still needs the property for the explicit `netty-*` declarations in `backend/data` and `backend/app`.
- `hibernateVersion` unchanged: it is a deliberate override (the Hibernate Gradle plugin is resolved from it in `settings.gradle:21`), so 4.1.1's move to 7.4.5 does not apply. Out of scope here.

## Verification

- `dependencyInsight` on `:billing-app:runtimeClasspath` — every artifact in the table resolves to a fixed version (7.0.9 / 1.17.1 / 3.8.7 / 1.3.7), with netty at 4.2.17 and Jackson at 3.1.5
- `:billing-app:compileKotlin`, `:billing-test:compileTestKotlin`, `:server-app:compileKotlin`, `:server-app:compileTestKotlin` pass
- `SelfHostedFreePlanTest` boots the full billing Spring context and passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spring Boot and Jackson to newer patch versions for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->