### PR TITLE
fix: reject requests on rate limit bucket contention instead of queueing threads

### DIFF
--- a/backend/api/src/main/kotlin/io/tolgee/component/lockingProvider/RedissonLockingProvider.kt
+++ b/backend/api/src/main/kotlin/io/tolgee/component/lockingProvider/RedissonLockingProvider.kt
@@ -31,6 +31,24 @@ open class RedissonLockingProvider(
     }
   }
 
+  override fun <T> tryWithLocking(
+    name: String,
+    waitTime: Duration,
+    fn: () -> T,
+  ): T? {
+    val lock = this.getLock(name)
+    if (!lock.tryLock(waitTime.toMillis(), TimeUnit.MILLISECONDS)) {
+      return null
+    }
+    try {
+      return fn()
+    } finally {
+      if (lock.isHeldByCurrentThread) {
+        lock.unlock()
+      }
+    }
+  }
+
   override fun <T> withLockingIfFree(
     name: String,
     leaseTime: Duration,

--- a/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/Metrics.kt
@@ -31,6 +31,18 @@ class Metrics(
       .register(meterRegistry)
   }
 
+  /**
+   * Requests rejected without consuming the bucket because of contention on a single rate limit
+   * bucket. Reasons: "concurrency_cap" (too many concurrent requests for the bucket),
+   * "lock_timeout" (the bucket lock was not acquired within the configured wait time).
+   */
+  fun rateLimitConcurrencyRejectionsCounter(reason: String): Counter =
+    Counter
+      .builder("tolgee.ratelimit.concurrency_rejections")
+      .description("Number of requests rejected due to contention on a single rate limit bucket")
+      .tag("reason", reason)
+      .register(meterRegistry)
+
   // ==========================================================================
   // Batch Job Metrics
   // ==========================================================================

--- a/backend/data/src/main/kotlin/io/tolgee/component/LockingProvider.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/component/LockingProvider.kt
@@ -1,6 +1,7 @@
 package io.tolgee.component
 
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.Lock
 
 interface LockingProvider {
@@ -10,6 +11,30 @@ interface LockingProvider {
     name: String,
     fn: () -> T,
   ): T
+
+  /**
+   * Executes the given function if the lock can be acquired within [waitTime].
+   * If the lock cannot be acquired in time, returns null without executing the function.
+   *
+   * @param name The name of the lock
+   * @param waitTime The maximum time to wait for the lock
+   * @param fn The function to execute while holding the lock
+   */
+  fun <T> tryWithLocking(
+    name: String,
+    waitTime: Duration,
+    fn: () -> T,
+  ): T? {
+    val lock = getLock(name)
+    if (!lock.tryLock(waitTime.toMillis(), TimeUnit.MILLISECONDS)) {
+      return null
+    }
+    try {
+      return fn()
+    } finally {
+      lock.unlock()
+    }
+  }
 
   /**
    * Executes the given function if the lock is free.

--- a/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/RateLimitProperties.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/configuration/tolgee/RateLimitProperties.kt
@@ -90,4 +90,20 @@ class RateLimitProperties(
     defaultExplanation = "= 1 minute",
   )
   var strikeResetWindowMs: Long = 60_000,
+  @DocProperty(
+    description =
+      "Maximum time, in milliseconds, a request waits for the internal per-bucket lock before it is\n" +
+        "rejected with a `429` response. This prevents requests from queueing on a heavily contended\n" +
+        "rate limit bucket and exhausting the server's worker threads.",
+  )
+  var lockWaitMs: Long = 500,
+  @DocProperty(
+    description =
+      "Maximum number of requests processed concurrently (per node) for a single rate limit bucket.\n" +
+        "Requests above this cap are rejected immediately with a `429` response, without waiting for\n" +
+        "the bucket lock. This protects the server's worker threads when a single client floods the\n" +
+        "API, while leaving room for legitimate bursts (e.g. an app fetching many namespaces in\n" +
+        "parallel on startup). Set to 0 to disable the cap.",
+  )
+  var maxConcurrentPerBucket: Int = 50,
 )

--- a/backend/data/src/main/kotlin/io/tolgee/security/ratelimit/RateLimitService.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/security/ratelimit/RateLimitService.kt
@@ -16,6 +16,7 @@
 
 package io.tolgee.security.ratelimit
 
+import io.tolgee.Metrics
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.LockingProvider
 import io.tolgee.component.ResilientCacheAccessor
@@ -28,6 +29,8 @@ import org.springframework.cache.CacheManager
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 @Service
 class RateLimitService(
@@ -38,11 +41,14 @@ class RateLimitService(
   @Lazy
   private val authenticationFacade: AuthenticationFacade,
   private val resilientCacheAccessor: ResilientCacheAccessor,
+  private val metrics: Metrics,
 ) {
   private val cache: Cache by lazy {
     cacheManager.getCache(Caches.RATE_LIMITS)
       ?: throw RuntimeException("Could not initialize cache!")
   }
+
+  private val inFlightConsumers = ConcurrentHashMap<String, AtomicInteger>()
 
   /**
    * Consumes a token from the provided rate limit policy.
@@ -70,26 +76,51 @@ class RateLimitService(
     if (policy == null) return
 
     val lockName = getLockName(policy)
-    lockingProvider.withLocking(lockName) {
-      val bucket = resilientCacheAccessor.get(cache, policy.bucketName, Bucket::class.java)
-      try {
-        val consumed = doConsumeBucket(policy, bucket)
+    val inFlight = inFlightConsumers.computeIfAbsent(lockName) { AtomicInteger() }
+    val concurrent = inFlight.incrementAndGet()
+    try {
+      val maxConcurrent = rateLimitProperties.maxConcurrentPerBucket
+      if (maxConcurrent > 0 && concurrent > maxConcurrent) {
+        rejectWithoutConsuming(policy, "concurrency_cap")
+      }
+
+      lockingProvider.tryWithLocking(lockName, Duration.ofMillis(rateLimitProperties.lockWaitMs)) {
+        val bucket = resilientCacheAccessor.get(cache, policy.bucketName, Bucket::class.java)
         try {
-          if (!cond()) {
+          val consumed = doConsumeBucket(policy, bucket)
+          try {
+            if (!cond()) {
+              cache.put(policy.bucketName, consumed)
+            }
+          } catch (e: Exception) {
             cache.put(policy.bucketName, consumed)
+            throw e
           }
-        } catch (e: Exception) {
-          cache.put(policy.bucketName, consumed)
+        } catch (e: RateLimitedException) {
+          updateCacheWithStrike(policy.bucketName, bucket, e.strikeCount, e.lastStrikeAt)
+          throw e
+        } catch (e: RateLimitBlockedException) {
+          updateCacheWithStrike(policy.bucketName, bucket, e.strikeCount, e.lastStrikeAt)
           throw e
         }
-      } catch (e: RateLimitedException) {
-        updateCacheWithStrike(policy.bucketName, bucket, e.strikeCount, e.lastStrikeAt)
-        throw e
-      } catch (e: RateLimitBlockedException) {
-        updateCacheWithStrike(policy.bucketName, bucket, e.strikeCount, e.lastStrikeAt)
-        throw e
+      } ?: rejectWithoutConsuming(policy, "lock_timeout")
+    } finally {
+      if (inFlight.decrementAndGet() <= 0) {
+        inFlightConsumers.remove(lockName, inFlight)
       }
     }
+  }
+
+  /**
+   * Rejects a request due to bucket contention, without touching the bucket itself.
+   * No strike is recorded — the bucket cannot be read or written safely without holding the lock.
+   */
+  private fun rejectWithoutConsuming(
+    policy: RateLimitPolicy,
+    reason: String,
+  ): Nothing {
+    metrics.rateLimitConcurrencyRejectionsCounter(reason).increment()
+    throw RateLimitedException(rateLimitProperties.lockWaitMs, policy.global)
   }
 
   /**

--- a/backend/data/src/test/kotlin/io/tolgee/security/ratelimit/RateLimitServiceTest.kt
+++ b/backend/data/src/test/kotlin/io/tolgee/security/ratelimit/RateLimitServiceTest.kt
@@ -16,6 +16,8 @@
 
 package io.tolgee.security.ratelimit
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.tolgee.Metrics
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.LockingProvider
 import io.tolgee.component.ResilientCacheAccessor
@@ -39,6 +41,10 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.web.servlet.HandlerMapping
 import java.time.Duration
 import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.Lock
 import java.util.concurrent.locks.ReentrantLock
 
@@ -66,6 +72,8 @@ class RateLimitServiceTest {
 
   private val resilientCacheAccessor = ResilientCacheAccessor()
 
+  private val meterRegistry = SimpleMeterRegistry()
+
   private val rateLimitService =
     Mockito.spy(
       RateLimitService(
@@ -75,6 +83,7 @@ class RateLimitServiceTest {
         rateLimitProperties,
         authenticationFacade,
         resilientCacheAccessor,
+        Metrics(meterRegistry),
       ),
     )
 
@@ -355,6 +364,7 @@ class RateLimitServiceTest {
         rateLimitProperties,
         authenticationFacade,
         mockAccessor,
+        Metrics(meterRegistry),
       )
 
     val testPolicy = RateLimitPolicy("corrupted_test", 5, Duration.ofSeconds(1), false)
@@ -363,7 +373,116 @@ class RateLimitServiceTest {
     serviceWithMockAccessor.consumeBucket(testPolicy)
   }
 
+  @Test
+  fun `it rejects instead of waiting when the bucket lock is not released in time`() {
+    Mockito.`when`(rateLimitProperties.lockWaitMs).thenReturn(50L)
+
+    val testPolicy = RateLimitPolicy("lock_timeout_test", 10, Duration.ofSeconds(1), false)
+    val lock = lockingProvider.getLock("tolgee.ratelimit.lock_timeout_test")
+
+    lock.lock()
+    try {
+      val thrown = AtomicReference<Throwable>()
+      val worker = Thread { runCatching { rateLimitService.consumeBucket(testPolicy) }.onFailure(thrown::set) }
+      worker.start()
+      worker.join(5_000)
+
+      assertThat(worker.isAlive).isFalse
+      assertThat(thrown.get()).isInstanceOf(RateLimitedException::class.java)
+    } finally {
+      lock.unlock()
+    }
+
+    assertThat(lockTimeoutRejections()).isEqualTo(1.0)
+  }
+
+  @Test
+  fun `it rejects requests above the per-bucket concurrency cap without waiting for the lock`() {
+    Mockito.`when`(rateLimitProperties.maxConcurrentPerBucket).thenReturn(1)
+    Mockito.`when`(rateLimitProperties.lockWaitMs).thenReturn(10_000L)
+
+    val testPolicy = RateLimitPolicy("cap_test", 10, Duration.ofSeconds(1), false)
+    val (worker, release) = consumeInBackgroundAndWaitUntilInsideLock(testPolicy)
+
+    val start = System.currentTimeMillis()
+    assertThrows<RateLimitedException> { rateLimitService.consumeBucket(testPolicy) }
+    // Rejected via the cap, not via the 10s lock wait
+    assertThat(System.currentTimeMillis() - start).isLessThan(5_000)
+
+    release.countDown()
+    worker.join(5_000)
+    assertThat(worker.isAlive).isFalse
+
+    assertThat(concurrencyCapRejections()).isEqualTo(1.0)
+    assertThat(lockTimeoutRejections()).isEqualTo(0.0)
+  }
+
+  @Test
+  fun `the concurrency cap of one bucket does not affect other buckets`() {
+    Mockito.`when`(rateLimitProperties.maxConcurrentPerBucket).thenReturn(1)
+
+    val blockedPolicy = RateLimitPolicy("cap_isolation_blocked", 10, Duration.ofSeconds(1), false)
+    val freePolicy = RateLimitPolicy("cap_isolation_free", 10, Duration.ofSeconds(1), false)
+    val (worker, release) = consumeInBackgroundAndWaitUntilInsideLock(blockedPolicy)
+
+    rateLimitService.consumeBucket(freePolicy)
+
+    release.countDown()
+    worker.join(5_000)
+    assertThat(worker.isAlive).isFalse
+    assertThat(concurrencyCapRejections()).isEqualTo(0.0)
+  }
+
+  @Test
+  fun `zero maxConcurrentPerBucket disables the concurrency cap`() {
+    Mockito.`when`(rateLimitProperties.maxConcurrentPerBucket).thenReturn(0)
+    Mockito.`when`(rateLimitProperties.lockWaitMs).thenReturn(10_000L)
+
+    val testPolicy = RateLimitPolicy("cap_disabled_test", 10, Duration.ofSeconds(1), false)
+    val (worker, release) = consumeInBackgroundAndWaitUntilInsideLock(testPolicy)
+
+    val thrown = AtomicReference<Throwable>()
+    val second = Thread { runCatching { rateLimitService.consumeBucket(testPolicy) }.onFailure(thrown::set) }
+    second.start()
+
+    release.countDown()
+    worker.join(5_000)
+    second.join(5_000)
+
+    assertThat(worker.isAlive).isFalse
+    assertThat(second.isAlive).isFalse
+    assertThat(thrown.get()).isNull()
+    assertThat(concurrencyCapRejections()).isEqualTo(0.0)
+  }
+
   // --- HELPERS
+
+  /**
+   * Starts a thread consuming [policy] and returns once that thread is inside the bucket lock,
+   * where it stays parked until the returned latch is counted down.
+   */
+  private fun consumeInBackgroundAndWaitUntilInsideLock(policy: RateLimitPolicy): Pair<Thread, CountDownLatch> {
+    val entered = CountDownLatch(1)
+    val release = CountDownLatch(1)
+    val worker =
+      Thread {
+        rateLimitService.consumeBucketUnless(policy) {
+          entered.countDown()
+          release.await(5, TimeUnit.SECONDS)
+          false
+        }
+      }
+    worker.start()
+    assertThat(entered.await(5, TimeUnit.SECONDS)).isTrue
+    return worker to release
+  }
+
+  private fun concurrencyCapRejections(): Double =
+    meterRegistry.counter("tolgee.ratelimit.concurrency_rejections", "reason", "concurrency_cap").count()
+
+  private fun lockTimeoutRejections(): Double =
+    meterRegistry.counter("tolgee.ratelimit.concurrency_rejections", "reason", "lock_timeout").count()
+
   private fun makeFakeGenericRequest(): MockHttpServletRequest {
     val fakeRequest = MockHttpServletRequest()
     fakeRequest.remoteAddr = "127.0.0.1"
@@ -375,14 +494,15 @@ class RateLimitServiceTest {
 
   // Accessing the one from API package is a pain here.
   class TestLockingProvider : LockingProvider {
-    private val lock = ReentrantLock()
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
 
-    override fun getLock(name: String): Lock = lock
+    override fun getLock(name: String): Lock = locks.computeIfAbsent(name) { ReentrantLock() }
 
     override fun <T> withLocking(
       name: String,
       fn: () -> T,
     ): T {
+      val lock = getLock(name)
       lock.lock()
       try {
         return fn()

--- a/backend/security/src/test/kotlin/io/tolgee/security/ratelimit/RateLimitInterceptorTest.kt
+++ b/backend/security/src/test/kotlin/io/tolgee/security/ratelimit/RateLimitInterceptorTest.kt
@@ -16,6 +16,8 @@
 
 package io.tolgee.security.ratelimit
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.tolgee.Metrics
 import io.tolgee.component.CurrentDateProvider
 import io.tolgee.component.LockingProvider
 import io.tolgee.component.ResilientCacheAccessor
@@ -61,6 +63,7 @@ class RateLimitInterceptorTest {
         rateLimitProperties,
         authenticationFacade,
         ResilientCacheAccessor(),
+        Metrics(SimpleMeterRegistry()),
       ),
     )
 


### PR DESCRIPTION
## Problem

All rate limit verdicts for a bucket — including "you are rate limited, 429" — are serialized behind a distributed Redisson lock, and `RateLimitService.consumeBucketUnless` blocks on it **indefinitely** (`lock.lock()`).

When many requests share one bucket (e.g. a single API key used by a large fleet of shipped clients), this becomes a self-inflicted denial of service: a turn on the lock costs ~4 Redis round-trips (acquire, bucket get, bucket/strike put, unlock + pub/sub), and Redisson's unfair wake-all handoff degrades to ~25–50 ms per turn with many waiters — so one bucket can only serve a few dozen verdicts per second. Once arrival on the bucket exceeds that, the queue grows without bound (wait = queue position × turn time), clients time out and retry — refilling the queue faster than it drains — and the entire worker pool ends up parked on a single bucket lock. The node stops serving *all* tenants while still passing health checks on the management port.

Per-IP rate limiting (proxy or app-level) cannot catch this shape: each client stays far below any per-IP threshold; it is the aggregate on one *bucket* that kills the node. And the failure mode is concurrency × duration, not request rate — so the fix is to stop queueing worker threads, not to tune limits.

## Fix

`RateLimitService` no longer queues unboundedly on the bucket lock:

1. **Per-bucket concurrency cap (per node)** — an in-flight counter per bucket; above `tolgee.rate-limits.max-concurrent-per-bucket` (default 50) requests are rejected with 429 immediately, without touching the lock. Node-local by design: the protected resource (worker threads) is node-local, and the cap keeps working even when Redis itself is slow. Set to 0 to disable.
2. **Bounded lock wait** — the bucket lock is acquired via the new `LockingProvider.tryWithLocking(name, waitTime, fn)` with `tolgee.rate-limits.lock-wait-ms` (default 500 ms) instead of an infinite `lock.lock()`; timeout → 429. `tryWithLocking` is a default interface method; `RedissonLockingProvider` overrides it only to keep its `isHeldByCurrentThread` unlock guard.

Neither rejection records a strike (the bucket cannot be read or written safely without holding the lock); both use `retryAfter = lock-wait-ms`.

New metric: `tolgee.ratelimit.concurrency_rejections` counter, tagged `reason=concurrency_cap|lock_timeout`.

## Behavior change

A client sending more than `max-concurrent-per-bucket` truly simultaneous requests per node to one bucket now gets 429s for the excess instead of having them queue briefly. The default of 50 covers the largest known legitimate burst — apps with 40+ namespaces fetch them all in parallel on startup through one API key (one bucket), even if the whole burst lands on a single node — while still limiting a single hot bucket to ~25% of a node's worker pool (~200 threads). The cap only bites the flood shape described above.

## Testing

- New unit tests in `RateLimitServiceTest`: rejection within the lock-wait bound when the lock is held; cap rejection happens without waiting for the lock (timing-asserted against a 10 s lock wait); cap on one bucket does not affect other buckets; `max-concurrent-per-bucket = 0` restores queueing. Metric counters asserted throughout.
- Existing `RateLimitServiceTest`, `:security` rate limit tests, and `RateLimitsTest` / `RedisRateLimitsTest` integration suites pass unchanged.
