### PR TITLE
fix: bump Jackson to 2.21.6 / 3.1.6 to patch CVE-2026-19032

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     implementation libs.springDocOpenApiCommon
     // Jackson-2 Kotlin module for swagger-core's schema introspection (registered on swagger's mapper
     // in OpenApiConfiguration; schema-gen only). Keep aligned with swagger-core's jackson-databind 2.x.
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.21.5'
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson2Version"
     implementation libs.redissonSpringBootStarter
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -158,18 +158,12 @@ subprojects {
     ext['hibernate.version'] = hibernateVersion
     ext['commons-lang3.version'] = commonsLang3Version
     ext['netty.version'] = nettyVersion
+    ext['jackson-bom.version'] = jacksonVersion
+    ext['jackson-2-bom.version'] = jackson2Version
 
-    // The transitive Jackson 2 stack (pulled in by swagger/springdoc for schema generation) is pinned
-    // to a vulnerable 2.21.4 by Spring's dependency management; override it to the patched 2.21.5
-    // (CVE-2026-59889/54515). A catalog platform() BOM can't do this — dependency-management wins over
-    // Gradle platform/enforcedPlatform constraints, so it must go through the plugin's own override.
     plugins.withId('io.spring.dependency-management') {
         dependencyManagement {
             dependencies {
-                dependencySet(group: 'com.fasterxml.jackson.core', version: '2.21.5') {
-                    entry 'jackson-databind'
-                    entry 'jackson-core'
-                }
                 // azure-core-amqp pins proton-j 0.34.1 (CVE-2026-66273/66274/66275/66276);
                 // no Azure SDK release ships the patched version yet.
                 dependency 'org.apache.qpid:proton-j:0.35.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,10 @@ jjwtVersion=0.11.2
 hibernateVersion=7.4.1.Final
 amazonAwsSdkVersion=2.46.15
 springDependencyManagementVersion=1.1.7
-# Keep aligned with the Spring Boot BOM's jackson-bom.version (used by the version
-# catalog so the standalone `misc` module, which has no Spring BOM, can resolve Jackson).
-jacksonVersion=3.1.5
+# Single source for both Jackson lines: build.gradle forces them into the Spring BOM, and the
+# version catalog uses them directly so the standalone `misc` module (no Spring BOM) matches.
+jacksonVersion=3.1.6
+jackson2Version=2.21.6
 slackSdkVersion=1.37.0
 nettyVersion=4.2.17.Final
 commonsLang3Version=3.20.0


### PR DESCRIPTION
Snyk flagged `com.fasterxml.jackson.core:jackson-databind:2.21.5` in the `tolgee/tolgee` image with **CVE-2026-19032** — CWE-470 unsafe reflection in `NioPathDeserializer` (CVSS 4.0 6.9, Medium). A non-`file` URI scheme (`jar:`, `http:`, `s3:`, a custom provider) in untrusted JSON reaches `new URI(value)` → `Path.of(uri)`, which triggers `ServiceLoader<FileSystemProvider>` resolution and runs the matching provider's `getPath(uri)` during deserialization.

Snyk only reported the Jackson 2 artifact, but **both** stacks in the image are in the vulnerable range — and Jackson 3 is the one that actually deserializes request bodies (Jackson 2 is only on the classpath for swagger-core's schema introspection):

| Artifact | Was | Now |
|---|---|---|
| `com.fasterxml.jackson.core:jackson-databind` | 2.21.5 | 2.21.6 |
| `tools.jackson.core:jackson-databind` | 3.1.5 | 3.1.6 |

Spring Boot 4.1.1 is the newest release and pins `jackson-2-bom.version=2.21.5` / `jackson-bom.version=3.1.5`, so both need an override.

Not exploitable here as far as I can tell — there is no `java.nio.file.Path` (or `File`) field on any DTO or entity, so no deserialization path reaches `NioPathDeserializer`. Patching anyway since it's a patch-level bump.

## Changes

Both Jackson lines now go through the Spring dependency-management version properties, the same mechanism already used above them for hibernate, netty and commons-lang3 (and proven by #3866):

```groovy
ext['jackson-bom.version']   = jacksonVersion    // 3.1.6
ext['jackson-2-bom.version'] = jackson2Version   // 2.21.6
```

This replaces the `com.fasterxml.jackson.core` `dependencySet`, which only covered `jackson-databind` and `jackson-core` and left `jsr310`, `jdk8`, `parameter-names` and `dataformat-yaml` on 2.21.5. `gradle.properties` holds both versions as the single source, and `backend/app/build.gradle` interpolates `$jackson2Version` rather than repeating a literal that has to be kept in sync by hand.

The old comment about a catalog `platform()` BOM not being able to do this is dropped — the `ext` property override sits at the BOM-import level, so the conflict it described doesn't apply.

Net: 9 insertions, 12 deletions.

## Also fixed by the same bump

2.21.6 and 3.1.6 (both 14-Aug-2026) additionally carry **CVE-2026-68497** (`StreamReadConstraints` number-length limit for `XMLGregorianCalendar`/`Duration`) and **CVE-2026-83557** (`java.lang.Comparable` added to the unsafe polymorphic base types).

## Verification

- `:server-app:dependencies` shows both BOMs moving (`com.fasterxml.jackson:jackson-bom:2.21.6`, `tools.jackson:jackson-bom:3.1.6`); confirmed for `:data`, `:ee-app` and `:misc` that no Jackson artifact resolves to 2.21.5 or 3.1.5.
- `./gradlew classes testClasses` — clean.
- `:data:test --tests "io.tolgee.unit.formats.*"` — all pass (the Jackson-heaviest unit suite: JSON/YAML/XLIFF/ARB/xcstrings import + export).
- Given #3840 and #3857 were Jackson-behavior regressions, I checked what 3.1.6 actually changes and grepped for each: `@JsonAnySetter` (#6115), `@JsonTypeInfo` / `Comparable`-typed fields / default typing (#6156). No hits in `backend/` or `ee/`. The rest (#6101 `@JsonInclude(NON_EMPTY, content=CUSTOM)`, #6133/#6165 number-length limits) don't apply.
- Billing needs no matching change — it has no root Gradle files and resolves through this catalog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jackson components to newer, centrally managed versions.
  * Improved version consistency across application modules and build configurations.
  * Retained the existing Proton-J version override while aligning related build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->