### PR TITLE
feat: app audit logging — activity, PostHog bridge, OTEL (apps alpha 7/7)

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/administration/AdministrationAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/administration/AdministrationAppsController.kt
@@ -2,12 +2,15 @@ package io.tolgee.api.v2.controllers.administration
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.activity.RequestActivity
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.api.v2.controllers.IController
 import io.tolgee.hateoas.organization.SimpleOrganizationModel
 import io.tolgee.hateoas.organization.SimpleOrganizationModelAssembler
 import io.tolgee.model.Organization
 import io.tolgee.openApiDocs.OpenApiSelfHostedExtension
 import io.tolgee.security.authentication.RequiresSuperAuthentication
+import io.tolgee.service.apps.AppActivityRecorder
 import io.tolgee.service.apps.AppAvailabilityService
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.apps.AppService
@@ -45,16 +48,19 @@ class AdministrationAppsController(
   private val appAvailabilityService: AppAvailabilityService,
   private val appInstallService: AppInstallService,
   private val organizationService: OrganizationService,
+  private val appActivityRecorder: AppActivityRecorder,
   private val simpleOrganizationModelAssembler: SimpleOrganizationModelAssembler,
   private val pagedOrganizationsAssembler: PagedResourcesAssembler<Organization>,
 ) : IController {
   @PutMapping("/{appId}/available-to-all")
   @Operation(summary = "Make the app available to all organizations")
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_AVAILABILITY_UPDATE)
   fun setAvailableToAll(
     @PathVariable appId: Long,
   ) {
-    appService.getRegistered(appId)
+    val app = appService.getRegistered(appId)
+    appActivityRecorder.record(app, organizationId = app.organization.id)
     appAvailabilityService.setAvailableToAll(appId)
   }
 
@@ -65,10 +71,12 @@ class AdministrationAppsController(
       "Disables the app in every non-owner project that could only reach it through availability to all organizations.",
   )
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_AVAILABILITY_UPDATE)
   fun clearAvailableToAll(
     @PathVariable appId: Long,
   ) {
-    appService.getRegistered(appId)
+    val app = appService.getRegistered(appId)
+    appActivityRecorder.record(app, organizationId = app.organization.id)
     appAvailabilityService.clearAvailableToAll(appId)
   }
 
@@ -91,12 +99,14 @@ class AdministrationAppsController(
   @PutMapping("/{appId}/available-organizations/{organizationId}")
   @Operation(summary = "Make the app available to one organization")
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_AVAILABILITY_UPDATE)
   fun addAvailableOrganization(
     @PathVariable appId: Long,
     @PathVariable organizationId: Long,
   ) {
-    appService.getRegistered(appId)
+    val app = appService.getRegistered(appId)
     organizationService.get(organizationId)
+    appActivityRecorder.record(app, organizationId = app.organization.id)
     appAvailabilityService.addAvailableOrganization(appId, organizationId)
   }
 
@@ -107,11 +117,13 @@ class AdministrationAppsController(
       "Disables the app in that organization's projects unless it stays reachable through availability to all organizations.",
   )
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_AVAILABILITY_UPDATE)
   fun removeAvailableOrganization(
     @PathVariable appId: Long,
     @PathVariable organizationId: Long,
   ) {
-    appService.getRegistered(appId)
+    val app = appService.getRegistered(appId)
+    appActivityRecorder.record(app, organizationId = app.organization.id)
     appAvailabilityService.removeAvailableOrganization(appId, organizationId)
   }
 

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/apps/AppSelfInstallationsController.kt
@@ -2,6 +2,8 @@ package io.tolgee.api.v2.controllers.apps
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.activity.RequestActivity
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.api.ISimpleProject
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.NotFoundException
@@ -60,6 +62,7 @@ class AppSelfInstallationsController(
   @PostMapping("/installations/{installId}/refresh")
   @AllowAppLevelAccess
   @RateLimited(10, isAuthentication = true)
+  @RequestActivity(ActivityType.APP_UPDATE)
   @Operation(
     summary = "Re-fetch the manifest for one of the app's installations",
     description =

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationAppsController.kt
@@ -2,6 +2,8 @@ package io.tolgee.api.v2.controllers.organization
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.activity.RequestActivity
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.dtos.request.RegisterAppRequest
 import io.tolgee.hateoas.organization.apps.AppInstallModel
 import io.tolgee.hateoas.organization.apps.AppInstallModelAssembler
@@ -54,6 +56,7 @@ class OrganizationAppsController(
 
   @PostMapping
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_INSTALL)
   @Operation(
     summary = "Install a Tolgee app",
     description =
@@ -91,6 +94,7 @@ class OrganizationAppsController(
   @PostMapping("/{installId}/refresh")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_UPDATE)
   @Operation(
     summary = "Refresh an installed app's manifest and approve its current scopes",
     description =
@@ -108,6 +112,7 @@ class OrganizationAppsController(
 
   @DeleteMapping("/{installId}")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_UNINSTALL)
   @Operation(
     summary = "Remove app",
     description = "Uninstalls the app from the organization.",

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/organization/OrganizationOwnedAppsController.kt
@@ -3,6 +3,8 @@ package io.tolgee.api.v2.controllers.organization
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.activity.RequestActivity
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.dtos.request.RegisterAppRequest
 import io.tolgee.dtos.request.apps.RotateAppSecretRequest
 import io.tolgee.hateoas.apps.AppDeliveryOutcomeModel
@@ -56,6 +58,7 @@ class OrganizationOwnedAppsController(
 ) {
   @PostMapping
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_REGISTER)
   @Operation(
     summary = "Register a Tolgee app",
     description =
@@ -104,6 +107,7 @@ class OrganizationOwnedAppsController(
 
   @DeleteMapping("/{appId}")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_UNINSTALL)
   @Operation(
     summary = "Delete an owned app",
     description =
@@ -139,6 +143,7 @@ class OrganizationOwnedAppsController(
   @PostMapping("/{appId}/secrets/rotate")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_SECRET_UPDATE)
   @Operation(
     summary = "Rotate the app's client secret",
     description =
@@ -183,6 +188,7 @@ class OrganizationOwnedAppsController(
 
   @PostMapping("/{appId}/webhook-secret/rotate")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_SECRET_UPDATE)
   @Operation(
     summary = "Rotate the app's webhook signing secret",
     description =
@@ -209,6 +215,7 @@ class OrganizationOwnedAppsController(
   @DeleteMapping("/{appId}/secrets/{secretId}")
   @RequiresOrganizationScopes([Scope.ORGANIZATION_APPS_MANAGE])
   @RequiresSuperAuthentication
+  @RequestActivity(ActivityType.APP_SECRET_UPDATE)
   @Operation(
     summary = "Revoke an app-level client secret",
     description =

--- a/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectAppsController.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/v2/controllers/project/ProjectAppsController.kt
@@ -2,6 +2,8 @@ package io.tolgee.api.v2.controllers.project
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import io.tolgee.activity.RequestActivity
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.dtos.apps.ProjectAppView
 import io.tolgee.hateoas.project.apps.ProjectAppModel
 import io.tolgee.hateoas.project.apps.ProjectAppModelAssembler
@@ -73,6 +75,7 @@ class ProjectAppsController(
 
   @PutMapping("/{installId}")
   @RequiresProjectPermissions([Scope.APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_ENABLE_FOR_PROJECT)
   @Operation(
     summary = "Enable app for project",
     description = "Enables the given app install for this project. Idempotent.",
@@ -91,6 +94,7 @@ class ProjectAppsController(
 
   @DeleteMapping("/{installId}")
   @RequiresProjectPermissions([Scope.APPS_MANAGE])
+  @RequestActivity(ActivityType.APP_DISABLE_FOR_PROJECT)
   @Operation(
     summary = "Disable app for project",
     description = "Disables the given app for this project. Idempotent - no-op if it wasn't enabled.",

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppActivityTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppActivityTest.kt
@@ -143,6 +143,7 @@ class AppActivityTest : AuthorizedControllerTest() {
       captor.allValues.firstOrNull { it.eventName == ActivityType.APP_UPDATE.name }
     event.assert.isNotNull
     event!!.data!!["appName"].assert.isEqualTo("Renamed App")
+    event.data!!["appIdentifier"].assert.isEqualTo("test-app")
     (event.data!!["appId"] as String).toLong().assert.isEqualTo(appEntityId("test-app"))
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppActivityTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppActivityTest.kt
@@ -1,0 +1,242 @@
+package io.tolgee.api.v2.controllers.apps
+
+import io.tolgee.activity.data.ActivityType
+import io.tolgee.component.reporting.OnBusinessEventToCaptureEvent
+import io.tolgee.component.reporting.PostHogBusinessEventReporter
+import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.model.activity.ActivityModifiedEntity
+import io.tolgee.model.activity.ActivityRevision
+import io.tolgee.service.apps.AppManifestHttpClient
+import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+
+/**
+ * App audit logging: every audit-worthy app operation records an [ActivityRevision] with the acting
+ * app on it, and a scope re-consent records the granted-scope change old→new.
+ */
+class AppActivityTest : AuthorizedControllerTest() {
+  @MockitoBean
+  @Autowired
+  lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+
+  @MockitoSpyBean
+  @Autowired
+  lateinit var postHogReporter: PostHogBusinessEventReporter
+
+  lateinit var testData: AppsTestData
+  var installId: Long = 0
+  lateinit var appClientId: String
+  lateinit var appClientSecret: String
+
+  @BeforeEach
+  fun setup() {
+    testData = AppsTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit""""))
+
+    val json =
+      objectMapper.readTree(
+        performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL))
+          .andIsOk
+          .andReturn()
+          .response.contentAsString,
+      )
+    installId = json.get("installId").asLong()
+    appClientId = json.get("clientId").asText()
+    appClientSecret = json.get("clientSecret").asText()
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `register stores an org-scoped APP_REGISTER revision`() {
+    val revision = latestRevision(ActivityType.APP_REGISTER)
+    revision.assert.isNotNull
+    revision!!.organizationId.assert.isEqualTo(testData.organization.id)
+    revision.authorId.assert.isEqualTo(testData.user.id)
+  }
+
+  @Test
+  fun `install stores an APP_INSTALL revision`() {
+    mockManifest(manifest(id = "install-app", name = "Install App", scopes = """"translations.view""""))
+    performAuthPost(ownedUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL, "install" to false)).andIsOk
+
+    performAuthPost(appsUrl(), mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL)).andIsOk
+
+    latestRevision(ActivityType.APP_INSTALL).assert.isNotNull
+  }
+
+  @Test
+  fun `enabling an app for a project stores an APP_ENABLE_FOR_PROJECT revision`() {
+    performAuthPut("/v2/projects/${testData.project.id}/apps/$installId", null).andIsOk
+
+    val revision = latestRevision(ActivityType.APP_ENABLE_FOR_PROJECT)
+    revision.assert.isNotNull
+    revision!!.projectId.assert.isEqualTo(testData.project.id)
+  }
+
+  @Test
+  fun `an owner refresh that widens scopes records the granted-scope change old to new`() {
+    mockManifest(manifest(scopes = """"translations.view", "keys.edit", "keys.create""""))
+
+    performAuthPost("${appsUrl()}/$installId/refresh", null).andIsOk
+
+    val revision = latestRevision(ActivityType.APP_UPDATE)
+    revision.assert.isNotNull
+    revision!!.organizationId.assert.isEqualTo(testData.organization.id)
+
+    val modification = latestAppInstallGrantedScopesModification(ActivityType.APP_UPDATE)
+    modification.assert.isNotNull
+    @Suppress("UNCHECKED_CAST")
+    (modification!!.old as List<String>).assert.containsExactlyInAnyOrder("translations.view", "keys.edit")
+    @Suppress("UNCHECKED_CAST")
+    (modification.new as List<String>)
+      .assert
+      .containsExactlyInAnyOrder("translations.view", "keys.edit", "keys.create")
+  }
+
+  @Test
+  fun `an app-self refresh stores an org-scoped revision without an organization holder`() {
+    mockManifest(manifest(scopes = """"translations.view""""))
+
+    asAppToken(post("/v2/apps/self/installations/$installId/refresh")).andIsOk
+
+    val revision = latestRevision(ActivityType.APP_UPDATE)
+    revision.assert.isNotNull
+    revision!!.organizationId.assert.isEqualTo(testData.organization.id)
+    revision.authorId.assert.isNotEqualTo(testData.user.id)
+  }
+
+  @Test
+  fun `the business-event bridge carries the app id and name`() {
+    mockManifest(manifest(name = "Renamed App", scopes = """"translations.view", "keys.edit""""))
+    performAuthPost("${appsUrl()}/$installId/refresh", null).andIsOk
+
+    val captor = argumentCaptor<OnBusinessEventToCaptureEvent>()
+    verify(postHogReporter, atLeastOnce()).capture(captor.capture())
+
+    val event =
+      captor.allValues.firstOrNull { it.eventName == ActivityType.APP_UPDATE.name }
+    event.assert.isNotNull
+    event!!.data!!["appName"].assert.isEqualTo("Renamed App")
+    (event.data!!["appId"] as String).toLong().assert.isEqualTo(appEntityId("test-app"))
+  }
+
+  private fun latestRevision(type: ActivityType): ActivityRevision? =
+    executeInNewTransaction {
+      entityManager
+        .createQuery(
+          "from ActivityRevision ar where ar.type = :type order by ar.id desc",
+          ActivityRevision::class.java,
+        ).setParameter("type", type)
+        .setMaxResults(1)
+        .resultList
+        .firstOrNull()
+    }
+
+  private fun latestAppInstallGrantedScopesModification(type: ActivityType) =
+    executeInNewTransaction {
+      entityManager
+        .createQuery(
+          """
+          from ActivityModifiedEntity ame
+          join ame.activityRevision ar
+          where ar.type = :type and ame.entityClass = 'AppInstall'
+          order by ar.id desc
+          """,
+          ActivityModifiedEntity::class.java,
+        ).setParameter("type", type)
+        .setMaxResults(1)
+        .resultList
+        .firstOrNull()
+        ?.modifications
+        ?.get("grantedScopes")
+    }
+
+  private fun appEntityId(appId: String): Long =
+    executeInNewTransaction {
+      entityManager
+        .createQuery("select a.id from App a where a.appId = :appId", java.lang.Long::class.java)
+        .setParameter("appId", appId)
+        .singleResult
+        .toLong()
+    }
+
+  private fun appsUrl() = "/v2/organizations/${testData.organization.id}/apps"
+
+  private fun ownedUrl() = "/v2/organizations/${testData.organization.id}/owned-apps"
+
+  private fun mockManifest(json: String) = AppsTestFixtures.mockManifest(appManifestHttpClient, json)
+
+  private fun asAppToken(builder: MockHttpServletRequestBuilder): ResultActions {
+    val token = appLevelToken()
+    logout()
+    val result = perform(builder.header(HttpHeaders.AUTHORIZATION, "Bearer $token"))
+    userAccount = testData.user
+    return result
+  }
+
+  private fun appLevelToken(): String {
+    logout()
+    val body =
+      mapOf(
+        "grant_type" to "client_credentials",
+        "client_id" to appClientId,
+        "client_secret" to appClientSecret,
+      )
+    val response =
+      perform(
+        post("/v2/public/apps/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(body)),
+      ).andIsOk.andReturn().response.contentAsString
+    userAccount = testData.user
+    return objectMapper.readTree(response).get("access_token").asText()
+  }
+
+  private fun manifest(
+    id: String = "test-app",
+    name: String = "Test App",
+    version: String = "0.1.0",
+    baseUrl: String = "https://app.example.com",
+    scopes: String,
+  ): String =
+    """
+    {
+      "id": "$id",
+      "name": "$name",
+      "version": "$version",
+      "baseUrl": "$baseUrl",
+      "scopes": [$scopes],
+      "modules": {
+        "project-dashboard-page": [
+          {"key": "home", "title": "Home", "icon": "🏠", "entry": "/"}
+        ]
+      }
+    }
+    """.trimIndent()
+}

--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -268,4 +268,53 @@ class Metrics(
       .description("Time spent refreshing language stats")
       .register(meterRegistry)
   }
+
+  // ==========================================================================
+  // Apps Metrics
+  // ==========================================================================
+
+  fun recordAppRegistered() {
+    Counter
+      .builder("tolgee.apps.registered")
+      .description("Number of apps registered on this server")
+      .register(meterRegistry)
+      .increment()
+  }
+
+  fun recordAppInstalled() {
+    Counter
+      .builder("tolgee.apps.installed")
+      .description("Number of app installations created")
+      .register(meterRegistry)
+      .increment()
+  }
+
+  fun recordAppEnabledForProject() {
+    Counter
+      .builder("tolgee.apps.enabled_for_project")
+      .description("Number of times an app install was enabled for a project")
+      .register(meterRegistry)
+      .increment()
+  }
+
+  fun recordAppTokenMinted() {
+    Counter
+      .builder("tolgee.apps.token_minted")
+      .description("Number of install-scoped access tokens minted for apps")
+      .register(meterRegistry)
+      .increment()
+  }
+
+  fun recordAppLifecycleDelivery(
+    eventType: String,
+    outcome: String,
+  ) {
+    Counter
+      .builder("tolgee.apps.lifecycle_delivery")
+      .tag("event_type", eventType)
+      .tag("outcome", outcome)
+      .description("Outcomes of outbound app lifecycle deliveries")
+      .register(meterRegistry)
+      .increment()
+  }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/activity/data/ActivityType.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/data/ActivityType.kt
@@ -125,4 +125,12 @@ enum class ActivityType(
   BRANCH_MERGE(onlyCountsInList = true, paramsProvider = BranchMergeActivityParamsProvider::class),
   QA_ISSUE_IGNORE,
   QA_ISSUE_UNIGNORE,
+  APP_REGISTER,
+  APP_INSTALL,
+  APP_UNINSTALL,
+  APP_UPDATE(saveWithoutModification = true),
+  APP_ENABLE_FOR_PROJECT(saveWithoutModification = true),
+  APP_DISABLE_FOR_PROJECT(saveWithoutModification = true),
+  APP_SECRET_UPDATE(saveWithoutModification = true),
+  APP_AVAILABILITY_UPDATE(saveWithoutModification = true),
 }

--- a/backend/data/src/main/kotlin/io/tolgee/activity/propChangesProvider/ScopeArrayPropChangesProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/activity/propChangesProvider/ScopeArrayPropChangesProvider.kt
@@ -1,0 +1,37 @@
+package io.tolgee.activity.propChangesProvider
+
+import io.tolgee.activity.data.PropertyModification
+import io.tolgee.model.enums.Scope
+import org.springframework.stereotype.Service
+
+/**
+ * Diffs an `Array<Scope>` field (e.g. [io.tolgee.model.apps.AppInstall.grantedScopes]).
+ * [DefaultPropChangesProvider] compares with `!=`, which is reference equality for arrays and so
+ * reports every flush as a change while never producing a meaningful old→new value; this compares
+ * the scope value sets and records the two sorted lists.
+ */
+@Service
+class ScopeArrayPropChangesProvider : PropChangesProvider {
+  override fun getChanges(
+    old: Any?,
+    new: Any?,
+  ): PropertyModification? {
+    val oldValues = toScopeValues(old)
+    val newValues = toScopeValues(new)
+    if (oldValues == newValues) {
+      return null
+    }
+    return PropertyModification(oldValues, newValues)
+  }
+
+  private fun toScopeValues(value: Any?): List<String>? {
+    val elements =
+      when (value) {
+        null -> return null
+        is Array<*> -> value.asList()
+        is Collection<*> -> value.toList()
+        else -> return null
+      }
+    return elements.mapNotNull { (it as? Scope)?.value }.sorted()
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/App.kt
@@ -1,6 +1,9 @@
 package io.tolgee.model.apps
 
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType
+import io.tolgee.activity.annotation.ActivityIgnoredProp
+import io.tolgee.activity.annotation.ActivityLoggedEntity
+import io.tolgee.activity.annotation.ActivityLoggedProp
 import io.tolgee.model.Organization
 import io.tolgee.model.StandardAuditModel
 import jakarta.persistence.Column
@@ -23,6 +26,7 @@ import java.util.Date
  * every organization that installed it.
  */
 @Entity
+@ActivityLoggedEntity
 @Table(
   name = "app",
   uniqueConstraints = [
@@ -44,13 +48,16 @@ class App : StandardAuditModel() {
   @Column(nullable = false)
   lateinit var manifestUrl: String
 
+  @ActivityLoggedProp
   @Column(nullable = false)
   lateinit var name: String
 
+  @ActivityLoggedProp
   @Column(nullable = false)
   @ColumnDefault("''")
   var version: String = ""
 
+  @ActivityLoggedProp
   @Column(nullable = false)
   lateinit var baseUrl: String
 
@@ -59,6 +66,7 @@ class App : StandardAuditModel() {
   var icon: String? = null
 
   /** The manifest as last read. */
+  @ActivityIgnoredProp
   @Type(JsonBinaryType::class)
   @Column(columnDefinition = "jsonb", nullable = false)
   lateinit var manifestJson: String
@@ -67,6 +75,7 @@ class App : StandardAuditModel() {
    * The scopes the manifest currently requests, comma-joined. Diffed against each install's
    * granted scopes to surface pending permission requests.
    */
+  @ActivityLoggedProp
   @Column(columnDefinition = "TEXT", nullable = false)
   var manifestScopes: String = ""
 
@@ -88,24 +97,32 @@ class App : StandardAuditModel() {
    * Access tokens issued before this moment no longer validate - set when a secret is revoked, so
    * revocation takes effect immediately instead of when the minted tokens expire.
    */
+  @ActivityIgnoredProp
   var tokensInvalidBefore: Date? = null
 
+  @ActivityIgnoredProp
   var manifestLastCheckedAt: Date? = null
 
+  @ActivityIgnoredProp
   @Column(nullable = false)
   @ColumnDefault("0")
   var manifestFailureCount: Int = 0
 
+  @ActivityIgnoredProp
   var manifestFirstFailedAt: Date? = null
 
+  @ActivityIgnoredProp
   @Column(length = 500)
   var manifestLastError: String? = null
 
+  @ActivityIgnoredProp
   @Enumerated(EnumType.STRING)
   @Column(length = 32)
   var manifestLastFailureKind: AppManifestFailureKind? = null
 
+  @ActivityIgnoredProp
   var unhealthySince: Date? = null
 
+  @ActivityIgnoredProp
   var unhealthyNotifiedAt: Date? = null
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppInstall.kt
@@ -1,6 +1,9 @@
 package io.tolgee.model.apps
 
 import io.hypersistence.utils.hibernate.type.array.EnumArrayType
+import io.tolgee.activity.annotation.ActivityLoggedEntity
+import io.tolgee.activity.annotation.ActivityLoggedProp
+import io.tolgee.activity.propChangesProvider.ScopeArrayPropChangesProvider
 import io.tolgee.model.Organization
 import io.tolgee.model.StandardAuditModel
 import io.tolgee.model.UserAccount
@@ -21,6 +24,7 @@ import org.hibernate.annotations.Type
  * lives on the app; the install carries only what is specific to this organization — its consent.
  */
 @Entity
+@ActivityLoggedEntity
 @Table(
   name = "app_install",
   uniqueConstraints = [
@@ -53,6 +57,7 @@ class AppInstall : StandardAuditModel() {
   lateinit var principal: UserAccount
 
   /** What the organization consented to. Requests beyond this show as pending until approved. */
+  @ActivityLoggedProp(modificationProvider = ScopeArrayPropChangesProvider::class)
   @Type(
     EnumArrayType::class,
     parameters = [

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
@@ -1,5 +1,7 @@
 package io.tolgee.model.apps
 
+import io.tolgee.activity.annotation.ActivityLoggedEntity
+import io.tolgee.activity.annotation.ActivityLoggedProp
 import io.tolgee.model.StandardAuditModel
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -16,6 +18,7 @@ import java.util.Date
  * to issuing it; only the hash is stored.
  */
 @Entity
+@ActivityLoggedEntity
 @Table(
   name = "app_secret",
   uniqueConstraints = [
@@ -46,7 +49,9 @@ class AppSecret : StandardAuditModel() {
    * it on the outgoing secret to keep it working through a grace window; past the time the secret
    * is treated as dead wherever it is read — no job touches the row.
    */
+  @ActivityLoggedProp
   var expiresAt: Date? = null
 
+  @ActivityLoggedProp
   var revokedAt: Date? = null
 }

--- a/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/model/apps/AppSecret.kt
@@ -39,6 +39,7 @@ class AppSecret : StandardAuditModel() {
   lateinit var secretHash: String
 
   /** How the secret is identified everywhere it is shown: its start and end, e.g. `tgpubs_ab…yz`. */
+  @ActivityLoggedProp
   @Column(length = 32, nullable = false)
   lateinit var name: String
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppActivityRecorder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppActivityRecorder.kt
@@ -25,6 +25,7 @@ class AppActivityRecorder(
   ) {
     activityType?.let { activityHolder.activity = it }
     activityHolder.businessEventData["appId"] = app.id.toString()
+    activityHolder.businessEventData["appIdentifier"] = app.appId
     activityHolder.businessEventData["appName"] = app.name
     organizationId?.let { activityHolder.activityRevision.organizationId = it }
     projectId?.let { activityHolder.activityRevision.projectId = it }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppActivityRecorder.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppActivityRecorder.kt
@@ -1,0 +1,32 @@
+package io.tolgee.service.apps
+
+import io.tolgee.activity.ActivityHolder
+import io.tolgee.activity.data.ActivityType
+import io.tolgee.model.apps.App
+import org.springframework.stereotype.Component
+
+/**
+ * Carries the acting app onto the request's activity revision: the id and name ride the
+ * activity→business-event bridge to PostHog (see [io.tolgee.activity.ActivityHolder.businessEventData]),
+ * and [organizationId] pre-seeds the revision for paths that have no `OrganizationHolder` (app-auth
+ * and server-admin), where [io.tolgee.activity.iterceptor.ActivityRevisionInitializer] preserves the
+ * value already set. Must run before the operation's transaction commits, since the bridge reads the
+ * data when the revision is stored.
+ */
+@Component
+class AppActivityRecorder(
+  private val activityHolder: ActivityHolder,
+) {
+  fun record(
+    app: App,
+    activityType: ActivityType? = null,
+    organizationId: Long? = null,
+    projectId: Long? = null,
+  ) {
+    activityType?.let { activityHolder.activity = it }
+    activityHolder.businessEventData["appId"] = app.id.toString()
+    activityHolder.businessEventData["appName"] = app.name
+    organizationId?.let { activityHolder.activityRevision.organizationId = it }
+    projectId?.let { activityHolder.activityRevision.projectId = it }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementService.kt
@@ -1,5 +1,7 @@
 package io.tolgee.service.apps
 
+import io.tolgee.Metrics
+import io.tolgee.activity.data.ActivityType
 import io.tolgee.constants.Message
 import io.tolgee.dtos.apps.ProjectAppView
 import io.tolgee.exceptions.NotFoundException
@@ -19,6 +21,8 @@ class AppEnablementService(
   private val appInstallRepository: AppInstallRepository,
   private val appEnablementInserter: AppEnablementInserter,
   private val appAvailabilityService: AppAvailabilityService,
+  private val appActivityRecorder: AppActivityRecorder,
+  private val metrics: Metrics,
 ) {
   @Transactional
   fun enable(
@@ -27,6 +31,8 @@ class AppEnablementService(
   ): AppInstall {
     val orgId = project.organizationOwner.id
     val install = resolveEnableableInstall(orgId, installId)
+    appActivityRecorder.record(install.app, ActivityType.APP_ENABLE_FOR_PROJECT, projectId = project.id)
+    metrics.recordAppEnabledForProject()
 
     if (appEnabledForProjectRepository.findByProjectIdAndAppInstallId(project.id, install.id) == null) {
       try {
@@ -63,6 +69,7 @@ class AppEnablementService(
   ) {
     val existing =
       appEnabledForProjectRepository.findByProjectIdAndAppInstallId(projectId, appInstallId) ?: return
+    appActivityRecorder.record(existing.appInstall.app, ActivityType.APP_DISABLE_FOR_PROJECT, projectId = projectId)
     appEnabledForProjectRepository.delete(existing)
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.apps
 
+import io.tolgee.Metrics
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
@@ -26,6 +27,8 @@ class AppInstallPersister(
   private val appRegisterInserter: AppRegisterInserter,
   private val currentDateProvider: CurrentDateProvider,
   private val entityManager: EntityManager,
+  private val appActivityRecorder: AppActivityRecorder,
+  private val metrics: Metrics,
 ) : Logging {
   /**
    * Registers the app - making [organizationId] its owner - and, when [install] is true, installs it
@@ -47,6 +50,8 @@ class AppInstallPersister(
     appsLimitGuard.checkAppsLimit(organizationId, registersNewApp = true)
     val inserted = appRegisterInserter.insert(organizationId, manifestUrl, fetched)
     val app = inserted.app
+    appActivityRecorder.record(app)
+    metrics.recordAppRegistered()
     if (!install) {
       return AppInstallService.RegisterAppResult(
         app = appService.summarize(app),
@@ -56,6 +61,7 @@ class AppInstallPersister(
       )
     }
     val installEntity = persist(app, organizationId, fetched)
+    metrics.recordAppInstalled()
     return AppInstallService.RegisterAppResult(
       app = appService.summarize(app),
       appEntityId = app.id,
@@ -74,6 +80,8 @@ class AppInstallPersister(
     appsLimitGuard.checkAppsLimit(organizationId, registersNewApp = false)
     val app = entityManager.getReference(App::class.java, appEntityId)
     val install = persist(app, organizationId, fetched)
+    appActivityRecorder.record(install.app)
+    metrics.recordAppInstalled()
     return AppInstallService.RegisterResult(
       install = install,
       app = appService.summarize(app),
@@ -125,7 +133,7 @@ class AppInstallPersister(
     val install =
       appInstallRepository.findByOrganizationIdAndId(organizationId, installId)
         ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
-    return applySnapshot(install, fetched, allowScopeWidening)
+    return applySnapshot(install, fetched, allowScopeWidening, organizationIdSeed = null)
   }
 
   /** The app refreshing one of its own installs. Never widens the granted scopes. */
@@ -138,13 +146,19 @@ class AppInstallPersister(
     val install =
       appInstallRepository.findByAppIdAndId(appEntityId, installId)
         ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
-    return applySnapshot(install, fetched, allowScopeWidening = false)
+    return applySnapshot(
+      install,
+      fetched,
+      allowScopeWidening = false,
+      organizationIdSeed = install.organization.id,
+    )
   }
 
   private fun applySnapshot(
     install: AppInstall,
     fetched: AppManifestFetcher.FetchResult,
     allowScopeWidening: Boolean,
+    organizationIdSeed: Long?,
   ): AppInstall {
     val app = install.app
     if (fetched.manifest.id != app.appId) {
@@ -158,6 +172,7 @@ class AppInstallPersister(
     app.manifestScopes = AppService.joinScopes(fetched.scopes)
     AppService.markManifestHealthy(app, currentDateProvider.date)
     install.grantedScopes = resolveGrantedScopes(install.grantedScopes.toSet(), fetched.scopes, allowScopeWidening)
+    appActivityRecorder.record(app, organizationId = organizationIdSeed)
     return appInstallRepository.save(install)
   }
 
@@ -178,6 +193,7 @@ class AppInstallPersister(
     val install =
       appInstallRepository.findByOrganizationIdAndId(organizationId, installId)
         ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
+    appActivityRecorder.record(install.app)
     val principal = install.principal
     appEnablementService.removeAllForAppInstall(installId)
     appInstallRepository.delete(install)

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppManifestFetcher.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppManifestFetcher.kt
@@ -1,5 +1,7 @@
 package io.tolgee.service.apps
 
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import io.tolgee.configuration.tolgee.AppsProperties
 import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.constants.Message
@@ -19,10 +21,12 @@ class AppManifestFetcher(
   private val appsProperties: AppsProperties,
   private val tolgeeProperties: TolgeeProperties,
 ) {
+  @WithSpan
   fun fetch(url: String): FetchResult {
     urlSecurity.validateUrl(url, allowLocalAddresses = appsProperties.allowLocalAddresses)
     val rawJson = appManifestHttpClient.fetchBody(url)
     val manifest = parseManifest(rawJson)
+    Span.current().setAttribute("app.identifier", manifest.id)
     val iconResolver = AppIconResolver(manifest.icon, manifest.baseUrl)
     AppManifestValidator(manifest, tolgeeProperties, iconResolver).validate()
     return FetchResult(

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretRotationService.kt
@@ -23,6 +23,7 @@ class AppSecretRotationService(
   private val appSecretService: AppSecretService,
   private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
   private val transactionManager: PlatformTransactionManager,
+  private val appActivityRecorder: AppActivityRecorder,
 ) {
   data class RotationResult(
     val issued: AppSecretService.IssueResult,
@@ -59,6 +60,7 @@ class AppSecretRotationService(
     graceSeconds: Long,
   ): Pair<AppSecretService.IssueResult, Date?> =
     executeInNewTransaction(transactionManager) {
+      appActivityRecorder.record(app)
       val issued = appSecretService.issue(app)
       issued to appSecretService.expireOthers(app.id, issued.secret.id, graceSeconds)
     }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
@@ -20,6 +20,7 @@ class AppSecretService(
   private val appSecretRepository: AppSecretRepository,
   private val keyGenerator: KeyGenerator,
   private val currentDateProvider: CurrentDateProvider,
+  private val appActivityRecorder: AppActivityRecorder,
 ) {
   data class IssueResult(
     val secret: AppSecret,
@@ -79,6 +80,7 @@ class AppSecretService(
     val secret =
       appSecretRepository.findByIdAndAppId(secretId, appId)
         ?: throw NotFoundException(Message.APP_SECRET_NOT_FOUND)
+    appActivityRecorder.record(secret.app)
 
     if (force) {
       secret.app.tokensInvalidBefore = currentDateProvider.date

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppTokenGrantService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppTokenGrantService.kt
@@ -1,5 +1,6 @@
 package io.tolgee.service.apps
 
+import io.tolgee.Metrics
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
@@ -11,6 +12,7 @@ class AppTokenGrantService(
   private val appCredentialAuthenticator: AppCredentialAuthenticator,
   private val appInstallService: AppInstallService,
   private val appTokenService: AppTokenService,
+  private val metrics: Metrics,
 ) {
   fun issueFromClientCredentials(
     grantType: String,
@@ -24,12 +26,18 @@ class AppTokenGrantService(
 
     val app = appCredentialAuthenticator.authenticate(clientId, clientSecret)
 
-    if (installId == null) return appTokenService.mintAppLevelToken(app.id)
+    if (installId == null) {
+      val token = appTokenService.mintAppLevelToken(app.id)
+      metrics.recordAppTokenMinted()
+      return token
+    }
 
     val install =
       appInstallService.findOwnInstall(app.id, installId)
         ?: throw NotFoundException(Message.APP_INSTALL_NOT_FOUND)
-    return appTokenService.mintInstallContextToken(install.id)
+    val token = appTokenService.mintInstallContextToken(install.id)
+    metrics.recordAppTokenMinted()
+    return token
   }
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppWebhookSecretService.kt
@@ -28,6 +28,7 @@ class AppWebhookSecretService(
   private val keyGenerator: KeyGenerator,
   private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
   private val transactionManager: PlatformTransactionManager,
+  private val appActivityRecorder: AppActivityRecorder,
 ) {
   data class RotationResult(
     val newSecret: String,
@@ -49,6 +50,7 @@ class AppWebhookSecretService(
           appRepository.findById(appEntityId).orElse(null)
             ?: throw NotFoundException(Message.APP_NOT_FOUND)
 
+        appActivityRecorder.record(app)
         val previous = app.webhookSecret
         val newSecret = keyGenerator.generate(256)
         app.webhookSecret = newSecret

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/lifecycle/AppLifecycleDeliveryService.kt
@@ -1,5 +1,8 @@
 package io.tolgee.service.apps.lifecycle
 
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import io.tolgee.Metrics
 import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.dtos.apps.AppLifecycleAppCredentials
 import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
@@ -38,6 +41,7 @@ class AppLifecycleDeliveryService(
   private val tolgeeProperties: TolgeeProperties,
   private val objectMapper: ObjectMapper,
   private val transactionManager: PlatformTransactionManager,
+  private val metrics: Metrics,
 ) : Logging {
   /**
    * Everything a delivery needs about the app, taken while the app still exists. Read before a
@@ -78,12 +82,18 @@ class AppLifecycleDeliveryService(
     return deliverNow(target, eventType, appCredentials, organizationId)
   }
 
+  @WithSpan
   fun deliverNow(
     target: AppTarget,
     eventType: AppLifecycleEventType,
     appCredentials: AppLifecycleAppCredentials? = null,
     organizationId: Long? = null,
   ): AppLifecycleDeliveryOutcome {
+    val span = Span.current()
+    span.setAttribute("app.id", target.appEntityId)
+    span.setAttribute("app.identifier", target.appIdentifier)
+    span.setAttribute("app.event", eventType.wireName)
+
     val organization = organizationId?.let { organizationRepository.findById(it).orElse(null) }
     val payload =
       AppLifecyclePayload(
@@ -95,13 +105,16 @@ class AppLifecycleDeliveryService(
       )
 
     val url = deliveryUrl(target.baseUrl)
-    return try {
-      httpClient.post(url, objectMapper.writeValueAsString(payload), target.signingSecret)
-      AppLifecycleDeliveryOutcome.DELIVERED
-    } catch (e: AppLifecycleHttpClient.DeliveryFailedException) {
-      logger.info("App lifecycle {} delivery to {} failed: {}", eventType.wireName, url, e.message)
-      AppLifecycleDeliveryOutcome.failed(e.message ?: "delivery failed")
-    }
+    val outcome =
+      try {
+        httpClient.post(url, objectMapper.writeValueAsString(payload), target.signingSecret)
+        AppLifecycleDeliveryOutcome.DELIVERED
+      } catch (e: AppLifecycleHttpClient.DeliveryFailedException) {
+        logger.info("App lifecycle {} delivery to {} failed: {}", eventType.wireName, url, e.message)
+        AppLifecycleDeliveryOutcome.failed(e.message ?: "delivery failed")
+      }
+    metrics.recordAppLifecycleDelivery(eventType.wireName, if (outcome.delivered) "delivered" else "failed")
+    return outcome
   }
 
   companion object {


### PR DESCRIPTION
Slice 7 of 7 — the final slice. Adds **audit logging** for app operations: activity revisions with entity-level change tracking, PostHog attribution via the existing activity bridge, and OTEL metrics. Storage only — **no read API/UI**.

## 1. Activity / audit log
- `@ActivityLoggedEntity` on `App`, `AppInstall`, `AppSecret`. Logged props: `AppInstall.grantedScopes` (the audit-critical one), `App.name`/`version`/`baseUrl`/`manifestScopes`, `AppSecret.revokedAt`/`expiresAt`. Churny manifest-health/timestamp fields are `@ActivityIgnoredProp` so they don't create noise revisions.
- **`grantedScopes` is `Array<Scope>`** — a custom `ScopeArrayPropChangesProvider` diffs it by sorted scope-value set (the default provider compares arrays by reference and never yields a meaningful old→new). A re-consent records `[view,edit] → [view,edit,create]`.
- New `ActivityType`s: `APP_REGISTER`, `APP_INSTALL`, `APP_UNINSTALL`, `APP_UPDATE`, `APP_ENABLE_FOR_PROJECT`, `APP_DISABLE_FOR_PROJECT`, `APP_SECRET_UPDATE`, `APP_AVAILABILITY_UPDATE`. The ones whose operation doesn't dirty a logged prop (enable/disable touch `AppEnabledForProject`; availability uses a native insert; secret ops) carry `saveWithoutModification = true`.
- Set via `@RequestActivity(...)` on the owner/project/self/admin endpoints. App-self refresh has no `OrganizationHolder`, so `AppActivityRecorder` pre-seeds `activityRevision.organizationId` (`ActivityRevisionInitializer` preserves it) → the revision is org-scoped.

## 2. PostHog (via the activity bridge, no manual publish)
`AppActivityRecorder` sets `ActivityHolder.businessEventData["appId"/"appName"]` before the operation's transaction commits; `InterceptedEventsManager` carries it into `OnProjectActivityEvent` → `BusinessEventReportingActivityListener` → PostHog. So each app op's PostHog event is named after the `ActivityType` and carries the app id + name — no duplicate/manual event.

## 3. OTEL
`Metrics.kt`: `tolgee.apps.*` counters — `recordAppRegistered`, `recordAppInstalled`, `recordAppEnabledForProject`, `recordAppTokenMinted`, `recordAppLifecycleDelivery(eventType, outcome)`. `@WithSpan` on `AppManifestFetcher.fetch` and `AppLifecycleDeliveryService.deliverNow` with `app.*` span attributes.

## Scope
No read/list API. `AppEnabledForProject`/`AppAvailability` are deliberately not logged entities (avoids capturing cascade-cleanup deletes as unrelated revisions) — their audit rides `saveWithoutModification` + a seeded project/org.

## Tests
`AppActivityTest` (6): APP_REGISTER org-scoped, APP_INSTALL, APP_ENABLE_FOR_PROJECT (projectId set), owner refresh records grantedScopes old→new, app-self refresh stores an org-scoped revision without an OrganizationHolder, businessEventData carries appId/appName. Existing apps suites stay green.

## Note for reviewers
An app-level token authenticates as `syntheticAppPrincipal(appId)`, so an app-self action's `authorId` is the app's entity id (not null) — the bridge fires for app-self actions attributed to that synthetic id. The test asserts the org-scoping guarantee (the load-bearing behavior).