### PR TITLE
fix: show the plan limit popover to members without an organization role

### DIFF
--- a/e2e/cypress/support/dataCyType.d.ts
+++ b/e2e/cypress/support/dataCyType.d.ts
@@ -551,6 +551,7 @@ declare namespace DataCy {
         "permissions-menu-reset-to-organization": true;
         "permissions-menu-save": true;
         "plan-limit-dialog-close": true;
+        "plan-limit-dialog-organization-limit-message": true;
         "plan-limit-exceeded-popover": true;
         "plan_seat_limit_exceeded_while_accepting_invitation_message": true;
         "profile": true;

--- a/webapp/src/ee/billing/component/CriticalUsageCircle.tsx
+++ b/webapp/src/ee/billing/component/CriticalUsageCircle.tsx
@@ -101,8 +101,12 @@ export const CriticalUsageCircle: FC<React.PropsWithChildren<unknown>> = () => {
       <>{children}</>
     );
 
-  if (!progressData || !showStats) {
+  if (!showStats) {
     return null;
+  }
+
+  if (!progressData) {
+    return <StyledContainer id={USAGE_ELEMENT_ID} />;
   }
 
   return (

--- a/webapp/src/ee/billing/limitPopover/PlanLimitPopoverCloud.tsx
+++ b/webapp/src/ee/billing/limitPopover/PlanLimitPopoverCloud.tsx
@@ -35,12 +35,13 @@ export const PlanLimitPopoverCloud: React.FC<
 
   const progressData = usage && getProgressData({ usage });
 
-  return progressData ? (
+  return (
     <GenericPlanLimitPopover
       onClose={onClose}
       open={open}
       isPayAsYouGo={usage?.isPayAsYouGo}
       progressData={progressData}
+      usageUnavailable={!usage}
       actionButton={
         isOwner && (
           <Button
@@ -53,5 +54,5 @@ export const PlanLimitPopoverCloud: React.FC<
         )
       }
     />
-  ) : null;
+  );
 };

--- a/webapp/src/ee/billing/limitPopover/generic/GenericPlanLimitPopover.tsx
+++ b/webapp/src/ee/billing/limitPopover/generic/GenericPlanLimitPopover.tsx
@@ -21,6 +21,7 @@ type PlanLimitPopoverProps = PlanLimitPopoverWrapperProps & {
   progressData?: Partial<ProgressData>;
   actionButton?: React.ReactNode;
   loading?: boolean;
+  usageUnavailable?: boolean;
 };
 
 const StyledDialogContent = styled(DialogContent)`
@@ -31,7 +32,15 @@ const StyledDialogContent = styled(DialogContent)`
 
 export const GenericPlanLimitPopover: FC<
   React.PropsWithChildren<PlanLimitPopoverProps>
-> = ({ open, onClose, isPayAsYouGo, progressData, actionButton, loading }) => {
+> = ({
+  open,
+  onClose,
+  isPayAsYouGo,
+  progressData,
+  actionButton,
+  loading,
+  usageUnavailable,
+}) => {
   return (
     <PlanLimitPopoverWrapper
       open={open}
@@ -43,7 +52,16 @@ export const GenericPlanLimitPopover: FC<
       </DialogTitle>
       <StyledDialogContent>
         <DialogContentText id="alert-dialog-description">
-          <T keyName="plan_limit_dialog_description" />
+          {usageUnavailable ? (
+            <span data-cy="plan-limit-dialog-organization-limit-message">
+              <T
+                keyName="plan_limit_dialog_organization_limit_description"
+                defaultValue="The organization's plan limit has been reached. Contact the organization owner to upgrade the plan."
+              />
+            </span>
+          ) : (
+            <T keyName="plan_limit_dialog_description" />
+          )}
         </DialogContentText>
         {progressData && isPayAsYouGo !== undefined ? (
           <UsageDetailed {...progressData} isPayAsYouGo={isPayAsYouGo} />

--- a/webapp/src/globalContext/useOrganizationUsageService.ts
+++ b/webapp/src/globalContext/useOrganizationUsageService.ts
@@ -4,7 +4,6 @@ import { useApiQuery } from 'tg.service/http/useQueryApi';
 import { isAtLeastMemberOrgRole } from 'tg.fixtures/organizationRole';
 
 type OrganizationModel = components['schemas']['OrganizationModel'];
-type UsageModel = components['schemas']['PublicUsageModel'];
 
 type Props = {
   organization?: OrganizationModel;
@@ -18,9 +17,6 @@ export const useOrganizationUsageService = ({
   const isOrganizationMember = isAtLeastMemberOrgRole(
     organization?.currentUserRole
   );
-  const [organizationUsage, setOrganizationUsage] = useState<
-    UsageModel | undefined
-  >(undefined);
   const [planLimitErrors, setPlanLimitErrors] = useState(0);
   const [spendingLimitErrors, setSpendingLimitErrors] = useState(0);
 
@@ -42,21 +38,10 @@ export const useOrganizationUsageService = ({
       refetchOnMount: false,
       cacheTime: Infinity,
       enabled: usageEnabled,
-      onSuccess(data) {
-        setOrganizationUsage(data);
-      },
     },
   });
 
-  const updateUsageData = (data: Partial<UsageModel>) =>
-    setOrganizationUsage((val) =>
-      val
-        ? {
-            ...val,
-            ...data,
-          }
-        : val
-    );
+  const usage = usageEnabled ? usageLoadable.data : undefined;
 
   const incrementPlanLimitErrors = () => {
     setPlanLimitErrors((v) => v + 1);
@@ -106,13 +91,12 @@ export const useOrganizationUsageService = ({
 
   return {
     state: {
-      usage: organizationUsage,
+      usage,
       planLimitErrors,
       spendingLimitErrors,
     },
     actions: {
       refetchUsage,
-      updateUsageData,
       incrementPlanLimitErrors,
       incrementSpendingLimitErrors,
       increaseCreditPlanLimitErrors,

--- a/webapp/src/views/projects/translations/TranslationsList/TranslationLabels.tsx
+++ b/webapp/src/views/projects/translations/TranslationsList/TranslationLabels.tsx
@@ -83,9 +83,6 @@ export const TranslationLabels = ({
   );
   const { isEnabled } = useEnabledFeatures();
   const labelsEnabled = isEnabled('TRANSLATION_LABELS');
-  if (!labelsEnabled) {
-    return null;
-  }
   const { t } = useTranslate();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -136,7 +133,7 @@ export const TranslationLabels = ({
 
   useLayoutEffect(() => {
     recalculate();
-  }, [labels, recalculate]);
+  }, [labels, recalculate, labelsEnabled]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -146,9 +143,13 @@ export const TranslationLabels = ({
       ro.disconnect();
       debouncedRecalculate.clear();
     };
-  }, [debouncedRecalculate]);
+  }, [debouncedRecalculate, labelsEnabled]);
 
   const overflowCount = labels?.length - visibleCount;
+
+  if (!labelsEnabled) {
+    return null;
+  }
 
   return (
     <StyledLabels className={className}>


### PR DESCRIPTION
## What changed

- The plan limit popover always opens when the server rejects a change because of the plan limit. Before, it rendered nothing when usage numbers were not loaded.
- When usage is not available, the popover shows a generic message ("The organization's plan limit has been reached. Contact the organization owner to upgrade the plan.") instead of the usage bars.
- The stored organization usage is reset when the preferred organization changes, so the popover never shows numbers of another organization.
- The popover keeps its top-right position when there is no usage circle to anchor to.
- `TranslationLabels` called its hooks after a conditional early return. React crashed with "Rendered more hooks than during the previous render" when the labels feature switched on after the first render.

## Why

Usage is fetched only for organizations where the user has a role. A user with project-level permission only (a real customer case, GoLogin org 1278) hit the key limit of the owner organization and saw:

- nothing at all on a fresh page load (Chrome, Firefox),
- or the usage of his own Free organization, "220 / 1000 strings", when he navigated in-app from his own organization (Safari).

Both hid the real cause from the user.

## Tests

Cypress tests are in tolgee/billing, same branch name: `dkrizan/limit-popover-project-members`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan limit dialogs remain available when usage information cannot be loaded.
  * Organization limit messaging is shown when usage data is unavailable.
  * Usage indicators preserve their layout while usage details are loading or unavailable.
  * Translation labels continue to follow their configured feature availability without disrupting component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->