### PR TITLE
fix: stop dropping characters typed into the AI prompt editor

### DIFF
--- a/webapp/src/component/editor/EditorHandlebars.tsx
+++ b/webapp/src/component/editor/EditorHandlebars.tsx
@@ -19,6 +19,7 @@ import {
   errorPlugin,
   setErrorsEffect,
 } from './utils/codemirrorError';
+import { isExternalValue } from './utils/externalValueSync';
 
 type PromptVariable = components['schemas']['PromptVariableDto'];
 
@@ -144,6 +145,7 @@ export const EditorHandlebars: React.FC<
 }) => {
   const ref = useRef<HTMLDivElement>(null);
   const editor = useRef<EditorView>();
+  const emittedValues = useRef(new Set<string>());
   const keyBindings = useRef(shortcuts);
   const variableRefs = useRef(availableVariables);
   const unknownVariableMessageRef = useRef(unknownVariableMessage);
@@ -195,7 +197,12 @@ export const EditorHandlebars: React.FC<
               }
             }
             if (v.docChanged) {
-              callbacksRef.current?.onChange?.(v.state.doc.toString());
+              const doc = v.state.doc.toString();
+              // The value before the edit was never emitted on the first edit,
+              // and the parent can still re-render carrying it.
+              emittedValues.current.add(v.startState.doc.toString());
+              emittedValues.current.add(doc);
+              callbacksRef.current?.onChange?.(doc);
             }
           }),
           EditorView.contentAttributes.of({
@@ -235,12 +242,18 @@ export const EditorHandlebars: React.FC<
 
   useEffect(() => {
     const state = editor.current?.state;
-    const editorValue = state?.doc.toString();
-    if (state && editorValue !== value) {
+    if (!state) {
+      return;
+    }
+    const editorValue = state.doc.toString();
+    if (isExternalValue(value, editorValue, emittedValues.current)) {
+      emittedValues.current.clear();
       const transaction = state.update({
         changes: { from: 0, to: state.doc.length, insert: value || '' },
       });
       editor.current?.update([transaction]);
+    } else if (editorValue === value) {
+      emittedValues.current.clear();
     }
   }, [editor.current, value]);
 

--- a/webapp/src/component/editor/utils/__tests__/externalValueSync.test.ts
+++ b/webapp/src/component/editor/utils/__tests__/externalValueSync.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { isExternalValue } from '../externalValueSync';
+
+describe('isExternalValue', () => {
+  it('ignores a value the editor emitted while the parent lagged behind', () => {
+    // user typed "ab" then "abc"; parent re-renders with the older "ab"
+    expect(isExternalValue('ab', 'abc', new Set(['ab', 'abc']))).toBe(false);
+  });
+
+  it('applies a value the editor never emitted', () => {
+    expect(
+      isExternalValue('loaded prompt', 'abc', new Set(['ab', 'abc']))
+    ).toBe(true);
+  });
+
+  it('does nothing when the parent has caught up', () => {
+    expect(isExternalValue('abc', 'abc', new Set(['abc']))).toBe(false);
+  });
+
+  it('applies an external value when nothing is in flight', () => {
+    expect(isExternalValue('loaded prompt', 'abc', new Set())).toBe(true);
+  });
+
+  it('ignores the value held before the first edit', () => {
+    // editor started empty, user typed "a", parent still renders the empty
+    // initial value; applying it would delete the typed character
+    expect(isExternalValue('', 'a', new Set(['', 'a']))).toBe(false);
+  });
+});

--- a/webapp/src/component/editor/utils/externalValueSync.ts
+++ b/webapp/src/component/editor/utils/externalValueSync.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether an incoming `value` is a genuine external update, or the parent
+ * echoing back an edit the editor emitted.
+ *
+ * While the user types, the parent's state trails the editor by at least one
+ * render. Writing such a trailing value into the document deletes every
+ * character typed since the parent last rendered.
+ *
+ * `emitted` holds the values the editor reported since the parent last caught
+ * up; the caller clears it once `value` matches the document.
+ */
+export function isExternalValue(
+  value: string,
+  editorValue: string,
+  emitted: Set<string>
+): boolean {
+  return editorValue !== value && !emitted.has(value);
+}


### PR DESCRIPTION
The AI prompt editor loses characters while you type.

The text lives in CodeMirror, but the React `value` prop is always at least one render behind. The old code wrote every incoming value back into the document, so each late value deleted the characters typed in the meantime.

On a slow or loaded machine this is easy to hit. With 20x CPU slowdown and 150ms between keystrokes, which is normal typing speed, `{{target.languageTag}}` arrives at the server as `{{trget.languageTag}}`.

It is also why `aiPlayground/customPrompt.cy.ts` is flaky. The test types a template and runs the preview. When characters are lost, the server gets a broken template and answers 400 `llm_template_parsing_error`. The spec failed in 9 of 88 pull request runs in the last 7 days, and it caused 9 of the 10 failures of that E2E job.

## What changed

- The editor now remembers the values it sent out. When the parent sends one of them back, it is ignored.
- Values the editor never produced are still applied, so loading a saved prompt works as before.
- Added a unit test for the rule.

## Testing

- Reproduced the character loss with CPU throttling. 3 of 3 runs failed before the change, 3 of 3 pass after it.
- Ran the whole aiPlayground suite 3 times. 93 tests, all pass.

## Note

`Editor.tsx` and `EditorJson.tsx` contain the same code and probably the same problem. `Editor.tsx` is the main translation editor, so I did not touch it here. It is worth a separate look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor synchronization with external updates.
  * Prevented delayed parent updates from overwriting more recent user edits.
  * Ensured genuine external changes still update the editor correctly.

* **Tests**
  * Added coverage for external updates, delayed echoes, matching values, and idle editor states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->