### PR TITLE
chore: run redis integration tests and local stacks on redis 8.10

### DIFF
--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/RedisRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/RedisRunner.kt
@@ -10,7 +10,7 @@ class RedisRunner {
 
   private val runner =
     DockerContainerRunner(
-      image = "redis:6",
+      image = "redis:8.10",
       expose = mapOf(port to "6379"),
       waitForLog = "Ready to accept connections",
       rm = true,

--- a/docker/docker-compose.local-observability-stack-dev.yaml
+++ b/docker/docker-compose.local-observability-stack-dev.yaml
@@ -134,7 +134,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:8.10-alpine
     command: ["redis-server", "--requirepass", "tolgee"]
     volumes:
       - redis-data:/data

--- a/docker/docker-compose.local-observability-stack.yaml
+++ b/docker/docker-compose.local-observability-stack.yaml
@@ -118,7 +118,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:8.10-alpine
     command: ["redis-server", "--requirepass", "tolgee"]
     volumes:
       - redis-data:/data


### PR DESCRIPTION
Production is moving from Redis 7.0.5 to 8.10.1 (tolgee/deployment#838), but nothing in CI exercises the version being deployed: `RedisRunner` still starts `redis:6`, and the observability compose stacks start `redis:7-alpine`.

Thirteen test classes use `RedisRunner` — cache, rate limits, websockets, MCP session recovery, batch job recovery, parallel batch execution — so bumping one string turns the existing suite into pre-merge coverage for the target version.

No application code changes. Redisson 4.6.1 supports the whole 6.x–8.x range, and there are no modules, Cluster mode, ACLs or TLS in play.

Verified locally against 8.10 before opening:

- `CacheWithRedisTest` — 15 passed (Kryo5 codec, cache-shape healing, previous-deploy entry fallbacks)
- `RedisRateLimitsTest` — passed
- `McpRedisSessionRecoveryTest` — passed
- `WebsocketWithRedisTest` — 8 passed

That covers the cache manager, `RAtomicLong`/`RBucket` atomics and pub/sub against the new server.

Merge order doesn't matter — this is independent of the deployment change, and is worth having in regardless since `redis:6` is four majors behind what runs anywhere.
