### PR TITLE
chore: add tolgee.internal.test-clock-enabled to expose only the test clock

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/api/publicConfiguration/PublicConfigurationAssembler.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/publicConfiguration/PublicConfigurationAssembler.kt
@@ -44,6 +44,7 @@ class PublicConfigurationAssembler(
       appName = properties.appName,
       showVersion = properties.internal.showVersion,
       internalControllerEnabled = properties.internal.controllerEnabled,
+      testClockEnabled = properties.internal.testClockEnabled,
       maxTranslationTextLength = properties.maxTranslationTextLength,
       recaptchaSiteKey = properties.recaptcha.siteKey,
       chatwootToken = properties.chatwootToken,

--- a/backend/api/src/main/kotlin/io/tolgee/api/publicConfiguration/PublicConfigurationDTO.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/api/publicConfiguration/PublicConfigurationDTO.kt
@@ -24,6 +24,7 @@ class PublicConfigurationDTO(
   val appName: String,
   val showVersion: Boolean,
   val internalControllerEnabled: Boolean,
+  val testClockEnabled: Boolean,
   val maxTranslationTextLength: Long,
   val recaptchaSiteKey: String?,
   val chatwootToken: String?,

--- a/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
+++ b/backend/app/src/main/kotlin/io/tolgee/configuration/WebSecurityConfig.kt
@@ -18,6 +18,7 @@ package io.tolgee.configuration
 
 import io.tolgee.component.ExceptionHandlerFilter
 import io.tolgee.component.TransferEncodingHeaderDebugFilter
+import io.tolgee.configuration.tolgee.TolgeeProperties
 import io.tolgee.security.authentication.AdminAccessInterceptor
 import io.tolgee.security.authentication.AuthenticationFilter
 import io.tolgee.security.authentication.AuthenticationInterceptor
@@ -77,6 +78,7 @@ class WebSecurityConfig(
   @Lazy
   private val featureAuthorizationInterceptor: FeatureAuthorizationInterceptor,
   private val exceptionHandlerFilter: ExceptionHandlerFilter,
+  private val tolgeeProperties: TolgeeProperties,
 ) : WebMvcConfigurer {
   @Bean
   fun securityFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
@@ -121,8 +123,17 @@ class WebSecurityConfig(
   fun internalSecurityFilterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
     return httpSecurity
       .securityMatcher(*INTERNAL_ENDPOINTS)
-      .authorizeHttpRequests { it.anyRequest().denyAll() }
-      .build()
+      .csrf { it.disable() }
+      .cors(Customizer.withDefaults())
+      .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+      .addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter::class.java)
+      .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+      .authorizeHttpRequests {
+        if (tolgeeProperties.internal.testClockEnabled) {
+          it.requestMatchers(*TEST_CLOCK_ENDPOINTS).hasRole("SUPPORTER")
+        }
+        it.anyRequest().denyAll()
+      }.build()
   }
 
   override fun addInterceptors(registry: InterceptorRegistry) {
@@ -172,6 +183,7 @@ class WebSecurityConfig(
       )
     private val ADMIN_ENDPOINTS = arrayOf("/v2/administration/**", "/v2/ee-license/**")
     private val INTERNAL_ENDPOINTS = arrayOf("/internal/**")
+    private val TEST_CLOCK_ENDPOINTS = arrayOf("/internal/time/**", "/internal/test-clock-helper/**")
     private val PROJECT_ENDPOINTS = arrayOf("/v2/projects/**", "/api/project/**", "/api/repository/**")
     private val ORGANIZATION_ENDPOINTS = arrayOf("/v2/organizations/**")
   }

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/internal/SqlControllerTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/internal/SqlControllerTest.kt
@@ -1,5 +1,8 @@
 package io.tolgee.controllers.internal
 
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
 import io.tolgee.testing.AbstractControllerTest
 import io.tolgee.testing.ContextRecreatingTest
 import io.tolgee.testing.assertions.Assertions.assertThat
@@ -42,6 +45,14 @@ class SqlControllerTest :
         key,
         value,
       )
+    }
+  }
+
+  @Test
+  fun `internal controllers alone do not expose the test clock page`() {
+    performGet("/api/public/configuration").andIsOk.andAssertThatJson {
+      node("internalControllerEnabled").isEqualTo(true)
+      node("testClockEnabled").isEqualTo(false)
     }
   }
 

--- a/backend/app/src/test/kotlin/io/tolgee/controllers/internal/TestClockFlagTest.kt
+++ b/backend/app/src/test/kotlin/io/tolgee/controllers/internal/TestClockFlagTest.kt
@@ -1,0 +1,81 @@
+package io.tolgee.controllers.internal
+
+import io.tolgee.development.testDataBuilder.data.TestClockTestData
+import io.tolgee.fixtures.andAssertThatJson
+import io.tolgee.fixtures.andIsForbidden
+import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.node
+import io.tolgee.testing.AuthorizedControllerTest
+import io.tolgee.testing.ContextRecreatingTest
+import io.tolgee.testing.assertions.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import java.util.Date
+
+@ContextRecreatingTest
+@SpringBootTest(
+  properties = [
+    "tolgee.internal.controller-enabled=false",
+    "tolgee.internal.test-clock-enabled=true",
+  ],
+)
+class TestClockFlagTest : AuthorizedControllerTest() {
+  lateinit var testData: TestClockTestData
+
+  @BeforeEach
+  fun setup() {
+    testData = TestClockTestData()
+    testDataService.saveTestData(testData.root)
+  }
+
+  @AfterEach
+  fun cleanup() {
+    currentDateProvider.forcedDate = null
+    testDataService.cleanTestData(testData.root)
+  }
+
+  @Test
+  fun `admin sets and releases the clock`() {
+    loginAsUser(testData.admin)
+    performAuthPut("/internal/time/1700000000000", null).andIsOk
+    assertThat(currentDateProvider.forcedDate).isEqualTo(Date(1700000000000))
+    performAuthDelete("/internal/time", null).andIsOk
+    assertThat(currentDateProvider.forcedDate).isNull()
+  }
+
+  @Test
+  fun `regular user cannot set the clock`() {
+    loginAsUser(testData.user)
+    performAuthPut("/internal/time/1700000000000", null).andIsForbidden
+    assertThat(currentDateProvider.forcedDate).isNull()
+  }
+
+  @Test
+  fun `other internal endpoints stay denied`() {
+    loginAsUser(testData.admin)
+    performAuthPost("/internal/sql/execute", "select 1").andIsForbidden
+  }
+
+  @Test
+  fun `cross-origin preflight is answered`() {
+    mvc
+      .perform(
+        options("/internal/time/1700000000000")
+          .header("Origin", "http://localhost:3000")
+          .header("Access-Control-Request-Method", "PUT"),
+      ).andIsOk
+      .andExpect(header().string("Access-Control-Allow-Origin", "*"))
+  }
+
+  @Test
+  fun `public configuration exposes the flag`() {
+    performGet("/api/public/configuration").andIsOk.andAssertThatJson {
+      node("testClockEnabled").isEqualTo(true)
+      node("internalControllerEnabled").isEqualTo(false)
+    }
+  }
+}

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/InternalProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/InternalProperties.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties(prefix = "tolgee.internal")
 class InternalProperties {
   var controllerEnabled = false
+  var testClockEnabled = false
   var fakeThirdPartyLogin = false
   var showVersion: Boolean = false
   var fakeMtProviders: Boolean = false

--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TestClockTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/TestClockTestData.kt
@@ -1,0 +1,15 @@
+package io.tolgee.development.testDataBuilder.data
+
+import io.tolgee.model.UserAccount
+
+class TestClockTestData : BaseTestData() {
+  lateinit var admin: UserAccount
+
+  init {
+    root.addUserAccount {
+      username = "admin@test-clock.com"
+      role = UserAccount.Role.ADMIN
+      admin = this
+    }
+  }
+}

--- a/backend/development/src/main/kotlin/io/tolgee/controllers/internal/TestClockController.kt
+++ b/backend/development/src/main/kotlin/io/tolgee/controllers/internal/TestClockController.kt
@@ -1,14 +1,23 @@
 package io.tolgee.controllers.internal
 
+import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Schema
 import io.tolgee.component.CurrentDateProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import java.util.Date
 
-@InternalController(["internal/time"])
+@RestController
+@CrossOrigin(origins = ["*"])
+@Hidden
+@RequestMapping(value = ["internal/time"])
+@ConditionalOnExpression("\${tolgee.internal.controller-enabled:false} or \${tolgee.internal.test-clock-enabled:false}")
 class TestClockController(
   val currentDateProvider: CurrentDateProvider,
 ) {

--- a/webapp/src/service/apiSchema.generated.ts
+++ b/webapp/src/service/apiSchema.generated.ts
@@ -5874,6 +5874,7 @@ export interface components {
       screenshotsUrl: string;
       showVersion: boolean;
       slack: components["schemas"]["SlackDTO"];
+      testClockEnabled: boolean;
       /** Format: int32 */
       translationsViewLanguagesLimit: number;
       userCanCreateOrganizations: boolean;

--- a/webapp/src/views/organizations/components/BaseOrganizationSettingsView.tsx
+++ b/webapp/src/views/organizations/components/BaseOrganizationSettingsView.tsx
@@ -133,7 +133,7 @@ export const BaseOrganizationSettingsView: React.FC<
         }),
         label: t('organization_menu_invoices'),
       });
-      if (config.internalControllerEnabled) {
+      if (config.testClockEnabled && isAdminOrSupporter) {
         menuItems.push({
           link: LINKS.ORGANIZATION_BILLING_TEST_CLOCK_HELPER.build({
             [PARAMS.ORGANIZATION_SLUG]: organizationSlug,


### PR DESCRIPTION
## What changed

- New property `tolgee.internal.test-clock-enabled`. When set, `/internal/time/**` and `/internal/test-clock-helper/**` are open to server admins (SUPPORTER role and above). The rest of `/internal/**` stays denied.
- `TestClockController` is registered under either this flag or `controller-enabled`.
- Public configuration gets `testClockEnabled`, and the organization settings menu shows the test clock page only when it is true.
- Regenerated the webapp API schema.

## Why

Previews needed `controller-enabled` to show the Stripe test clock page. That opens every internal endpoint with no authentication, including the SQL console. This flag opens just the two endpoints the page uses, and only to admins.

## Notes

- With only `controller-enabled` set (e2e, local dev), the page is hidden but the `/internal/time` API still works as before. To see the page locally, add `tolgee.internal.test-clock-enabled: true` to your dev yaml.
- Companion PRs on the same branch in `tolgee/billing` and `tolgee/deployment`.

## Tests

- `TestClockFlagTest`: admin sets and releases the clock, regular user gets 403, SQL console stays 403, config exposes the flag.
- `SqlControllerTest`: `controller-enabled` alone does not expose the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated configuration option for enabling the test clock independently from other internal tools.
  * The test clock can now remain available when general internal controllers are disabled.
  * Organization settings display the billing test-clock option when the feature is enabled for authorized administrators or supporters.
  * Test-clock access is restricted to authorized support administrators, while unrelated internal endpoints remain unavailable.

* **Bug Fixes**
  * Public configuration now accurately reports whether the test clock is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->