### PR TITLE
feat: app lifecycle webhook delivery (apps alpha 5/7)

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import io.tolgee.dtos.request.RegisterAppRequest
 import io.tolgee.dtos.request.apps.RotateAppSecretRequest
+import io.tolgee.hateoas.apps.AppDeliveryOutcomeModel
 import io.tolgee.hateoas.apps.AppRegisteredModel
 import io.tolgee.hateoas.apps.AppRegisteredModelAssembler
 import io.tolgee.hateoas.apps.AppSecretModel
 import io.tolgee.hateoas.apps.AppSecretModelAssembler
 import io.tolgee.hateoas.apps.AppSecretRotationModel
+import io.tolgee.hateoas.apps.AppWebhookSecretModel
 import io.tolgee.hateoas.organization.apps.OwnedAppModel
 import io.tolgee.hateoas.organization.apps.OwnedAppModelAssembler
 import io.tolgee.model.enums.Scope
@@ -18,8 +20,10 @@ import io.tolgee.security.authentication.RequiresSuperAuthentication
 import io.tolgee.security.authorization.RequiresOrganizationScopes
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.apps.AppOwnerRemovalService
+import io.tolgee.service.apps.AppSecretRotationService
 import io.tolgee.service.apps.AppSecretService
 import io.tolgee.service.apps.AppService
+import io.tolgee.service.apps.AppWebhookSecretService
 import jakarta.validation.Valid
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.hateoas.CollectionModel
@@ -46,6 +50,8 @@ class OrganizationOwnedAppsController(
   private val appRegisteredModelAssembler: AppRegisteredModelAssembler,
   private val appOwnerRemovalService: AppOwnerRemovalService,
   private val appSecretService: AppSecretService,
+  private val appSecretRotationService: AppSecretRotationService,
+  private val appWebhookSecretService: AppWebhookSecretService,
   private val appSecretModelAssembler: AppSecretModelAssembler,
 ) {
   @PostMapping
@@ -150,10 +156,57 @@ class OrganizationOwnedAppsController(
   ): AppSecretRotationModel {
     val app = appService.getOwned(organizationId, appId)
     val request = body ?: RotateAppSecretRequest()
-    val rotation = appSecretService.rotate(app, request.graceSeconds)
+    val rotation = appSecretRotationService.rotate(app, request.graceSeconds)
     return AppSecretRotationModel(
-      secret = appSecretModelAssembler.toModelWithSecret(rotation.issued.secret, rotation.issued.plaintextSecret),
+      secret =
+        appSecretModelAssembler.toModelWithSecret(
+          rotation.issued.secret,
+          rotation.issued.plaintextSecret,
+          rotation.delivery,
+        ),
       previousExpiresAt = rotation.previousExpiresAt?.time,
+    )
+  }
+
+  @GetMapping("/{appId}/webhook-secret")
+  @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @Operation(
+    summary = "Reveal the app's current webhook signing secret",
+    description =
+      "Unlike a client secret, the webhook signing secret is stored in the clear — Tolgee needs it " +
+        "to sign every delivery — so the owner can read it back here to configure the app by hand. " +
+        "It signs outbound lifecycle deliveries and authenticates nothing towards Tolgee.",
+  )
+  fun getWebhookSecret(
+    @PathVariable organizationId: Long,
+    @PathVariable appId: Long,
+  ): AppWebhookSecretModel {
+    val app = appService.getOwned(organizationId, appId)
+    return AppWebhookSecretModel(secret = app.webhookSecret)
+  }
+
+  @PostMapping("/{appId}/webhook-secret/rotate")
+  @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @Operation(
+    summary = "Rotate the app's webhook signing secret",
+    description =
+      "Mints a new webhook signing secret. The new secret is both returned here — the only place it " +
+        "is disclosed — and delivered to the app, signed with the old secret so a running app adopts " +
+        "it automatically; the `delivery` field says whether it landed. A running app keeps accepting " +
+        "the old secret during the overlap and drops it on its own next rotation.",
+  )
+  fun rotateWebhookSecret(
+    @PathVariable organizationId: Long,
+    @PathVariable appId: Long,
+  ): AppWebhookSecretModel {
+    val app = appService.getOwned(organizationId, appId)
+    val rotation = appWebhookSecretService.rotate(app.id)
+    return AppWebhookSecretModel(
+      secret = rotation.newSecret,
+      delivery =
+        rotation.delivery?.let {
+          AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error)
+        },
     )
   }
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
@@ -158,13 +158,9 @@ class OrganizationOwnedAppsController(
     val request = body ?: RotateAppSecretRequest()
     val rotation = appSecretRotationService.rotate(app, request.graceSeconds)
     return AppSecretRotationModel(
-      secret =
-        appSecretModelAssembler.toModelWithSecret(
-          rotation.issued.secret,
-          rotation.issued.plaintextSecret,
-          rotation.delivery,
-        ),
+      secret = appSecretModelAssembler.toModelWithSecret(rotation.issued.secret, rotation.issued.plaintextSecret),
       previousExpiresAt = rotation.previousExpiresAt?.time,
+      delivery = AppDeliveryOutcomeModel.of(rotation.delivery),
     )
   }
 

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppDeliveryOutcomeModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppDeliveryOutcomeModel.kt
@@ -1,0 +1,17 @@
+package io.tolgee.hateoas.apps
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * Whether Tolgee managed to hand the just-disclosed credentials to the app. Present only in the
+ * registration and rotation responses, so the dialog can tell the operator whether the app got them
+ * or whether they still have to copy the secret by hand.
+ */
+@Schema(description = "Outcome of pushing the disclosed credentials to the app's base URL")
+data class AppDeliveryOutcomeModel(
+  @Schema(description = "False when there was nothing to deliver to")
+  val attempted: Boolean,
+  val delivered: Boolean,
+  @Schema(description = "Short reason when the delivery was attempted and failed; null otherwise")
+  val error: String?,
+)

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppDeliveryOutcomeModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppDeliveryOutcomeModel.kt
@@ -1,6 +1,7 @@
 package io.tolgee.hateoas.apps
 
 import io.swagger.v3.oas.annotations.media.Schema
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 
 /**
  * Whether Tolgee managed to hand the just-disclosed credentials to the app. Present only in the
@@ -14,4 +15,9 @@ data class AppDeliveryOutcomeModel(
   val delivered: Boolean,
   @Schema(description = "Short reason when the delivery was attempted and failed; null otherwise")
   val error: String?,
-)
+) {
+  companion object {
+    fun of(outcome: AppLifecycleDeliveryOutcome?): AppDeliveryOutcomeModel? =
+      outcome?.let { AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error) }
+  }
+}

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModel.kt
@@ -35,4 +35,10 @@ open class AppRegisteredModel(
   val webhookSecret: String? = null,
   @Schema(description = "Id of the install created for this organization, or null when install was skipped")
   val installId: Long? = null,
+  @Schema(
+    description =
+      "Whether the app-level credentials reached the app over the lifecycle channel. Present only " +
+        "when this call registered the app; null when nothing was disclosed to deliver.",
+  )
+  val delivery: AppDeliveryOutcomeModel? = null,
 ) : RepresentationModel<AppRegisteredModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModelAssembler.kt
@@ -15,6 +15,10 @@ class AppRegisteredModelAssembler {
       clientSecret = credentials?.clientSecret,
       webhookSecret = credentials?.webhookSecret,
       installId = result.install?.id,
+      delivery =
+        result.delivery?.let {
+          AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error)
+        },
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppRegisteredModelAssembler.kt
@@ -15,10 +15,7 @@ class AppRegisteredModelAssembler {
       clientSecret = credentials?.clientSecret,
       webhookSecret = credentials?.webhookSecret,
       installId = result.install?.id,
-      delivery =
-        result.delivery?.let {
-          AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error)
-        },
+      delivery = AppDeliveryOutcomeModel.of(result.delivery),
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModel.kt
@@ -31,10 +31,4 @@ open class AppSecretModel(
         "endpoint exchanges it for the short-lived tokens that reach translation data.",
   )
   val secret: String? = null,
-  @Schema(
-    description =
-      "Whether the freshly issued secret reached the app over the lifecycle channel. Present only " +
-        "in the response to rotating the secret.",
-  )
-  val delivery: AppDeliveryOutcomeModel? = null,
 ) : RepresentationModel<AppSecretModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModel.kt
@@ -31,4 +31,10 @@ open class AppSecretModel(
         "endpoint exchanges it for the short-lived tokens that reach translation data.",
   )
   val secret: String? = null,
+  @Schema(
+    description =
+      "Whether the freshly issued secret reached the app over the lifecycle channel. Present only " +
+        "in the response to rotating the secret.",
+  )
+  val delivery: AppDeliveryOutcomeModel? = null,
 ) : RepresentationModel<AppSecretModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModelAssembler.kt
@@ -1,5 +1,6 @@
 package io.tolgee.hateoas.apps
 
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 import io.tolgee.model.apps.AppSecret
 import org.springframework.hateoas.server.RepresentationModelAssembler
 import org.springframework.stereotype.Component
@@ -7,20 +8,22 @@ import org.springframework.stereotype.Component
 @Component
 class AppSecretModelAssembler : RepresentationModelAssembler<AppSecret, AppSecretModel> {
   override fun toModel(entity: AppSecret): AppSecretModel {
-    return build(entity, plaintextSecret = null)
+    return build(entity, plaintextSecret = null, delivery = null)
   }
 
   /** Builds the model including the plaintext — used once, in the response to issuing the secret. */
   fun toModelWithSecret(
     entity: AppSecret,
     plaintextSecret: String,
+    delivery: AppLifecycleDeliveryOutcome? = null,
   ): AppSecretModel {
-    return build(entity, plaintextSecret)
+    return build(entity, plaintextSecret, delivery)
   }
 
   private fun build(
     entity: AppSecret,
     plaintextSecret: String?,
+    delivery: AppLifecycleDeliveryOutcome?,
   ): AppSecretModel {
     return AppSecretModel(
       id = entity.id,
@@ -30,6 +33,10 @@ class AppSecretModelAssembler : RepresentationModelAssembler<AppSecret, AppSecre
       expiresAt = entity.expiresAt?.time,
       revokedAt = entity.revokedAt?.time,
       secret = plaintextSecret,
+      delivery =
+        delivery?.let {
+          AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error)
+        },
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretModelAssembler.kt
@@ -1,6 +1,5 @@
 package io.tolgee.hateoas.apps
 
-import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 import io.tolgee.model.apps.AppSecret
 import org.springframework.hateoas.server.RepresentationModelAssembler
 import org.springframework.stereotype.Component
@@ -8,22 +7,20 @@ import org.springframework.stereotype.Component
 @Component
 class AppSecretModelAssembler : RepresentationModelAssembler<AppSecret, AppSecretModel> {
   override fun toModel(entity: AppSecret): AppSecretModel {
-    return build(entity, plaintextSecret = null, delivery = null)
+    return build(entity, plaintextSecret = null)
   }
 
   /** Builds the model including the plaintext — used once, in the response to issuing the secret. */
   fun toModelWithSecret(
     entity: AppSecret,
     plaintextSecret: String,
-    delivery: AppLifecycleDeliveryOutcome? = null,
   ): AppSecretModel {
-    return build(entity, plaintextSecret, delivery)
+    return build(entity, plaintextSecret)
   }
 
   private fun build(
     entity: AppSecret,
     plaintextSecret: String?,
-    delivery: AppLifecycleDeliveryOutcome?,
   ): AppSecretModel {
     return AppSecretModel(
       id = entity.id,
@@ -33,10 +30,6 @@ class AppSecretModelAssembler : RepresentationModelAssembler<AppSecret, AppSecre
       expiresAt = entity.expiresAt?.time,
       revokedAt = entity.revokedAt?.time,
       secret = plaintextSecret,
-      delivery =
-        delivery?.let {
-          AppDeliveryOutcomeModel(attempted = it.attempted, delivered = it.delivered, error = it.error)
-        },
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretRotationModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSecretRotationModel.kt
@@ -17,4 +17,10 @@ open class AppSecretRotationModel(
         "earlier deadline and can lapse before this value.",
   )
   val previousExpiresAt: Long?,
+  @Schema(
+    description =
+      "Whether the freshly issued secret reached the app over the lifecycle channel, or null when " +
+        "there was nothing to deliver to.",
+  )
+  val delivery: AppDeliveryOutcomeModel? = null,
 ) : RepresentationModel<AppSecretRotationModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppWebhookSecretModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppWebhookSecretModel.kt
@@ -1,0 +1,21 @@
+package io.tolgee.hateoas.apps
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.hateoas.RepresentationModel
+
+/** The app's webhook signing secret — revealed on read, or freshly minted on rotation. */
+open class AppWebhookSecretModel(
+  @Schema(
+    description =
+      "The webhook signing secret in plaintext. Tolgee signs lifecycle deliveries with it; the " +
+        "app verifies against it. On rotation this is the new secret — store it like a password.",
+  )
+  val secret: String,
+  @Schema(
+    description =
+      "Whether the new secret reached the app over the lifecycle channel. Present only on rotation; " +
+        "the rotation delivery is signed with the previous secret, so an app already running takes " +
+        "the new one automatically.",
+  )
+  val delivery: AppDeliveryOutcomeModel? = null,
+) : RepresentationModel<AppWebhookSecretModel>()

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppCredentialTokenTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppCredentialTokenTest.kt
@@ -6,6 +6,7 @@ import io.tolgee.fixtures.andIsOk
 import io.tolgee.fixtures.node
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -25,6 +26,10 @@ class AppCredentialTokenTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
   lateinit var appClientId: String

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppInstallPrincipalTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppInstallPrincipalTest.kt
@@ -15,6 +15,7 @@ import io.tolgee.security.authentication.AuthenticationFilter
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -38,6 +39,10 @@ class AppInstallPrincipalTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
   var installId: Long = 0

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppLifecycleDeliveryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppLifecycleDeliveryTest.kt
@@ -1,0 +1,279 @@
+package io.tolgee.api.v2.controllers.apps
+
+import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.fixtures.andIsNotFound
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.repository.apps.AppRepository
+import io.tolgee.service.apps.AppManifestHttpClient
+import io.tolgee.service.apps.AppSecretRotationService
+import io.tolgee.service.apps.AppService
+import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assert
+import io.tolgee.util.executeInNewTransaction
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import tools.jackson.databind.JsonNode
+
+/**
+ * The outbound lifecycle channel: registering an app and rolling either of its secrets hands the
+ * app a signed POST, synchronously, and the triggering response says whether it landed. A dead app
+ * host makes the delivery fail as a reported value, never undoing the change that produced the
+ * credentials.
+ */
+class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
+  @Autowired
+  lateinit var appRepository: AppRepository
+
+  @Autowired
+  lateinit var appService: AppService
+
+  @Autowired
+  lateinit var appSecretRotationService: AppSecretRotationService
+
+  @MockitoBean
+  @Autowired
+  lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
+
+  lateinit var testData: AppsTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = AppsTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    AppsTestFixtures.mockManifest(appManifestHttpClient)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `registering an app delivers app_registered with the disclosed credentials`() {
+    val registered = register()
+
+    registered
+      .at("/delivery/attempted")
+      .asBoolean()
+      .assert
+      .isTrue()
+    registered.at("/delivery/delivered").assert.isNotNull
+    registered
+      .get("delivery")
+      .get("delivered")
+      .asBoolean()
+      .assert
+      .isTrue()
+
+    val payload = deliveredPayloads().single { it.get("eventType").asText() == "app.registered" }
+    payload
+      .at("/app/clientId")
+      .asText()
+      .assert
+      .isEqualTo(registered.get("clientId").asText())
+    payload
+      .at("/app/clientSecret")
+      .asText()
+      .assert
+      .isEqualTo(registered.get("clientSecret").asText())
+    payload
+      .at("/app/webhookSecret")
+      .asText()
+      .assert
+      .isEqualTo(registered.get("webhookSecret").asText())
+    payload
+      .at("/organization/id")
+      .asLong()
+      .assert
+      .isEqualTo(testData.organization.id)
+  }
+
+  @Test
+  fun `a failed registration delivery is reported, not thrown, and the app still registers`() {
+    failDelivery()
+
+    val registered = register()
+
+    registered
+      .at("/delivery/attempted")
+      .asBoolean()
+      .assert
+      .isTrue()
+    registered
+      .at("/delivery/delivered")
+      .asBoolean()
+      .assert
+      .isFalse()
+    registered
+      .at("/delivery/error")
+      .asText()
+      .assert
+      .isNotEmpty()
+
+    val appEntityId = registered.get("id").asLong()
+    executeInNewTransaction(platformTransactionManager) {
+      appRepository
+        .findById(appEntityId)
+        .orElse(null)
+        .assert.isNotNull
+    }
+  }
+
+  @Test
+  fun `the owner reveals the current webhook secret`() {
+    val appEntityId = register().get("id").asLong()
+    val stored = webhookSecretOf(appEntityId)
+
+    val revealed =
+      objectMapper
+        .readTree(
+          performAuthGet("${ownedUrl()}/$appEntityId/webhook-secret")
+            .andIsOk
+            .andReturn()
+            .response.contentAsString,
+        ).get("secret")
+        .asText()
+
+    revealed.assert.isEqualTo(stored)
+  }
+
+  @Test
+  fun `rotating the webhook secret mints a new one and delivers it signed with the old secret`() {
+    val registered = register()
+    val appEntityId = registered.get("id").asLong()
+    val oldSecret = registered.get("webhookSecret").asText()
+    reset(appLifecycleHttpClient)
+
+    val rotated =
+      objectMapper.readTree(
+        performAuthPost("${ownedUrl()}/$appEntityId/webhook-secret/rotate", null)
+          .andIsOk
+          .andReturn()
+          .response.contentAsString,
+      )
+
+    val newSecret = rotated.get("secret").asText()
+    newSecret.assert.isNotEqualTo(oldSecret)
+    rotated
+      .at("/delivery/delivered")
+      .asBoolean()
+      .assert
+      .isTrue()
+    webhookSecretOf(appEntityId).assert.isEqualTo(newSecret)
+
+    val call = capturedDeliveries().single { it.payload.get("eventType").asText() == "app.secret_rotated" }
+    call.payload
+      .at("/app/webhookSecret")
+      .asText()
+      .assert
+      .isEqualTo(newSecret)
+    call.payload
+      .at("/app/clientSecret")
+      .isMissingNode.assert
+      .isTrue()
+    // The rotation delivery is signed with the previous secret so a running app can verify it.
+    call.signingSecret.assert.isEqualTo(oldSecret)
+  }
+
+  @Test
+  fun `rolling the client secret delivers app_secret_rotated with the new client secret`() {
+    val registered = register()
+    val appEntityId = registered.get("id").asLong()
+    reset(appLifecycleHttpClient)
+
+    executeInNewTransaction(platformTransactionManager) {
+      val app = appService.getRegistered(appEntityId)
+      appSecretRotationService.rotate(app, ONE_DAY)
+    }
+
+    val call = capturedDeliveries().single { it.payload.get("eventType").asText() == "app.secret_rotated" }
+    call.payload
+      .at("/app/clientSecret")
+      .asText()
+      .assert
+      .startsWith(AppService.APP_CLIENT_SECRET_PREFIX)
+    call.payload
+      .at("/app/webhookSecret")
+      .isMissingNode.assert
+      .isTrue()
+  }
+
+  @Test
+  fun `an organization that does not own the app reaches none of its webhook secret`() {
+    val appEntityId = register().get("id").asLong()
+
+    userAccount = testData.otherOwner
+    val otherOwned = "/v2/organizations/${testData.otherOrganization.id}/owned-apps"
+    performAuthGet("$otherOwned/$appEntityId/webhook-secret").andIsNotFound
+    performAuthPost("$otherOwned/$appEntityId/webhook-secret/rotate", null).andIsNotFound
+  }
+
+  private fun register(): JsonNode {
+    userAccount = testData.user
+    return objectMapper.readTree(
+      performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL))
+        .andIsOk
+        .andReturn()
+        .response.contentAsString,
+    )
+  }
+
+  private data class Delivery(
+    val url: String,
+    val payload: JsonNode,
+    val signingSecret: String,
+  )
+
+  private fun capturedDeliveries(): List<Delivery> {
+    val urlCaptor = argumentCaptor<String>()
+    val payloadCaptor = argumentCaptor<String>()
+    val secretCaptor = argumentCaptor<String>()
+    verify(
+      appLifecycleHttpClient,
+      atLeastOnce(),
+    ).post(urlCaptor.capture(), payloadCaptor.capture(), secretCaptor.capture())
+    return urlCaptor.allValues.indices.map {
+      Delivery(
+        url = urlCaptor.allValues[it],
+        payload = objectMapper.readTree(payloadCaptor.allValues[it]),
+        signingSecret = secretCaptor.allValues[it],
+      )
+    }
+  }
+
+  private fun deliveredPayloads(): List<JsonNode> = capturedDeliveries().map { it.payload }
+
+  private fun failDelivery() {
+    doThrow(AppLifecycleHttpClient.DeliveryFailedException("app unreachable"))
+      .whenever(appLifecycleHttpClient)
+      .post(any(), any(), any())
+  }
+
+  private fun webhookSecretOf(appEntityId: Long): String =
+    executeInNewTransaction(platformTransactionManager) {
+      appRepository.findById(appEntityId).orElseThrow().webhookSecret
+    }
+
+  private fun ownedUrl() = "/v2/organizations/${testData.organization.id}/owned-apps"
+
+  companion object {
+    const val ONE_DAY = 86_400L
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppLifecycleDeliveryTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppLifecycleDeliveryTest.kt
@@ -1,8 +1,10 @@
 package io.tolgee.api.v2.controllers.apps
 
 import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
 import io.tolgee.repository.apps.AppRepository
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppSecretRotationService
@@ -12,6 +14,7 @@ import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
+import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,6 +27,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.ResultActions
 import tools.jackson.databind.JsonNode
 
 /**
@@ -67,65 +71,39 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
 
   @Test
   fun `registering an app delivers app_registered with the disclosed credentials`() {
-    val registered = register()
+    val registered =
+      objectMapper.readTree(
+        registerResult()
+          .andAssertThatJson {
+            node("delivery.attempted").isEqualTo(true)
+            node("delivery.delivered").isEqualTo(true)
+          }.andReturn()
+          .response.contentAsString,
+      )
 
-    registered
-      .at("/delivery/attempted")
-      .asBoolean()
-      .assert
-      .isTrue()
-    registered.at("/delivery/delivered").assert.isNotNull
-    registered
-      .get("delivery")
-      .get("delivered")
-      .asBoolean()
-      .assert
-      .isTrue()
-
-    val payload = deliveredPayloads().single { it.get("eventType").asText() == "app.registered" }
-    payload
-      .at("/app/clientId")
-      .asText()
-      .assert
-      .isEqualTo(registered.get("clientId").asText())
-    payload
-      .at("/app/clientSecret")
-      .asText()
-      .assert
-      .isEqualTo(registered.get("clientSecret").asText())
-    payload
-      .at("/app/webhookSecret")
-      .asText()
-      .assert
-      .isEqualTo(registered.get("webhookSecret").asText())
-    payload
-      .at("/organization/id")
-      .asLong()
-      .assert
-      .isEqualTo(testData.organization.id)
+    val delivered = capturedDeliveries().single { it.eventType == "app.registered" }
+    assertThatJson(delivered.payload).apply {
+      node("app.clientId").isEqualTo(registered.get("clientId").asText())
+      node("app.clientSecret").isEqualTo(registered.get("clientSecret").asText())
+      node("app.webhookSecret").isEqualTo(registered.get("webhookSecret").asText())
+      node("organization.id").isEqualTo(testData.organization.id)
+    }
   }
 
   @Test
   fun `a failed registration delivery is reported, not thrown, and the app still registers`() {
     failDelivery()
 
-    val registered = register()
-
-    registered
-      .at("/delivery/attempted")
-      .asBoolean()
-      .assert
-      .isTrue()
-    registered
-      .at("/delivery/delivered")
-      .asBoolean()
-      .assert
-      .isFalse()
-    registered
-      .at("/delivery/error")
-      .asText()
-      .assert
-      .isNotEmpty()
+    val registered =
+      objectMapper.readTree(
+        registerResult()
+          .andAssertThatJson {
+            node("delivery.attempted").isEqualTo(true)
+            node("delivery.delivered").isEqualTo(false)
+            node("delivery.error").isString.isNotEmpty()
+          }.andReturn()
+          .response.contentAsString,
+      )
 
     val appEntityId = registered.get("id").asLong()
     executeInNewTransaction(platformTransactionManager) {
@@ -141,17 +119,9 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
     val appEntityId = register().get("id").asLong()
     val stored = webhookSecretOf(appEntityId)
 
-    val revealed =
-      objectMapper
-        .readTree(
-          performAuthGet("${ownedUrl()}/$appEntityId/webhook-secret")
-            .andIsOk
-            .andReturn()
-            .response.contentAsString,
-        ).get("secret")
-        .asText()
-
-    revealed.assert.isEqualTo(stored)
+    performAuthGet("${ownedUrl()}/$appEntityId/webhook-secret").andIsOk.andAssertThatJson {
+      node("secret").isEqualTo(stored)
+    }
   }
 
   @Test
@@ -165,37 +135,28 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
       objectMapper.readTree(
         performAuthPost("${ownedUrl()}/$appEntityId/webhook-secret/rotate", null)
           .andIsOk
-          .andReturn()
+          .andAssertThatJson {
+            node("secret").isString.isNotEqualTo(oldSecret)
+            node("delivery.delivered").isEqualTo(true)
+          }.andReturn()
           .response.contentAsString,
       )
 
     val newSecret = rotated.get("secret").asText()
-    newSecret.assert.isNotEqualTo(oldSecret)
-    rotated
-      .at("/delivery/delivered")
-      .asBoolean()
-      .assert
-      .isTrue()
     webhookSecretOf(appEntityId).assert.isEqualTo(newSecret)
 
-    val call = capturedDeliveries().single { it.payload.get("eventType").asText() == "app.secret_rotated" }
-    call.payload
-      .at("/app/webhookSecret")
-      .asText()
-      .assert
-      .isEqualTo(newSecret)
-    call.payload
-      .at("/app/clientSecret")
-      .isMissingNode.assert
-      .isTrue()
-    // The rotation delivery is signed with the previous secret so a running app can verify it.
+    val call = capturedDeliveries().single { it.eventType == "app.secret_rotated" }
+    assertThatJson(call.payload).apply {
+      node("app.webhookSecret").isEqualTo(newSecret)
+      node("app.clientSecret").isAbsent()
+    }
+    // Signed with the previous secret so a running app can verify the delivery that carries the new one.
     call.signingSecret.assert.isEqualTo(oldSecret)
   }
 
   @Test
   fun `rolling the client secret delivers app_secret_rotated with the new client secret`() {
-    val registered = register()
-    val appEntityId = registered.get("id").asLong()
+    val appEntityId = register().get("id").asLong()
     reset(appLifecycleHttpClient)
 
     executeInNewTransaction(platformTransactionManager) {
@@ -203,16 +164,11 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
       appSecretRotationService.rotate(app, ONE_DAY)
     }
 
-    val call = capturedDeliveries().single { it.payload.get("eventType").asText() == "app.secret_rotated" }
-    call.payload
-      .at("/app/clientSecret")
-      .asText()
-      .assert
-      .startsWith(AppService.APP_CLIENT_SECRET_PREFIX)
-    call.payload
-      .at("/app/webhookSecret")
-      .isMissingNode.assert
-      .isTrue()
+    val call = capturedDeliveries().single { it.eventType == "app.secret_rotated" }
+    assertThatJson(call.payload).apply {
+      node("app.clientSecret").isString.startsWith(AppService.APP_CLIENT_SECRET_PREFIX)
+      node("app.webhookSecret").isAbsent()
+    }
   }
 
   @Test
@@ -225,19 +181,17 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
     performAuthPost("$otherOwned/$appEntityId/webhook-secret/rotate", null).andIsNotFound
   }
 
-  private fun register(): JsonNode {
+  private fun registerResult(): ResultActions {
     userAccount = testData.user
-    return objectMapper.readTree(
-      performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL))
-        .andIsOk
-        .andReturn()
-        .response.contentAsString,
-    )
+    return performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL)).andIsOk
   }
+
+  private fun register(): JsonNode = objectMapper.readTree(registerResult().andReturn().response.contentAsString)
 
   private data class Delivery(
     val url: String,
-    val payload: JsonNode,
+    val eventType: String,
+    val payload: String,
     val signingSecret: String,
   )
 
@@ -250,15 +204,15 @@ class AppLifecycleDeliveryTest : AuthorizedControllerTest() {
       atLeastOnce(),
     ).post(urlCaptor.capture(), payloadCaptor.capture(), secretCaptor.capture())
     return urlCaptor.allValues.indices.map {
+      val payload = payloadCaptor.allValues[it]
       Delivery(
         url = urlCaptor.allValues[it],
-        payload = objectMapper.readTree(payloadCaptor.allValues[it]),
+        eventType = objectMapper.readTree(payload).get("eventType").asText(),
+        payload = payload,
         signingSecret = secretCaptor.allValues[it],
       )
     }
   }
-
-  private fun deliveredPayloads(): List<JsonNode> = capturedDeliveries().map { it.payload }
 
   private fun failDelivery() {
     doThrow(AppLifecycleHttpClient.DeliveryFailedException("app unreachable"))

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRegistrationControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRegistrationControllerTest.kt
@@ -14,6 +14,7 @@ import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppSecretService
 import io.tolgee.service.apps.AppService
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
@@ -43,6 +44,10 @@ class AppRegistrationControllerTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: NativeAppsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppSecretRotationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppSecretRotationTest.kt
@@ -15,6 +15,7 @@ import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppSecretService
 import io.tolgee.service.apps.AppService
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -38,6 +39,10 @@ class AppSecretRotationTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
   var installId: Long = 0

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsControllerTest.kt
@@ -13,6 +13,7 @@ import io.tolgee.security.authentication.AppTokenService
 import io.tolgee.security.authentication.AuthenticationFilter
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -38,6 +39,10 @@ class AppSelfInstallationsControllerTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
   var installId: Long = 0

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppTokenAuthorizationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppTokenAuthorizationTest.kt
@@ -13,6 +13,7 @@ import io.tolgee.model.enums.OrganizationRoleType
 import io.tolgee.security.authentication.AppTokenService
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -39,6 +40,10 @@ class AppTokenAuthorizationTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
   var installId: Long = 0

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsControllerTest.kt
@@ -14,6 +14,7 @@ import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppService
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -37,6 +38,10 @@ class OrganizationAppsControllerTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/project/ProjectAppsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/project/ProjectAppsControllerTest.kt
@@ -9,6 +9,7 @@ import io.tolgee.fixtures.node
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.apps.AppManifestHttpClient
 import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.AuthorizedControllerTest
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.AfterEach
@@ -24,6 +25,10 @@ class ProjectAppsControllerTest : AuthorizedControllerTest() {
   @MockitoBean
   @Autowired
   lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   lateinit var testData: AppsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/apps/AppEnablementConcurrencyTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/apps/AppEnablementConcurrencyTest.kt
@@ -2,6 +2,7 @@ package io.tolgee.service.apps
 
 import io.tolgee.AbstractSpringTest
 import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
 import org.junit.jupiter.api.AfterEach
@@ -26,6 +27,10 @@ class AppEnablementConcurrencyTest : AbstractSpringTest() {
   @MockitoBean
   @Autowired
   private lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  private lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   private lateinit var testData: AppsTestData
   private var installId: Long = 0

--- a/backend/app/src/test/kotlin/io/tolgee/service/apps/AppPrincipalSeatTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/apps/AppPrincipalSeatTest.kt
@@ -3,6 +3,7 @@ package io.tolgee.service.apps
 import io.tolgee.AbstractSpringTest
 import io.tolgee.development.testDataBuilder.data.AppsTestData
 import io.tolgee.repository.PermissionRepository
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
 import org.junit.jupiter.api.AfterEach
@@ -26,6 +27,10 @@ class AppPrincipalSeatTest : AbstractSpringTest() {
   @MockitoBean
   @Autowired
   private lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  private lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   private lateinit var testData: AppsTestData
 

--- a/backend/app/src/test/kotlin/io/tolgee/service/apps/AppsDeletionTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/apps/AppsDeletionTest.kt
@@ -3,6 +3,7 @@ package io.tolgee.service.apps
 import io.tolgee.AbstractSpringTest
 import io.tolgee.development.testDataBuilder.data.AppsTestData
 import io.tolgee.model.Project
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
 import io.tolgee.service.project.ProjectHardDeletingService
 import io.tolgee.testing.assert
 import io.tolgee.util.executeInNewTransaction
@@ -28,6 +29,10 @@ class AppsDeletionTest : AbstractSpringTest() {
   @MockitoBean
   @Autowired
   private lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  private lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
 
   private lateinit var testData: AppsTestData
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookExecutor.kt
@@ -1,7 +1,5 @@
 package io.tolgee.component.automations.processors
 
-import io.tolgee.component.CurrentDateProvider
-import io.tolgee.fixtures.computeHmacSha256
 import io.tolgee.model.webhook.WebhookConfig
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpEntity
@@ -18,7 +16,7 @@ import tools.jackson.module.kotlin.jacksonObjectMapper
 class WebhookExecutor(
   @Qualifier("webhookRestTemplate")
   private val restTemplate: RestTemplate,
-  private val currentDateProvider: CurrentDateProvider,
+  private val webhookSigner: WebhookSigner,
 ) {
   fun signAndExecute(
     config: WebhookConfig,
@@ -27,7 +25,7 @@ class WebhookExecutor(
     val stringData = jacksonObjectMapper().writeValueAsString(data)
     val headers = HttpHeaders()
     @Suppress("UastIncorrectHttpHeaderInspection")
-    headers.add("Tolgee-Signature", generateSigHeader(stringData, config.webhookSecret))
+    headers.add(WebhookSigner.SIGNATURE_HEADER, webhookSigner.signatureHeader(stringData, config.webhookSecret))
     headers.contentType = MediaType.APPLICATION_JSON
 
     val request = HttpEntity(stringData, headers)
@@ -47,14 +45,5 @@ class WebhookExecutor(
     } catch (e: Exception) {
       throw WebhookExecutionFailed(e)
     }
-  }
-
-  private fun generateSigHeader(
-    payload: String,
-    key: String,
-  ): String {
-    val timestamp = currentDateProvider.date.time
-    val signature = computeHmacSha256(key, "$timestamp.$payload")
-    return String.format("""{"timestamp": $timestamp, "signature": "$signature"}""")
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookSigner.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/automations/processors/WebhookSigner.kt
@@ -1,0 +1,28 @@
+package io.tolgee.component.automations.processors
+
+import io.tolgee.component.CurrentDateProvider
+import io.tolgee.fixtures.computeHmacSha256
+import org.springframework.stereotype.Component
+
+/**
+ * The one signature scheme every outbound signed POST Tolgee makes uses — project webhooks and app
+ * lifecycle deliveries alike. A second scheme would mean an app author verifying two different
+ * things depending on which of our features sent the request.
+ */
+@Component
+class WebhookSigner(
+  private val currentDateProvider: CurrentDateProvider,
+) {
+  fun signatureHeader(
+    payload: String,
+    key: String,
+  ): String {
+    val timestamp = currentDateProvider.date.time
+    val signature = computeHmacSha256(key, "$timestamp.$payload")
+    return """{"timestamp": $timestamp, "signature": "$signature"}"""
+  }
+
+  companion object {
+    const val SIGNATURE_HEADER = "Tolgee-Signature"
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/apps/AppLifecycleDeliveryOutcome.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/apps/AppLifecycleDeliveryOutcome.kt
@@ -1,0 +1,27 @@
+package io.tolgee.dtos.apps
+
+/**
+ * What happened when Tolgee tried to hand a secret-carrying event to an app, synchronously, so the
+ * dialog that triggered it can tell the operator whether the app got the credentials or whether they
+ * still have to copy them by hand.
+ *
+ * A failure is a value here, never an exception: the credentials were already disclosed in the
+ * response, so a dead app host must not roll back the registration or rotation that produced them.
+ */
+data class AppLifecycleDeliveryOutcome(
+  /** False when there was nothing to deliver to (no app, no base URL). */
+  val attempted: Boolean,
+  val delivered: Boolean,
+  /** Short, safe-to-show reason when [attempted] but not [delivered]; null otherwise. */
+  val error: String?,
+) {
+  companion object {
+    val NOT_ATTEMPTED = AppLifecycleDeliveryOutcome(attempted = false, delivered = false, error = null)
+    val DELIVERED = AppLifecycleDeliveryOutcome(attempted = true, delivered = true, error = null)
+
+    fun failed(reason: String): AppLifecycleDeliveryOutcome =
+      AppLifecycleDeliveryOutcome(attempted = true, delivered = false, error = reason.take(MAX_ERROR_LENGTH))
+
+    private const val MAX_ERROR_LENGTH = 300
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/apps/AppLifecyclePayload.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/apps/AppLifecyclePayload.kt
@@ -1,0 +1,35 @@
+package io.tolgee.dtos.apps
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+/**
+ * The body of a lifecycle delivery. It is what the signature covers, so its serialized form is
+ * computed once and both signed and sent — never rebuilt.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AppLifecyclePayload(
+  val eventType: String,
+  /** The manifest id of the app the event is about. */
+  val appId: String,
+  /**
+   * Which Tolgee this came from. An app installed on several servers keeps one credential set per
+   * server, and this is what tells them apart.
+   */
+  val tolgeeInstanceUrl: String?,
+  val app: AppLifecycleAppCredentials? = null,
+  val organization: AppLifecycleOrganization? = null,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class AppLifecycleAppCredentials(
+  val clientId: String,
+  /** Present only when this delivery is the one disclosing it. */
+  val clientSecret: String? = null,
+  val webhookSecret: String? = null,
+)
+
+data class AppLifecycleOrganization(
+  val id: Long,
+  val name: String,
+  val slug: String,
+)

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppLifecycleEventType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppLifecycleEventType.kt
@@ -1,0 +1,12 @@
+package io.tolgee.model.apps
+
+/**
+ * What a lifecycle delivery tells the app. The wire value is [wireName] — an app matches on it, so
+ * it may not follow the enum constant if that is ever renamed.
+ */
+enum class AppLifecycleEventType(
+  val wireName: String,
+) {
+  APP_REGISTERED("app.registered"),
+  APP_SECRET_ROTATED("app.secret_rotated"),
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
@@ -1,13 +1,17 @@
 package io.tolgee.service.apps
 
 import io.tolgee.constants.Message
+import io.tolgee.dtos.apps.AppLifecycleAppCredentials
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.PermissionException
 import io.tolgee.model.Organization
 import io.tolgee.model.apps.App
 import io.tolgee.model.apps.AppInstall
+import io.tolgee.model.apps.AppLifecycleEventType
 import io.tolgee.repository.apps.AppInstallRepository
+import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
 import org.apache.commons.codec.digest.DigestUtils
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
@@ -25,6 +29,7 @@ class AppInstallService(
   private val appInstallPersister: AppInstallPersister,
   private val appService: AppService,
   private val appAvailabilityService: AppAvailabilityService,
+  private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
 ) {
   data class RegisterResult(
     val install: AppInstall,
@@ -37,6 +42,11 @@ class AppInstallService(
     val appEntityId: Long,
     val appCredentials: AppService.AppCredentials?,
     val install: AppInstall?,
+    /**
+     * Whether the just-disclosed credentials reached the app over the lifecycle channel. Null when
+     * nothing was disclosed (there is no such flow yet — registration always discloses).
+     */
+    val delivery: AppLifecycleDeliveryOutcome? = null,
   )
 
   fun register(
@@ -47,11 +57,37 @@ class AppInstallService(
   ): RegisterAppResult {
     val fetched = appManifestFetcher.fetch(manifestUrl)
     verifyManifestUnchanged(manifestHash, fetched)
-    return try {
-      appInstallPersister.registerAndMaybeInstall(organization.id, manifestUrl, fetched, install)
-    } catch (_: DataIntegrityViolationException) {
-      throw BadRequestException(Message.APP_ALREADY_REGISTERED)
-    }
+    val result =
+      try {
+        appInstallPersister.registerAndMaybeInstall(organization.id, manifestUrl, fetched, install)
+      } catch (_: DataIntegrityViolationException) {
+        throw BadRequestException(Message.APP_ALREADY_REGISTERED)
+      }
+    return result.copy(delivery = deliverRegistered(organization, result))
+  }
+
+  /**
+   * Hands the app its just-issued credentials, synchronously, so the registration dialog can say
+   * whether the app got them or the operator still has to copy them. A failure is reported, never
+   * thrown: the credentials were returned in the response too, so a dead app host does not undo the
+   * registration. Runs after [registerAndMaybeInstall]'s transaction commits.
+   */
+  private fun deliverRegistered(
+    organization: Organization,
+    result: RegisterAppResult,
+  ): AppLifecycleDeliveryOutcome? {
+    val credentials = result.appCredentials ?: return null
+    return appLifecycleDeliveryService.deliverNow(
+      appEntityId = result.appEntityId,
+      eventType = AppLifecycleEventType.APP_REGISTERED,
+      organizationId = organization.id,
+      appCredentials =
+        AppLifecycleAppCredentials(
+          clientId = credentials.clientId,
+          clientSecret = credentials.clientSecret,
+          webhookSecret = credentials.webhookSecret,
+        ),
+    )
   }
 
   fun install(

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
@@ -5,8 +5,9 @@ import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 import io.tolgee.model.apps.App
 import io.tolgee.model.apps.AppLifecycleEventType
 import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import io.tolgee.util.executeInNewTransaction
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
 import java.util.Date
 
 /**
@@ -21,6 +22,7 @@ import java.util.Date
 class AppSecretRotationService(
   private val appSecretService: AppSecretService,
   private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
+  private val transactionManager: PlatformTransactionManager,
 ) {
   data class RotationResult(
     val issued: AppSecretService.IssueResult,
@@ -29,13 +31,18 @@ class AppSecretRotationService(
     val previousExpiresAt: Date?,
   )
 
-  @Transactional
   fun rotate(
     app: App,
     graceSeconds: Long,
   ): RotationResult {
-    val issued = appSecretService.issue(app)
-    val previousExpiresAt = appSecretService.expireOthers(app.id, issued.secret.id, graceSeconds)
+    // Persist and commit before delivering: an app may test the new secret the moment it receives it,
+    // and authentication reads only committed secret hashes, so a delivery inside the transaction
+    // could hand the app a secret its next request would then reject.
+    val (issued, previousExpiresAt) =
+      executeInNewTransaction(transactionManager) {
+        val result = appSecretService.issue(app)
+        result to appSecretService.expireOthers(app.id, result.secret.id, graceSeconds)
+      }
     val delivery =
       appLifecycleDeliveryService.deliverNow(
         appEntityId = app.id,

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
@@ -35,14 +35,8 @@ class AppSecretRotationService(
     app: App,
     graceSeconds: Long,
   ): RotationResult {
-    // Persist and commit before delivering: an app may test the new secret the moment it receives it,
-    // and authentication reads only committed secret hashes, so a delivery inside the transaction
-    // could hand the app a secret its next request would then reject.
-    val (issued, previousExpiresAt) =
-      executeInNewTransaction(transactionManager) {
-        val result = appSecretService.issue(app)
-        result to appSecretService.expireOthers(app.id, result.secret.id, graceSeconds)
-      }
+    // Committed before delivery so an app that tests the new secret immediately isn't rejected.
+    val (issued, previousExpiresAt) = issueAndExpireOthersInNewTransaction(app, graceSeconds)
     val delivery =
       appLifecycleDeliveryService.deliverNow(
         appEntityId = app.id,
@@ -59,4 +53,13 @@ class AppSecretRotationService(
       previousExpiresAt = previousExpiresAt,
     )
   }
+
+  private fun issueAndExpireOthersInNewTransaction(
+    app: App,
+    graceSeconds: Long,
+  ): Pair<AppSecretService.IssueResult, Date?> =
+    executeInNewTransaction(transactionManager) {
+      val issued = appSecretService.issue(app)
+      issued to appSecretService.expireOthers(app.id, issued.secret.id, graceSeconds)
+    }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
@@ -1,0 +1,52 @@
+package io.tolgee.service.apps
+
+import io.tolgee.dtos.apps.AppLifecycleAppCredentials
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
+import io.tolgee.model.apps.App
+import io.tolgee.model.apps.AppLifecycleEventType
+import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import org.springframework.stereotype.Service
+import java.util.Date
+
+/**
+ * Rolls an app-level client secret and hands the replacement to the app over the lifecycle channel.
+ * The secret is minted and the old ones put on a deadline in [AppSecretService.rotate]'s own
+ * transaction; the delivery runs after that commits, so a dead app host reports a failed delivery
+ * without undoing the rotation. The old secrets are never revoked here — a landed delivery only
+ * proves the app received the webhook, not that it adopted the secret, so cutting anything off is
+ * left to the grace window or to the operator's explicit revoke.
+ */
+@Service
+class AppSecretRotationService(
+  private val appSecretService: AppSecretService,
+  private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
+) {
+  data class RotationResult(
+    val issued: AppSecretService.IssueResult,
+    val delivery: AppLifecycleDeliveryOutcome?,
+    /** When the outgoing secrets lapse, or null when there was nothing to retire. */
+    val previousExpiresAt: Date?,
+  )
+
+  fun rotate(
+    app: App,
+    graceSeconds: Long,
+  ): RotationResult {
+    val rotated = appSecretService.rotate(app, graceSeconds)
+    val delivery =
+      appLifecycleDeliveryService.deliverNow(
+        appEntityId = app.id,
+        eventType = AppLifecycleEventType.APP_SECRET_ROTATED,
+        appCredentials =
+          AppLifecycleAppCredentials(
+            clientId = app.clientId,
+            clientSecret = rotated.issued.plaintextSecret,
+          ),
+      )
+    return RotationResult(
+      issued = rotated.issued,
+      delivery = delivery,
+      previousExpiresAt = rotated.previousExpiresAt,
+    )
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
@@ -6,15 +6,16 @@ import io.tolgee.model.apps.App
 import io.tolgee.model.apps.AppLifecycleEventType
 import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.Date
 
 /**
  * Rolls an app-level client secret and hands the replacement to the app over the lifecycle channel.
- * The secret is minted and the old ones put on a deadline in [AppSecretService.rotate]'s own
- * transaction; the delivery runs after that commits, so a dead app host reports a failed delivery
- * without undoing the rotation. The old secrets are never revoked here — a landed delivery only
- * proves the app received the webhook, not that it adopted the secret, so cutting anything off is
- * left to the grace window or to the operator's explicit revoke.
+ * A new secret is minted and every other active one put on a deadline, then the new secret is
+ * delivered. A dead app host makes the delivery a reported failure, never undoing the rotation. The
+ * old secrets are never revoked here — a landed delivery only proves the app received the webhook,
+ * not that it adopted the secret, so cutting anything off is left to the grace window or to the
+ * operator's explicit revoke.
  */
 @Service
 class AppSecretRotationService(
@@ -28,11 +29,13 @@ class AppSecretRotationService(
     val previousExpiresAt: Date?,
   )
 
+  @Transactional
   fun rotate(
     app: App,
     graceSeconds: Long,
   ): RotationResult {
-    val rotated = appSecretService.rotate(app, graceSeconds)
+    val issued = appSecretService.issue(app)
+    val previousExpiresAt = appSecretService.expireOthers(app.id, issued.secret.id, graceSeconds)
     val delivery =
       appLifecycleDeliveryService.deliverNow(
         appEntityId = app.id,
@@ -40,13 +43,13 @@ class AppSecretRotationService(
         appCredentials =
           AppLifecycleAppCredentials(
             clientId = app.clientId,
-            clientSecret = rotated.issued.plaintextSecret,
+            clientSecret = issued.plaintextSecret,
           ),
       )
     return RotationResult(
-      issued = rotated.issued,
+      issued = issued,
       delivery = delivery,
-      previousExpiresAt = rotated.previousExpiresAt,
+      previousExpiresAt = previousExpiresAt,
     )
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
@@ -26,11 +26,6 @@ class AppSecretService(
     val plaintextSecret: String,
   )
 
-  data class RotationResult(
-    val issued: IssueResult,
-    val previousExpiresAt: Date?,
-  )
-
   fun mintSecret(app: App): IssueResult {
     val plaintext = AppService.APP_CLIENT_SECRET_PREFIX + keyGenerator.generate(256)
     val secret =
@@ -50,18 +45,12 @@ class AppSecretService(
     return mintSecret(app)
   }
 
-  /** issue + expireOthers in one transaction, so a failure cannot leave a deadline-less extra secret. */
-  @Transactional
-  fun rotate(
-    app: App,
-    graceSeconds: Long,
-  ): RotationResult {
-    val issued = issue(app)
-    val previousExpiresAt = expireOthers(app.id, issued.secret.id, graceSeconds)
-    return RotationResult(issued, previousExpiresAt)
-  }
-
-  private fun expireOthers(
+  /**
+   * Puts every active secret except [keepSecretId] on a [graceSeconds] deadline, never extending one
+   * already expiring sooner, and returns the latest of those deadlines. Call inside the same
+   * transaction as [issue] so a failure cannot leave a deadline-less extra secret.
+   */
+  fun expireOthers(
     appId: Long,
     keepSecretId: Long,
     graceSeconds: Long,

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
@@ -8,8 +8,9 @@ import io.tolgee.exceptions.NotFoundException
 import io.tolgee.model.apps.AppLifecycleEventType
 import io.tolgee.repository.apps.AppRepository
 import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import io.tolgee.util.executeInNewTransaction
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
 
 /**
  * Rotates the secret Tolgee signs an app's lifecycle deliveries with. The new secret is delivered to
@@ -26,42 +27,58 @@ class AppWebhookSecretService(
   private val appRepository: AppRepository,
   private val keyGenerator: KeyGenerator,
   private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
+  private val transactionManager: PlatformTransactionManager,
 ) {
   data class RotationResult(
     val newSecret: String,
     val delivery: AppLifecycleDeliveryOutcome?,
   )
 
-  @Transactional
+  private data class NewWebhookSecret(
+    val target: AppLifecycleDeliveryService.AppTarget,
+    val clientId: String,
+    val newSecret: String,
+  )
+
   fun rotate(appEntityId: Long): RotationResult {
-    val app =
-      appRepository.findById(appEntityId).orElse(null)
-        ?: throw NotFoundException(Message.APP_NOT_FOUND)
+    // Persist and commit the new secret before delivering it, so Tolgee never signs a later delivery
+    // with a secret the app already switched to but this transaction hadn't yet committed.
+    val rotated =
+      executeInNewTransaction(transactionManager) {
+        val app =
+          appRepository.findById(appEntityId).orElse(null)
+            ?: throw NotFoundException(Message.APP_NOT_FOUND)
 
-    val previous = app.webhookSecret
-    val newSecret = keyGenerator.generate(256)
-    app.webhookSecret = newSecret
-    appRepository.save(app)
+        val previous = app.webhookSecret
+        val newSecret = keyGenerator.generate(256)
+        app.webhookSecret = newSecret
+        appRepository.save(app)
 
-    val target =
-      AppLifecycleDeliveryService.AppTarget(
-        appEntityId = app.id,
-        appIdentifier = app.appId,
-        baseUrl = app.baseUrl,
-        // Signed with the old secret so a running app can verify the delivery that carries the new one.
-        signingSecret = previous,
-      )
+        NewWebhookSecret(
+          target =
+            AppLifecycleDeliveryService.AppTarget(
+              appEntityId = app.id,
+              appIdentifier = app.appId,
+              baseUrl = app.baseUrl,
+              // Signed with the old secret so a running app can verify the delivery that carries the new one.
+              signingSecret = previous,
+            ),
+          clientId = app.clientId,
+          newSecret = newSecret,
+        )
+      }
+
     val delivery =
       appLifecycleDeliveryService.deliverNow(
-        target = target,
+        target = rotated.target,
         eventType = AppLifecycleEventType.APP_SECRET_ROTATED,
         appCredentials =
           AppLifecycleAppCredentials(
-            clientId = app.clientId,
+            clientId = rotated.clientId,
             clientSecret = null,
-            webhookSecret = newSecret,
+            webhookSecret = rotated.newSecret,
           ),
       )
-    return RotationResult(newSecret, delivery)
+    return RotationResult(rotated.newSecret, delivery)
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
@@ -1,0 +1,67 @@
+package io.tolgee.service.apps
+
+import io.tolgee.component.KeyGenerator
+import io.tolgee.constants.Message
+import io.tolgee.dtos.apps.AppLifecycleAppCredentials
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
+import io.tolgee.exceptions.NotFoundException
+import io.tolgee.model.apps.AppLifecycleEventType
+import io.tolgee.repository.apps.AppRepository
+import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Rotates the secret Tolgee signs an app's lifecycle deliveries with. The new secret is delivered to
+ * the app **signed with the old one** — the only secret the app is guaranteed to already hold — so a
+ * running app can verify that delivery and adopt the new secret without being locked out. Tolgee
+ * signs every later delivery with the new secret.
+ *
+ * A running app keeps accepting deliveries signed with the previous secret during the overlap and
+ * drops it on its own next rotation — that overlap is the app's concern, not Tolgee's, so there is
+ * nothing here to "revoke".
+ */
+@Service
+class AppWebhookSecretService(
+  private val appRepository: AppRepository,
+  private val keyGenerator: KeyGenerator,
+  private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
+) {
+  data class RotationResult(
+    val newSecret: String,
+    val delivery: AppLifecycleDeliveryOutcome?,
+  )
+
+  @Transactional
+  fun rotate(appEntityId: Long): RotationResult {
+    val app =
+      appRepository.findById(appEntityId).orElse(null)
+        ?: throw NotFoundException(Message.APP_NOT_FOUND)
+
+    val previous = app.webhookSecret
+    val newSecret = keyGenerator.generate(256)
+    app.webhookSecret = newSecret
+    appRepository.save(app)
+
+    val target =
+      AppLifecycleDeliveryService.AppTarget(
+        appEntityId = app.id,
+        appIdentifier = app.appId,
+        baseUrl = app.baseUrl,
+        // Signed with the old secret so a running app can verify the delivery that carries the new one.
+        signingSecret = previous,
+      )
+    val delivery =
+      appLifecycleDeliveryService.deliverNow(
+        target = target,
+        eventType = AppLifecycleEventType.APP_SECRET_ROTATED,
+        appCredentials =
+          AppLifecycleAppCredentials(
+            clientId = app.clientId,
+            clientSecret = null,
+            webhookSecret = newSecret,
+          ),
+      )
+    return RotationResult(newSecret, delivery)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
@@ -1,0 +1,112 @@
+package io.tolgee.service.apps.lifecycle
+
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.dtos.apps.AppLifecycleAppCredentials
+import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
+import io.tolgee.dtos.apps.AppLifecycleOrganization
+import io.tolgee.dtos.apps.AppLifecyclePayload
+import io.tolgee.model.apps.AppLifecycleEventType
+import io.tolgee.repository.OrganizationRepository
+import io.tolgee.repository.apps.AppRepository
+import io.tolgee.util.Logging
+import io.tolgee.util.executeInNewTransaction
+import io.tolgee.util.logger
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Hands an app a secret-carrying event over a signed POST to `<baseUrl>/tolgee/lifecycle` — a
+ * dedicated path rather than the base URL itself, because the base URL serves the app's UI (in
+ * development typically a Vite server that has no idea about POSTs, and can only proxy a known path
+ * through to the app server). Tells the caller whether it landed. Only two events travel this way
+ * now — an app being registered and an operator rotating one of its secrets — and both happen with a
+ * human at a dialog, so the delivery is **synchronous** and its outcome is shown there. An app that
+ * discovers the rest (its installs) asks Tolgee itself.
+ *
+ * A failure never propagates: the credentials were already returned in the response, so a dead app
+ * host must not roll back the registration or rotation. The blast radius of the synchronous call is
+ * bounded by the shared apps HTTP timeout, and Tolgee just fetched the manifest from this same host
+ * seconds earlier, so the host is already known reachable.
+ */
+@Service
+class AppLifecycleDeliveryService(
+  private val appRepository: AppRepository,
+  private val organizationRepository: OrganizationRepository,
+  private val httpClient: AppLifecycleHttpClient,
+  private val tolgeeProperties: TolgeeProperties,
+  private val objectMapper: ObjectMapper,
+  private val transactionManager: PlatformTransactionManager,
+) : Logging {
+  /**
+   * Everything a delivery needs about the app, taken while the app still exists. Read before a
+   * removal that will delete the app so the app can still be told about it.
+   */
+  data class AppTarget(
+    val appEntityId: Long,
+    val appIdentifier: String,
+    val baseUrl: String,
+    val signingSecret: String,
+  )
+
+  /** Reads the app's delivery target. */
+  fun resolveTarget(appEntityId: Long): AppTarget? {
+    return executeInNewTransaction(transactionManager) {
+      val app = appRepository.findById(appEntityId).orElse(null) ?: return@executeInNewTransaction null
+      AppTarget(
+        appEntityId = app.id,
+        appIdentifier = app.appId,
+        baseUrl = app.baseUrl,
+        signingSecret = app.webhookSecret,
+      )
+    }
+  }
+
+  /**
+   * Delivers [eventType] now and reports whether the app took it. Returns
+   * [AppLifecycleDeliveryOutcome.NOT_ATTEMPTED] when the app is already gone (nothing to deliver to);
+   * a failure is a value, never thrown.
+   */
+  fun deliverNow(
+    appEntityId: Long,
+    eventType: AppLifecycleEventType,
+    appCredentials: AppLifecycleAppCredentials? = null,
+    organizationId: Long? = null,
+  ): AppLifecycleDeliveryOutcome {
+    val target = resolveTarget(appEntityId) ?: return AppLifecycleDeliveryOutcome.NOT_ATTEMPTED
+    return deliverNow(target, eventType, appCredentials, organizationId)
+  }
+
+  fun deliverNow(
+    target: AppTarget,
+    eventType: AppLifecycleEventType,
+    appCredentials: AppLifecycleAppCredentials? = null,
+    organizationId: Long? = null,
+  ): AppLifecycleDeliveryOutcome {
+    val organization = organizationId?.let { organizationRepository.findById(it).orElse(null) }
+    val payload =
+      AppLifecyclePayload(
+        eventType = eventType.wireName,
+        appId = target.appIdentifier,
+        tolgeeInstanceUrl = tolgeeProperties.backEndUrl,
+        app = appCredentials,
+        organization = organization?.let { AppLifecycleOrganization(id = it.id, name = it.name, slug = it.slug) },
+      )
+
+    val url = deliveryUrl(target.baseUrl)
+    return try {
+      httpClient.post(url, objectMapper.writeValueAsString(payload), target.signingSecret)
+      AppLifecycleDeliveryOutcome.DELIVERED
+    } catch (e: AppLifecycleHttpClient.DeliveryFailedException) {
+      logger.info("App lifecycle {} delivery to {} failed: {}", eventType.wireName, url, e.message)
+      AppLifecycleDeliveryOutcome.failed(e.message ?: "delivery failed")
+    }
+  }
+
+  companion object {
+    /** The well-known path the SDK's `mountTolgeeLifecycle` listens on. */
+    const val LIFECYCLE_PATH = "/tolgee/lifecycle"
+
+    fun deliveryUrl(baseUrl: String): String = baseUrl.trimEnd('/') + LIFECYCLE_PATH
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
@@ -109,8 +109,6 @@ class AppLifecycleDeliveryService(
     const val LIFECYCLE_PATH = "/tolgee/lifecycle"
 
     fun deliveryUrl(baseUrl: String): String {
-      // Append to the URL's path component, not the raw string: a base URL carrying a query or
-      // fragment would otherwise splice the path into the wrong place.
       val base = URI(baseUrl)
       val path = (base.path ?: "").trimEnd('/') + LIFECYCLE_PATH
       return URI(base.scheme, base.authority, path, null, null).toString()

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
@@ -14,6 +14,7 @@ import io.tolgee.util.logger
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 import tools.jackson.databind.ObjectMapper
+import java.net.URI
 
 /**
  * Hands an app a secret-carrying event over a signed POST to `<baseUrl>/tolgee/lifecycle` — a
@@ -107,6 +108,12 @@ class AppLifecycleDeliveryService(
     /** The well-known path the SDK's `mountTolgeeLifecycle` listens on. */
     const val LIFECYCLE_PATH = "/tolgee/lifecycle"
 
-    fun deliveryUrl(baseUrl: String): String = baseUrl.trimEnd('/') + LIFECYCLE_PATH
+    fun deliveryUrl(baseUrl: String): String {
+      // Append to the URL's path component, not the raw string: a base URL carrying a query or
+      // fragment would otherwise splice the path into the wrong place.
+      val base = URI(baseUrl)
+      val path = (base.path ?: "").trimEnd('/') + LIFECYCLE_PATH
+      return URI(base.scheme, base.authority, path, null, null).toString()
+    }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleHttpClient.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleHttpClient.kt
@@ -1,0 +1,76 @@
+package io.tolgee.service.apps.lifecycle
+
+import io.tolgee.component.automations.processors.WebhookSigner
+import io.tolgee.configuration.tolgee.AppsProperties
+import io.tolgee.util.UrlSecurity
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+/**
+ * Posts a lifecycle delivery to an app-controlled URL. Shares `appsRestTemplate` with the manifest
+ * fetch, so both go through the same SSRF guard: the URL is validated here and every address the
+ * client actually connects to is re-checked by that template's DNS resolver, which is what closes
+ * DNS rebinding.
+ */
+@Component
+class AppLifecycleHttpClient(
+  @Qualifier("appsRestTemplate")
+  private val restTemplate: RestTemplate,
+  private val urlSecurity: UrlSecurity,
+  private val appsProperties: AppsProperties,
+  private val webhookSigner: WebhookSigner,
+) {
+  class DeliveryFailedException(
+    message: String,
+  ) : RuntimeException(message)
+
+  fun post(
+    url: String,
+    payload: String,
+    signingSecret: String,
+  ) {
+    validateTarget(url)
+
+    val headers = HttpHeaders()
+    @Suppress("UastIncorrectHttpHeaderInspection")
+    headers.add(WebhookSigner.SIGNATURE_HEADER, webhookSigner.signatureHeader(payload, signingSecret))
+    headers.contentType = MediaType.APPLICATION_JSON
+
+    val response =
+      try {
+        restTemplate.exchange(URI(url), HttpMethod.POST, HttpEntity(payload, headers), String::class.java)
+      } catch (e: Exception) {
+        throw DeliveryFailedException(e.message ?: e.javaClass.simpleName)
+      }
+
+    if (!response.statusCode.is2xxSuccessful) {
+      throw DeliveryFailedException("app responded with status ${response.statusCode.value()}")
+    }
+  }
+
+  private fun validateTarget(url: String) {
+    try {
+      urlSecurity.validateUrl(url, allowLocalAddresses = appsProperties.allowLocalAddresses)
+    } catch (e: Exception) {
+      throw DeliveryFailedException(e.message ?: "delivery URL rejected")
+    }
+    requireHttps(url)
+  }
+
+  /**
+   * Credentials travel in the body, so plaintext HTTP is refused. `allowLocalAddresses` is the
+   * development switch the manifest fetch already uses, and it is what also permits `http://` here.
+   */
+  private fun requireHttps(url: String) {
+    if (appsProperties.allowLocalAddresses) return
+    val scheme = URI(url).scheme?.lowercase()
+    if (scheme == "https") return
+    throw DeliveryFailedException("lifecycle deliveries require https, got $scheme")
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/util/dateExt.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/util/dateExt.kt
@@ -16,6 +16,9 @@ fun Date.addSeconds(seconds: Int): Date = addToCalendar(Calendar.SECOND, seconds
 
 fun Date.addMilliseconds(milliseconds: Int): Date = addToCalendar(Calendar.MILLISECOND, milliseconds)
 
+/** Epoch seconds, dropping sub-second millis — for comparing against a JWT `iat`, which is second-precision. */
+fun Date.toWholeSeconds(): Long = time / 1000L
+
 private fun Date.addToCalendar(
   field: Int,
   amount: Int,

--- a/backend/data/src/test/kotlin/io/tolgee/unit/apps/AppLifecycleDeliveryUrlTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/apps/AppLifecycleDeliveryUrlTest.kt
@@ -1,0 +1,43 @@
+package io.tolgee.unit.apps
+
+import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+
+class AppLifecycleDeliveryUrlTest {
+  @Test
+  fun `appends the lifecycle path to a bare origin`() {
+    AppLifecycleDeliveryService
+      .deliveryUrl("https://app.example.com")
+      .assert
+      .isEqualTo("https://app.example.com/tolgee/lifecycle")
+  }
+
+  @Test
+  fun `collapses a trailing slash`() {
+    AppLifecycleDeliveryService
+      .deliveryUrl("https://app.example.com/")
+      .assert
+      .isEqualTo("https://app.example.com/tolgee/lifecycle")
+  }
+
+  @Test
+  fun `keeps an existing base path`() {
+    AppLifecycleDeliveryService
+      .deliveryUrl("https://app.example.com/mounted")
+      .assert
+      .isEqualTo("https://app.example.com/mounted/tolgee/lifecycle")
+  }
+
+  @Test
+  fun `does not splice the path into a query or fragment`() {
+    AppLifecycleDeliveryService
+      .deliveryUrl("https://app.example.com?tenant=1")
+      .assert
+      .isEqualTo("https://app.example.com/tolgee/lifecycle")
+    AppLifecycleDeliveryService
+      .deliveryUrl("https://app.example.com#section")
+      .assert
+      .isEqualTo("https://app.example.com/tolgee/lifecycle")
+  }
+}

--- a/backend/data/src/test/kotlin/io/tolgee/unit/apps/AppLifecycleHttpClientTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/apps/AppLifecycleHttpClientTest.kt
@@ -1,0 +1,116 @@
+package io.tolgee.unit.apps
+
+import io.tolgee.component.CurrentDateProvider
+import io.tolgee.component.automations.processors.WebhookSigner
+import io.tolgee.configuration.tolgee.AppsProperties
+import io.tolgee.configuration.tolgee.InternalProperties
+import io.tolgee.fixtures.verifyWebhookSignatureHeader
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+import io.tolgee.testing.assert
+import io.tolgee.util.UrlSecurity
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.header
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withStatus
+import org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
+import org.springframework.web.client.RestTemplate
+import java.util.Date
+
+/**
+ * The signature an app has to verify. It must be the same envelope project webhooks already use, so
+ * an app author implements one verification and not two.
+ */
+class AppLifecycleHttpClientTest {
+  private val restTemplate = RestTemplate()
+  private val server: MockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).build()
+
+  private val now = Date(1_700_000_000_000)
+  private val currentDateProvider =
+    mock<CurrentDateProvider> {
+      on { date } doReturn now
+    }
+  private val appsProperties = AppsProperties()
+  private val signer = WebhookSigner(currentDateProvider)
+
+  /** The host in these tests does not exist, so address checking has to be off to reach the send. */
+  private val client =
+    AppLifecycleHttpClient(
+      restTemplate,
+      UrlSecurity(InternalProperties().apply { disableUrlSsrfProtection = true }),
+      appsProperties,
+      signer,
+    )
+
+  private val guardedClient =
+    AppLifecycleHttpClient(restTemplate, UrlSecurity(InternalProperties()), appsProperties, signer)
+
+  private val url = "https://app.example.com"
+  private val payload = """{"eventType":"app.registered"}"""
+  private val secret = "signing-secret"
+
+  @Test
+  fun `signs the payload with the app's secret, in the webhook envelope`() {
+    var seenHeader: String? = null
+    server
+      .expect(requestTo(url))
+      .andExpect(header("Content-Type", "application/json"))
+      .andRespond { request ->
+        seenHeader = request!!.headers.getFirst(WebhookSigner.SIGNATURE_HEADER)
+        withSuccess().createResponse(request)
+      }
+
+    client.post(url, payload, secret)
+
+    server.verify()
+    verifyWebhookSignatureHeader(
+      payload = payload,
+      sigHeader = seenHeader!!,
+      secret = secret,
+      tolerance = 0,
+      currentTimeInMs = now.time,
+    ).assert.isTrue()
+  }
+
+  @Test
+  fun `treats a non-2xx response as a failure`() {
+    server.expect(requestTo(url)).andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR))
+
+    assertThrows<AppLifecycleHttpClient.DeliveryFailedException> { client.post(url, payload, secret) }
+  }
+
+  /** Credentials travel in the body, so an app that moved to plaintext HTTP gets nothing. */
+  @Test
+  fun `refuses to deliver over http`() {
+    val thrown =
+      assertThrows<AppLifecycleHttpClient.DeliveryFailedException> {
+        client.post("http://app.example.com", payload, secret)
+      }
+
+    thrown.message.assert.contains("https")
+    server.verify()
+  }
+
+  @Test
+  fun `refuses a target the SSRF guard blocks`() {
+    assertThrows<AppLifecycleHttpClient.DeliveryFailedException> {
+      guardedClient.post("https://127.0.0.1/hook", payload, secret)
+    }
+
+    server.verify()
+  }
+
+  @Test
+  fun `allows http and local addresses when local addresses are allowed`() {
+    appsProperties.allowLocalAddresses = true
+    server.expect(requestTo("http://127.0.0.1:3000")).andRespond(withSuccess())
+
+    client.post("http://127.0.0.1:3000", payload, secret)
+
+    server.verify()
+  }
+}

--- a/backend/security/src/main/kotlin/io/tolgee/security/authentication/AppTokenAuthenticator.kt
+++ b/backend/security/src/main/kotlin/io/tolgee/security/authentication/AppTokenAuthenticator.kt
@@ -24,6 +24,7 @@ import io.tolgee.exceptions.AuthenticationException
 import io.tolgee.model.apps.App
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.security.UserAccountService
+import io.tolgee.util.toWholeSeconds
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Component
@@ -129,9 +130,9 @@ class AppTokenAuthenticator(
     claims: AppTokenClaims,
   ) {
     val cutoff = app.tokensInvalidBefore ?: return
-    // A JWT `iat` is second-precision, so compare at whole seconds — otherwise a token minted in the
-    // same second as the cutoff reads as older than it and is wrongly rejected.
-    if (claims.issuedAt.time / 1000L < cutoff.time / 1000L) {
+    // Compare at whole seconds: a JWT `iat` is second-precision, so a token minted in the same second
+    // as the cutoff would otherwise read as older than it and be wrongly rejected.
+    if (claims.issuedAt.toWholeSeconds() < cutoff.toWholeSeconds()) {
       throw AuthExpiredException(Message.EXPIRED_JWT_TOKEN)
     }
   }


### PR DESCRIPTION
Slice 5 of 7 (base: `feat-apps-alpha`). Builds on slice 4's secret model.

The outbound **lifecycle** channel that notifies an installed app's own webhook URL, signed with the app's `webhookSecret`. Distinct from the EE activity-webhook infra.

## Scope note (please read)
The lifecycle subsystem on the source branch defines exactly **two** events — `app.registered` and `app.secret_rotated` — and is **synchronous-only** (its own docstring: "Only two events travel this way now"). There is **no** install/uninstall/enable/disable/scopes_updated event and **no** delete-retry engine in any branch. I ported the subsystem that exists rather than inventing speculative events/retry. `APP_INSTALLED` is a PostHog business event (slice 7). If we want more lifecycle events or async retry, that's net-new work for a later slice — flag if so.

## What's here
- **`AppLifecycleEventType`** — `app.registered`, `app.secret_rotated` (wire names).
- **`AppLifecycleHttpClient`** — https-only, SSRF-guarded POST of a signed envelope (`WebhookSigner`, extracted from `WebhookExecutor` and shared).
- **`AppLifecycleDeliveryService`** — synchronous delivery after the triggering transaction commits; a failed delivery is **reported, not thrown** (registration/rotation still succeed).
- **`AppWebhookSecretService`** + `GET /owned-apps/{id}/webhook-secret` (reveal) and `POST .../webhook-secret/rotate` (rotate, delivered signed with the **previous** secret).
- **`AppSecretRotationService`** — wraps slice-4's atomic `AppSecretService.rotate`, then delivers `app.secret_rotated`.
- Fire sites: **registration** → `app.registered`; **client-secret rotation** → `app.secret_rotated`; **webhook-secret rotation** → `app.secret_rotated`.
- Response models surface a `delivery` outcome.

## Migration
None — `App.webhookSecret` (non-null, set at registration) already landed in an earlier slice; this slice only consumes it.

## Tests
`AppLifecycleHttpClientTest` (signature envelope, non-2xx failure, https-only, SSRF guard, local-address allowance), `AppLifecycleDeliveryTest` (registered delivery + payload, failed-delivery-reported-not-thrown, webhook-secret reveal/rotate signed-with-old, client-secret rotation delivery, cross-org isolation). Existing apps suites (`AppSecretRotationTest`, `AppCredentialTokenTest`, `AppTokenAuthorizationTest`, registration/installation/deletion/enablement) stay green; the 11 register/rotate tests get a mocked `AppLifecycleHttpClient` so the new synchronous delivery never hits the network. EE `WebhookAutomationTest` validates the `WebhookSigner` extraction. All pass locally; CI not gated per the slice workflow.

## Deferred
- **Slice 6**: self-refresh controller, manifest re-fetch, scope-widening refresh, `pendingScopes`, re-consent.
- **Slice 7**: PostHog business events (`APP_INSTALLED`/`APP_REGISTERED`), `@RequestActivity` attribution, ActivityTypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app lifecycle notifications for registration and credential rotation.
  * Added webhook signing-secret viewing and rotation.
  * Added delivery status details, including success and failure information.
  * Added secure, signed lifecycle webhook delivery with HTTPS and local-address protections.
* **Bug Fixes**
  * Credential rotation and registration now remain successful even when notification delivery fails.
* **Tests**
  * Added coverage for lifecycle delivery, secret rotation, authorization, signing, and URL security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->