### PR TITLE
fix: keep re-launched batch chunks cancellable

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
@@ -41,13 +41,7 @@ class BatchJobConcurrentLauncher(
   /**
    * launch id -> Pair(BatchJobDto, Job)
    *
-   * Job is the result of a launch method executing the execution in a separate coroutine.
-   *
-   * The key must stay unique per launch, never the chunk execution id: the queue can hand out
-   * the same execution again while its previous coroutine is still running (the Redis queue
-   * re-delivers items), and a shared key drops that coroutine from the map. A dropped coroutine
-   * can no longer be cancelled, so it keeps its pessimistic row lock forever and job
-   * cancellation times out.
+   * Job is the result of a launch method executing the execution in a separate coroutine
    */
   val runningJobs: ConcurrentHashMap<Long, Pair<BatchJobDto, Job>> = ConcurrentHashMap()
 
@@ -252,7 +246,8 @@ class BatchJobConcurrentLauncher(
     job.invokeOnCompletion {
       onJobCompleted(launchId, executionItem, batchJobDto.jobCharacter)
     }
-    // Starting only after the registration above keeps a concurrent cancel from missing it.
+    // The coroutine must not run before it is in runningJobs: a cancel or pause scanning the map
+    // while it runs unregistered cannot stop it, and it then blocks holding its execution row lock.
     job.start()
     logger.debug("Execution ${executionItem.chunkExecutionId} launched. Running jobs: ${runningJobs.size}")
     return true

--- a/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/batch/BatchJobConcurrentLauncher.kt
@@ -11,6 +11,7 @@ import io.tolgee.util.Logging
 import io.tolgee.util.logger
 import io.tolgee.util.trace
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -19,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Component
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.ceil
 
 @Component
@@ -37,11 +39,19 @@ class BatchJobConcurrentLauncher(
   }
 
   /**
-   * execution id -> Pair(BatchJobDto, Job)
+   * launch id -> Pair(BatchJobDto, Job)
    *
-   * Job is the result of a launch method executing the execution in a separate coroutine
+   * Job is the result of a launch method executing the execution in a separate coroutine.
+   *
+   * The key must stay unique per launch, never the chunk execution id: the queue can hand out
+   * the same execution again while its previous coroutine is still running (the Redis queue
+   * re-delivers items), and a shared key drops that coroutine from the map. A dropped coroutine
+   * can no longer be cancelled, so it keeps its pessimistic row lock forever and job
+   * cancellation times out.
    */
   val runningJobs: ConcurrentHashMap<Long, Pair<BatchJobDto, Job>> = ConcurrentHashMap()
+
+  private val launchIdProvider = AtomicLong()
 
   /**
    * O(1) counter for running jobs by character - avoids O(n) iteration on every chunk
@@ -230,17 +240,20 @@ class BatchJobConcurrentLauncher(
 
     // Launch with OTEL context propagation to ensure tracing context
     // survives coroutine suspension/resumption
+    val launchId = launchIdProvider.incrementAndGet()
     val job =
-      launch(tracingContext.asCoroutineContext()) {
+      launch(tracingContext.asCoroutineContext(), start = CoroutineStart.LAZY) {
         batchJobActionService.handleItem(executionItem, batchJobDto)
       }
 
-    runningJobs[executionItem.chunkExecutionId] = batchJobDto to job
+    runningJobs[launchId] = batchJobDto to job
     incrementRunningCharacterCount(batchJobDto.jobCharacter)
 
     job.invokeOnCompletion {
-      onJobCompleted(executionItem, batchJobDto.jobCharacter)
+      onJobCompleted(launchId, executionItem, batchJobDto.jobCharacter)
     }
+    // Starting only after the registration above keeps a concurrent cancel from missing it.
+    job.start()
     logger.debug("Execution ${executionItem.chunkExecutionId} launched. Running jobs: ${runningJobs.size}")
     return true
   }
@@ -251,10 +264,11 @@ class BatchJobConcurrentLauncher(
   }
 
   private fun onJobCompleted(
+    launchId: Long,
     executionItem: ExecutionQueueItem,
     jobCharacter: JobCharacter,
   ) {
-    runningJobs.remove(executionItem.chunkExecutionId)
+    runningJobs.remove(launchId)
     decrementRunningCharacterCount(jobCharacter)
     // Decrement running count when coroutine actually finishes to align with runningJobs
     progressManager.onExecutionCoroutineComplete(executionItem.jobId)


### PR DESCRIPTION
## Problem

`BatchJobsGeneralWithRedisTest` is one of the top flaky tests in CI — 12 job failures across 9 different PRs in the last month, each forcing a manual re-run. The dominant symptoms:

- `cancels the job()` → `CancellationTimeoutException` at `BatchJobCancellationManager.kt:133-134`
- `cancels the job()` / `retries failed with generic exception()` → `waitFor` timeouts

It is not just a test problem. The same race makes a real batch job permanently uncancellable on any Redis deployment.

## Root cause

`BatchJobConcurrentLauncher.runningJobs` was keyed by **chunk execution id**:

```kotlin
runningJobs[executionItem.chunkExecutionId] = batchJobDto to job
```

The queue can hand out the same execution again while its previous coroutine is still running. With Redis this is easy to hit: `addItemsToQueue` publishes to pub/sub and the local queue is fed by the async loopback, so ADD and REMOVE events race and an in-flight item gets re-delivered. The second launch then **overwrites the map entry of a still-active coroutine**.

An overwritten coroutine is unreachable — both `cancelLocalJob` and the `pause` setter iterate `runningJobs`, so nothing can cancel it. From there:

1. It keeps running, holding its `PESSIMISTIC_WRITE` row lock.
2. `cancelExecutions`' `SKIP_LOCKED` query therefore skips that row, so the execution stays `PENDING`.
3. The job never reaches a completed status, so both 30 s attempts in `cancel()` time out and it throws `CancellationTimeoutException`.
4. The orphan is a child of the launcher's master coroutine, so `stop()` blocks forever joining it.

That last point is why the flake sometimes shows up as a hung job rather than a failed assertion.

## Evidence

- Reproduced locally with `@RepeatedTest(50)` — failed at repetition 19 with the exact CI stack trace.
- `jstack` on the hung JVM showed a coroutine stuck **47 minutes** inside the chunk processor, with the test worker blocked in `BatchJobConcurrentLauncher.stop()`.
- Instrumenting the map put printed `DIAG-OVERWRITE chunk=1000077056 job=1000010023 previousActive=true` — a still-active coroutine being evicted — in exactly the repetition where the run hung.

## Fix

- Key `runningJobs` by a unique per-launch id (`AtomicLong`) instead of the chunk execution id, so concurrent launches of the same execution can no longer evict or stale-remove each other. Nothing looks the map up by execution id — only `size`, `values` and `remove` — so the re-key is safe.
- Launch with `CoroutineStart.LAZY` and call `job.start()` only after the map registration and `invokeOnCompletion`, closing the smaller window where a coroutine could run before being registered.

## Verification

| Run | Result |
|---|---|
| `cancels the job` ×50 (Redis) | 50/50 passed, 2m16s — before the fix: failed at repetition 19, then hung |
| Full `BatchJobsGeneralWithRedisTest`, with ×25 on `retries failed with generic exception`, `retries and fails on management exceptions issues`, `MultipleItemsFailedException retries the job` | 86/86 passed |
| General Redis + non-Redis, failure/cancellation, project locking, recovery, `BatchJobManagementControllerCancellationTest` | 37/37 passed |
| Concurrency, finalization, parallel execution, round-robin, progress, startup delay, contribution, stress | 11/11 passed |
| `BatchJobManagementControllerCancellationTest.cancels a job` ×20, with and against the unpatched launcher | 20/20 in both — that test's own known flakiness is unrelated and unchanged |

`ktlintCheck` clean.

## Note

PR #3651 ("chore: fix flaky BatchJobsGeneralWithRedisTest") is already merged and did not fix this — it closed the Redis loopback window in `cancelLocalJob`, which is a different race.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch job tracking to prevent duplicate deliveries from replacing active jobs.
  * Enhanced job cancellation reliability by ensuring jobs are registered before starting.
  * Ensured completed jobs are removed from active tracking consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->