### PR TITLE
fix: wrap long unbreakable comment text so the resolve action stays reachable

### DIFF
--- a/e2e/cypress/e2e/translations/comments.cy.ts
+++ b/e2e/cypress/e2e/translations/comments.cy.ts
@@ -27,6 +27,28 @@ describe('Translation comments', () => {
     createComment('Cool comment 1', 'A key', 'en');
   });
 
+  it('wraps a long link and keeps the resolve button on screen', () => {
+    logInAs('franta');
+    const longLink =
+      'https://tolgee-workspace.slack.com/archives/C01ABCDEFGH/p1712345678901234';
+    createComment(longLink, 'A key', 'en');
+
+    cy.gcy('comment-text')
+      .contains(longLink)
+      .closestDcy('comment')
+      .findDcy('comment-resolve')
+      .should(($button) => {
+        const panelRight = $button
+          .closest('[data-cy="translation-panel-content"]')[0]
+          .getBoundingClientRect().right;
+        expect($button[0].getBoundingClientRect().right).to.be.at.most(
+          panelRight
+        );
+      });
+
+    resolveComment(longLink);
+  });
+
   it('franta can delete all comments (manage)', () => {
     logInAs('franta');
     userCanDeleteComment('C key', 'en', 'First comment');

--- a/webapp/src/views/projects/translations/ToolsPanel/panels/Comments/Comment.tsx
+++ b/webapp/src/views/projects/translations/ToolsPanel/panels/Comments/Comment.tsx
@@ -77,7 +77,7 @@ const StyledTextPre = styled('pre')`
   line-height: 1.1;
   font-family: ${({ theme }) => theme.typography.fontFamily};
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: anywhere;
 
   &.textUnresolved {
     font-weight: 700;


### PR DESCRIPTION
Closes #3905

## Problem

A translation comment whose body is a single long unbreakable string (a Slack permalink is the case reported on the TAB call) blows the comments panel layout out horizontally. The link is clipped at the panel edge, and the timestamp, resolve and menu buttons are pushed outside the panel, so the comment cannot be resolved at all.

Because all comments of the same day share one grid container, a single long comment also pushes the timestamp and actions off screen for **every other comment in that day group**.

## Cause

`Comment.tsx` lays each comment out as a grid with `grid-template-columns: auto 1fr auto auto`, and the comment text `<pre>` sits in the `1fr` track with `word-wrap: break-word`.

`overflow-wrap: break-word` (`word-wrap` is its legacy alias) allows a mid-word break when a word does not fit a line, but per CSS Text it does **not** reduce the element's min-content intrinsic size. The `1fr` track's automatic minimum is that min-content size, so the track is forced to the full width of the unbroken URL and the remaining columns are pushed out of the panel.

`overflow-wrap: anywhere` behaves the same for line breaking but *does* affect min-content sizing, so the track can shrink. It is a one-property swap rather than an added `min-width: 0` workaround.

## Measurements

Measured in the running app at a 1440px viewport, comments panel 345px wide with its right edge at x=1416:

| | comment grid width | resolve button | reachable |
|---|---|---|---|
| before | 604px | x = 1639..1659 | no, 223px outside the panel and off the viewport |
| after | 331px | x = 1366..1386 | yes |
| after, 299px panel | 285px | ends at x=946 of 1000 | yes |

Clicking resolve in the fixed build resolves the comment (the `unresolved` class and the button both go away).

## Testing

New spec in `e2e/cypress/e2e/translations/comments.cy.ts` asserts the resolve button's right edge stays within the enclosing `translation-panel-content`. That container keeps its correct width even when the comment overflows, so the assertion is independent of scroll position and viewport size.

Verified red/green against a real backend + webapp:

- without the fix: fails, `1661.4375` vs panel right `1416`
- with the fix: passes, and the full `comments.cy.ts` spec is 16/16

`npm run eslint -- --fix && npm run tsc` clean in both `webapp/` and `e2e/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long comment links now wrap correctly within the translation panel, keeping comment actions visible and usable.
  - Improved comment resolution behavior for content containing lengthy links.

- **Tests**
  - Added end-to-end coverage to verify long-link wrapping and comment resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->