### PR TITLE
perf: cache App and AppInstall on the app-auth path (auth-cache items 2 & 3)

### DIFF
--- a/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppAuthCacheTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/api/v2/controllers/apps/AppAuthCacheTest.kt
@@ -1,0 +1,228 @@
+package io.tolgee.api.v2.controllers.apps
+
+import io.tolgee.constants.Caches
+import io.tolgee.development.testDataBuilder.data.AppsTestData
+import io.tolgee.dtos.cacheable.AppDto
+import io.tolgee.dtos.cacheable.AppInstallDto
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.service.apps.AppManifestHttpClient
+import io.tolgee.service.apps.AppsTestFixtures
+import io.tolgee.service.apps.lifecycle.AppLifecycleHttpClient
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.Duration
+
+/**
+ * The app-auth caches must never outlive the security decision they cache: a force-revoke, an
+ * uninstall, or a scope reduction has to take effect on the very next request, not two hours later.
+ * These run with the cache on so a missed eviction is a red test.
+ */
+@ContextRecreatingTest
+@SpringBootTest(
+  properties = [
+    "tolgee.cache.enabled=true",
+  ],
+)
+@AutoConfigureMockMvc
+class AppAuthCacheTest : AuthorizedControllerTest() {
+  @MockitoBean
+  @Autowired
+  lateinit var appManifestHttpClient: AppManifestHttpClient
+
+  @MockitoBean
+  @Autowired
+  lateinit var appLifecycleHttpClient: AppLifecycleHttpClient
+
+  lateinit var testData: AppsTestData
+  lateinit var appClientId: String
+  lateinit var appClientSecret: String
+  var appEntityId: Long = 0
+  var installId: Long = 0
+
+  @BeforeEach
+  fun setup() {
+    testData = AppsTestData()
+    testDataService.saveTestData(testData.root)
+    userAccount = testData.user
+    AppsTestFixtures.mockManifest(appManifestHttpClient, manifest(""""translations.view""""))
+
+    val json = objectMapper.readTree(register())
+    installId = json.get("installId").asLong()
+    appEntityId = json.get("id").asLong()
+    appClientId = json.get("clientId").asText()
+    appClientSecret = json.get("clientSecret").asText()
+
+    performAuthPut("/v2/projects/${testData.project.id}/apps/$installId", null).andIsOk
+
+    clearCaches()
+  }
+
+  @AfterEach
+  fun cleanup() {
+    currentDateProvider.forcedDate = null
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `force-revoke kills already-minted app and install tokens on the next request`() {
+    val installToken = mintInstallToken()
+    val appLevelToken = mintAppLevelToken()
+
+    translationsWith(installToken).andIsOk
+    installationsWith(appLevelToken).andIsOk
+
+    // Both requests loaded the app snapshot into the APPS cache with no cutoff.
+    (cachedApp()!!.tokensInvalidBefore).assert.isNull()
+
+    issueSecret()
+    currentDateProvider.move(Duration.ofSeconds(2))
+    forceRevoke(firstSecretId())
+
+    cachedApp().assert.isNull()
+
+    translationsWith(installToken).andExpect(status().isUnauthorized)
+    installationsWith(appLevelToken).andExpect(status().isUnauthorized)
+  }
+
+  @Test
+  fun `uninstall stops an already-minted install token on the next request`() {
+    val installToken = mintInstallToken()
+    translationsWith(installToken).andIsOk
+    cachedInstall().assert.isNotNull
+
+    loginAsUser()
+    performAuthDelete("/v2/organizations/${testData.organization.id}/apps/$installId").andIsOk
+
+    cachedInstall().assert.isNull()
+
+    translationsWith(installToken).andExpect(status().isUnauthorized)
+  }
+
+  @Test
+  fun `an owner refresh that drops a scope is enforced on the next request`() {
+    val installToken = mintInstallToken()
+    translationsWith(installToken).andIsOk
+    cachedInstall()!!
+      .grantedScopes
+      .map { it.value }
+      .assert
+      .containsExactly("translations.view")
+
+    AppsTestFixtures.mockManifest(appManifestHttpClient, manifest(""""activity.view""""))
+    loginAsUser()
+    performAuthPost("/v2/organizations/${testData.organization.id}/apps/$installId/refresh", null).andIsOk
+
+    cachedInstall().assert.isNull()
+
+    translationsWith(installToken).andExpect(status().isForbidden)
+  }
+
+  private fun cachedApp(): AppDto? = cacheManager.getCache(Caches.APPS)!!.get(appEntityId)?.get() as AppDto?
+
+  private fun cachedInstall(): AppInstallDto? =
+    cacheManager.getCache(Caches.APP_INSTALLS)!!.get(installId)?.get() as AppInstallDto?
+
+  private fun register(): String =
+    performAuthPost(
+      "/v2/organizations/${testData.organization.id}/owned-apps",
+      mapOf("manifestUrl" to AppsTestFixtures.MANIFEST_URL),
+    ).andIsOk.andReturn().response.contentAsString
+
+  private fun mintInstallToken(): String = mintToken(installId)
+
+  private fun mintAppLevelToken(): String = mintToken(null)
+
+  private fun mintToken(installId: Long?): String {
+    logout()
+    val body =
+      mutableMapOf<String, Any>(
+        "grant_type" to "client_credentials",
+        "client_id" to appClientId,
+        "client_secret" to appClientSecret,
+      )
+    installId?.let { body["install_id"] = it }
+    val response =
+      perform(
+        post("/v2/public/apps/token")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(objectMapper.writeValueAsString(body)),
+      ).andIsOk.andReturn().response.contentAsString
+    userAccount = testData.user
+    return objectMapper.readTree(response).get("access_token").asText()
+  }
+
+  private fun issueSecret() {
+    loginAsUser()
+    performAuthPost(
+      "/v2/organizations/${testData.organization.id}/owned-apps/$appEntityId/secrets/rotate",
+      mapOf("graceSeconds" to 86_400L),
+    ).andIsOk
+  }
+
+  private fun firstSecretId(): Long {
+    loginAsUser()
+    val response =
+      performAuthGet("/v2/organizations/${testData.organization.id}/owned-apps/$appEntityId/secrets")
+        .andIsOk
+        .andReturn()
+        .response.contentAsString
+    val secrets = objectMapper.readTree(response).get("_embedded").get("appSecrets")
+    return secrets.minByOrNull { it.get("createdAt").asLong() }!!.get("id").asLong()
+  }
+
+  private fun forceRevoke(secretId: Long) {
+    loginAsUser()
+    performAuthDelete(
+      "/v2/organizations/${testData.organization.id}/owned-apps/$appEntityId/secrets/$secretId?force=true",
+    ).andIsOk
+  }
+
+  private fun loginAsUser() {
+    userAccount = testData.user
+  }
+
+  private fun translationsWith(token: String): ResultActions {
+    logout()
+    return perform(
+      get("/v2/projects/${testData.project.id}/translations")
+        .header(HttpHeaders.AUTHORIZATION, "Bearer $token"),
+    )
+  }
+
+  private fun installationsWith(token: String): ResultActions {
+    logout()
+    return perform(
+      get("/v2/apps/self/installations").header(HttpHeaders.AUTHORIZATION, "Bearer $token"),
+    )
+  }
+
+  private fun manifest(scopes: String): String =
+    """
+    {
+      "id": "test-app",
+      "name": "Test App",
+      "version": "0.1.0",
+      "baseUrl": "https://app.example.com",
+      "scopes": [$scopes],
+      "modules": {
+        "project-dashboard-page": [
+          {"key": "home", "title": "Home", "icon": "🏠", "entry": "/"}
+        ]
+      }
+    }
+    """.trimIndent()
+}

--- a/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/constants/Caches.kt
@@ -22,6 +22,9 @@ interface Caches {
     const val LLM_PROVIDERS = "llmProviders"
     const val LANGUAGE_TOOL_RESULTS = "languageToolResults"
 
+    const val APPS = "apps"
+    const val APP_INSTALLS = "appInstalls"
+
     const val EE_LAST_REPORTED_USAGE = "eeLastReportedUsage"
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/cacheable/AppDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/cacheable/AppDto.kt
@@ -1,0 +1,21 @@
+package io.tolgee.dtos.cacheable
+
+import io.tolgee.model.apps.App
+import java.io.Serializable
+
+/**
+ * The app-auth view of an [App]: only the force-revoke cutoff the token check needs. Kept minimal so
+ * a manifest refresh, which never touches [App.tokensInvalidBefore], does not have to evict it.
+ */
+data class AppDto(
+  val id: Long,
+  val tokensInvalidBefore: Long?,
+) : Serializable {
+  companion object {
+    fun fromEntity(app: App): AppDto =
+      AppDto(
+        id = app.id,
+        tokensInvalidBefore = app.tokensInvalidBefore?.time,
+      )
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/dtos/cacheable/AppInstallDto.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/dtos/cacheable/AppInstallDto.kt
@@ -1,0 +1,28 @@
+package io.tolgee.dtos.cacheable
+
+import io.tolgee.model.apps.AppInstall
+import io.tolgee.model.enums.Scope
+import java.io.Serializable
+
+/**
+ * The app-auth view of an [AppInstall]. Refers to the app by id ([appEntityId]) rather than
+ * embedding it, so a force-revoke evicts only the one app snapshot, not every install of it.
+ */
+data class AppInstallDto(
+  val id: Long,
+  val appEntityId: Long,
+  val organizationId: Long,
+  val principalUserId: Long,
+  val grantedScopes: Array<Scope>,
+) : Serializable {
+  companion object {
+    fun fromEntity(install: AppInstall): AppInstallDto =
+      AppInstallDto(
+        id = install.id,
+        appEntityId = install.app.id,
+        organizationId = install.organization.id,
+        principalUserId = install.principal.id,
+        grantedScopes = install.grantedScopes,
+      )
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/security/authentication/AppAuthentication.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/security/authentication/AppAuthentication.kt
@@ -1,13 +1,13 @@
 package io.tolgee.security.authentication
 
+import io.tolgee.dtos.cacheable.AppInstallDto
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.model.UserAccount
-import io.tolgee.model.apps.AppInstall
 
 class AppAuthentication(
   credentials: Any?,
   userAccount: UserAccountDto,
-  private val appInstallOrNull: AppInstall?,
+  private val appInstallOrNull: AppInstallDto?,
   val appId: Long,
   val isInstallContext: Boolean,
   isReadOnly: Boolean,
@@ -25,7 +25,7 @@ class AppAuthentication(
   val isAppLevel: Boolean
     get() = appInstallOrNull == null
 
-  val appInstall: AppInstall
+  val appInstall: AppInstallDto
     get() = appInstallOrNull ?: throw IllegalStateException("An app-level token is not bound to an install")
 
   companion object {

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallPersister.kt
@@ -2,6 +2,7 @@ package io.tolgee.service.apps
 
 import io.tolgee.Metrics
 import io.tolgee.component.CurrentDateProvider
+import io.tolgee.constants.Caches
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
@@ -13,6 +14,7 @@ import io.tolgee.repository.apps.AppInstallRepository
 import io.tolgee.util.Logging
 import io.tolgee.util.logger
 import jakarta.persistence.EntityManager
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -124,6 +126,7 @@ class AppInstallPersister(
    * install to the acting organization.
    */
   @Transactional
+  @CacheEvict(cacheNames = [Caches.APP_INSTALLS], key = "#installId")
   fun applySnapshotForOrgInstall(
     organizationId: Long,
     installId: Long,
@@ -138,6 +141,7 @@ class AppInstallPersister(
 
   /** The app refreshing one of its own installs. Never widens the granted scopes. */
   @Transactional
+  @CacheEvict(cacheNames = [Caches.APP_INSTALLS], key = "#installId")
   fun applySnapshotForApp(
     appEntityId: Long,
     installId: Long,
@@ -186,6 +190,7 @@ class AppInstallPersister(
   }
 
   @Transactional
+  @CacheEvict(cacheNames = [Caches.APP_INSTALLS], key = "#installId")
   fun remove(
     organizationId: Long,
     installId: Long,

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppInstallService.kt
@@ -1,19 +1,24 @@
 package io.tolgee.service.apps
 
+import io.tolgee.constants.Caches
 import io.tolgee.constants.Message
 import io.tolgee.dtos.apps.AppLifecycleAppCredentials
 import io.tolgee.dtos.apps.AppLifecycleDeliveryOutcome
+import io.tolgee.dtos.cacheable.AppDto
+import io.tolgee.dtos.cacheable.AppInstallDto
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
 import io.tolgee.exceptions.PermissionException
 import io.tolgee.model.Organization
-import io.tolgee.model.apps.App
 import io.tolgee.model.apps.AppInstall
 import io.tolgee.model.apps.AppLifecycleEventType
 import io.tolgee.repository.apps.AppInstallRepository
 import io.tolgee.service.apps.lifecycle.AppLifecycleDeliveryService
+import io.tolgee.service.security.UserAccountService
 import org.apache.commons.codec.digest.DigestUtils
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.context.annotation.Lazy
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,6 +36,9 @@ class AppInstallService(
   private val appService: AppService,
   private val appAvailabilityService: AppAvailabilityService,
   private val appLifecycleDeliveryService: AppLifecycleDeliveryService,
+  private val userAccountService: UserAccountService,
+  @Lazy
+  private val self: AppInstallService,
 ) {
   data class RegisterResult(
     val install: AppInstall,
@@ -214,19 +222,20 @@ class AppInstallService(
     return appInstallRepository.findByOrganizationIdAndId(organizationId, installId)
   }
 
+  @Cacheable(cacheNames = [Caches.APP_INSTALLS], key = "#installId")
   @Transactional(readOnly = true)
-  fun findForAppAuth(installId: Long): AppInstall? {
-    return appInstallRepository.findWithAppById(installId)
+  fun findForAppAuth(installId: Long): AppInstallDto? {
+    return appInstallRepository.findWithAppById(installId)?.let { AppInstallDto.fromEntity(it) }
   }
 
-  @Transactional(readOnly = true)
   fun resolveForAppAuth(installId: Long): AppAuthResolution? {
-    val install = appInstallRepository.findWithAppById(installId) ?: return null
-    return AppAuthResolution(install, UserAccountDto.fromEntity(install.principal))
+    val install = self.findForAppAuth(installId) ?: return null
+    val principal = userAccountService.findDto(install.principalUserId) ?: return null
+    return AppAuthResolution(install, principal)
   }
 
   data class AppAuthResolution(
-    val install: AppInstall,
+    val install: AppInstallDto,
     val principal: UserAccountDto,
   )
 
@@ -245,8 +254,9 @@ class AppInstallService(
     return install
   }
 
+  @Cacheable(cacheNames = [Caches.APPS], key = "#appEntityId")
   @Transactional(readOnly = true)
-  fun findAppForAppAuth(appEntityId: Long): App? {
-    return appService.findForAppAuth(appEntityId)
+  fun findAppForAppAuth(appEntityId: Long): AppDto? {
+    return appService.findForAppAuth(appEntityId)?.let { AppDto.fromEntity(it) }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppOwnerRemovalService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppOwnerRemovalService.kt
@@ -1,10 +1,12 @@
 package io.tolgee.service.apps
 
+import io.tolgee.constants.Caches
 import io.tolgee.repository.apps.AppInstallRepository
 import io.tolgee.repository.apps.AppRepository
 import io.tolgee.util.Logging
 import io.tolgee.util.executeInNewTransaction
 import io.tolgee.util.logger
+import org.springframework.cache.CacheManager
 import org.springframework.stereotype.Service
 import org.springframework.transaction.PlatformTransactionManager
 
@@ -24,6 +26,7 @@ class AppOwnerRemovalService(
   private val appAvailabilityService: AppAvailabilityService,
   private val appInstallPrincipalService: AppInstallPrincipalService,
   private val transactionManager: PlatformTransactionManager,
+  private val cacheManager: CacheManager,
 ) : Logging {
   fun removeEverywhere(appEntityId: Long) {
     val count = executeInNewTransaction(transactionManager) { purge(appEntityId) }
@@ -47,6 +50,10 @@ class AppOwnerRemovalService(
     appRepository.deleteById(appEntityId)
     appRepository.flush()
     principals.forEach { appInstallPrincipalService.retire(it) }
+
+    val appInstallsCache = cacheManager.getCache(Caches.APP_INSTALLS)
+    installs.forEach { appInstallsCache?.evict(it.id) }
+    cacheManager.getCache(Caches.APPS)?.evict(appEntityId)
 
     return installs.size
   }

--- a/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/service/apps/AppSecretService.kt
@@ -2,6 +2,7 @@ package io.tolgee.service.apps
 
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.KeyGenerator
+import io.tolgee.constants.Caches
 import io.tolgee.constants.Message
 import io.tolgee.exceptions.BadRequestException
 import io.tolgee.exceptions.NotFoundException
@@ -10,6 +11,7 @@ import io.tolgee.model.apps.AppSecret
 import io.tolgee.repository.apps.AppSecretRepository
 import io.tolgee.util.constantTimeEquals
 import io.tolgee.util.runSentryCatching
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -72,6 +74,7 @@ class AppSecretService(
   }
 
   @Transactional
+  @CacheEvict(cacheNames = [Caches.APPS], key = "#appId", condition = "#force")
   fun revoke(
     appId: Long,
     secretId: Long,

--- a/backend/security/src/main/kotlin/io/tolgee/security/AppProjectContextBinder.kt
+++ b/backend/security/src/main/kotlin/io/tolgee/security/AppProjectContextBinder.kt
@@ -37,7 +37,7 @@ class AppProjectContextBinder(
     project: ProjectDto,
   ): Boolean {
     if (appAuth.isInstallContext) return false
-    if (project.organizationOwnerId != appAuth.appInstall.organization.id) return false
+    if (project.organizationOwnerId != appAuth.appInstall.organizationId) return false
     return !permissionService.getProjectPermissionScopesNoApiKey(project.id, appAuth.principal.id).isNullOrEmpty()
   }
 

--- a/backend/security/src/main/kotlin/io/tolgee/security/authentication/AppTokenAuthenticator.kt
+++ b/backend/security/src/main/kotlin/io/tolgee/security/authentication/AppTokenAuthenticator.kt
@@ -18,10 +18,10 @@ package io.tolgee.security.authentication
 
 import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.constants.Message
+import io.tolgee.dtos.cacheable.AppDto
 import io.tolgee.dtos.cacheable.UserAccountDto
 import io.tolgee.exceptions.AuthExpiredException
 import io.tolgee.exceptions.AuthenticationException
-import io.tolgee.model.apps.App
 import io.tolgee.service.apps.AppInstallService
 import io.tolgee.service.security.UserAccountService
 import io.tolgee.util.toWholeSeconds
@@ -89,14 +89,14 @@ class AppTokenAuthenticator(
       appInstallService.findForAppAuth(claims.installId!!)
         ?: throw AuthenticationException(Message.INVALID_JWT_TOKEN)
 
-    checkAppTokenCutoff(install.app, claims)
+    checkAppTokenCutoff(requireApp(install.appEntityId), claims)
 
     val user = resolveAppTokenUser(claims.userId!!, claims)
 
     return AppAuthentication(
       credentials = token,
       appInstallOrNull = install,
-      appId = install.app.id,
+      appId = install.appEntityId,
       userAccount = user,
       isInstallContext = false,
       isReadOnly = claims.isReadOnly,
@@ -112,12 +112,12 @@ class AppTokenAuthenticator(
       appInstallService.resolveForAppAuth(claims.installId!!)
         ?: throw AuthenticationException(Message.INVALID_JWT_TOKEN)
 
-    checkAppTokenCutoff(resolution.install.app, claims)
+    checkAppTokenCutoff(requireApp(resolution.install.appEntityId), claims)
 
     return AppAuthentication(
       credentials = token,
       appInstallOrNull = resolution.install,
-      appId = resolution.install.app.id,
+      appId = resolution.install.appEntityId,
       userAccount = resolution.principal,
       isInstallContext = true,
       isReadOnly = claims.isReadOnly,
@@ -125,14 +125,19 @@ class AppTokenAuthenticator(
     )
   }
 
+  private fun requireApp(appEntityId: Long): AppDto {
+    return appInstallService.findAppForAppAuth(appEntityId)
+      ?: throw AuthenticationException(Message.INVALID_JWT_TOKEN)
+  }
+
   private fun checkAppTokenCutoff(
-    app: App,
+    app: AppDto,
     claims: AppTokenClaims,
   ) {
     val cutoff = app.tokensInvalidBefore ?: return
     // Compare at whole seconds: a JWT `iat` is second-precision, so a token minted in the same second
     // as the cutoff would otherwise read as older than it and be wrongly rejected.
-    if (claims.issuedAt.toWholeSeconds() < cutoff.toWholeSeconds()) {
+    if (claims.issuedAt.toWholeSeconds() < cutoff / 1000L) {
       throw AuthExpiredException(Message.EXPIRED_JWT_TOKEN)
     }
   }


### PR DESCRIPTION
The second app-auth caching follow-up (items 2 & 3 of the hot-path analysis). Moves the per-request app-auth loads off JPA entities onto cacheable DTOs, so an app request doesn't reload the App and AppInstall every time. **Security-preserving: the force-revoke kill switch still stops tokens immediately.**

## DTOs (serializable, `io.tolgee.dtos.cacheable`)
- `AppDto(id, tokensInvalidBefore: Long?)` — deliberately minimal, so a manifest refresh (which never touches `tokensInvalidBefore`) needs no `APPS` eviction.
- `AppInstallDto(id, appEntityId, organizationId, principalUserId, grantedScopes: Array<Scope>)` — refers to the app by id, so a force-revoke touches only the one app snapshot.

## What's cached
`AppInstallService.findForAppAuth` → `@Cacheable(APP_INSTALLS, key=installId)`; `findAppForAppAuth` → `@Cacheable(APPS, key=appEntityId)`. `resolveForAppAuth` composes the cached install DTO (via `@Lazy self` so the proxy isn't bypassed) with the already-cached `userAccountService.findDto(principalUserId)` — zero queries when warm. `AppAuthentication` now holds `AppInstallDto`; `AppTokenAuthenticator`/`AppProjectContextBinder`/`SecurityService` read DTO fields; `checkAppTokenCutoff(AppDto)` keeps the whole-second `iat` comparison.

## Eviction (all inside the existing `@Transactional` methods → deferred to commit)
- **`AppSecretService.revoke` → `@CacheEvict(APPS, key="#appId", condition="#force")`** — the force-revoke kill switch. Non-force revoke doesn't change the AppDto, so the condition scopes it exactly.
- `AppInstallPersister.remove` → evict `APP_INSTALLS[installId]` (uninstall).
- `AppInstallPersister.applySnapshotForOrgInstall` / `applySnapshotForApp` → evict `APP_INSTALLS[installId]` (owner re-consent and app self-refresh both reduce `grantedScopes`; a stale wider set would be a hole).
- `AppOwnerRemovalService` → evict each removed install from `APP_INSTALLS` + the app from `APPS`.
- enable/disable untouched (that's the separate enablement cache).

## Tests
`AppAuthCacheTest` (cache enabled via `tolgee.cache.enabled=true`), all pass:
1. **force-revoke kills immediately** — app-level + install tokens authenticate, then a force-revoke evicts `APPS[appId]` and both tokens get 401 on the very next request (without the evict, the cached AppDto keeps `tokensInvalidBefore=null` and they'd keep working).
2. **uninstall evicts** — the install token 401s on the next request.
3. **scope re-consent evicts** — a refresh that drops a granted scope is enforced immediately (403), not stale-allowed.
Existing `AppCredentialTokenTest`, `AppTokenAuthorizationTest`, `AppRefreshTest`, `AppInstallPrincipalTest` stay green.

## Residual note
On a Caffeine-only (non-Redis) multi-node deployment a force-revoke on one node wouldn't evict the others' local `APPS` cache until TTL. Tolgee's shared-cache deployments use Redis, where the transaction-aware evict is authoritative.