### PR TITLE
test: fix flaky GlossaryGuestAccessTest export test

### DIFF
--- a/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryGuestAccessTestData.kt
+++ b/backend/data/src/main/kotlin/io/tolgee/development/testDataBuilder/data/GlossaryGuestAccessTestData.kt
@@ -65,6 +65,11 @@ class GlossaryGuestAccessTestData : BaseTestData() {
       }.build {
         publicProject = self
         addBaseLanguage()
+        addLanguage {
+          name = "French"
+          tag = "fr"
+          originalName = "Français"
+        }
       }
 
       addProject(organizationOwner = userAccountBuilder.defaultOrganizationBuilder.self) {

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryGuestAccessTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryGuestAccessTest.kt
@@ -10,6 +10,7 @@ import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsNotFound
 import io.tolgee.fixtures.andIsOk
+import io.tolgee.fixtures.ignoreTestOnSpringBug
 import io.tolgee.fixtures.node
 import io.tolgee.model.UserAccount
 import io.tolgee.testing.AuthorizedControllerTest
@@ -45,7 +46,6 @@ class GlossaryGuestAccessTest : AuthorizedControllerTest() {
   @AfterEach
   fun cleanup() {
     testDataService.cleanTestData(testData.root)
-    userAccount = null
     enabledFeaturesProvider.forceEnabled = null
   }
 
@@ -186,16 +186,27 @@ class GlossaryGuestAccessTest : AuthorizedControllerTest() {
 
   @Test
   fun `guest export omits a private co-assigned project's languages`() {
-    exportLanguageHeaders(testData.virtualGuest).assert.doesNotContain("de")
-    exportLanguageHeaders(testData.user).assert.contains("de")
+    exportMixedGlossaryLanguageHeaders(testData.virtualGuest).assert.isEqualTo(listOf("fr"))
+    exportMixedGlossaryLanguageHeaders(testData.user).assert.isEqualTo(listOf("de", "fr"))
   }
 
-  private fun exportLanguageHeaders(user: UserAccount): List<String> {
+  @Test
+  fun `guest may call the glossary export endpoint`() {
+    userAccount = testData.virtualGuest
+    ignoreTestOnSpringBug {
+      performAuthGet(
+        "/v2/organizations/${testData.organization.id}/glossaries/${testData.mixedGlossary.id}/export",
+      ).andIsOk
+    }
+  }
+
+  private fun exportMixedGlossaryLanguageHeaders(user: UserAccount): List<String> {
+    userAccount = user
     setSecurityContext(user)
     val csv =
       executeInNewTransaction {
         val glossary = glossaryService.get(testData.organization.id, testData.mixedGlossary.id)
-        glossaryExportService.exportCsv(glossary).readBytes().toString(Charsets.UTF_8)
+        glossaryExportService.exportCsv(glossary).bufferedReader().readText()
       }
     val headers = csv.lines()[0].split(",").map { it.trim().removeSurrounding("\"") }
     headers.take(GLOSSARY_CSV_HEADER_NAMES.size).assert.isEqualTo(GLOSSARY_CSV_HEADER_NAMES)

--- a/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryGuestAccessTest.kt
+++ b/ee/backend/tests/src/test/kotlin/io/tolgee/ee/api/v2/controllers/glossary/GlossaryGuestAccessTest.kt
@@ -3,7 +3,9 @@ package io.tolgee.ee.api.v2.controllers.glossary
 import io.tolgee.constants.Feature
 import io.tolgee.development.testDataBuilder.data.GlossaryGuestAccessTestData
 import io.tolgee.ee.component.PublicEnabledFeaturesProvider
+import io.tolgee.ee.service.glossary.GlossaryExportService
 import io.tolgee.ee.service.glossary.GlossaryService
+import io.tolgee.ee.service.glossary.formats.csv.GLOSSARY_CSV_HEADER_NAMES
 import io.tolgee.fixtures.andAssertThatJson
 import io.tolgee.fixtures.andIsForbidden
 import io.tolgee.fixtures.andIsNotFound
@@ -27,6 +29,9 @@ class GlossaryGuestAccessTest : AuthorizedControllerTest() {
 
   @Autowired
   private lateinit var glossaryService: GlossaryService
+
+  @Autowired
+  private lateinit var glossaryExportService: GlossaryExportService
 
   lateinit var testData: GlossaryGuestAccessTestData
 
@@ -181,21 +186,20 @@ class GlossaryGuestAccessTest : AuthorizedControllerTest() {
 
   @Test
   fun `guest export omits a private co-assigned project's languages`() {
-    userAccount = testData.virtualGuest
-    exportLanguageHeaders(testData.mixedGlossary.id).assert.doesNotContain("de")
-
-    userAccount = testData.user
-    exportLanguageHeaders(testData.mixedGlossary.id).assert.contains("de")
+    exportLanguageHeaders(testData.virtualGuest).assert.doesNotContain("de")
+    exportLanguageHeaders(testData.user).assert.contains("de")
   }
 
-  private fun exportLanguageHeaders(glossaryId: Long): List<String> {
+  private fun exportLanguageHeaders(user: UserAccount): List<String> {
+    setSecurityContext(user)
     val csv =
-      performAuthGet("/v2/organizations/${testData.organization.id}/glossaries/$glossaryId/export")
-        .andIsOk
-        .andReturn()
-        .response.contentAsString
+      executeInNewTransaction {
+        val glossary = glossaryService.get(testData.organization.id, testData.mixedGlossary.id)
+        glossaryExportService.exportCsv(glossary).readBytes().toString(Charsets.UTF_8)
+      }
     val headers = csv.lines()[0].split(",").map { it.trim().removeSurrounding("\"") }
-    return headers.drop(6)
+    headers.take(GLOSSARY_CSV_HEADER_NAMES.size).assert.isEqualTo(GLOSSARY_CSV_HEADER_NAMES)
+    return headers.drop(GLOSSARY_CSV_HEADER_NAMES.size)
   }
 
   private fun assertGuestList(


### PR DESCRIPTION
## The flake

`GlossaryGuestAccessTest > guest export omits a private co-assigned project's languages` failed
intermittently in CI: five failures across four branches between 2026-08-28 and 08-31, each one
passing on the in-job retry with no code change. It never failed on an assertion — always
`java.util.ConcurrentModificationException` raised inside the request. Reproduced locally at
**19 failures per 100 repetitions**.

## Cause

spring-security#9175, already described in `io.tolgee.fixtures.springBug`. The glossary export
returns a `StreamingResponseBody`; under MockMvc that body runs on its own thread and mutates the
response header map while the security filter chain is still writing headers to it. The stack
matches `isSpringBug` exactly:

```
java.util.HashMap.computeIfAbsent
  -> org.springframework.util.LinkedCaseInsensitiveMap.computeIfAbsent
  -> org.springframework.mock.web.MockHttpServletResponse.addHeader
  -> jakarta.servlet.http.HttpServletResponseWrapper.addHeader
  -> org.springframework.security.web.header.writers.StaticHeadersWriter.writeHeaders
  -> org.springframework.security.web.header.HeaderWriterFilter.doHeadersAfter
```

## Fix

The repo's established workaround, `ignoreTestOnSpringBug`, does not fix the race — it converts it
into an *aborted* test. Measured, that meant the assertions silently stopped running in about one
run in six, and because the guest call ran first, an abort there also skipped the member call that
acts as the positive control. That trade is right where the streaming transport is itself under
test; it is wrong here, where the subject is which languages a guest may resolve.

That filtering does not live in the HTTP layer — it is
`GlossaryExportService.getOrganizationLanguageTagsForExport` ->
`GlossaryService.getAssignedProjectsForCurrentUser` -> `isBelowMemberReader`, which reads the
current user from `AuthenticationFacade`. So the test now drives the service directly under
`setSecurityContext`. No MockMvc, no async dispatch, no race, no aborts.

The endpoint keeps streaming: `StreamingResponseBodyProvider` still sets the
`STREAM_STARTED_ATTRIBUTE` that `ExceptionHandlers` depends on and records the
`StreamType.EXPORT_GLOSSARY` metric. De-streaming it is a separate decision that this test no
longer depends on.

## The test is now stronger than before the flake

Two pre-existing holes turned up while fixing it:

- **The guest half could not fail.** `mixedGlossary`'s public project carried only the base language
  `en`, which the exporter drops from the language columns, so the guest's *correct* list was empty
  and `doesNotContain("de")` held no matter what the filtering did. Only the member half could ever
  go red. The guest-visible public project now has a second language, and both sides assert exact
  equality — so over-filtering (losing `fr`) and under-filtering (leaking `de`) both fail.
- **An empty or truncated CSV passed trivially.** The fixed columns are now checked against the
  production `GLOSSARY_CSV_HEADER_NAMES` constant, which also removes an unexplained `drop(6)`.

Moving the assertion below HTTP would have dropped the only check that a guest may reach the export
endpoint at all (`GlossaryExportControllerTest` exercises it solely as `userOwner`), so that is
restored as a separate status-only test — keeping the guard it needs away from the filtering
assertions.

## Verification

| | failures / 100 reps | aborted |
|---|---|---|
| before any fix | 19 | 0 |
| with `ignoreTestOnSpringBug` only | 0 | 16 |
| this PR | **0** | **0** |

Full class 13/13 green, `ktlintFormat` clean. No production code changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for guest glossary exports, including CSV headers and accessible language columns.
  - Added validation for glossary export access through the guest-facing endpoint.
  - Updated public project test data to include French (`fr`) with its localized name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->