### PR TITLE
feat: app manifest refresh & scope re-consent (apps alpha 6/7)

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsController.kt
@@ -24,6 +24,7 @@ import org.springframework.hateoas.PagedModel
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -54,6 +55,23 @@ class AppSelfInstallationsController(
     val appId = authenticationFacade.appAuthentication.appId
     val models = appInstallService.findAllByRegisteredApp(appId).map { appSelfInstallationModelAssembler.toModel(it) }
     return CollectionModel.of(models)
+  }
+
+  @PostMapping("/installations/{installId}/refresh")
+  @AllowAppLevelAccess
+  @RateLimited(10, isAuthentication = true)
+  @Operation(
+    summary = "Re-fetch the manifest for one of the app's installations",
+    description =
+      "Re-reads the app's manifest and updates the stored snapshot. Never widens the install's " +
+        "granted scopes: a manifest that requests more surfaces those as `pendingScopes` until the " +
+        "organization's owner approves them; scopes the manifest no longer requests are dropped.",
+  )
+  fun refreshInstallation(
+    @PathVariable installId: Long,
+  ): AppSelfInstallationModel {
+    val appId = authenticationFacade.appAuthentication.appId
+    return appSelfInstallationModelAssembler.toModel(appInstallService.refreshForApp(appId, installId))
   }
 
   @GetMapping("/installations/{installId}/projects")

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsController.kt
@@ -9,6 +9,7 @@ import io.tolgee.hateoas.organization.apps.AppManifestPreviewModel
 import io.tolgee.hateoas.organization.apps.AppManifestPreviewModelAssembler
 import io.tolgee.model.enums.Scope
 import io.tolgee.security.OrganizationHolder
+import io.tolgee.security.authentication.RequiresSuperAuthentication
 import io.tolgee.security.authorization.RequiresOrganizationScopes
 import io.tolgee.service.apps.AppInstallService
 import jakarta.validation.Valid
@@ -85,6 +86,24 @@ class OrganizationAppsController(
     @PathVariable organizationId: Long,
   ): CollectionModel<AppInstallModel> {
     return appInstallModelAssembler.toCollectionModel(appInstallService.findAll(organizationId))
+  }
+
+  @PostMapping("/{installId}/refresh")
+  @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequiresSuperAuthentication
+  @Operation(
+    summary = "Refresh an installed app's manifest and approve its current scopes",
+    description =
+      "Re-fetches the app's manifest and updates the stored snapshot. As the organization's consent " +
+        "authority, this also approves the scopes the manifest now requests: the install adopts that " +
+        "scope set, clearing any pending permission requests. This is the only path that may widen an " +
+        "install's granted scopes.",
+  )
+  fun refresh(
+    @PathVariable organizationId: Long,
+    @PathVariable installId: Long,
+  ): AppInstallModel {
+    return appInstallModelAssembler.toModel(appInstallService.refresh(organizationId, installId))
   }
 
   @DeleteMapping("/{installId}")

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSelfInstallationModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSelfInstallationModel.kt
@@ -13,4 +13,10 @@ open class AppSelfInstallationModel(
   val version: String,
   @Schema(description = "Permission scopes granted to the install at consent time")
   val scopes: List<String>,
+  @Schema(
+    description =
+      "Scopes the current manifest requests that are not granted yet. Non-empty after the app " +
+        "widens its manifest, until the organization's owner approves them.",
+  )
+  val pendingScopes: List<String> = emptyList(),
 ) : RepresentationModel<AppSelfInstallationModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSelfInstallationModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/apps/AppSelfInstallationModelAssembler.kt
@@ -1,17 +1,20 @@
 package io.tolgee.hateoas.apps
 
 import io.tolgee.model.apps.AppInstall
+import io.tolgee.service.apps.AppService
 import org.springframework.stereotype.Component
 
 @Component
 class AppSelfInstallationModelAssembler {
   fun toModel(install: AppInstall): AppSelfInstallationModel {
+    val grantedScopes = install.grantedScopes.map { it.value }
     return AppSelfInstallationModel(
       id = install.id,
       appId = install.app.appId,
       name = install.app.name,
       version = install.app.version,
-      scopes = install.grantedScopes.map { it.value },
+      scopes = grantedScopes,
+      pendingScopes = (AppService.splitScopes(install.app.manifestScopes) - grantedScopes.toSet()).sorted(),
     )
   }
 }

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/apps/AppInstallModel.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/apps/AppInstallModel.kt
@@ -24,4 +24,10 @@ open class AppInstallModel(
   val enabledProjectCount: Long = 0,
   val modules: AppManifestModulesDto,
   val scopes: List<String>,
+  @Schema(
+    description =
+      "Scopes the current manifest requests that the install has not consented to yet. Non-empty " +
+        "after the app widens its manifest; an owner refresh approves them and clears this list.",
+  )
+  val pendingScopes: List<String> = emptyList(),
 ) : RepresentationModel<AppInstallModel>()

--- a/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/apps/AppInstallModelAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/hateoas/organization/apps/AppInstallModelAssembler.kt
@@ -3,6 +3,7 @@ package io.tolgee.hateoas.organization.apps
 import io.tolgee.dtos.apps.AppManifestDto
 import io.tolgee.model.apps.AppInstall
 import io.tolgee.service.apps.AppEnablementService
+import io.tolgee.service.apps.AppService
 import org.springframework.hateoas.CollectionModel
 import org.springframework.hateoas.server.RepresentationModelAssembler
 import org.springframework.stereotype.Component
@@ -31,6 +32,8 @@ class AppInstallModelAssembler(
   ): AppInstallModel {
     val registeredApp = entity.app
     val manifest = objectMapper.readValue<AppManifestDto>(registeredApp.manifestJson)
+    val grantedScopes = entity.grantedScopes.map { it.value }
+    val pendingScopes = (AppService.splitScopes(registeredApp.manifestScopes) - grantedScopes.toSet()).sorted()
     return AppInstallModel(
       id = entity.id,
       manifestUrl = registeredApp.manifestUrl,
@@ -41,7 +44,8 @@ class AppInstallModelAssembler(
       icon = registeredApp.icon,
       enabledProjectCount = enabledProjectCount,
       modules = manifest.modules,
-      scopes = entity.grantedScopes.map { it.value },
+      scopes = grantedScopes,
+      pendingScopes = pendingScopes,
     )
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRefreshTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRefreshTest.kt
@@ -1,7 +1,10 @@
 package io.tolgee.api.v2.controllers.apps
 
+import io.tolgee.constants.Message
 import io.tolgee.development.testDataBuilder.data.AppsTestData
 import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andHasErrorMessage
+import io.tolgee.fixtures.andIsBadRequest
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
 import io.tolgee.model.enums.Scope
@@ -134,6 +137,46 @@ class AppRefreshTest : AuthorizedControllerTest() {
     grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
   }
 
+  @Test
+  fun `refresh refuses a manifest whose app id no longer matches`() {
+    mockManifest(manifest(id = "a-different-app", scopes = """"translations.view""""))
+
+    performAuthPost("${appsUrl()}/$installId/refresh", null)
+      .andIsBadRequest
+      .andHasErrorMessage(Message.APP_MANIFEST_INVALID)
+
+    grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
+  }
+
+  @Test
+  fun `an app cannot refresh an install that is not its own`() {
+    mockManifest(
+      manifest(
+        id = "other-app",
+        name = "Other App",
+        baseUrl = "https://other-app.example.com",
+        scopes = """"translations.view"""",
+      ),
+    )
+    userAccount = testData.otherOwner
+    val other =
+      objectMapper.readTree(
+        performAuthPost(
+          "/v2/organizations/${testData.otherOrganization.id}/owned-apps",
+          mapOf("manifestUrl" to OTHER_MANIFEST_URL),
+        ).andIsOk.andReturn().response.contentAsString,
+      )
+    userAccount = testData.user
+    val otherToken = appLevelToken(other.get("clientId").asText(), other.get("clientSecret").asText())
+
+    logout()
+    perform(post("${selfInstallations()}/$installId/refresh").header(HttpHeaders.AUTHORIZATION, "Bearer $otherToken"))
+      .andIsNotFound
+    userAccount = testData.user
+
+    grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
+  }
+
   private fun grantedScopeValues(): List<String> =
     appInstallService.find(testData.organization.id, installId)!!.grantedScopes.map { it.value }
 
@@ -145,6 +188,10 @@ class AppRefreshTest : AuthorizedControllerTest() {
 
   private fun mockManifest(json: String) = AppsTestFixtures.mockManifest(appManifestHttpClient, json)
 
+  private companion object {
+    const val OTHER_MANIFEST_URL = "https://example.com/other/manifest.json"
+  }
+
   private fun asAppToken(builder: MockHttpServletRequestBuilder): ResultActions {
     val token = appLevelToken()
     logout()
@@ -153,13 +200,16 @@ class AppRefreshTest : AuthorizedControllerTest() {
     return result
   }
 
-  private fun appLevelToken(): String {
+  private fun appLevelToken(
+    clientId: String = appClientId,
+    clientSecret: String = appClientSecret,
+  ): String {
     logout()
     val body =
       mapOf(
         "grant_type" to "client_credentials",
-        "client_id" to appClientId,
-        "client_secret" to appClientSecret,
+        "client_id" to clientId,
+        "client_secret" to clientSecret,
       )
     val response =
       perform(
@@ -172,16 +222,18 @@ class AppRefreshTest : AuthorizedControllerTest() {
   }
 
   private fun manifest(
+    id: String = "test-app",
     name: String = "Test App",
     version: String = "0.1.0",
+    baseUrl: String = "https://app.example.com",
     scopes: String,
   ): String =
     """
     {
-      "id": "test-app",
+      "id": "$id",
       "name": "$name",
       "version": "$version",
-      "baseUrl": "https://app.example.com",
+      "baseUrl": "$baseUrl",
       "scopes": [$scopes],
       "modules": {
         "project-dashboard-page": [

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRefreshTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppRefreshTest.kt
@@ -1,0 +1,193 @@
+package io.tolgee.api.v2.controllers.apps
+
+import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsNotFound
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.model.enums.Scope
+import io.tolgee.service.apps.AppInstallService
+import io.tolgee.service.apps.AppManifestHttpClient
+import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+/**
+ * Manifest refresh and re-consent: the org owner's refresh approves the scopes a manifest now
+ * requests, while an app refreshing its own install can never widen the grant.
+ */
+class AppRefreshTest : AuthorizedControllerTest() {
+  @Autowired
+  lateinit var appInstallService: AppInstallService
+
+  @MockitoBean
+  @Autowired
+  lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
+
+  lateinit var testData: AppsTestData
+  var installId: Long = 0
+  lateinit var appClientId: String
+  lateinit var appClientSecret: String
+
+  @BeforeEach
+  fun setup() {
+    testData = AppsTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit""""))
+
+    val response =
+      performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL))
+        .andIsOk
+        .andReturn()
+        .response.contentAsString
+    val json = objectMapper.readTree(response)
+    installId = json.get("installId").asLong()
+    appClientId = json.get("clientId").asText()
+    appClientSecret = json.get("clientSecret").asText()
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `owner refresh re-fetches the manifest snapshot`() {
+    mockManifest(manifest(name = "Renamed App", version = "0.2.0", scopes = """"translations.view", "keys.edit""""))
+
+    performAuthPost("${appsUrl()}/$installId/refresh", null).andIsOk.andAssertThatJson {
+      node("name").isEqualTo("Renamed App")
+      node("version").isEqualTo("0.2.0")
+    }
+
+    performAuthGet(appsUrl()).andIsOk.andAssertThatJson {
+      node("_embedded.appInstalls[0].name").isEqualTo("Renamed App")
+      node("_embedded.appInstalls[0].version").isEqualTo("0.2.0")
+    }
+  }
+
+  @Test
+  fun `an app-initiated refresh surfaces a widened scope as pending without granting it`() {
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit", "keys.create""""))
+
+    asAppToken(post("${selfInstallations()}/$installId/refresh")).andIsOk.andAssertThatJson {
+      node("scopes").isArray.containsExactlyInAnyOrder("translations.view", "keys.edit")
+      node("pendingScopes").isArray.containsExactly("keys.create")
+    }
+
+    grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
+
+    performAuthGet(appsUrl()).andIsOk.andAssertThatJson {
+      node("_embedded.appInstalls[0].scopes").isArray.containsExactlyInAnyOrder("translations.view", "keys.edit")
+      node("_embedded.appInstalls[0].pendingScopes").isArray.containsExactly("keys.create")
+    }
+  }
+
+  @Test
+  fun `an owner refresh approves the widened scopes`() {
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit", "keys.create""""))
+    asAppToken(post("${selfInstallations()}/$installId/refresh")).andIsOk
+
+    performAuthPost("${appsUrl()}/$installId/refresh", null).andIsOk.andAssertThatJson {
+      node("scopes").isArray.containsExactlyInAnyOrder("translations.view", "keys.edit", "keys.create")
+      node("pendingScopes").isArray.isEmpty()
+    }
+
+    grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit", "keys.create")
+  }
+
+  @Test
+  fun `an app-initiated refresh drops a scope the manifest no longer requests`() {
+    mockManifest(manifest(scopes = """"translations.view""""))
+
+    asAppToken(post("${selfInstallations()}/$installId/refresh")).andIsOk.andAssertThatJson {
+      node("scopes").isArray.containsExactly("translations.view")
+      node("pendingScopes").isArray.isEmpty()
+    }
+
+    grantedScopeValues().assert.containsExactly("translations.view")
+  }
+
+  @Test
+  fun `refresh does not reach an install belonging to another organization`() {
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit", "keys.create""""))
+
+    userAccount = testData.otherOwner
+    performAuthPost("/v2/organizations/${testData.otherOrganization.id}/apps/$installId/refresh", null)
+      .andIsNotFound
+
+    grantedScopeValues().assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
+  }
+
+  private fun grantedScopeValues(): List<String> =
+    appInstallService.find(testData.organization.id, installId)!!.grantedScopes.map { it.value }
+
+  private fun appsUrl() = "/v2/organizations/${testData.organization.id}/apps"
+
+  private fun ownedUrl() = "/v2/organizations/${testData.organization.id}/owned-apps"
+
+  private fun selfInstallations() = "/v2/apps/self/installations"
+
+  private fun mockManifest(json: String) = AppsTestFixtures.mockManifest(appManifestHttpClient, json)
+
+  private fun asAppToken(builder: MockHttpServletRequestBuilder): ResultActions {
+    val token = appLevelToken()
+    logout()
+    val result = perform(builder.header(HttpHeaders.AUTHORIZATION, "Bearer $token"))
+    userAccount = testData.user
+    return result
+  }
+
+  private fun appLevelToken(): String {
+    logout()
+    val body =
+      mapOf(
+        "grant_type" to "client_credentials",
+        "client_id" to appClientId,
+        "client_secret" to appClientSecret,
+      )
+    val response =
+      perform(
+        post("/v2/public/apps/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(body)),
+      ).andIsOk.andReturn().response.contentAsString
+    userAccount = testData.user
+    return objectMapper.readTree(response).get("access_token").asText()
+  }
+
+  private fun manifest(
+    name: String = "Test App",
+    version: String = "0.1.0",
+    scopes: String,
+  ): String =
+    """
+    {
+      "id": "test-app",
+      "name": "$name",
+      "version": "$version",
+      "baseUrl": "https://app.example.com",
+      "scopes": [$scopes],
+      "modules": {
+        "project-dashboard-page": [
+          {"key": "home", "title": "Home", "icon": "🏠", "entry": "/"}
+        ]
+      }
+    }
+    """.trimIndent()
+}

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsControllerTest.kt
@@ -230,6 +230,7 @@ class OrganizationAppsControllerTest : AuthorizedControllerTest() {
     performAuthPost(registerUrl(), registerBody()).andIsForbidden
     performAuthGet(ownedUrl()).andIsForbidden
     performAuthPost("${appsUrl()}/preview", registerBody()).andIsForbidden
+    performAuthPost("${appsUrl()}/$installId/refresh", null).andIsForbidden
     performAuthDelete("${appsUrl()}/$installId").andIsForbidden
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppInstallRepository.kt
@@ -24,6 +24,12 @@ interface AppInstallRepository : JpaRepository<AppInstall, Long> {
     id: Long,
   ): AppInstall?
 
+  @Query("select i from AppInstall i join fetch i.app where i.app.id = :appEntityId and i.id = :id")
+  fun findByAppIdAndId(
+    @Param("appEntityId") appEntityId: Long,
+    @Param("id") id: Long,
+  ): AppInstall?
+
   @Query(
     """
     select i from AppInstall i

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
@@ -136,7 +136,7 @@ class AppInstallPersister(
     fetched: AppManifestFetcher.FetchResult,
   ): AppInstall {
     val install =
-      appInstallRepository.findWithAppById(installId)?.takeIf { it.app.id == appEntityId }
+      appInstallRepository.findByAppIdAndId(appEntityId, installId)
         ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
     return applySnapshot(install, fetched, allowScopeWidening = false)
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
@@ -1,11 +1,13 @@
 package io.tolgee.service.apps
 
+import io.tolgee.component.CurrentDateProvider
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.model.Organization
 import io.tolgee.model.apps.App
 import io.tolgee.model.apps.AppInstall
+import io.tolgee.model.enums.Scope
 import io.tolgee.repository.apps.AppInstallRepository
 import io.tolgee.util.Logging
 import io.tolgee.util.logger
@@ -22,6 +24,7 @@ class AppInstallPersister(
   private val appInstallPrincipalService: AppInstallPrincipalService,
   private val appsLimitGuard: AppsLimitGuard,
   private val appRegisterInserter: AppRegisterInserter,
+  private val currentDateProvider: CurrentDateProvider,
   private val entityManager: EntityManager,
 ) : Logging {
   /**
@@ -102,6 +105,69 @@ class AppInstallPersister(
       logger.debug("Concurrent app install collided on the unique constraint", e)
       throw BadRequestException(Message.APP_ALREADY_INSTALLED)
     }
+  }
+
+  /**
+   * Re-reads the app's manifest into the shared app snapshot and reconciles one install's granted
+   * scopes. Owner-consented callers pass [allowScopeWidening] true to adopt the manifest's current
+   * scope set; every other caller (an app refreshing its own install) passes false, which can only
+   * drop scopes the manifest no longer requests — an app can never self-grant a scope its owner has
+   * not consented to. The tenant check lives on the caller's lookup: [organizationId] scopes the
+   * install to the acting organization.
+   */
+  @Transactional
+  fun applySnapshotForOrgInstall(
+    organizationId: Long,
+    installId: Long,
+    fetched: AppManifestFetcher.FetchResult,
+    allowScopeWidening: Boolean,
+  ): AppInstall {
+    val install =
+      appInstallRepository.findByOrganizationIdAndId(organizationId, installId)
+        ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
+    return applySnapshot(install, fetched, allowScopeWidening)
+  }
+
+  /** The app refreshing one of its own installs. Never widens the granted scopes. */
+  @Transactional
+  fun applySnapshotForApp(
+    appEntityId: Long,
+    installId: Long,
+    fetched: AppManifestFetcher.FetchResult,
+  ): AppInstall {
+    val install =
+      appInstallRepository.findWithAppById(installId)?.takeIf { it.app.id == appEntityId }
+        ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
+    return applySnapshot(install, fetched, allowScopeWidening = false)
+  }
+
+  private fun applySnapshot(
+    install: AppInstall,
+    fetched: AppManifestFetcher.FetchResult,
+    allowScopeWidening: Boolean,
+  ): AppInstall {
+    val app = install.app
+    if (fetched.manifest.id != app.appId) {
+      throw BadRequestException(Message.APP_MANIFEST_INVALID)
+    }
+    app.name = fetched.manifest.name
+    app.version = fetched.manifest.version
+    app.baseUrl = fetched.manifest.baseUrl
+    app.icon = fetched.icon
+    app.manifestJson = fetched.rawJson
+    app.manifestScopes = AppService.joinScopes(fetched.scopes)
+    AppService.markManifestHealthy(app, currentDateProvider.date)
+    install.grantedScopes = resolveGrantedScopes(install.grantedScopes.toSet(), fetched.scopes, allowScopeWidening)
+    return appInstallRepository.save(install)
+  }
+
+  private fun resolveGrantedScopes(
+    current: Set<Scope>,
+    fetched: Set<Scope>,
+    allowScopeWidening: Boolean,
+  ): Array<Scope> {
+    if (allowScopeWidening) return fetched.toTypedArray()
+    return fetched.intersect(current).toTypedArray()
   }
 
   @Transactional

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
@@ -5,6 +5,7 @@ import io.tolgee.dtos.apps.AppLifecycleAppCredentials
 import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.exceptions.BadRequestException
+import io.tolgee.exceptions.NotFoundException
 import io.tolgee.exceptions.PermissionException
 import io.tolgee.model.Organization
 import io.tolgee.model.apps.App
@@ -121,6 +122,53 @@ class AppInstallService(
 
   fun previewManifest(manifestUrl: String): AppManifestFetcher.FetchResult {
     return appManifestFetcher.fetch(manifestUrl)
+  }
+
+  /**
+   * Re-fetches the manifest for an organization's install and reconciles the snapshot. The caller is
+   * the organization's app manager and the consent authority, so [allowScopeWidening] is true: the
+   * install adopts the scope set the manifest currently requests, which is how a widened permission
+   * request is approved. The fetch runs outside a transaction — see the class doc.
+   */
+  fun refresh(
+    organizationId: Long,
+    installId: Long,
+  ): AppInstall {
+    val manifestUrl = requireOrgInstallManifestUrl(organizationId, installId)
+    val fetched = appManifestFetcher.fetch(manifestUrl)
+    return appInstallPersister.applySnapshotForOrgInstall(
+      organizationId = organizationId,
+      installId = installId,
+      fetched = fetched,
+      allowScopeWidening = true,
+    )
+  }
+
+  /**
+   * Re-fetches the manifest for an install on the calling app's own behalf. Never widens the granted
+   * scopes: a manifest that requests more surfaces those as pending until the organization's owner
+   * approves them through [refresh]. Refuses when the install is not the app's own.
+   */
+  fun refreshForApp(
+    appEntityId: Long,
+    installId: Long,
+  ): AppInstall {
+    val manifestUrl =
+      findOwnInstall(appEntityId, installId)?.app?.manifestUrl
+        ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
+    val fetched = appManifestFetcher.fetch(manifestUrl)
+    return appInstallPersister.applySnapshotForApp(appEntityId, installId, fetched)
+  }
+
+  @Transactional(readOnly = true)
+  fun requireOrgInstallManifestUrl(
+    organizationId: Long,
+    installId: Long,
+  ): String {
+    return (
+      appInstallRepository.findByOrganizationIdAndId(organizationId, installId)
+        ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
+    ).app.manifestUrl
   }
 
   fun manifestHash(fetched: AppManifestFetcher.FetchResult): String {


### PR DESCRIPTION
Slice 6 of 7 (base: `feat-apps-alpha`). Re-fetch an installed app's manifest, and handle a manifest that now requests **more** scopes than were consented to.

## Consent model (refresh-as-approval)
Two refresh paths, distinguished by whether they may widen an install's `grantedScopes`:

- **Owner path — widening/consent.** `POST /v2/organizations/{orgId}/apps/{installId}/refresh`, gated `@RequiresOrganizationScopes([ORGANIZATION_APPS_MANAGE])` + `@RequiresSuperAuthentication`. Re-fetches the manifest, updates the shared `App` snapshot, and **adopts the manifest's current scopes into the install's `grantedScopes`** (`allowScopeWidening = true`). This is the re-consent.
- **App-self path — never widens.** `POST /v2/apps/self/installations/{installId}/refresh`, `@AllowAppLevelAccess`, `@RateLimited`. Re-fetches and updates the snapshot but reconciles `grantedScopes = fetched ∩ current` (`allowScopeWidening = false`): newly requested scopes stay **pending**, dropped scopes are removed, nothing is ever added.

`pendingScopes` = `manifestScopes − grantedScopes`, surfaced on `AppInstallModel` and `AppSelfInstallationModel`; owner refresh clears it.

## Security invariant
Scope widening happens **only** through the owner-consented path. An app/self-initiated refresh can never add a scope — the test suite pins this (asserts the DB `grantedScopes` is unchanged when the manifest widens on a self refresh).

## Migration
None — `App.manifestScopes` and `AppInstall.grantedScopes` already exist on `feat-apps-alpha`.

## Files
`AppInstallPersister` (org vs app snapshot apply + scope reconcile), `AppInstallService` (`refresh` / `refreshForApp`, manifest fetched outside the tx), `OrganizationAppsController` + `AppSelfInstallationsController` (endpoints), `AppInstall(Model|Assembler)` + `AppSelfInstallation(Model|Assembler)` (`pendingScopes`). Tests: new `AppRefreshTest` (5).

## Tests
`AppRefreshTest`: owner refresh re-fetches; app refresh surfaces a widened scope as pending without granting it; owner refresh approves the widened scopes; app refresh drops a no-longer-requested scope; cross-org isolation (org B → 404, grant untouched). `OrganizationAppsControllerTest` + `AppSelfInstallationsControllerTest` stay green. JSON asserts use the `andAssertThatJson`/`node()` DSL.

## Deferred / not included
- **Not ported:** the source's `PATCH manifest-url` — on this model `manifestUrl` is an app-owner/dev concern, not part of re-consent.
- **Slice 7:** no `@RequestActivity`/ActivityTypes, no PostHog business events for refresh/consent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to refresh installed app manifests and update installation details.
  - Organization owners can approve newly requested permissions during refresh.
  - Apps can refresh their own installations without expanding granted permissions.
  - Installation details now show permissions that are pending approval.
- **Bug Fixes**
  - Improved access control for installation refresh actions.
  - Refreshing an installation now updates metadata, permissions, and health information consistently.
  - Added safeguards to prevent unauthorized access across organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->