### PR TITLE
feat: support Azure Blob Storage as main file storage

### DIFF
--- a/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
@@ -31,14 +31,28 @@ class FileStorageConfiguration(
       "Both tolgee.file-storage.s3 and tolgee.file-storage.azure are enabled. Configure exactly one file storage."
     }
     if (azureConfig.enabled) {
-      check(!azureConfig.connectionString.isNullOrBlank() && !azureConfig.containerName.isNullOrBlank()) {
-        "tolgee.file-storage.azure is enabled, but connection-string or container-name is not set."
-      }
-      return azureFileStorageFactory.create(azureConfig)
+      return createAzureFileStorage()
     }
     if (s3config.enabled) {
       return s3FileStorageFactory.create(s3config)
     }
     return LocalFileStorage(tolgeeProperties = properties)
+  }
+
+  private fun createAzureFileStorage(): FileStorage {
+    check(!azureConfig.connectionString.isNullOrBlank()) {
+      "tolgee.file-storage.azure is enabled, but connection-string is not set."
+    }
+    check(!azureConfig.containerName.isNullOrBlank()) {
+      "tolgee.file-storage.azure is enabled, but container-name is not set."
+    }
+    try {
+      return azureFileStorageFactory.create(azureConfig)
+    } catch (e: Exception) {
+      throw IllegalStateException(
+        "Cannot create the Azure Blob Storage client from tolgee.file-storage.azure: ${e.cause?.message ?: e.message}",
+        e,
+      )
+    }
   }
 }

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
@@ -4,6 +4,7 @@
 
 package io.tolgee.configuration
 
+import io.tolgee.component.fileStorage.AzureFileStorageFactory
 import io.tolgee.component.fileStorage.FileStorage
 import io.tolgee.component.fileStorage.LocalFileStorage
 import io.tolgee.component.fileStorage.S3FileStorageFactory
@@ -16,13 +17,24 @@ import org.springframework.context.annotation.Configuration
 class FileStorageConfiguration(
   private val properties: TolgeeProperties,
   private val s3FileStorageFactory: S3FileStorageFactory,
+  private val azureFileStorageFactory: AzureFileStorageFactory,
 ) {
   private val s3config = properties.fileStorage.s3
+  private val azureConfig = properties.fileStorage.azure
 
   @Bean
   fun fileStorage(): FileStorage {
     if (properties.internal.useInMemoryFileStorage) {
       return InMemoryFileStorage()
+    }
+    check(!(s3config.enabled && azureConfig.enabled)) {
+      "Both tolgee.file-storage.s3 and tolgee.file-storage.azure are enabled. Configure exactly one file storage."
+    }
+    if (azureConfig.enabled) {
+      check(!azureConfig.connectionString.isNullOrBlank() && !azureConfig.containerName.isNullOrBlank()) {
+        "tolgee.file-storage.azure is enabled, but connection-string or container-name is not set."
+      }
+      return azureFileStorageFactory.create(azureConfig)
     }
     if (s3config.enabled) {
       return s3FileStorageFactory.create(s3config)

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/FileStorageConfiguration.kt
@@ -19,7 +19,7 @@ class FileStorageConfiguration(
   private val s3FileStorageFactory: S3FileStorageFactory,
   private val azureFileStorageFactory: AzureFileStorageFactory,
 ) {
-  private val s3config = properties.fileStorage.s3
+  private val s3Config = properties.fileStorage.s3
   private val azureConfig = properties.fileStorage.azure
 
   @Bean
@@ -27,14 +27,14 @@ class FileStorageConfiguration(
     if (properties.internal.useInMemoryFileStorage) {
       return InMemoryFileStorage()
     }
-    check(!(s3config.enabled && azureConfig.enabled)) {
+    check(!(s3Config.enabled && azureConfig.enabled)) {
       "Both tolgee.file-storage.s3 and tolgee.file-storage.azure are enabled. Configure exactly one file storage."
     }
     if (azureConfig.enabled) {
       return createAzureFileStorage()
     }
-    if (s3config.enabled) {
-      return s3FileStorageFactory.create(s3config)
+    if (s3Config.enabled) {
+      return s3FileStorageFactory.create(s3Config)
     }
     return LocalFileStorage(tolgeeProperties = properties)
   }
@@ -49,10 +49,7 @@ class FileStorageConfiguration(
     try {
       return azureFileStorageFactory.create(azureConfig)
     } catch (e: Exception) {
-      throw IllegalStateException(
-        "Cannot create the Azure Blob Storage client from tolgee.file-storage.azure: ${e.cause?.message ?: e.message}",
-        e,
-      )
+      throw IllegalStateException("Cannot create the Azure Blob Storage client from tolgee.file-storage.azure.", e)
     }
   }
 }

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureBlobTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureBlobTest.kt
@@ -1,0 +1,128 @@
+package io.tolgee.component.fileStorage
+
+import com.azure.core.util.BinaryData
+import com.azure.storage.blob.BlobContainerClient
+import com.azure.storage.blob.BlobServiceClientBuilder
+import io.tolgee.fixtures.AzuriteRunner
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.util.TestPropertyValues
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.test.context.ContextConfiguration
+
+@ContextRecreatingTest
+@SpringBootTest(
+  properties = [
+    "tolgee.internal.use-in-memory-file-storage=false",
+    "tolgee.file-storage.azure.enabled=true",
+    "tolgee.file-storage.azure.container-name=${FileStorageAzureBlobTest.CONTAINER_NAME}",
+  ],
+)
+@ContextConfiguration(initializers = [FileStorageAzureBlobTest.Companion.Initializer::class])
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FileStorageAzureBlobTest : AbstractFileStorageServiceTest() {
+  companion object {
+    const val CONTAINER_NAME = "tolgee-test"
+    val azuriteRunner = AzuriteRunner()
+
+    val container: BlobContainerClient by lazy {
+      BlobServiceClientBuilder()
+        .connectionString(AzuriteRunner.connectionString)
+        .buildClient()
+        .getBlobContainerClient(CONTAINER_NAME)
+    }
+
+    /**
+     * Beans write to the storage during context startup, so the container must exist before the context is built.
+     */
+    class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+      override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
+        azuriteRunner.run()
+        container.createIfNotExists()
+        TestPropertyValues
+          .of(mapOf("tolgee.file-storage.azure.connection-string" to AzuriteRunner.connectionString))
+          .applyTo(configurableApplicationContext)
+      }
+    }
+  }
+
+  @AfterAll
+  fun tearDown() {
+    azuriteRunner.stop()
+  }
+
+  @BeforeEach
+  fun cleanContainer() {
+    container.listBlobs().forEach { container.getBlobClient(it.name).delete() }
+  }
+
+  @Test
+  fun `is AzureBlobFileStorage`() {
+    fileStorage.assert.isInstanceOf(AzureBlobFileStorage::class.java)
+  }
+
+  @Test
+  fun testStoreFile() {
+    fileStorage.storeFile(testFilePath, testFileContent.toByteArray(Charsets.UTF_8))
+    container
+      .getBlobClient(testFilePath)
+      .downloadContent()
+      .toString()
+      .assert
+      .isEqualTo(testFileContent)
+  }
+
+  @Test
+  fun testReadFile() {
+    uploadTestFile()
+    fileStorage
+      .readFile(testFilePath)
+      .toString(Charsets.UTF_8)
+      .assert
+      .isEqualTo(testFileContent)
+  }
+
+  @Test
+  fun testDeleteFile() {
+    uploadTestFile()
+    fileStorage.deleteFile(testFilePath)
+    container
+      .getBlobClient(testFilePath)
+      .exists()
+      .assert
+      .isFalse()
+  }
+
+  @Test
+  fun testFileExists() {
+    uploadTestFile()
+    fileStorage.fileExists(testFilePath).assert.isTrue()
+    fileStorage.fileExists("not_existing").assert.isFalse()
+  }
+
+  @Test
+  fun testPruneDirectory() {
+    val content = testFileContent.toByteArray(Charsets.UTF_8)
+    fileStorage.storeFile("test/a.txt", content)
+    fileStorage.storeFile("test/sub/b.txt", content)
+    fileStorage.storeFile("other/c.txt", content)
+
+    fileStorage.pruneDirectory("test")
+
+    container
+      .listBlobs()
+      .map { it.name }
+      .assert
+      .containsExactly("other/c.txt")
+  }
+
+  private fun uploadTestFile() {
+    container.getBlobClient(testFilePath).upload(BinaryData.fromString(testFileContent), true)
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
@@ -46,14 +46,14 @@ class FileStorageAzureTest {
       .readFile(filePath)
       .toString(Charsets.UTF_8)
       .assert
-      .isEqualTo("hello")
+      .isEqualTo(content)
     verifyGetsClient()
   }
 
   @Test
   fun testDeleteFile() {
     azureFs.deleteFile(filePath)
-    verify(blobClientMock, times(1)).delete()
+    verify(blobClientMock, times(1)).deleteIfExists()
     verifyGetsClient()
   }
 
@@ -112,6 +112,12 @@ class FileStorageAzureTest {
   fun `fileExists wraps client failures`() {
     whenever(blobClientMock.exists()).thenThrow(RuntimeException("boom"))
     assertThrows<FileStoreException> { azureFs.fileExists(filePath) }
+  }
+
+  @Test
+  fun `pruneDirectory wraps client failures`() {
+    whenever(containerClientMock.listBlobs(any(), eq(null))).thenThrow(RuntimeException("boom"))
+    assertThrows<FileStoreException> { azureFs.pruneDirectory("hello") }
   }
 
   private fun verifyGetsClient() {

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
@@ -14,9 +14,9 @@ import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -61,14 +61,9 @@ class FileStorageAzureTest {
   fun testStoreFile() {
     val bytes = content.toByteArray(Charsets.UTF_8)
     azureFs.storeFile(filePath, bytes)
-    verify(blobClientMock, times(1)).upload(any<BinaryData>(), eq(true))
-    val binaryData =
-      Mockito
-        .mockingDetails(blobClientMock)
-        .invocations
-        .single()
-        .arguments[0] as BinaryData
-    binaryData
+    val uploaded = argumentCaptor<BinaryData>()
+    verify(blobClientMock, times(1)).upload(uploaded.capture(), eq(true))
+    uploaded.firstValue
       .toBytes()
       .toString(Charsets.UTF_8)
       .assert
@@ -89,7 +84,7 @@ class FileStorageAzureTest {
     )
     azureFs.pruneDirectory("hello")
     verifyGetsClient()
-    verify(blobClientMock, times(1)).delete()
+    verify(blobClientMock, times(1)).deleteIfExists()
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
@@ -9,6 +9,7 @@ import com.azure.core.util.BinaryData
 import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.models.BlobItem
+import com.azure.storage.blob.models.ListBlobsOptions
 import io.tolgee.exceptions.FileStoreException
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
@@ -25,7 +26,7 @@ import org.mockito.kotlin.whenever
 class FileStorageAzureTest {
   private lateinit var azureFs: AzureBlobFileStorage
   private lateinit var containerClientMock: BlobContainerClient
-  private val filePath = "/hello/hello/en.json"
+  private val filePath = "hello/hello/en.json"
   private val content = "hello"
   private lateinit var blobClientMock: BlobClient
 
@@ -83,6 +84,10 @@ class FileStorageAzureTest {
       ).iterator(),
     )
     azureFs.pruneDirectory("hello")
+    val options = argumentCaptor<ListBlobsOptions>()
+    verify(containerClientMock, times(1)).listBlobs(options.capture(), eq(null))
+    options.firstValue.prefix.assert
+      .isEqualTo("hello/")
     verifyGetsClient()
     verify(blobClientMock, times(1)).deleteIfExists()
   }

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzureTest.kt
@@ -9,9 +9,11 @@ import com.azure.core.util.BinaryData
 import com.azure.storage.blob.BlobClient
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.models.BlobItem
+import io.tolgee.exceptions.FileStoreException
 import io.tolgee.testing.assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
@@ -96,6 +98,20 @@ class FileStorageAzureTest {
     azureFs.fileExists(filePath).assert.isTrue()
     verifyGetsClient()
     verify(blobClientMock, times(1)).exists()
+  }
+
+  @Test
+  fun `fileExists returns false when blob is missing`() {
+    whenever(blobClientMock.exists()).thenReturn(false)
+    azureFs.fileExists(filePath).assert.isFalse()
+    verifyGetsClient()
+    verify(blobClientMock, times(1)).exists()
+  }
+
+  @Test
+  fun `fileExists wraps client failures`() {
+    whenever(blobClientMock.exists()).thenThrow(RuntimeException("boom"))
+    assertThrows<FileStoreException> { azureFs.fileExists(filePath) }
   }
 
   private fun verifyGetsClient() {

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
@@ -21,12 +21,12 @@ import org.springframework.test.context.ContextConfiguration
   properties = [
     "tolgee.internal.use-in-memory-file-storage=false",
     "tolgee.file-storage.azure.enabled=true",
-    "tolgee.file-storage.azure.container-name=${FileStorageAzureBlobTest.CONTAINER_NAME}",
+    "tolgee.file-storage.azure.container-name=${FileStorageAzuriteTest.CONTAINER_NAME}",
   ],
 )
-@ContextConfiguration(initializers = [FileStorageAzureBlobTest.Companion.Initializer::class])
+@ContextConfiguration(initializers = [FileStorageAzuriteTest.Companion.Initializer::class])
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class FileStorageAzureBlobTest : AbstractFileStorageServiceTest() {
+class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
   companion object {
     const val CONTAINER_NAME = "tolgee-test"
     val azuriteRunner = AzuriteRunner()
@@ -97,6 +97,11 @@ class FileStorageAzureBlobTest : AbstractFileStorageServiceTest() {
       .exists()
       .assert
       .isFalse()
+  }
+
+  @Test
+  fun `deleteFile tolerates a missing blob`() {
+    fileStorage.deleteFile("not_existing")
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
@@ -25,7 +25,7 @@ import org.springframework.test.context.ContextConfiguration
     "tolgee.file-storage.azure.container-name=${FileStorageAzuriteTest.CONTAINER_NAME}",
   ],
 )
-@ContextConfiguration(initializers = [FileStorageAzuriteTest.Companion.Initializer::class])
+@ContextConfiguration(initializers = [FileStorageAzuriteTest.Initializer::class])
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
   companion object {
@@ -34,22 +34,22 @@ class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
 
     val container: BlobContainerClient by lazy {
       BlobServiceClientBuilder()
-        .connectionString(AzuriteRunner.connectionString)
+        .connectionString(azuriteRunner.connectionString)
         .buildClient()
         .getBlobContainerClient(CONTAINER_NAME)
     }
+  }
 
-    /**
-     * Beans write to the storage during context startup, so the container must exist before the context is built.
-     */
-    class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
-      override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
-        azuriteRunner.run()
-        container.createIfNotExists()
-        TestPropertyValues
-          .of(mapOf("tolgee.file-storage.azure.connection-string" to AzuriteRunner.connectionString))
-          .applyTo(configurableApplicationContext)
-      }
+  /**
+   * Beans write to the storage during context startup, so the container must exist before the context is built.
+   */
+  class Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
+      azuriteRunner.run()
+      container.createIfNotExists()
+      TestPropertyValues
+        .of(mapOf("tolgee.file-storage.azure.connection-string" to azuriteRunner.connectionString))
+        .applyTo(configurableApplicationContext)
     }
   }
 
@@ -117,7 +117,8 @@ class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
     val content = testFileContent.toByteArray(Charsets.UTF_8)
     fileStorage.storeFile("test/a.txt", content)
     fileStorage.storeFile("test/sub/b.txt", content)
-    fileStorage.storeFile("other/c.txt", content)
+    fileStorage.storeFile("test-v2/c.txt", content)
+    fileStorage.storeFile("other/d.txt", content)
 
     fileStorage.pruneDirectory("test")
 
@@ -125,7 +126,7 @@ class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
       .listBlobs()
       .map { it.name }
       .assert
-      .containsExactly("other/c.txt")
+      .containsExactlyInAnyOrder("test-v2/c.txt", "other/d.txt")
   }
 
   private fun uploadTestFile() {

--- a/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/component/fileStorage/FileStorageAzuriteTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.context.ApplicationContextInitializer
@@ -101,7 +102,7 @@ class FileStorageAzuriteTest : AbstractFileStorageServiceTest() {
 
   @Test
   fun `deleteFile tolerates a missing blob`() {
-    fileStorage.deleteFile("not_existing")
+    assertDoesNotThrow { fileStorage.deleteFile("not_existing") }
   }
 
   @Test

--- a/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
@@ -1,0 +1,91 @@
+package io.tolgee.unit.configuration
+
+import io.tolgee.component.fileStorage.AzureBlobFileStorage
+import io.tolgee.component.fileStorage.AzureFileStorageFactory
+import io.tolgee.component.fileStorage.LocalFileStorage
+import io.tolgee.component.fileStorage.S3FileStorage
+import io.tolgee.component.fileStorage.S3FileStorageFactory
+import io.tolgee.configuration.FileStorageConfiguration
+import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.fixtures.AzuriteRunner
+import io.tolgee.testing.assert
+import io.tolgee.util.InMemoryFileStorage
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class FileStorageConfigurationTest {
+  private val properties = TolgeeProperties()
+
+  @Test
+  fun `defaults to local storage`() {
+    fileStorage().assert.isInstanceOf(LocalFileStorage::class.java)
+  }
+
+  @Test
+  fun `in-memory storage wins over azure`() {
+    properties.internal.useInMemoryFileStorage = true
+    enableAzure()
+    fileStorage().assert.isInstanceOf(InMemoryFileStorage::class.java)
+  }
+
+  @Test
+  fun `selects azure when enabled`() {
+    enableAzure()
+    fileStorage().assert.isInstanceOf(AzureBlobFileStorage::class.java)
+  }
+
+  @Test
+  fun `selects s3 when enabled`() {
+    enableS3()
+    fileStorage().assert.isInstanceOf(S3FileStorage::class.java)
+  }
+
+  @Test
+  fun `fails when both s3 and azure are enabled`() {
+    enableS3()
+    enableAzure()
+    assertThrows<IllegalStateException> { fileStorage() }
+      .message
+      .assert
+      .contains("exactly one")
+  }
+
+  @Test
+  fun `fails when azure is enabled without connection string`() {
+    enableAzure()
+    properties.fileStorage.azure.connectionString = null
+    assertThrows<IllegalStateException> { fileStorage() }
+      .message
+      .assert
+      .contains("connection-string")
+  }
+
+  @Test
+  fun `fails when azure is enabled without container name`() {
+    enableAzure()
+    properties.fileStorage.azure.containerName = ""
+    assertThrows<IllegalStateException> { fileStorage() }
+  }
+
+  private fun fileStorage() =
+    FileStorageConfiguration(properties, S3FileStorageFactory(), AzureFileStorageFactory()).fileStorage()
+
+  private fun enableAzure() {
+    properties.fileStorage.azure.apply {
+      enabled = true
+      connectionString = AzuriteRunner.connectionString
+      containerName = "container"
+    }
+  }
+
+  private fun enableS3() {
+    properties.fileStorage.s3.apply {
+      enabled = true
+      bucketName = "bucket"
+      endpoint = "http://localhost:1"
+      signingRegion = "us-east-1"
+      accessKey = "access"
+      secretKey = "secret"
+    }
+  }
+}

--- a/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
@@ -7,10 +7,14 @@ import io.tolgee.component.fileStorage.S3FileStorage
 import io.tolgee.component.fileStorage.S3FileStorageFactory
 import io.tolgee.configuration.FileStorageConfiguration
 import io.tolgee.configuration.tolgee.TolgeeProperties
+import io.tolgee.exceptions.InvalidConnectionStringException
 import io.tolgee.testing.assert
 import io.tolgee.util.InMemoryFileStorage
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullSource
+import org.junit.jupiter.params.provider.ValueSource
 
 class FileStorageConfigurationTest {
   companion object {
@@ -54,37 +58,44 @@ class FileStorageConfigurationTest {
       .contains("exactly one")
   }
 
-  @Test
-  fun `fails when azure is enabled without connection string`() {
-    listOf(null, " ").forEach { blank ->
-      enableAzure()
-      properties.fileStorage.azure.connectionString = blank
-      assertThrows<IllegalStateException> { fileStorage() }
-        .message
-        .assert
-        .contains("connection-string is not set")
-    }
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = [" "])
+  fun `fails when azure is enabled without connection string`(blank: String?) {
+    enableAzure()
+    properties.fileStorage.azure.connectionString = blank
+    assertThrows<IllegalStateException> { fileStorage() }
+      .message
+      .assert
+      .contains("connection-string is not set")
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = [" "])
+  fun `fails when azure is enabled without container name`(blank: String?) {
+    enableAzure()
+    properties.fileStorage.azure.containerName = blank
+    assertThrows<IllegalStateException> { fileStorage() }
+      .message
+      .assert
+      .contains("container-name is not set")
   }
 
   @Test
-  fun `fails when azure is enabled without container name`() {
-    listOf(null, " ").forEach { blank ->
-      enableAzure()
-      properties.fileStorage.azure.containerName = blank
-      assertThrows<IllegalStateException> { fileStorage() }
-        .message
-        .assert
-        .contains("container-name is not set")
-    }
-  }
-
-  @Test
-  fun `names the azure properties when the connection string is malformed`() {
+  fun `names the azure properties and keeps the SDK cause when the connection string is malformed`() {
     enableAzure()
     properties.fileStorage.azure.connectionString = "not-a-connection-string"
     val exception = assertThrows<IllegalStateException> { fileStorage() }
     exception.message.assert.contains("tolgee.file-storage.azure")
-    exception.cause.assert.isNotNull
+    exception.cause.assert.isInstanceOf(InvalidConnectionStringException::class.java)
+    exception.cause!!
+      .cause.assert
+      .isInstanceOf(IllegalArgumentException::class.java)
+    exception.cause!!
+      .cause!!
+      .message.assert
+      .isEqualTo("Invalid connection string.")
   }
 
   private fun fileStorage() =

--- a/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
@@ -7,13 +7,17 @@ import io.tolgee.component.fileStorage.S3FileStorage
 import io.tolgee.component.fileStorage.S3FileStorageFactory
 import io.tolgee.configuration.FileStorageConfiguration
 import io.tolgee.configuration.tolgee.TolgeeProperties
-import io.tolgee.fixtures.AzuriteRunner
 import io.tolgee.testing.assert
 import io.tolgee.util.InMemoryFileStorage
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class FileStorageConfigurationTest {
+  companion object {
+    const val WELL_FORMED_CONNECTION_STRING =
+      "DefaultEndpointsProtocol=http;AccountName=unit;AccountKey=dGVzdA==;BlobEndpoint=http://127.0.0.1:1/unit;"
+  }
+
   private val properties = TolgeeProperties()
 
   @Test
@@ -52,19 +56,35 @@ class FileStorageConfigurationTest {
 
   @Test
   fun `fails when azure is enabled without connection string`() {
-    enableAzure()
-    properties.fileStorage.azure.connectionString = null
-    assertThrows<IllegalStateException> { fileStorage() }
-      .message
-      .assert
-      .contains("connection-string")
+    listOf(null, " ").forEach { blank ->
+      enableAzure()
+      properties.fileStorage.azure.connectionString = blank
+      assertThrows<IllegalStateException> { fileStorage() }
+        .message
+        .assert
+        .contains("connection-string is not set")
+    }
   }
 
   @Test
   fun `fails when azure is enabled without container name`() {
+    listOf(null, " ").forEach { blank ->
+      enableAzure()
+      properties.fileStorage.azure.containerName = blank
+      assertThrows<IllegalStateException> { fileStorage() }
+        .message
+        .assert
+        .contains("container-name is not set")
+    }
+  }
+
+  @Test
+  fun `names the azure properties when the connection string is malformed`() {
     enableAzure()
-    properties.fileStorage.azure.containerName = ""
-    assertThrows<IllegalStateException> { fileStorage() }
+    properties.fileStorage.azure.connectionString = "not-a-connection-string"
+    val exception = assertThrows<IllegalStateException> { fileStorage() }
+    exception.message.assert.contains("tolgee.file-storage.azure")
+    exception.cause.assert.isNotNull
   }
 
   private fun fileStorage() =
@@ -73,7 +93,7 @@ class FileStorageConfigurationTest {
   private fun enableAzure() {
     properties.fileStorage.azure.apply {
       enabled = true
-      connectionString = AzuriteRunner.connectionString
+      connectionString = WELL_FORMED_CONNECTION_STRING
       containerName = "container"
     }
   }

--- a/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/unit/configuration/FileStorageConfigurationTest.kt
@@ -88,14 +88,11 @@ class FileStorageConfigurationTest {
     properties.fileStorage.azure.connectionString = "not-a-connection-string"
     val exception = assertThrows<IllegalStateException> { fileStorage() }
     exception.message.assert.contains("tolgee.file-storage.azure")
-    exception.cause.assert.isInstanceOf(InvalidConnectionStringException::class.java)
-    exception.cause!!
-      .cause.assert
-      .isInstanceOf(IllegalArgumentException::class.java)
-    exception.cause!!
-      .cause!!
-      .message.assert
-      .isEqualTo("Invalid connection string.")
+    val factoryFailure = exception.cause
+    factoryFailure.assert.isInstanceOf(InvalidConnectionStringException::class.java)
+    val sdkFailure = factoryFailure?.cause
+    sdkFailure.assert.isInstanceOf(IllegalArgumentException::class.java)
+    sdkFailure?.message.assert.isEqualTo("Invalid connection string.")
   }
 
   private fun fileStorage() =

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
@@ -8,7 +8,6 @@ import com.azure.core.util.BinaryData
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.models.ListBlobsOptions
 import io.tolgee.exceptions.FileStoreException
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException
 
 open class AzureBlobFileStorage(
   private val client: BlobContainerClient,
@@ -44,11 +43,10 @@ open class AzureBlobFileStorage(
   }
 
   override fun fileExists(storageFilePath: String): Boolean {
-    return try {
-      client.getBlobClient(storageFilePath).exists()
-      true
-    } catch (e: NoSuchKeyException) {
-      false
+    try {
+      return client.getBlobClient(storageFilePath).exists()
+    } catch (e: Exception) {
+      throw FileStoreException("Can not check file existence using Azure Blob!", storageFilePath, e)
     }
   }
 

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
@@ -22,8 +22,7 @@ open class AzureBlobFileStorage(
 
   override fun deleteFile(storageFilePath: String) {
     try {
-      client.getBlobClient(storageFilePath).delete()
-      return
+      client.getBlobClient(storageFilePath).deleteIfExists()
     } catch (e: Exception) {
       throw FileStoreException("Can not delete file using Azure Blob!", storageFilePath, e)
     }
@@ -34,12 +33,10 @@ open class AzureBlobFileStorage(
     bytes: ByteArray,
   ) {
     try {
-      val client = client.getBlobClient(storageFilePath)
-      client.upload(BinaryData.fromBytes(bytes), true)
+      client.getBlobClient(storageFilePath).upload(BinaryData.fromBytes(bytes), true)
     } catch (e: Exception) {
       throw FileStoreException("Can not store file using Azure Blob!", storageFilePath, e)
     }
-    return
   }
 
   override fun fileExists(storageFilePath: String): Boolean {
@@ -54,8 +51,12 @@ open class AzureBlobFileStorage(
     val prefix = path.removePrefix("/").removeSuffix("/") + "/"
     val options = ListBlobsOptions()
     options.prefix = prefix
-    client.listBlobs(options, null).forEach {
-      client.getBlobClient(it.name).delete()
+    try {
+      client.listBlobs(options, null).forEach {
+        client.getBlobClient(it.name).delete()
+      }
+    } catch (e: Exception) {
+      throw FileStoreException("Can not prune directory using Azure Blob!", path, e)
     }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureBlobFileStorage.kt
@@ -48,12 +48,10 @@ open class AzureBlobFileStorage(
   }
 
   override fun pruneDirectory(path: String) {
-    val prefix = path.removePrefix("/").removeSuffix("/") + "/"
-    val options = ListBlobsOptions()
-    options.prefix = prefix
+    val options = ListBlobsOptions().setPrefix(path.removePrefix("/").removeSuffix("/") + "/")
     try {
       client.listBlobs(options, null).forEach {
-        client.getBlobClient(it.name).delete()
+        client.getBlobClient(it.name).deleteIfExists()
       }
     } catch (e: Exception) {
       throw FileStoreException("Can not prune directory using Azure Blob!", path, e)

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureFileStorageFactory.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureFileStorageFactory.kt
@@ -20,9 +20,9 @@ class AzureFileStorageFactory {
       return AzureBlobFileStorage(containerClient)
     } catch (e: Exception) {
       if (e is IllegalArgumentException && e.message == "Invalid connection string.") {
-        throw InvalidConnectionStringException()
+        throw InvalidConnectionStringException(e)
       }
-      throw BadRequestException(Message.CANNOT_CREATE_AZURE_STORAGE_CLIENT)
+      throw BadRequestException(Message.CANNOT_CREATE_AZURE_STORAGE_CLIENT, e)
     }
   }
 }

--- a/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureFileStorageFactory.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/fileStorage/AzureFileStorageFactory.kt
@@ -9,17 +9,20 @@ import org.springframework.stereotype.Component
 
 @Component
 class AzureFileStorageFactory {
+  companion object {
+    private const val SDK_INVALID_CONNECTION_STRING_MESSAGE = "Invalid connection string."
+  }
+
   fun create(config: AzureBlobConfig): AzureBlobFileStorage {
     try {
-      val connectionString = config.connectionString
       val blobServiceClient =
         BlobServiceClientBuilder()
-          .connectionString(connectionString)
+          .connectionString(config.connectionString)
           .buildClient()
       val containerClient = blobServiceClient.getBlobContainerClient(config.containerName)
       return AzureBlobFileStorage(containerClient)
     } catch (e: Exception) {
-      if (e is IllegalArgumentException && e.message == "Invalid connection string.") {
+      if (e is IllegalArgumentException && e.message == SDK_INVALID_CONNECTION_STRING_MESSAGE) {
         throw InvalidConnectionStringException(e)
       }
       throw BadRequestException(Message.CANNOT_CREATE_AZURE_STORAGE_CLIENT, e)

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/AzureBlobSettings.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/AzureBlobSettings.kt
@@ -1,0 +1,26 @@
+package io.tolgee.configuration.tolgee
+
+import io.tolgee.configuration.annotations.DocProperty
+import io.tolgee.model.contentDelivery.AzureBlobConfig
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "tolgee.file-storage.azure")
+@DocProperty(
+  description =
+    "Tolgee supports storing its files in Azure Blob Storage. " +
+      "When enabled, Tolgee will store all its files in the configured container rather than in filesystem. " +
+      "The container has to exist already.",
+  displayName = "Azure Blob Storage",
+)
+class AzureBlobSettings(
+  @DocProperty(
+    description =
+      "Whether Azure Blob Storage is enabled. If enabled, you need to set all remaining properties below. " +
+        "Cannot be enabled together with S3.",
+  )
+  override var enabled: Boolean = false,
+  @DocProperty(description = "Connection string of the Azure Storage account.")
+  override var connectionString: String? = null,
+  @DocProperty(description = "Name of the container where Tolgee will store its files.")
+  override var containerName: String? = null,
+) : AzureBlobConfig

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/FileStorageProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/FileStorageProperties.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @DocProperty(description = "Configuration of Tolgee file storage.", displayName = "File storage")
 class FileStorageProperties(
   var s3: S3Settings = S3Settings(),
+  var azure: AzureBlobSettings = AzureBlobSettings(),
   @DocProperty(
     description = "Path to directory where Tolgee will store its files.",
     defaultExplanation = ", with docker `/data/`",

--- a/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidConnectionStringException.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/exceptions/InvalidConnectionStringException.kt
@@ -2,4 +2,6 @@ package io.tolgee.exceptions
 
 import io.tolgee.constants.Message
 
-class InvalidConnectionStringException : BadRequestException(Message.INVALID_CONNECTION_STRING)
+class InvalidConnectionStringException(
+  cause: Exception? = null,
+) : BadRequestException(Message.INVALID_CONNECTION_STRING, cause)

--- a/backend/data/src/test/kotlin/io/tolgee/unit/component/fileStorage/AzureFileStorageFactoryTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/component/fileStorage/AzureFileStorageFactoryTest.kt
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class AzureFileStorageFactoryTest {
+  companion object {
+    const val BAD_ENDPOINT_CONNECTION_STRING =
+      "DefaultEndpointsProtocol=http;AccountName=unit;AccountKey=dGVzdA==;BlobEndpoint=::not-a-url::;"
+  }
+
   private val factory = AzureFileStorageFactory()
 
   @Test
@@ -38,10 +43,5 @@ class AzureFileStorageFactoryTest {
   ) = object : AzureBlobConfig {
     override var connectionString: String? = connectionString
     override var containerName: String? = containerName
-  }
-
-  companion object {
-    const val BAD_ENDPOINT_CONNECTION_STRING =
-      "DefaultEndpointsProtocol=http;AccountName=unit;AccountKey=dGVzdA==;BlobEndpoint=::not-a-url::;"
   }
 }

--- a/backend/data/src/test/kotlin/io/tolgee/unit/component/fileStorage/AzureFileStorageFactoryTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/unit/component/fileStorage/AzureFileStorageFactoryTest.kt
@@ -1,0 +1,47 @@
+package io.tolgee.unit.component.fileStorage
+
+import io.tolgee.component.fileStorage.AzureFileStorageFactory
+import io.tolgee.exceptions.BadRequestException
+import io.tolgee.exceptions.InvalidConnectionStringException
+import io.tolgee.model.contentDelivery.AzureBlobConfig
+import io.tolgee.testing.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AzureFileStorageFactoryTest {
+  private val factory = AzureFileStorageFactory()
+
+  @Test
+  fun `keeps the SDK cause when the connection string is malformed`() {
+    val exception =
+      assertThrows<InvalidConnectionStringException> {
+        factory.create(config(connectionString = "not-a-connection-string", containerName = "container"))
+      }
+    exception.cause.assert.isInstanceOf(IllegalArgumentException::class.java)
+    exception.cause!!
+      .message.assert
+      .isEqualTo("Invalid connection string.")
+  }
+
+  @Test
+  fun `keeps the cause when the client cannot be created for another reason`() {
+    val exception =
+      assertThrows<BadRequestException> {
+        factory.create(config(connectionString = BAD_ENDPOINT_CONNECTION_STRING, containerName = "container"))
+      }
+    exception.cause.assert.isNotNull
+  }
+
+  private fun config(
+    connectionString: String?,
+    containerName: String?,
+  ) = object : AzureBlobConfig {
+    override var connectionString: String? = connectionString
+    override var containerName: String? = containerName
+  }
+
+  companion object {
+    const val BAD_ENDPOINT_CONNECTION_STRING =
+      "DefaultEndpointsProtocol=http;AccountName=unit;AccountKey=dGVzdA==;BlobEndpoint=::not-a-url::;"
+  }
+}

--- a/backend/misc/src/main/kotlin/io/tolgee/misc/dockerRunner/DockerContainerRunner.kt
+++ b/backend/misc/src/main/kotlin/io/tolgee/misc/dockerRunner/DockerContainerRunner.kt
@@ -54,9 +54,37 @@ class DockerContainerRunner(
   }
 
   private fun startNewContainer() {
+    pullImageIfMissing()
     val startTime = System.currentTimeMillis()
     "docker run $rmString -d $exposeString$envString --name $containerName $image $command".runCommand()
     waitForContainerLoggedOutput(startTime, waitForLogTimesForNewContainer)
+  }
+
+  /**
+   * A cold pull inside `docker run` can exceed the command timeout on a slow CI runner.
+   */
+  private fun pullImageIfMissing() {
+    try {
+      "docker image inspect $image".runCommand()
+      return
+    } catch (_: CommandRunFailedException) {
+      "docker pull -q $image".runCommand(timeoutAmount = 10, timeoutUnit = TimeUnit.MINUTES)
+    }
+  }
+
+  /**
+   * Host port published for [containerPort]; use it with an exposed host port of `0`, which lets Docker pick one.
+   */
+  fun publishedPort(containerPort: String): String {
+    val port =
+      "docker port $containerName $containerPort"
+        .runCommand()
+        .lineSequence()
+        .first()
+        .substringAfterLast(':')
+        .trim()
+    check(port.isNotBlank()) { "Container $containerName publishes no host port for $containerPort" }
+    return port
   }
 
   private fun startExistingContainer() {

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
@@ -2,11 +2,11 @@ package io.tolgee.fixtures
 
 import io.tolgee.misc.dockerRunner.DockerContainerRunner
 import java.io.IOException
-import java.net.ServerSocket
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.nio.file.Files
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -15,25 +15,28 @@ class AzuriteRunner {
   companion object {
     const val IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.37.0"
 
-    val port: String = System.getenv("TOLGEE_TEST_AZURITE_PORT") ?: freePort()
+    private val configuredPort: String? = System.getenv("TOLGEE_TEST_AZURITE_PORT")
 
     val containerName: String =
       System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite-${UUID.randomUUID()}"
 
-    /** Microsoft's published Azurite development account, so the key below is not a secret. */
-    val connectionString: String =
-      "DefaultEndpointsProtocol=http;" +
-        "AccountName=devstoreaccount1;" +
-        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
-        "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
+    /** Known after [run]: the configured port, or the one Docker published. */
+    lateinit var port: String
+      private set
 
-    private fun freePort(): String = ServerSocket(0).use { it.localPort.toString() }
+    /** Microsoft's published Azurite development account, so the key below is not a secret. */
+    val connectionString: String
+      get() =
+        "DefaultEndpointsProtocol=http;" +
+          "AccountName=devstoreaccount1;" +
+          "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+          "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
   }
 
   private val runner =
     DockerContainerRunner(
       image = IMAGE,
-      expose = mapOf(port to "10000"),
+      expose = mapOf((configuredPort ?: "0") to "10000"),
       waitForLog = "Azurite Blob service successfully listens on",
       rm = true,
       name = containerName,
@@ -41,8 +44,9 @@ class AzuriteRunner {
     )
 
   fun run() {
-    pullImage()
+    pullImageIfMissing()
     runner.run()
+    port = configuredPort ?: publishedPort()
     waitForBlobEndpoint()
   }
 
@@ -53,10 +57,22 @@ class AzuriteRunner {
   /**
    * A cold pull inside `docker run` can exceed DockerContainerRunner's command timeout on a slow CI runner.
    */
-  private fun pullImage() {
-    val process = ProcessBuilder("docker", "pull", IMAGE).redirectErrorStream(true).start()
-    process.waitFor(10, TimeUnit.MINUTES)
-    check(process.exitValue() == 0) { "docker pull $IMAGE failed:\n${process.inputStream.bufferedReader().readText()}" }
+  private fun pullImageIfMissing() {
+    if (docker("image", "inspect", IMAGE).exitValue == 0) {
+      return
+    }
+    val pull = docker("pull", IMAGE, timeoutMinutes = 10)
+    check(pull.exitValue == 0) { "docker pull $IMAGE failed:\n${pull.output}" }
+  }
+
+  private fun publishedPort(): String {
+    val published = docker("port", containerName, "10000")
+    check(published.exitValue == 0) { "docker port $containerName failed:\n${published.output}" }
+    return published.output
+      .lineSequence()
+      .first()
+      .substringAfterLast(':')
+      .trim()
   }
 
   /**
@@ -78,4 +94,30 @@ class AzuriteRunner {
       }
     }
   }
+
+  private fun docker(
+    vararg args: String,
+    timeoutMinutes: Long = 1,
+  ): DockerResult {
+    val outputFile = Files.createTempFile("docker-", ".log").toFile()
+    try {
+      val process =
+        ProcessBuilder("docker", *args)
+          .redirectErrorStream(true)
+          .redirectOutput(outputFile)
+          .start()
+      if (!process.waitFor(timeoutMinutes, TimeUnit.MINUTES)) {
+        process.destroyForcibly()
+        throw IllegalStateException("docker ${args.joinToString(" ")} did not finish within $timeoutMinutes minute(s)")
+      }
+      return DockerResult(process.exitValue(), outputFile.readText())
+    } finally {
+      outputFile.delete()
+    }
+  }
+
+  private class DockerResult(
+    val exitValue: Int,
+    val output: String,
+  )
 }

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
@@ -6,73 +6,48 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.nio.file.Files
 import java.time.Duration
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 class AzuriteRunner {
   companion object {
-    const val IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.37.0"
-
+    private const val CONTAINER_PORT = "10000"
+    private const val ANY_FREE_HOST_PORT = "0"
     private val configuredPort: String? = System.getenv("TOLGEE_TEST_AZURITE_PORT")
 
     val containerName: String =
       System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite-${UUID.randomUUID()}"
-
-    /** Known after [run]: the configured port, or the one Docker published. */
-    lateinit var port: String
-      private set
-
-    /** Microsoft's published Azurite development account, so the key below is not a secret. */
-    val connectionString: String
-      get() =
-        "DefaultEndpointsProtocol=http;" +
-          "AccountName=devstoreaccount1;" +
-          "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
-          "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
   }
 
   private val runner =
     DockerContainerRunner(
-      image = IMAGE,
-      expose = mapOf((configuredPort ?: "0") to "10000"),
+      image = "mcr.microsoft.com/azure-storage/azurite:3.37.0",
+      expose = mapOf((configuredPort ?: ANY_FREE_HOST_PORT) to CONTAINER_PORT),
       waitForLog = "Azurite Blob service successfully listens on",
       rm = true,
       name = containerName,
-      command = "azurite-blob --blobHost 0.0.0.0 --blobPort 10000",
+      command = "azurite-blob --blobHost 0.0.0.0 --blobPort $CONTAINER_PORT",
     )
 
+  lateinit var port: String
+    private set
+
+  /** Microsoft's published Azurite development account, so the key below is not a secret. */
+  val connectionString: String
+    get() =
+      "DefaultEndpointsProtocol=http;" +
+        "AccountName=devstoreaccount1;" +
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+        "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
+
   fun run() {
-    pullImageIfMissing()
     runner.run()
-    port = configuredPort ?: publishedPort()
+    port = configuredPort ?: runner.publishedPort(CONTAINER_PORT)
     waitForBlobEndpoint()
   }
 
   fun stop() {
     runner.stop()
-  }
-
-  /**
-   * A cold pull inside `docker run` can exceed DockerContainerRunner's command timeout on a slow CI runner.
-   */
-  private fun pullImageIfMissing() {
-    if (docker("image", "inspect", IMAGE).exitValue == 0) {
-      return
-    }
-    val pull = docker("pull", IMAGE, timeoutMinutes = 10)
-    check(pull.exitValue == 0) { "docker pull $IMAGE failed:\n${pull.output}" }
-  }
-
-  private fun publishedPort(): String {
-    val published = docker("port", containerName, "10000")
-    check(published.exitValue == 0) { "docker port $containerName failed:\n${published.output}" }
-    return published.output
-      .lineSequence()
-      .first()
-      .substringAfterLast(':')
-      .trim()
   }
 
   /**
@@ -94,30 +69,4 @@ class AzuriteRunner {
       }
     }
   }
-
-  private fun docker(
-    vararg args: String,
-    timeoutMinutes: Long = 1,
-  ): DockerResult {
-    val outputFile = Files.createTempFile("docker-", ".log").toFile()
-    try {
-      val process =
-        ProcessBuilder("docker", *args)
-          .redirectErrorStream(true)
-          .redirectOutput(outputFile)
-          .start()
-      if (!process.waitFor(timeoutMinutes, TimeUnit.MINUTES)) {
-        process.destroyForcibly()
-        throw IllegalStateException("docker ${args.joinToString(" ")} did not finish within $timeoutMinutes minute(s)")
-      }
-      return DockerResult(process.exitValue(), outputFile.readText())
-    } finally {
-      outputFile.delete()
-    }
-  }
-
-  private class DockerResult(
-    val exitValue: Int,
-    val output: String,
-  )
 }

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
@@ -1,15 +1,18 @@
 package io.tolgee.fixtures
 
 import io.tolgee.misc.dockerRunner.DockerContainerRunner
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 class AzuriteRunner {
   companion object {
     val port: String = System.getenv("TOLGEE_TEST_AZURITE_PORT") ?: "51000"
     val containerName: String = System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite"
 
-    /**
-     * Well-known Azurite development account, publicly documented by Microsoft. Not a secret.
-     */
+    /** Microsoft's published Azurite development account, so the key below is not a secret. */
     val connectionString: String =
       "DefaultEndpointsProtocol=http;" +
         "AccountName=devstoreaccount1;" +
@@ -19,20 +22,36 @@ class AzuriteRunner {
 
   private val runner =
     DockerContainerRunner(
-      image = "mcr.microsoft.com/azure-storage/azurite:3.35.0",
+      image = "mcr.microsoft.com/azure-storage/azurite:3.37.0",
       expose = mapOf(port to "10000"),
       waitForLog = "Azurite Blob service successfully listens on",
       rm = true,
       name = containerName,
-      // The Azure SDK sends a newer x-ms-version than Azurite knows; without the flag every request is rejected.
-      command = "azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck --loose",
+      command = "azurite-blob --blobHost 0.0.0.0 --blobPort 10000",
     )
 
   fun run() {
     runner.run()
+    waitForBlobEndpoint()
   }
 
   fun stop() {
     runner.stop()
+  }
+
+  /**
+   * The container log says "listening" before the published port accepts connections on Docker Desktop.
+   */
+  private fun waitForBlobEndpoint() {
+    val client = HttpClient.newHttpClient()
+    val request = HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port/devstoreaccount1?comp=list")).build()
+    waitFor(timeout = 30000, pollTime = 100) {
+      try {
+        client.send(request, HttpResponse.BodyHandlers.discarding())
+        true
+      } catch (e: IOException) {
+        false
+      }
+    }
   }
 }

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
@@ -2,15 +2,23 @@ package io.tolgee.fixtures
 
 import io.tolgee.misc.dockerRunner.DockerContainerRunner
 import java.io.IOException
+import java.net.ServerSocket
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 class AzuriteRunner {
   companion object {
-    val port: String = System.getenv("TOLGEE_TEST_AZURITE_PORT") ?: "51000"
-    val containerName: String = System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite"
+    const val IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.37.0"
+
+    val port: String = System.getenv("TOLGEE_TEST_AZURITE_PORT") ?: freePort()
+
+    val containerName: String =
+      System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite-${UUID.randomUUID()}"
 
     /** Microsoft's published Azurite development account, so the key below is not a secret. */
     val connectionString: String =
@@ -18,11 +26,13 @@ class AzuriteRunner {
         "AccountName=devstoreaccount1;" +
         "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
         "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
+
+    private fun freePort(): String = ServerSocket(0).use { it.localPort.toString() }
   }
 
   private val runner =
     DockerContainerRunner(
-      image = "mcr.microsoft.com/azure-storage/azurite:3.37.0",
+      image = IMAGE,
       expose = mapOf(port to "10000"),
       waitForLog = "Azurite Blob service successfully listens on",
       rm = true,
@@ -31,6 +41,7 @@ class AzuriteRunner {
     )
 
   fun run() {
+    pullImage()
     runner.run()
     waitForBlobEndpoint()
   }
@@ -40,16 +51,29 @@ class AzuriteRunner {
   }
 
   /**
+   * A cold pull inside `docker run` can exceed DockerContainerRunner's command timeout on a slow CI runner.
+   */
+  private fun pullImage() {
+    val process = ProcessBuilder("docker", "pull", IMAGE).redirectErrorStream(true).start()
+    process.waitFor(10, TimeUnit.MINUTES)
+    check(process.exitValue() == 0) { "docker pull $IMAGE failed:\n${process.inputStream.bufferedReader().readText()}" }
+  }
+
+  /**
    * The container log says "listening" before the published port accepts connections on Docker Desktop.
    */
   private fun waitForBlobEndpoint() {
-    val client = HttpClient.newHttpClient()
-    val request = HttpRequest.newBuilder(URI.create("http://127.0.0.1:$port/devstoreaccount1?comp=list")).build()
+    val client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build()
+    val request =
+      HttpRequest
+        .newBuilder(URI.create("http://127.0.0.1:$port/devstoreaccount1?comp=list"))
+        .timeout(Duration.ofSeconds(2))
+        .build()
     waitFor(timeout = 30000, pollTime = 100) {
       try {
         client.send(request, HttpResponse.BodyHandlers.discarding())
         true
-      } catch (e: IOException) {
+      } catch (_: IOException) {
         false
       }
     }

--- a/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
+++ b/backend/testing/src/main/kotlin/io/tolgee/fixtures/AzuriteRunner.kt
@@ -1,0 +1,38 @@
+package io.tolgee.fixtures
+
+import io.tolgee.misc.dockerRunner.DockerContainerRunner
+
+class AzuriteRunner {
+  companion object {
+    val port: String = System.getenv("TOLGEE_TEST_AZURITE_PORT") ?: "51000"
+    val containerName: String = System.getenv("TOLGEE_TEST_AZURITE_CONTAINER") ?: "server-integration-test-azurite"
+
+    /**
+     * Well-known Azurite development account, publicly documented by Microsoft. Not a secret.
+     */
+    val connectionString: String =
+      "DefaultEndpointsProtocol=http;" +
+        "AccountName=devstoreaccount1;" +
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+        "BlobEndpoint=http://127.0.0.1:$port/devstoreaccount1;"
+  }
+
+  private val runner =
+    DockerContainerRunner(
+      image = "mcr.microsoft.com/azure-storage/azurite:3.35.0",
+      expose = mapOf(port to "10000"),
+      waitForLog = "Azurite Blob service successfully listens on",
+      rm = true,
+      name = containerName,
+      // The Azure SDK sends a newer x-ms-version than Azurite knows; without the flag every request is rejected.
+      command = "azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck --loose",
+    )
+
+  fun run() {
+    runner.run()
+  }
+
+  fun stop() {
+    runner.stop()
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `tolgee.file-storage.azure.{enabled,connection-string,container-name}` (`AzureBlobSettings`, documented via `@DocProperty`) and wires the already existing `AzureBlobFileStorage` / `AzureFileStorageFactory` into `FileStorageConfiguration` as a third option next to local FS and S3.
- Enabling both S3 and Azure, or enabling Azure without a connection string or container name, fails at startup with a readable message.
- Fixes `AzureBlobFileStorage.fileExists`: it ignored the result of `exists()` and always returned `true` (and caught the AWS S3 `NoSuchKeyException`). Content delivery never calls `fileExists`, the main storage does (screenshots, avatars).

## Tests

- `FileStorageConfigurationTest`: storage selection (local default, in-memory precedence, azure, s3, both enabled, azure misconfigured).
- `FileStorageAzureTest`: `fileExists` now covers the missing-blob and failure cases.
- `FileStorageAzureBlobTest` (`@ContextRecreatingTest`): Spring context booted with Azure enabled against an Azurite container started by the new `AzuriteRunner` (same `DockerContainerRunner` used for Postgres and Redis). Verifies store/read/delete/exists/prune through an independent blob client. Azurite needs `--skipApiVersionCheck` because the SDK sends a newer `x-ms-version` than Azurite knows.

Docs: the regenerated `configuration.mdx` is in tolgee/documentation (separate PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Azure Blob Storage as a file-storage provider.
  - Added configuration options for enabling Azure storage, specifying a connection string, and selecting a container.
  - Azure storage is selected according to configured provider settings, with validation for conflicting choices.

- **Bug Fixes**
  - Improved handling of missing files, deletion requests, and directory cleanup in Azure Blob Storage.
  - Added validation for incomplete Azure settings.
  - Azure storage failures now retain their underlying causes for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->