### PR TITLE
perf: cache the per-request app enablement check

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/service/apps/AppEnablementCacheTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/service/apps/AppEnablementCacheTest.kt
@@ -1,0 +1,98 @@
+package io.tolgee.service.apps
+
+import io.tolgee.AbstractSpringTest
+import io.tolgee.development.testDataBuilder.data.AppsWithInstallsTestData
+import io.tolgee.repository.apps.AppEnabledForProjectRepository
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+
+@SpringBootTest(
+  properties = [
+    "tolgee.cache.enabled=true",
+  ],
+)
+class AppEnablementCacheTest : AbstractSpringTest() {
+  @MockitoSpyBean
+  @Autowired
+  private lateinit var appEnabledForProjectRepository: AppEnabledForProjectRepository
+
+  @Autowired
+  private lateinit var appEnablementService: AppEnablementService
+
+  @MockitoBean
+  @Autowired
+  private lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  private lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
+
+  private lateinit var testData: AppsWithInstallsTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = AppsWithInstallsTestData()
+    testDataService.saveTestData(testData.root)
+    clearCaches()
+    Mockito.reset(appEnabledForProjectRepository)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `serves the enablement check from cache on the second call`() {
+    val projectId = testData.projectBuilder.self.id
+    val installId = testData.enabledInstall.id
+
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(true)
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(true)
+
+    verify(appEnabledForProjectRepository, times(1)).findEnabledProjectIdsByInstallId(installId)
+  }
+
+  @Test
+  fun `disable evicts so the check does not read stale as enabled`() {
+    val projectId = testData.projectBuilder.self.id
+    val installId = testData.enabledInstall.id
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(true)
+
+    appEnablementService.disable(projectId, installId)
+
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(false)
+  }
+
+  @Test
+  fun `uninstall evicts so the check does not read stale as enabled`() {
+    val projectId = testData.projectBuilder.self.id
+    val installId = testData.enabledInstall.id
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(true)
+
+    appEnablementService.removeAllForAppInstall(installId)
+
+    appEnablementService.isEnabledForProject(projectId, installId).assert.isEqualTo(false)
+  }
+
+  @Test
+  fun `enable evicts the negative entry so the check reads enabled immediately`() {
+    val siblingProject = testData.siblingProject
+    val installId = testData.enabledInstall.id
+    appEnablementService.isEnabledForProject(siblingProject.id, installId).assert.isEqualTo(false)
+
+    appEnablementService.enable(siblingProject, installId)
+
+    appEnablementService.isEnabledForProject(siblingProject.id, installId).assert.isEqualTo(true)
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
@@ -21,6 +21,7 @@ interface Caches {
     const val SSO_TENANTS = "ssoTenants"
     const val LLM_PROVIDERS = "llmProviders"
     const val LANGUAGE_TOOL_RESULTS = "languageToolResults"
+    const val APP_ENABLEMENTS = "appEnablements"
 
     const val EE_LAST_REPORTED_USAGE = "eeLastReportedUsage"
   }

--- a/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/repository/apps/AppEnabledForProjectRepository.kt
@@ -49,6 +49,11 @@ interface AppEnabledForProjectRepository : JpaRepository<AppEnabledForProject, L
     pageable: Pageable,
   ): Page<Project>
 
+  @Query("select e.project.id from AppEnabledForProject e where e.appInstall.id = :appInstallId")
+  fun findEnabledProjectIdsByInstallId(
+    @Param("appInstallId") appInstallId: Long,
+  ): List<Long>
+
   fun deleteByAppInstallId(appInstallId: Long)
 
   fun deleteByProjectId(projectId: Long)

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementCache.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementCache.kt
@@ -1,0 +1,24 @@
+package io.tolgee.service.apps
+
+import io.tolgee.constants.Caches
+import io.tolgee.repository.apps.AppEnabledForProjectRepository
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class AppEnablementCache(
+  private val appEnabledForProjectRepository: AppEnabledForProjectRepository,
+) {
+  @Cacheable(cacheNames = [Caches.APP_ENABLEMENTS], key = "#appInstallId")
+  @Transactional(readOnly = true)
+  fun getEnabledProjectIds(appInstallId: Long): Set<Long> =
+    appEnabledForProjectRepository.findEnabledProjectIdsByInstallId(appInstallId).toSet()
+
+  @CacheEvict(cacheNames = [Caches.APP_ENABLEMENTS], key = "#appInstallId")
+  fun evict(appInstallId: Long) {}
+
+  @CacheEvict(cacheNames = [Caches.APP_ENABLEMENTS], allEntries = true)
+  fun evictAll() {}
+}

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppEnablementService.kt
@@ -22,6 +22,7 @@ class AppEnablementService(
   private val appEnablementInserter: AppEnablementInserter,
   private val appAvailabilityService: AppAvailabilityService,
   private val appActivityRecorder: AppActivityRecorder,
+  private val appEnablementCache: AppEnablementCache,
   private val metrics: Metrics,
 ) {
   @Transactional
@@ -45,6 +46,7 @@ class AppEnablementService(
       }
     }
 
+    appEnablementCache.evict(install.id)
     return install
   }
 
@@ -71,6 +73,7 @@ class AppEnablementService(
       appEnabledForProjectRepository.findByProjectIdAndAppInstallId(projectId, appInstallId) ?: return
     appActivityRecorder.record(existing.appInstall.app, ActivityType.APP_DISABLE_FOR_PROJECT, projectId = projectId)
     appEnabledForProjectRepository.delete(existing)
+    appEnablementCache.evict(appInstallId)
   }
 
   @Transactional(readOnly = true)
@@ -107,21 +110,24 @@ class AppEnablementService(
     return appEnabledForProjectRepository.findEnabledProjectsByAppInstallId(appInstallId, pageable)
   }
 
-  @Transactional(readOnly = true)
   fun isEnabledForProject(
     projectId: Long,
     appInstallId: Long,
   ): Boolean {
-    return appEnabledForProjectRepository.findByProjectIdAndAppInstallId(projectId, appInstallId) != null
+    return projectId in appEnablementCache.getEnabledProjectIds(appInstallId)
   }
 
   @Transactional
   fun removeAllForAppInstall(appInstallId: Long) {
     appEnabledForProjectRepository.deleteByAppInstallId(appInstallId)
+    appEnablementCache.evict(appInstallId)
   }
 
   @Transactional
   fun removeAllForProject(projectId: Long) {
     appEnabledForProjectRepository.deleteByProjectId(projectId)
+    // A project delete touches many installs' enabled-project sets; per-install eviction would need an
+    // extra query and project deletion is rare, so evict every entry.
+    appEnablementCache.evictAll()
   }
 }


### PR DESCRIPTION
First of the app-auth caching follow-ups (see the hot-path analysis). Every project-scoped app request runs `AppEnablementService.isEnabledForProject` → a DB query; this caches it.

## What
- New cache `Caches.APP_ENABLEMENTS`, keyed **`installId → Set<enabled projectId>`**, so the per-request check is a set-contains and an uninstall evicts a single key. Created on-demand under the uniform default TTL.
- `AppEnablementCache` is a **separate bean** (so the `@Cacheable` call isn't a self-invocation bypass) exposing `getEnabledProjectIds(installId)` + `evict(installId)` + `evictAll()`.
- `isEnabledForProject(projectId, installId)` → `projectId in appEnablementCache.getEnabledProjectIds(installId)`.

## Eviction (the correctness-critical part)
All evicts live **inside the existing `@Transactional` methods**, so the `TransactionAwareCacheManagerProxy` defers them to commit (a rolled-back change never evicts):
- `enable` → evict the install (new project shows up; also clears a stale negative entry).
- `disable` → evict the install.
- `removeAllForAppInstall` (uninstall) → evict the install.
- `removeAllForProject` (project delete, rare) → `evictAll()` — it touches many installs' sets; per-install eviction would need an extra query.

Missing an evict on enable/disable/uninstall would let a disabled or uninstalled app keep project access from a stale entry — so the tests pin exactly that.

## Tests
`AppEnablementCacheTest` (cache enabled via `tolgee.cache.enabled=true`, repository spied):
1. the check is served from cache on the second call (DB hit once);
2. **disable evicts** — no stale "enabled";
3. **uninstall evicts** — no stale "enabled";
4. **enable evicts the negative entry** — reads enabled immediately.
Existing `ProjectAppsControllerTest`, `AppTokenAuthorizationTest`, `AppRefreshTest` stay green.

## Scope
Item 1 only. Caching `App`/`AppInstall` (incl. the force-revoke eviction) needs the `AppAuthentication`/binder DTO refactor and is a separate follow-up.